### PR TITLE
add ner and pos feature to drqa

### DIFF
--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -32,6 +32,7 @@ import copy
 import importlib
 import math
 import os
+import spacy
 
 def run_eval(agent, opt, datatype, still_training=False, max_exs=-1):
     ''' Eval on validation/test data. '''
@@ -141,9 +142,10 @@ def main():
                 train_report = world.report()
                 world.reset_metrics()
 
-            if hasattr(train_report, 'get') and train_report.get('total'):
-                total_exs += train_report['total']
-                logs.append('total_exs:{}'.format(total_exs))
+            # if hasattr(train_report, 'get') and train_report.get('total'):
+            #     total_exs += train_report['total']
+            #     logs.append('total_exs:{}'.format(total_exs))
+            total_exs += 1
 
             # check if we should log amount of time remaining
             time_left = None
@@ -194,6 +196,7 @@ def main():
         # reload best validation model
         agent = create_agent(opt)
 
+    print('total used {}'.format(train_time.time()))
     run_eval(agent, opt, 'valid')
     run_eval(agent, opt, 'test')
 

--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -32,7 +32,6 @@ import copy
 import importlib
 import math
 import os
-import spacy
 
 def run_eval(agent, opt, datatype, still_training=False, max_exs=-1):
     ''' Eval on validation/test data. '''
@@ -142,10 +141,9 @@ def main():
                 train_report = world.report()
                 world.reset_metrics()
 
-            # if hasattr(train_report, 'get') and train_report.get('total'):
-            #     total_exs += train_report['total']
-            #     logs.append('total_exs:{}'.format(total_exs))
-            total_exs += 1
+            if hasattr(train_report, 'get') and train_report.get('total'):
+                total_exs += train_report['total']
+                logs.append('total_exs:{}'.format(total_exs))
 
             # check if we should log amount of time remaining
             time_left = None
@@ -196,7 +194,6 @@ def main():
         # reload best validation model
         agent = create_agent(opt)
 
-    print('total used {}'.format(train_time.time()))
     run_eval(agent, opt, 'valid')
     run_eval(agent, opt, 'test')
 

--- a/parlai/agents/drqa/config.py
+++ b/parlai/agents/drqa/config.py
@@ -78,6 +78,10 @@ def add_cmdline_args(parser):
                         help='Whether to use in_question features')
     agent.add_argument('--use_tf', type='bool', default=True,
                         help='Whether to use tf features')
+    agent.add_argument('--use_pos', type='bool', default=True,
+                        help='Whether to use pos features')
+    agent.add_argument('--use_ner', type='bool', default=True,
+                        help='Whether to use ner features')
     agent.add_argument('--use_time', type=int, default=0,
                         help='Time features marking how recent word was said')
 
@@ -109,8 +113,8 @@ def override_args(opt, override_opt):
     # Non-architecture args (like dropout) are kept.
     args = set(['embedding_file', 'embedding_dim', 'hidden_size', 'doc_layers',
                 'question_layers', 'rnn_type', 'optimizer', 'concat_rnn_layers',
-                'question_merge', 'use_qemb', 'use_in_question', 'use_tf',
-                'vocab_size', 'num_features', 'use_time'])
+                'question_merge', 'use_qemb', 'use_in_question', 'use_tf', 'use_pos', 
+                'use_ner', 'vocab_size', 'num_features', 'use_time'])
     for k, v in override_opt.items():
         if k in args:
             opt[k] = v

--- a/parlai/agents/drqa/config.py
+++ b/parlai/agents/drqa/config.py
@@ -78,9 +78,9 @@ def add_cmdline_args(parser):
                         help='Whether to use in_question features')
     agent.add_argument('--use_tf', type='bool', default=True,
                         help='Whether to use tf features')
