### PR TITLE
Add VQA V2.0 and Visual Dialog V0.9.

### DIFF
--- a/parlai/core/dialog_teacher.py
+++ b/parlai/core/dialog_teacher.py
@@ -265,7 +265,7 @@ class DialogData(object):
                 table['reward'] = entry[2]
                 if len(entry) > 3:
                     table['label_candidates'] = entry[3]
-                    if len(entry) > 4 and not opt.get('no_images', False):
+                    if len(entry) > 4 and not self.opt.get('no_images', False):
                         table['image'] = load_image(self.opt, entry[4])
 
 

--- a/parlai/tasks/visdial/__init__.py
+++ b/parlai/tasks/visdial/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/tasks/visdial/agents.py
+++ b/parlai/tasks/visdial/agents.py
@@ -5,7 +5,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 from parlai.core.dialog_teacher import DialogTeacher
-from .build import build
+from .build import build, buildImage
 
 from PIL import Image
 import json
@@ -14,6 +14,7 @@ import os
 
 def _path(opt):
     build(opt)
+    buildImage(opt)
     dt = opt['datatype'].split(':')[0]
 
     if dt == 'train':
@@ -28,7 +29,7 @@ def _path(opt):
     data_path = os.path.join(opt['datapath'], 'VisDial-v0.9',
         'visdial_0.9_' + suffix + '.json')
 
-    image_path = os.path.join(opt['download_path'], img_suffix)
+    image_path = os.path.join(opt['datapath'], 'COCO-IMG', img_suffix)
 
     return data_path, image_path
 
@@ -50,7 +51,7 @@ class DefaultTeacher(DialogTeacher):
     def __init__(self, opt, shared=None):
 
         self.datatype = opt['datatype']
-        data_path, image_path = _path(opt)
+        data_path, self.image_path = _path(opt)
         opt['datafile'] = data_path
         self.id = 'visdial'
 
@@ -66,8 +67,10 @@ class DefaultTeacher(DialogTeacher):
 
         for dialog in self.visdial['data']['dialogs']:
             # for each dialog
-            image_id = dialog['dialog']
+            image_id = dialog['image_id']
             caption = dialog['caption']
+            img_path = self.image_path + '%012d.jpg' % (image_id)
+
             episode_done = False
             for i, qa in enumerate(dialog['dialog']):
                 if i == len(dialog['dialog']):
@@ -80,4 +83,4 @@ class DefaultTeacher(DialogTeacher):
                     answer_options.append(self.answers[ans_id])
                 #answer_options = qa['answer_options']
                 gt_index = qa['gt_index']
-                yield (question, answer, 'None', answer_options), True
+                yield (question, answer, 'None', answer_options, img_path), True

--- a/parlai/tasks/visdial/agents.py
+++ b/parlai/tasks/visdial/agents.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+from parlai.core.dialog_teacher import DialogTeacher
+from .build import build
+
+from PIL import Image
+import json
+import random
+import os
+
+def _path(opt):
+    build(opt)
+    dt = opt['datatype'].split(':')[0]
+
+    if dt == 'train':
+        suffix = 'train'
+        img_suffix = os.path.join('train2014', 'COCO_train2014_')
+    elif dt == 'valid':
+        suffix = 'val'
+        img_suffix = os.path.join('val2014', 'COCO_val2014_')
+    else:
+        raise RuntimeError('Not valid datatype.')
+
+    data_path = os.path.join(opt['datapath'], 'VisDial-v0.9',
+        'visdial_0.9_' + suffix + '.json')
+
+    image_path = os.path.join(opt['download_path'], img_suffix)
+
+    return data_path, image_path
+
+
+def _image_loader(path):
+    """
+    Loads the appropriate image from the image_id and returns PIL Image format.
+    """
+    return Image.open(path).convert('RGB')
+
+
+class DefaultTeacher(DialogTeacher):
+    """
+    This version of VisDial inherits from the core Dialog Teacher, which just
+    requires it to define an iterator over its data `setup_data` in order to
+    inherit basic metrics, a `act` function, and enables
+    Hogwild training with shared memory with no extra work.
+    """
+    def __init__(self, opt, shared=None):
+
+        self.datatype = opt['datatype']
+        data_path, image_path = _path(opt)
+        opt['datafile'] = data_path
+        self.id = 'visdial'
+
+        super().__init__(opt, shared)
+
+    def setup_data(self, path):
+        print('loading: ' + path)
+        with open(path) as data_file:
+            self.visdial = json.load(data_file)
+
+        self.questions = self.visdial['data']['questions']
+        self.answers = self.visdial['data']['answers']
+
+        for dialog in self.visdial['data']['dialogs']:
+            # for each dialog
+            image_id = dialog['dialog']
+            caption = dialog['caption']
+            episode_done = False
+            for i, qa in enumerate(dialog['dialog']):
+                if i == len(dialog['dialog']):
+                    episode_done = True
+                # for each question answer pair.
+                question = self.questions[qa['question']]
+                answer = [self.answers[qa['answer']]]
+                answer_options = []
+                for ans_id in qa['answer_options']:
+                    answer_options.append(self.answers[ans_id])
+                #answer_options = qa['answer_options']
+                gt_index = qa['gt_index']
+                yield (question, answer, 'None', answer_options), True

