### PR TITLE
Pytorch example nits

### DIFF
--- a/examples/drqa/train.py
+++ b/examples/drqa/train.py
@@ -10,6 +10,10 @@ Reading Wikipedia to Answer Open-Domain Questions.
 In Association for Computational Linguistics (ACL).
 
 Link: https://arxiv.org/abs/1704.00051
+
+Note:
+To use pretrained word embeddings, set the --embeddings_file path argument.
+GloVe is recommended, see http://nlp.stanford.edu/data/glove.840B.300d.zip.
 """
 import torch
 import numpy as np
@@ -45,7 +49,9 @@ def build_dict(opt):
 
 
 def validate(opt, agent, n_iter):
+    opt = copy.deepcopy(opt)
     opt['datatype'] = 'valid'
+    opt['batchsize'] = 1
     valid_world = create_task(opt, agent)
 
     logger.info('[ Running validation... ]')
@@ -81,7 +87,7 @@ def main(opt):
     train_time = Timer()
 
     # Keep track of best model + how long since the last improvement
-    best_valid = validate(opt, doc_reader, -1)
+    best_valid = 0
     impatience = 0
 
     logger.info("[ Ok, let's go... ]")

--- a/parlai/agents/drqa/config.py
+++ b/parlai/agents/drqa/config.py
@@ -32,7 +32,7 @@ def add_cmdline_args(parser):
     parser.add_argument('--fix_embeddings', type='bool', default=True)
     parser.add_argument('--tune_partial', type=int, default=0,
                         help='Train the K most frequent word embeddings')
-    parser.add_argument('--embedding_dim', type=int, default=None,
+    parser.add_argument('--embedding_dim', type=int, default=300,
                         help=('Default embedding size if '
                               'embedding_file is not given'))
     parser.add_argument('--hidden_size', type=int, default=128,
@@ -90,9 +90,6 @@ def set_defaults(opt):
             raise IOError('No such file: %s' % args.embedding_file)
         with open(opt['embedding_file']) as f:
             dim = len(f.readline().strip().split(' ')) - 1
-        if 'embedding_dim' in opt and opt['embedding_dim'] != dim:
-            raise ValueError('embedding_dim = %d, but %s has %d dims.' %
-                             (opt['embedding_dim'], opt['embedding_file'], dim))
         opt['embedding_dim'] = dim
     elif 'embedding_dim' not in opt:
         raise RuntimeError(('Either embedding_file or embedding_dim '


### PR DESCRIPTION
* Added note for using pretrained embeddings.
* Also fixed args/batchsize so that you can just run python examples/drqa/train.py -t squad -b 32
* Skipped initial validation because it takes a long time with batchsize 1... so better for demonstration purposes to jump straight into training.