### PR TITLE
updated dictionary_class(), added params argument groups, bug fixes

### DIFF
--- a/examples/build_dict.py
+++ b/examples/build_dict.py
@@ -23,12 +23,9 @@ def build_dict(opt):
         # Dictionary already built
         print("[ dictionary already built .]")
         return
-    if 'dict_class' in opt:
+    if opt.get('dict_class'):
         # Custom dictionary class
-        name = opt['dict_class'].split(':')
-        module = importlib.import_module(name[0])
-        dict_class = getattr(module, name[1])
-        dictionary = dict_class(opt)
+        dictionary = opt['dict_class'](opt)
     else:
         # Default dictionary class
         dictionary = DictionaryAgent(opt)

--- a/examples/build_dict.py
+++ b/examples/build_dict.py
@@ -7,7 +7,7 @@
 
 from parlai.core.dict import DictionaryAgent
 from parlai.core.worlds import DialogPartnerWorld
-from parlai.core.params import ParlaiParser
+from parlai.core.params import ParlaiParser, str2class
 from parlai.core.worlds import create_task
 import copy
 import importlib
@@ -25,7 +25,7 @@ def build_dict(opt):
         return
     if opt.get('dict_class'):
         # Custom dictionary class
-        dictionary = opt['dict_class'](opt)
+        dictionary = str2class(opt['dict_class'])(opt)
     else:
         # Default dictionary class
         dictionary = DictionaryAgent(opt)

--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -64,23 +64,24 @@ def run_eval(agent, opt, datatype, still_training=False):
 def main():
     # Get command line arguments
     parser = ParlaiParser(True, True)
