### PR TITLE
Add Dockerfile. Fix #75

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3
+WORKDIR /ParlAI
+ADD . /ParlAI/
+RUN pip install -r requirements.txt
+RUN python setup.py develop
+CMD cd tests && ./run_tests_short.sh


### PR DESCRIPTION
This is a basic Dockerfile to get started. The short tests run by the default CMD all pass, but the `tests/check_examples.sh` script fails due to a missing dependency, pytorch. Since pytorch isn't a requirement for the base framework I'd recommend a separate requirements.txt and Dockerfile for the pytorch example and others where appropriate. I'm currently running the `tests/run_tests_long.sh` script in a container built with this Dockerfile; will comment later with results once that is done.