--- a/parlai/tasks/visdial/build.py
+++ b/parlai/tasks/visdial/build.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+# Download and build the data if it does not exist.
+
+import parlai.core.build_data as build_data
+import os
+
+
+def build(opt):
+    dpath = os.path.join(opt['datapath'], 'VisDial-v0.9')
+
+    if not build_data.built(dpath):
+        print('[building data: ' + dpath + ']')
+        build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # Download the data.
+        fname1 = 'visdial_0.9_train.zip'
+        fname2 = 'visdial_0.9_val.zip'
+
+        url = 'https://computing.ece.vt.edu/~abhshkdz/data/visdial/'
+        build_data.download(dpath, url + fname1)
+        build_data.download(dpath, url + fname2)
+
+
+        build_data.untar(dpath, fname1)
+        build_data.untar(dpath, fname2)
+
+        # Mark the data as built.
+        build_data.mark_done(dpath)

--- a/parlai/tasks/visdial/build.py
+++ b/parlai/tasks/visdial/build.py
@@ -9,6 +9,33 @@ import parlai.core.build_data as build_data
 import os
 
 
+def buildImage(opt):
+    dpath = os.path.join(opt['datapath'], 'COCO-IMG')
+
+    if not build_data.built(dpath):
+        print('[building image data: ' + dpath + ']')
+        build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # download the image data.
+        fname1 = 'train2014.zip'
+        fname2 = 'val2014.zip'
+        fname3 = 'test2014.zip'
+
+        url = 'http://msvocds.blob.core.windows.net/coco2014/'
+
+        build_data.download(dpath, url + fname1)
+        build_data.download(dpath, url + fname2)
+        build_data.download(dpath, url + fname3)
+
+        build_data.untar(dpath, fname1, False)
+        build_data.untar(dpath, fname2, False)
+        build_data.untar(dpath, fname3, False)
+
+        # Mark the data as built.
+        build_data.mark_done(dpath)
+
+
 def build(opt):
     dpath = os.path.join(opt['datapath'], 'VisDial-v0.9')
 

--- a/parlai/tasks/vqa_coco2014/agents.py
+++ b/parlai/tasks/vqa_coco2014/agents.py
@@ -11,7 +11,7 @@ from PIL import Image
 import json
 import random
 import os
-
+import pdb
 
 def _path(opt):
     build(opt)
@@ -36,7 +36,7 @@ def _path(opt):
     annotation_path = os.path.join(opt['datapath'], 'VQA-COCO2014',
         annotation_suffix + '_annotations.json')
 
-    image_path = os.path.join(opt['datapath'], 'VQA-COCO2014', img_suffix)
+    image_path = os.path.join(opt['download_path'], img_suffix)
 
     return data_path, annotation_path, image_path
 

--- a/parlai/tasks/vqa_coco2014/agents.py
+++ b/parlai/tasks/vqa_coco2014/agents.py
@@ -14,6 +14,7 @@ import os
 
 def _path(opt):
     build(opt)
+    buildImage(opt)
     dt = opt['datatype'].split(':')[0]
 
     if dt == 'train':
@@ -35,7 +36,7 @@ def _path(opt):
     annotation_path = os.path.join(opt['datapath'], 'VQA-COCO2014',
         annotation_suffix + '_annotations.json')
 