-    agent.add_argument('--use_pos', type='bool', default=True,
+    agent.add_argument('--use_pos', type='bool', default=False,
                         help='Whether to use pos features')
-    agent.add_argument('--use_ner', type='bool', default=True,
+    agent.add_argument('--use_ner', type='bool', default=False,
                         help='Whether to use ner features')
     agent.add_argument('--use_time', type=int, default=0,
                         help='Time features marking how recent word was said')

--- a/parlai/agents/drqa/utils.py
+++ b/parlai/agents/drqa/utils.py
@@ -7,6 +7,20 @@ import torch
 import time
 import unicodedata
 from collections import Counter
+import spacy
+
+NLP = spacy.load('en')
+pos_list = [
+    'DET', 'ADP', 'PART', 'ADJ', 'PUNCT', 'INTJ', 'NOUN', 'ADV', 'X', 'PRON',
+    'PROPN', 'VERB', 'CONJ', 'SPACE', 'NUM', 'SYM', 'CCONJ'
+]
+ner_list = [
+    'QUANTITY', 'PRODUCT', 'EVENT', 'FACILITY', 'NORP', 'TIME', 'LANGUAGE',
+    'ORG', 'DATE', 'CARDINAL', 'PERSON', 'ORDINAL', 'LOC', 'PERCENT', 'MONEY',
+    'WORK_OF_ART', 'GPE', 'FAC', 'LAW'
+]
+pos_dict = {i: pos_list.index(i)/len(pos_list) for i in pos_list}
+ner_dict = {i: ner_list.index(i)/len(ner_list) for i in ner_list}
 
 
 # ------------------------------------------------------------------------------
@@ -49,6 +63,10 @@ def build_feature_dict(opt):
         feature_dict['in_question_uncased'] = len(feature_dict)
     if opt['use_tf']:
         feature_dict['tf'] = len(feature_dict)
+    if opt['use_ner']:
+        feature_dict['ner_type'] = len(feature_dict)
+    if opt['use_pos']:
+        feature_dict['pos_type'] = len(feature_dict)
     if opt['use_time'] > 0:
         for i in range(opt['use_time'] - 1):
             feature_dict['time=T%d' % (i + 1)] = len(feature_dict)
@@ -70,6 +88,8 @@ def vectorize(opt, ex, word_dict, feature_dict):
     # Create extra features vector
     features = torch.zeros(len(ex['document']), len(feature_dict))
 
+    spacy_doc = NLP(' '.join(ex['document']))
+
     # f_{exact_match}
     if opt['use_in_question']:
         q_words_cased = set([w for w in ex['question']])
@@ -86,6 +106,17 @@ def vectorize(opt, ex, word_dict, feature_dict):
         l = len(ex['document'])
         for i, w in enumerate(ex['document']):
             features[i][feature_dict['tf']] = counter[w.lower()] * 1.0 / l
+    if opt['use_ner']:
+        for i, w in enumerate(ex['document']):
+            if spacy_doc[i].ent_type_:
+                features[i][feature_dict['ner_type']] = ner_dict[spacy_doc[
+                    i].ent_type_]
+
+    if opt['use_pos']:
+        for i, w in enumerate(ex['document']):
+            if spacy_doc[i].pos_:
+                features[i][feature_dict['pos_type']] = pos_dict[spacy_doc[
+                    i].pos_]
 
     if opt['use_time'] > 0:
         # Counting from the end, each (full-stop terminated) sentence gets


### PR DESCRIPTION
I found in http://arxiv.org/abs/1704.00051v1, there implement artificial feature "POS" and "NER", but in ParlAI, it seems we don't implement these function.

So i add code to reproduce Drqa like http://arxiv.org/abs/1704.00051v1.

After experiment, after use these feature, I got
test:{'accuracy': 0.6616840113528856, 'hits@k': {1: 0.6288552507095554, 10: 0.6288552507095554, 50: 0.6288552507095554, 100: 0.6288552507095554, 5: 0.6288552507095554}, 'total': 10570, 'f1': 0.761960913560991}

when i use these parameter:
python3 examples/train_model.py -m drqa -t squad -bs 32 -dbf True -mf 'drqa' -vtim 3600 -e 10 --embedding_file glove.840B.300d.txt --tune_partial 1000 --dropout_emb 0.3 --dropout_rnn 0.3

Compared without these features:
valid:{'accuracy': 0.6526963103122043, 'f1': 0.7543689069607271, 'total': 10570, 'hits@k': {1: 0.6203405865657521, 10: 0.6203405865657521, 50: 0.6203405865657521, 100: 0.6203405865657521, 5: 0.6203405865657521}}

python3 examples/train_model.py -m drqa -t squad -bs 32 -dbf True -mf 'drqa' -vtim 3600 -e 10 --embedding_file glove.840B.300d.txt --tune_partial 1000 --dropout_emb 0.3 --dropout_rnn 0.3