### PR TITLE
Fixed: Documentation page updated as per example guideline 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,9 @@ ENV/
 
 # OS X files
 .DS_Store
+
+# Editor temporaries
+*.swn
+*.swo
+*.swp
+*~

--- a/docs/source/basic_tutorial.rst
+++ b/docs/source/basic_tutorial.rst
@@ -195,6 +195,7 @@ Now that we have our our agent, we'll set up the display loop.
         if world.epoch_done():
             print('EPOCH DONE')
             break
+    world.shutdown()
 
 And that's it! The world.display() automatically cycles through each of the
 world's agents and displays their last action. If you run this on the command


### PR DESCRIPTION
What were proposed in this Pull Request ?
* Documentation page has example code at http://ec2-35-162-199-80.us-west-2.compute.amazonaws.com/static/docs/basic_tutorial.html which had disconnect with given example https://github.com/facebookresearch/ParlAI/blob/master/examples/eval_model.py.
* task created with agent and parser were not calling shutdown and it is without with so no by default shutdown call.