-    image_path = os.path.join(opt['download_path'], img_suffix)
+    image_path = os.path.join(opt['datapath'], 'COCO-IMG', img_suffix)
 
     return data_path, annotation_path, image_path
 
@@ -99,7 +100,7 @@ class OeTeacher(Teacher):
             self.episode_idx = (self.episode_idx + self.step_size) % len(self)
             if self.episode_idx == len(self) - self.step_size:
                 self.epochDone = True
-            # always showing the same index now.
+
         qa = self.ques['questions'][self.episode_idx]
         question = qa['question']
         image_id = qa['image_id']

--- a/parlai/tasks/vqa_coco2014/build.py
+++ b/parlai/tasks/vqa_coco2014/build.py
@@ -9,22 +9,30 @@ import parlai.core.build_data as build_data
 import os
 
 
-def buildImage(dpath):
-    print('[building image data: ' + dpath + ']')
-    # download the image data.
-    fname1 = 'train2014.zip'
-    fname2 = 'val2014.zip'
-    fname3 = 'test2014.zip'
+def buildImage(opt):
+    dpath = os.path.join(opt['datapath'], 'COCO-IMG')
 
-    url = 'http://msvocds.blob.core.windows.net/coco2014/'
+    if not build_data.built(dpath):
+        print('[building image data: ' + dpath + ']')
+        build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+        # download the image data.
+        fname1 = 'train2014.zip'
+        fname2 = 'val2014.zip'
+        fname3 = 'test2014.zip'
 
-    build_data.download(os.path.join(dpath, fname1), url + fname1, False)
-    build_data.download(os.path.join(dpath, fname2), url + fname2, False)
-    build_data.download(os.path.join(dpath, fname3), url + fname3, False)
+        url = 'http://msvocds.blob.core.windows.net/coco2014/'
 
-    build_data.untar(dpath, fname1)
-    build_data.untar(dpath, fname2)
-    build_data.untar(dpath, fname3)
+        build_data.download(dpath, url + fname1)
+        build_data.download(dpath, url + fname2)
+        build_data.download(dpath, url + fname3)
+
+        build_data.untar(dpath, fname1, False)
+        build_data.untar(dpath, fname2, False)
+        build_data.untar(dpath, fname3, False)
+
+        # Mark the data as built.
+        build_data.mark_done(dpath)
 
 
 
@@ -60,8 +68,6 @@ def build(opt):
         build_data.untar(dpath, fname3)
         build_data.untar(dpath, fname4)
         build_data.untar(dpath, fname5)
-
-        # buildImage(dpath)
 
         # Mark the data as built.
         build_data.mark_done(dpath)

--- a/parlai/tasks/vqa_coco2014/build.py
+++ b/parlai/tasks/vqa_coco2014/build.py
@@ -58,7 +58,7 @@ def build(opt):
         build_data.untar(dpath, fname4)
         build_data.untar(dpath, fname5)
 
-        buildImage(dpath)
+        # buildImage(dpath)
 
         # Mark the data as built.
         build_data.mark_done(dpath)

--- a/parlai/tasks/vqa_coco2014_v2/__init__.py
+++ b/parlai/tasks/vqa_coco2014_v2/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/tasks/vqa_coco2014_v2/agents.py
+++ b/parlai/tasks/vqa_coco2014_v2/agents.py
@@ -106,12 +106,6 @@ class OeTeacher(Teacher):
         question = qa['question']
         image_id = qa['image_id']
 
