### PR TITLE
updated requirements

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -49,7 +49,7 @@ Train a simple cpu-based memory network on the "10k training examples" bAbI task
 python memnn_luatorch_cpu/full_task_train.py -t babi:task10k:1 -nt 8
 ```
 
-Trains an attentive LSTM model on the SQuAD dataset with a batch size of 32 examples (pytorch and regex):
+Trains an attentive LSTM model on the SQuAD dataset with a batch size of 32 examples (requires pytorch):
 ```bash
 python drqa/train.py -t squad -bs 32
 ```

--- a/requirements_ext.txt
+++ b/requirements_ext.txt
@@ -1,2 +1,0 @@
-pytorch
-regex


### PR DESCRIPTION
requirements_ext.txt is confusing, no longer need regex and if pytorch isn't installed we display a message already to install it from their website.