-    parser.add_argument('-et', '--evaltask',
+    train = parser.add_argument_group('Training Loop Arguments')
+    train.add_argument('-et', '--evaltask',
                         help=('task to use for valid/test (defaults to the ' +
                               'one used for training if not set)'))
-    parser.add_argument('-d', '--display-examples',
+    train.add_argument('-d', '--display-examples',
                         type='bool', default=False)
-    parser.add_argument('-e', '--num-epochs', type=int, default=1)
-    parser.add_argument('-ttim', '--max-train-time',
+    train.add_argument('-e', '--num-epochs', type=int, default=1)
+    train.add_argument('-ttim', '--max-train-time',
                         type=float, default=float('inf'))
-    parser.add_argument('-ltim', '--log-every-n-secs',
+    train.add_argument('-ltim', '--log-every-n-secs',
                         type=float, default=1)
-    parser.add_argument('-vtim', '--validation-every-n-secs',
+    train.add_argument('-vtim', '--validation-every-n-secs',
                         type=float, default=0)
-    parser.add_argument('-vp', '--validation-patience',
+    train.add_argument('-vp', '--validation-patience',
                         type=int, default=5,
                         help=('number of iterations of validation where result '
                               + 'does not improve before we stop training'))
-    parser.add_argument('-dbf', '--dict-build-first',
+    train.add_argument('-dbf', '--dict-build-first',
                         type='bool', default=True,
                         help='build dictionary first before training agent')
     opt = parser.parse_args()

--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -26,7 +26,6 @@ TODO List:
 from parlai.core.agents import create_agent
 from parlai.core.worlds import create_task
 from parlai.core.params import ParlaiParser
-from parlai.core.dict import DictionaryAgent
 from parlai.core.utils import Timer
 import build_dict
 import copy

--- a/parlai/agents/drqa/config.py
+++ b/parlai/agents/drqa/config.py
@@ -100,7 +100,7 @@ def set_defaults(opt):
 
     # Make sure fix_embeddings and embedding_file are consistent
     if opt['fix_embeddings']:
-        if opt.get('embedding_file') and not opt.get('pretrained_model'):
+        if not opt.get('embedding_file') and not opt.get('pretrained_model'):
             print('Setting fix_embeddings to False as embeddings are random.')
             opt['fix_embeddings'] = False
 

--- a/parlai/agents/drqa/config.py
+++ b/parlai/agents/drqa/config.py
@@ -13,71 +13,72 @@ def str2bool(v):
 
 def add_cmdline_args(parser):
     # Runtime environment
-    parser.add_argument('--no_cuda', type='bool', default=False)
-    parser.add_argument('--gpu', type=int, default=-1)
-    parser.add_argument('--random_seed', type=int, default=1013)
+    agent = parser.add_argument_group('DrQA Arguments')
+    agent.add_argument('--no_cuda', type='bool', default=False)
+    agent.add_argument('--gpu', type=int, default=-1)
+    agent.add_argument('--random_seed', type=int, default=1013)
 
     # Basics
-    parser.add_argument('--embedding_file', type=str, default=None,
+    agent.add_argument('--embedding_file', type=str, default=None,
                         help='File of space separated embeddings: w e1 ... ed')
-    parser.add_argument('--pretrained_model', type=str, default=None,
+    agent.add_argument('--pretrained_model', type=str, default=None,
                         help='Load dict/features/weights/opts from this file')
-    parser.add_argument('--log_file', type=str, default=None)
+    agent.add_argument('--log_file', type=str, default=None)
 
     # Model details
-    parser.add_argument('--fix_embeddings', type='bool', default=True)
-    parser.add_argument('--tune_partial', type=int, default=0,
+    agent.add_argument('--fix_embeddings', type='bool', default=True)
+    agent.add_argument('--tune_partial', type=int, default=0,
                         help='Train the K most frequent word embeddings')
-    parser.add_argument('--embedding_dim', type=int, default=300,
+    agent.add_argument('--embedding_dim', type=int, default=300,
                         help=('Default embedding size if '
                               'embedding_file is not given'))
-    parser.add_argument('--hidden_size', type=int, default=128,
+    agent.add_argument('--hidden_size', type=int, default=128,
                         help='Hidden size of RNN units')
-    parser.add_argument('--doc_layers', type=int, default=3,
+    agent.add_argument('--doc_layers', type=int, default=3,
                         help='Number of RNN layers for passage')
-    parser.add_argument('--question_layers', type=int, default=3,
+    agent.add_argument('--question_layers', type=int, default=3,
                         help='Number of RNN layers for question')
-    parser.add_argument('--rnn_type', type=str, default='lstm',
+    agent.add_argument('--rnn_type', type=str, default='lstm',
                         help='RNN type: lstm (default), gru, or rnn')
 
     # Optimization details
-    parser.add_argument('--valid_metric', type=str,
+    agent.add_argument('--valid_metric', type=str,
                         choices=['accuracy', 'f1'], default='f1',
                         help='Metric for choosing best valid model')
-    parser.add_argument('--max_len', type=int, default=15,
+    agent.add_argument('--max_len', type=int, default=15,
                         help='The max span allowed during decoding')
-    parser.add_argument('--rnn_padding', type='bool', default=False)
-    parser.add_argument('--display_iter', type=int, default=10,
+    agent.add_argument('--rnn_padding', type='bool', default=False)
+    agent.add_argument('--display_iter', type=int, default=10,
                         help='Print train error after every \
                               <display_iter> epoches (default 10)')
-    parser.add_argument('--dropout_emb', type=float, default=0.4,
+    agent.add_argument('--dropout_emb', type=float, default=0.4,
                         help='Dropout rate for word embeddings')
-    parser.add_argument('--dropout_rnn', type=float, default=0.4,
+    agent.add_argument('--dropout_rnn', type=float, default=0.4,
                         help='Dropout rate for RNN states')
-    parser.add_argument('--dropout_rnn_output', type='bool', default=True,
+    agent.add_argument('--dropout_rnn_output', type='bool', default=True,
                         help='Whether to dropout the RNN output')
-    parser.add_argument('--optimizer', type=str, default='adamax',
+    agent.add_argument('--optimizer', type=str, default='adamax',
                         help='Optimizer: sgd or adamax (default)')
-    parser.add_argument('--learning_rate', '-lr', type=float, default=0.1,
+    agent.add_argument('--learning_rate', '-lr', type=float, default=0.1,
                         help='Learning rate for SGD (default 0.1)')
-    parser.add_argument('--grad_clipping', type=float, default=10,
+    agent.add_argument('--grad_clipping', type=float, default=10,
                         help='Gradient clipping (default 10.0)')
-    parser.add_argument('--weight_decay', type=float, default=0,
+    agent.add_argument('--weight_decay', type=float, default=0,
                         help='Weight decay (default 0)')
-    parser.add_argument('--momentum', type=float, default=0,
+    agent.add_argument('--momentum', type=float, default=0,
                         help='Momentum (default 0)')
 
     # Model-specific
-    parser.add_argument('--concat_rnn_layers', type='bool', default=True)
-    parser.add_argument('--question_merge', type=str, default='self_attn',
+    agent.add_argument('--concat_rnn_layers', type='bool', default=True)
+    agent.add_argument('--question_merge', type=str, default='self_attn',
                         help='The way of computing question representation')
-    parser.add_argument('--use_qemb', type='bool', default=True,
+    agent.add_argument('--use_qemb', type='bool', default=True,
                         help='Whether to use weighted question embeddings')
-    parser.add_argument('--use_in_question', type='bool', default=True,
+    agent.add_argument('--use_in_question', type='bool', default=True,
                         help='Whether to use in_question features')
-    parser.add_argument('--use_tf', type='bool', default=True,
+    agent.add_argument('--use_tf', type='bool', default=True,
                         help='Whether to use tf features')
-    parser.add_argument('--use_time', type=int, default=0,
+    agent.add_argument('--use_time', type=int, default=0,
                         help='Time features marking how recent word was said')
 
 def set_defaults(opt):
@@ -88,7 +89,7 @@ def set_defaults(opt):
         with open(opt['embedding_file']) as f:
             dim = len(f.readline().strip().split(' ')) - 1
         opt['embedding_dim'] = dim
-    elif 'embedding_dim' not in opt:
+    elif not opt.get('embedding_dim'):
         raise RuntimeError(('Either embedding_file or embedding_dim '
                             'needs to be specified.'))
 
@@ -99,10 +100,8 @@ def set_defaults(opt):
 
     # Make sure fix_embeddings and embedding_file are consistent
     if opt['fix_embeddings']:
-        if not 'embedding_file' in opt and not 'pretrained_model' in opt:
-            print(
-                'Setting fix_embeddings to False as embeddings are random.'
-                )
+        if opt.get('embedding_file') and not opt.get('pretrained_model'):
+            print('Setting fix_embeddings to False as embeddings are random.')
             opt['fix_embeddings'] = False
 
 def override_args(opt, override_opt):

--- a/parlai/agents/drqa/drqa.py
+++ b/parlai/agents/drqa/drqa.py
@@ -49,14 +49,14 @@ class SimpleDictionaryAgent(DictionaryAgent):
 
     @staticmethod
     def add_cmdline_args(argparser):
-        DictionaryAgent.add_cmdline_args(argparser)
-        argparser.add_arg(
+        group = DictionaryAgent.add_cmdline_args(argparser)
+        group.add_argument(
             '--pretrained_words', type='bool', default=True,
             help='Use only words found in provided embedding_file'
         )
 
     def __init__(self, *args, **kwargs):
-        super(SimpleDictionaryAgent, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Index words in embedding file
         if self.opt['pretrained_words'] and self.opt.get('embedding_file'):
@@ -104,11 +104,11 @@ class DrqaAgent(Agent):
     @staticmethod
     def add_cmdline_args(argparser):
         config.add_cmdline_args(argparser)
-        SimpleDictionaryAgent.add_cmdline_args(argparser)
+        DrqaAgent.dictionary_class().add_cmdline_args(argparser)
 
     @staticmethod
     def dictionary_class():
-        return "parlai.agents.drqa.drqa:SimpleDictionaryAgent"
+        return SimpleDictionaryAgent
 
     def __init__(self, opt, shared=None):
         if opt['numthreads'] >1:
@@ -116,7 +116,7 @@ class DrqaAgent(Agent):
 
         # Load dict.
         if not shared:
-            word_dict = SimpleDictionaryAgent(opt)
+            word_dict = DrqaAgent.dictionary_class()(opt)
         # All agents keep track of the episode (for multiple questions)
         self.episode_done = True
 
@@ -132,10 +132,10 @@ class DrqaAgent(Agent):
         self.opt = copy.deepcopy(opt)
         config.set_defaults(self.opt)
 
-        if 'model_file' in self.opt and os.path.isfile(opt['model_file']):
+        if self.opt.get('model_file') and os.path.isfile(opt['model_file']):
             self._init_from_saved(opt['model_file'])
         else:
-            if 'pretrained_model' in self.opt:
+            if self.opt.get('pretrained_model'):
                 self._init_from_saved(opt['pretrained_model'])
             else:
                 self._init_from_scratch()

--- a/parlai/agents/drqa/model.py
+++ b/parlai/agents/drqa/model.py
@@ -52,7 +52,7 @@ class DocReaderModel(object):
 
     def set_embeddings(self):
         # Read word embeddings.
-        if 'embedding_file' not in self.opt:
+        if not self.opt.get('embedding_file'):
             logger.warning('[ WARNING: No embeddings provided. '
                            'Keeping random initialization. ]')
             return

--- a/parlai/agents/drqa/utils.py
+++ b/parlai/agents/drqa/utils.py
@@ -24,6 +24,8 @@ def load_embeddings(opt, word_dict):
     embeddings.normal_(0, 1)
 
     # Fill in embeddings
+    if not opt.get('embedding_file'):
+        raise RuntimeError('Tried to load embeddings with no embedding file.')
     with open(opt['embedding_file']) as f:
         for line in f:
             parsed = line.rstrip().split(' ')

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -22,17 +22,18 @@ class Seq2seqAgent(Agent):
     @staticmethod
     def add_cmdline_args(argparser):
         DictionaryAgent.add_cmdline_args(argparser)
-        argparser.add_arg('-hs', '--hiddensize', type=int, default=64,
+        agent = argparser.add_argument_group('Seq2Seq Arguments')
+        agent.add_argument('-hs', '--hiddensize', type=int, default=64,
             help='size of the hidden layers and embeddings')
-        argparser.add_arg('-nl', '--numlayers', type=int, default=2,
+        agent.add_argument('-nl', '--numlayers', type=int, default=2,
             help='number of hidden layers')
-        argparser.add_arg('-lr', '--learningrate', type=float, default=0.5,
+        agent.add_argument('-lr', '--learningrate', type=float, default=0.5,
             help='learning rate')
-        argparser.add_arg('-dr', '--dropout', type=float, default=0.1,
+        agent.add_argument('-dr', '--dropout', type=float, default=0.1,
             help='dropout rate')
-        argparser.add_arg('--no-cuda', action='store_true', default=False,
+        agent.add_argument('--no-cuda', action='store_true', default=False,
             help='disable GPUs even if available')
-        argparser.add_arg('--gpu', type=int, default=-1,
+        agent.add_argument('--gpu', type=int, default=-1,
             help='which GPU device to use')
 
     def __init__(self, opt, shared=None):
@@ -51,10 +52,7 @@ class Seq2seqAgent(Agent):
             self.num_layers = opt['numlayers']
             self.learning_rate = opt['learningrate']
             self.use_cuda = opt.get('cuda', False)
-            self.longest_label = 2  # TODO: 1
-            if 'babi' in opt['task']:
-                self.babi_mode = True
-                self.dirs = set(['n', 's', 'e', 'w'])
+            self.longest_label = 1
 
             self.criterion = nn.NLLLoss()
             self.lt = nn.Embedding(len(self.dict), hsz, padding_idx=0,
@@ -215,11 +213,6 @@ class Seq2seqAgent(Agent):
                         total_done += 1
                     else:
                         output_lines[i].append(token)
-                        if self.babi_mode and token not in self.dirs:
-                            # for babi, only output one token except when
-                            # giving directions
-                            done[i] = True
-                            total_done += 1
         if random.random() < 0.1:
             print('prediction:', ' '.join(output_lines[0]))
         return output_lines

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -6,16 +6,16 @@
 """This module provides a set of basic agents:
 
     ``Agent(object)``
-    base class for all other agents, implements the ``observe()`` method 
+    base class for all other agents, implements the ``observe()`` method
     which receives an observation/action dict and the ``act()`` method which
     returns a dict in response.
 
     ``Teacher(Agent)``
-    also implements the ``report()`` method for returning metrics. All ParlAI tasks implement 
+    also implements the ``report()`` method for returning metrics. All ParlAI tasks implement
     the ``Teacher`` class.
 
     ``MultiTaskTeacher(Teacher)``
-    creates a set of teachers based on a "task string" passed to the ``Teacher``, 
+    creates a set of teachers based on a "task string" passed to the ``Teacher``,
     creating multiple teachers within it and alternating between them.
 
 All agents are initialized with the following parameters:
@@ -32,7 +32,7 @@ All agents are initialized with the following parameters:
 This module also provides a utility method:
 
     ``create_task_agents(str)``: instantiate task-specific agents (e.g. a teacher)
-    from a given task string (e.g. 'babi:task1k:1' or 'squad'). Used by 
+    from a given task string (e.g. 'babi:task1k:1' or 'squad'). Used by
     ``MultiTaskTeacher``.
 
 """
@@ -237,7 +237,7 @@ class MultiTaskTeacher(Teacher):
         if num_tasks > 0:
             m['accuracy'] = sum_accuracy / num_tasks
         return m
-      
+
     def reset(self):
         for t in self.tasks:
             t.reset()
@@ -300,10 +300,13 @@ def create_task_agent_from_taskname(opt):
     """Creates task agent(s) assuming the input ``task_dir:teacher_class``.
 
     e.g. def_string is a shorthand path like ``babi:Task1k:1`` or ``#babi``
-    or a complete path like ``parlai.tasks.babi.agents:Task1kTeacher:1``, 
+    or a complete path like ``parlai.tasks.babi.agents:Task1kTeacher:1``,
     which essentially performs ``from parlai.tasks.babi import Task1kTeacher``
     with the parameter ``1`` in ``opt['task']`` to be used by the class ``Task1kTeacher``.
     """
+    if not opt.get('task'):
+        raise RuntimeError('No task specified. Please select a task with ' +
+                           '--task {task_name}.')
     if ',' not in opt['task']:
         # Single task
         sp = opt['task'].strip().split(':')

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -75,12 +75,13 @@ class DictionaryAgent(Agent):
             '--dict-language', default=DictionaryAgent.default_lang,
             help='sets language for the punkt sentence tokenizer')
         dictionary.add_argument(
-            '--dict-max-ngram-size', default=DictionaryAgent.default_maxngram,
+            '--dict-max-ngram-size', type=int,
+            default=DictionaryAgent.default_maxngram,
             help='looks for ngrams of up to this size. this is ignored when ' +
                  'building the dictionary. note: this takes approximate ' +
                  'runtime of len(sentence)^max_ngram_size')
         dictionary.add_argument(
-            '--dict-minfreq', default=DictionaryAgent.default_minfreq,
+            '--dict-minfreq', default=DictionaryAgent.default_minfreq, type=int,
             help='minimum frequency of words to include them in the dictionary')
         dictionary.add_argument(
            '--dict-nulltoken', default=DictionaryAgent.default_null,
@@ -128,14 +129,14 @@ class DictionaryAgent(Agent):
                 index = len(self.tok2ind)
                 self.tok2ind[self.unk_token] = index
                 self.ind2tok[index] = self.unk_token
-              
+
             if opt.get('dict_file') and os.path.isfile(opt['dict_file']):
                 # load pre-existing dictionary
                 self.load(opt['dict_file'])
             elif opt.get('dict_initpath'):
                 # load seed dictionary
                 self.load(opt['dict_initpath'])
-            
+
 
         # initialize tokenizers
         st_path = 'tokenizers/punkt/{0}.pickle'.format(opt['dict_language'])

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -62,37 +62,39 @@ class DictionaryAgent(Agent):
 
     @staticmethod
     def add_cmdline_args(argparser):
-        argparser.add_arg(
+        dictionary = argparser.add_argument_group('Dictionary Arguments')
+        dictionary.add_argument(
             '--dict-file',
             help='if set, the dictionary will automatically save to this path' +
                  ' during shutdown')
-        argparser.add_arg(
+        dictionary.add_argument(
             '--dict-initpath',
             help='path to a saved dictionary to load tokens / counts from to ' +
                  'seed the dictionary with initial tokens and/or frequencies')
-        argparser.add_arg(
+        dictionary.add_argument(
             '--dict-language', default=DictionaryAgent.default_lang,
             help='sets language for the punkt sentence tokenizer')
-        argparser.add_arg(
+        dictionary.add_argument(
             '--dict-max-ngram-size', default=DictionaryAgent.default_maxngram,
             help='looks for ngrams of up to this size. this is ignored when ' +
                  'building the dictionary. note: this takes approximate ' +
                  'runtime of len(sentence)^max_ngram_size')
-        argparser.add_arg(
+        dictionary.add_argument(
             '--dict-minfreq', default=DictionaryAgent.default_minfreq,
             help='minimum frequency of words to include them in the dictionary')
-        argparser.add_arg(
+        dictionary.add_argument(
            '--dict-nulltoken', default=DictionaryAgent.default_null,
            help='empty token, can be used for padding or just empty values')
-        argparser.add_arg(
+        dictionary.add_argument(
            '--dict-eostoken', default=DictionaryAgent.default_eos,
            help='token for end of sentence markers, if needed')
-        argparser.add_arg(
+        dictionary.add_argument(
             '--dict-unktoken', default=DictionaryAgent.default_unk,
             help='token to return for unavailable words')
-        argparser.add_arg(
+        dictionary.add_argument(
             '--dict-maxexs', default=100000, type=int,
             help='max number of examples to build dict on')
+        return dictionary
 
     def __init__(self, opt, shared=None):
         # initialize fields

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -140,7 +140,7 @@ class ParlaiParser(argparse.ArgumentParser):
         self.add_parlai_data_path(parlai)
 
     def add_model_args(self, args=None):
-        model_args = self.add_argument_group('ParlAIModel Arguments')
+        model_args = self.add_argument_group('ParlAI Model Arguments')
         model_args.add_argument(
             '-m', '--model', default='repeat_label',
             help='the model class name, should match parlai/agents/<model>')

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -8,12 +8,25 @@ using the ParlAI package.
 """
 
 import argparse
+import importlib
 import os
 import sys
 from parlai.core.agents import get_agent_module
 
 def str2bool(value):
-    return value.lower() in ('yes', 'true', 't', '1', 'y')
+    v = value.lower()
+    if v in ('yes', 'true', 't', '1', 'y'):
+        return True
+    elif v in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+
+def str2class(value):
+    # e.g. 'parlai.agents.drqa.drqa:SimpleDictionaryAgent'
+    name = value.split(':')
+    module = importlib.import_module(name[0])
+    return getattr(module, name[1])
 
 
 class ParlaiParser(argparse.ArgumentParser):
@@ -35,6 +48,7 @@ class ParlaiParser(argparse.ArgumentParser):
         """
         super().__init__(description='ParlAI parser.')
         self.register('type', 'bool', str2bool)
+        self.register('type', 'class', str2class)
         self.parlai_home = (os.path.dirname(os.path.dirname(os.path.dirname(
                             os.path.realpath(__file__)))))
         os.environ['PARLAI_HOME'] = self.parlai_home
@@ -46,75 +60,84 @@ class ParlaiParser(argparse.ArgumentParser):
         if add_model_args:
             self.add_model_args(model_argv)
 
-    def add_parlai_data_path(self):
+    def add_parlai_data_path(self, argument_group=None):
+        if argument_group is None:
+            argument_group = self
         default_data_path = os.path.join(self.parlai_home, 'data')
-        self.add_argument(
+        argument_group.add_argument(
             '-dp', '--datapath', default=default_data_path,
             help='path to datasets, defaults to {parlai_dir}/data')
 
     def add_mturk_args(self):
+        mturk = self.add_argument_group('Mechanical Turk')
         default_log_path = os.path.join(self.parlai_home, 'logs', 'mturk')
-        self.add_argument(
+        mturk.add_argument(
             '--mturk-log-path', default=default_log_path,
             help='path to MTurk logs, defaults to {parlai_dir}/logs/mturk')
-        self.add_argument(
+        mturk.add_argument(
             '-t', '--task',
             help='MTurk task, e.g. "qa_data_collection" or "model_evaluator"')
-        self.add_argument(
+        mturk.add_argument(
             '-nh', '--num-hits', default=2, type=int,
             help='number of HITs you want to create for this task')
-        self.add_argument(
+        mturk.add_argument(
             '-na', '--num-assignments', default=1, type=int,
             help='number of assignments for each HIT')
-        self.add_argument(
+        mturk.add_argument(
             '-r', '--reward', default=0.05, type=float,
             help='reward for each HIT, in US dollars')
-        self.add_argument(
+        mturk.add_argument(
             '--sandbox', dest='is_sandbox', action='store_true',
             help='submit the HITs to MTurk sandbox site')
-        self.add_argument(
+        mturk.add_argument(
             '--live', dest='is_sandbox', action='store_false',
             help='submit the HITs to MTurk live site')
-        self.set_defaults(is_sandbox=True)
-        self.add_argument(
+        mturk.add_argument(
             '--verbose', dest='verbose', action='store_true',
             help='print out all messages sent/received in all conversations')
-        self.set_defaults(verbose=False)
+
+        mturk.set_defaults(is_sandbox=True)
+        mturk.set_defaults(verbose=False)
 
     def add_parlai_args(self):
         default_downloads_path = os.path.join(self.parlai_home, 'downloads')
-        self.add_argument(
+        parlai = self.add_argument_group('Main ParlAI Arguments')
+        parlai.add_argument(
             '-t', '--task',
             help='ParlAI task(s), e.g. "babi:Task1" or "babi,cbt"')
-        self.add_argument(
+        parlai.add_argument(
             '--download-path', default=default_downloads_path,
             help='path for non-data dependencies to store any needed files.' +
                  'defaults to {parlai_dir}/downloads')
-        self.add_argument(
+        parlai.add_argument(
             '-dt', '--datatype', default='train',
             choices=['train', 'train:ordered', 'valid', 'test'],
             help='choose from: train, train:ordered, valid, test. ' +
                  'by default: train is random with replacement, ' +
                  'valid is ordered, test is ordered.')
-        self.add_argument(
+        parlai.add_argument(
             '-im', '--image-mode', default='raw', type=str,
             help='image preprocessor to use. default is "raw". set to "none" '
                  'to skip image loading.')
-        self.add_argument(
+        parlai.add_argument(
             '-nt', '--numthreads', default=1, type=int,
             help='number of threads, e.g. for hogwild')
-        self.add_argument(
+        parlai.add_argument(
             '-bs', '--batchsize', default=1, type=int,
             help='batch size for minibatch training schemes')
-        self.add_parlai_data_path()
+        self.add_parlai_data_path(parlai)
 
     def add_model_args(self, args=None):
-        self.add_argument(
+        model_args = self.add_argument_group('ParlAIModel Arguments')
+        model_args.add_argument(
             '-m', '--model', default='repeat_label',
             help='the model class name, should match parlai/agents/<model>')
-        self.add_argument(
+        model_args.add_argument(
             '-mf', '--model-file', default=None,
             help='model file name for loading and saving models')
+        model_args.add_argument(
+            '--dict-class', type='class',
+            help='the class of the dictionary agent used')
         # Find which model specified, and add its specific arguments.
         if args is None:
             args = sys.argv
@@ -127,9 +150,7 @@ class ParlaiParser(argparse.ArgumentParser):
             if hasattr(agent, 'add_cmdline_args'):
                 agent.add_cmdline_args(self)
             if hasattr(agent, 'dictionary_class'):
-                self.add_argument(
-                    '--dict-class', default=agent.dictionary_class(), type=str,
-                    help='the class of the dictionary agent used')
+                model_args.set_defaults(dict_class=agent.dictionary_class())
 
     def parse_args(self, args=None, namespace=None, print_args=True):
         """Parses the provided arguments and returns a dictionary of the ``args``.
@@ -137,12 +158,16 @@ class ParlaiParser(argparse.ArgumentParser):
         the style ``opt.get(key, default)``, which would otherwise return ``None``.
         """
         self.opt = vars(super().parse_args(args=args))
+
+        # custom post-parsing
         self.opt['parlai_home'] = self.parlai_home
-        if 'download_path' in self.opt:
-            self.opt['download_path'] = self.opt['download_path']
+
+        # set environment variables
+        if self.opt.get('download_path'):
             os.environ['PARLAI_DOWNPATH'] = self.opt['download_path']
-        if 'datapath' in self.opt:
-            self.opt['datapath'] = self.opt['datapath']
+        if self.opt.get('datapath'):
+            os.environ['PARLAI_DATAPATH'] = self.opt['datapath']
+
         if print_args:
             self.print_args()
         return self.opt

--- a/parlai/tasks/tasks.py
+++ b/parlai/tasks/tasks.py
@@ -53,6 +53,9 @@ def _id_to_task(t_id):
 
 
 def ids_to_tasks(ids):
+    if ids is None:
+        raise RuntimeError('No task specified. Please select a task with ' +
+                           '--task {task_name}.')
     return ','.join((_id_to_task(i) for i in ids.split(',') if len(i) > 0))
 
 # Build the task list from the json file.


### PR DESCRIPTION
- Fixed some bugs with check parameters which used to be missing rather than none
- Updated dictionary_class to return a class, but allow users to specify a class on the command line and have the params class parse that into a specific class automatically
- Updated params to use argument groups per @ajfisch (you're beautiful), so now you get e.g.
```bash
$ py examples/train_model.py -m drqa --help
...
usage:
...
...
ParlAI parser.

optional arguments:
  -h, --help            show this help message and exit

Main ParlAI Arguments:
  -t TASK, --task TASK  ParlAI task(s), e.g. "babi:Task1" or "babi,cbt"
  --download-path DOWNLOAD_PATH
                        path for non-data dependencies to store any needed
                        files.defaults to {parlai_dir}/downloads
  -dt {train,train:ordered,valid,test}, --datatype {train,train:ordered,valid,test}
                        choose from: train, train:ordered, valid, test. by
                        default: train is random with replacement, valid is
                        ordered, test is ordered.
  -im IMAGE_MODE, --image-mode IMAGE_MODE
                        image preprocessor to use. default is "raw". set to
                        "none" to skip image loading.
  -nt NUMTHREADS, --numthreads NUMTHREADS
                        number of threads, e.g. for hogwild
  -bs BATCHSIZE, --batchsize BATCHSIZE
                        batch size for minibatch training schemes
  -dp DATAPATH, --datapath DATAPATH
                        path to datasets, defaults to {parlai_dir}/data

ParlAIModel Arguments:
  -m MODEL, --model MODEL
                        the model class name, should match
                        parlai/agents/<model>
  -mf MODEL_FILE, --model-file MODEL_FILE
                        model file name for loading and saving models
  --dict-class DICT_CLASS
                        the class of the dictionary agent used

DrQA Arguments:
  --no_cuda NO_CUDA
  --gpu GPU
...
...
```