-        if self.datatype != 'test':
-            anno = self.annotation['annotations'][self.episode_idx]
-            answers = [ans['answer'] for ans in anno['answers']]
-        else:
-            answers = ['fake_answer']
-
         img_path = self.image_path + '%012d.jpg' % (image_id)
 
         action = {

--- a/parlai/tasks/vqa_coco2014_v2/build.py
+++ b/parlai/tasks/vqa_coco2014_v2/build.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+# Download and build the data if it does not exist.
+
+import parlai.core.build_data as build_data
+import os
+
+
+def buildImage(dpath):
+    print('[building image data: ' + dpath + ']')
+    # download the image data.
+    fname1 = 'train2014.zip'
+    fname2 = 'val2014.zip'
+    fname3 = 'test2014.zip'
+
+    url = 'http://msvocds.blob.core.windows.net/coco2014/'
+
+    build_data.download(dpath, url + fname1)
+    build_data.download(dpath, url + fname2)
+    build_data.download(dpath, url + fname3)
+
+    build_data.untar(dpath, fname1, False)
+    build_data.untar(dpath, fname2, False)
+    build_data.untar(dpath, fname3, False)
+
+
+
+def build(opt):
+    dpath = os.path.join(opt['datapath'], 'VQA-COCO2014-v2')
+
+    if not build_data.built(dpath):
+        print('[building data: ' + dpath + ']')
+        build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # Download the data.
+        fname1 = 'v2_Questions_Train_mscoco.zip'
+        fname2 = 'v2_Questions_Val_mscoco.zip'
+        fname3 = 'v2_Questions_Test_mscoco.zip'
+
+        fname4 = 'v2_Annotations_Val_mscoco.zip'
+        fname5 = 'v2_Annotations_Train_mscoco.zip'
+
+        url = 'http://visualqa.org/data/mscoco/vqa/'
+        build_data.download(dpath, url + fname1)
+        build_data.download(dpath, url + fname2)
+        build_data.download(dpath, url + fname3)
+
+        build_data.download(dpath, url + fname4)
+        build_data.download(dpath, url + fname5)
+
+        build_data.untar(dpath, fname1)
+        build_data.untar(dpath, fname2)
+        build_data.untar(dpath, fname3)
+        build_data.untar(dpath, fname4)
+        build_data.untar(dpath, fname5)
+
+        # buildImage(dpath)
+
+        # Mark the data as built.
+        build_data.mark_done(dpath)

--- a/parlai/tasks/vqa_coco2014_v2/build.py
+++ b/parlai/tasks/vqa_coco2014_v2/build.py
@@ -9,22 +9,30 @@ import parlai.core.build_data as build_data
 import os
 
 
-def buildImage(dpath):
-    print('[building image data: ' + dpath + ']')
-    # download the image data.
-    fname1 = 'train2014.zip'
-    fname2 = 'val2014.zip'
-    fname3 = 'test2014.zip'
+def buildImage(opt):
+    dpath = os.path.join(opt['datapath'], 'COCO-IMG')
 
-    url = 'http://msvocds.blob.core.windows.net/coco2014/'
+    if not build_data.built(dpath):
+        print('[building image data: ' + dpath + ']')
+        build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+        # download the image data.
+        fname1 = 'train2014.zip'
+        fname2 = 'val2014.zip'
+        fname3 = 'test2014.zip'
 
-    build_data.download(dpath, url + fname1)
-    build_data.download(dpath, url + fname2)
-    build_data.download(dpath, url + fname3)
+        url = 'http://msvocds.blob.core.windows.net/coco2014/'
 
-    build_data.untar(dpath, fname1, False)
-    build_data.untar(dpath, fname2, False)
-    build_data.untar(dpath, fname3, False)
+        build_data.download(dpath, url + fname1)
+        build_data.download(dpath, url + fname2)
+        build_data.download(dpath, url + fname3)
+
+        build_data.untar(dpath, fname1, False)
+        build_data.untar(dpath, fname2, False)
+        build_data.untar(dpath, fname3, False)
+
+        # Mark the data as built.
+        build_data.mark_done(dpath)
 
 
 
@@ -57,8 +65,6 @@ def build(opt):
         build_data.untar(dpath, fname3)
         build_data.untar(dpath, fname4)
         build_data.untar(dpath, fname5)
-
-        # buildImage(dpath)
 
         # Mark the data as built.
         build_data.mark_done(dpath)


### PR DESCRIPTION
This pull request contains 
1: add vqa_v2 task loader.
2: add VisDial_v0.9 task loader.
3: disable download COCO image as default 
4: move COCO image path to "--download_path" 

To test the new added task

For VQA 2.0: python examples/display_data.py -t vqa_coco2014_v2 --download-path 'path_to_COCO_img'

For Visual Dialog: python examples/display_data.py -t visdial

Currently, the Visual Dialog inherit from the default "DialogTeacher" class. There is no placeholder for the additional image information. The "DialogData" class with the format [(x, y, r, c), new_episode?], could we extend this to  [(x, y, r, c, i), new_episode?] where "i" is some optional additional information such as image_id? If so, I can send another pull request to modify that. 


