### PR TITLE
bug fixes in drqa

### DIFF
--- a/parlai/agents/drqa/drqa.py
+++ b/parlai/agents/drqa/drqa.py
@@ -190,7 +190,7 @@ class DrqaAgent(Agent):
         if ex is None:
             return reply
         batch = batchify(
-            [ex], null=self.word_dict['__NULL__'], cuda=self.opt['cuda']
+            [ex], null=self.word_dict[self.word_dict.null_token], cuda=self.opt['cuda']
         )
 
         # Either train or predict
@@ -223,7 +223,7 @@ class DrqaAgent(Agent):
 
         # Else, use what we have (hopefully everything).
         batch = batchify(
-            examples, null=self.word_dict['__NULL__'], cuda=self.opt['cuda']
+            examples, null=self.word_dict[self.word_dict.null_token], cuda=self.opt['cuda']
         )
 
         # Either train or predict

--- a/parlai/agents/drqa/drqa.py
+++ b/parlai/agents/drqa/drqa.py
@@ -190,7 +190,7 @@ class DrqaAgent(Agent):
         if ex is None:
             return reply
         batch = batchify(
-            [ex], null=self.word_dict['<NULL>'], cuda=self.opt['cuda']
+            [ex], null=self.word_dict['__NULL__'], cuda=self.opt['cuda']
         )
 
         # Either train or predict
@@ -223,7 +223,7 @@ class DrqaAgent(Agent):
 
         # Else, use what we have (hopefully everything).
         batch = batchify(
-            examples, null=self.word_dict['<NULL>'], cuda=self.opt['cuda']
+            examples, null=self.word_dict['__NULL__'], cuda=self.opt['cuda']
         )
 
         # Either train or predict

--- a/parlai/agents/drqa/rnn_reader.py
+++ b/parlai/agents/drqa/rnn_reader.py
@@ -77,7 +77,7 @@ class RnnDocReader(nn.Module):
 
         # Question merging
         if opt['question_merge'] not in ['avg', 'self_attn']:
-            raise NotImplementedError('merge_mode = %s' % opt['merge_mode'])
+            raise NotImplementedError('question_merge = %s' % opt['question_merge'])
         if opt['question_merge'] == 'self_attn':
             self.self_attn = layers.LinearSeqAttn(question_hidden_size)
 


### PR DESCRIPTION
The default key for the NULL token is `'__NULL__'` (See line 59 in
parlai/core/dict.py), but `'<NULL>'` is used in line 193 and line 226
of parlai/agents/drqa/drqa.py. As a result, `'<NULL>'` is treated as an
unknown word and the index of `'__UNK__'` is actually used for padding,
which is not expected.

The string 'merge\_mode' only appears in line 80 of
parlai/agents/drqa/rnn\_reader.py, which seems to be a typo. It should
be 'question\_mode' according to the context.