### PR TITLE
Batch observe

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -73,6 +73,10 @@ class Agent(object):
     def getID(self):
         return self.id
 
+    @property
+    def internal_states(self):
+        return ['observation']
+
     def reset(self):
         self.observation = None
 

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -73,8 +73,8 @@ class Agent(object):
     def getID(self):
         return self.id
 
-    @property
-    def internal_states(self):
+    @staticmethod
+    def internal_states():
         return ['observation']
 
     def reset(self):

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -73,8 +73,8 @@ class Agent(object):
     def getID(self):
         return self.id
 
-    @staticmethod
-    def internal_states():
+    @classmethod
+    def internal_states(cls):
         return ['observation']
 
     def reset(self):

--- a/parlai/core/dialog_teacher.py
+++ b/parlai/core/dialog_teacher.py
@@ -83,6 +83,10 @@ class DialogTeacher(Teacher):
         if self.epochDone:
             raise StopIteration()
 
+    @property
+    def internal_states(self):
+        return super().internal_states + ['lastY']
+
     def share(self):
         shared = super().share()
         shared['data'] = self.data

--- a/parlai/core/dialog_teacher.py
+++ b/parlai/core/dialog_teacher.py
@@ -85,7 +85,7 @@ class DialogTeacher(Teacher):
 
     @staticmethod
     def internal_states():
-        return super(DialogTeacher, DialogTeacher).internal_states() + ['lastY']
+        return super().internal_states() + ['lastY']
 
     def share(self):
         shared = super().share()

--- a/parlai/core/dialog_teacher.py
+++ b/parlai/core/dialog_teacher.py
@@ -83,9 +83,9 @@ class DialogTeacher(Teacher):
         if self.epochDone:
             raise StopIteration()
 
-    @property
-    def internal_states(self):
-        return super().internal_states + ['lastY']
+    @staticmethod
+    def internal_states():
+        return super(DialogTeacher, DialogTeacher).internal_states() + ['lastY']
 
     def share(self):
         shared = super().share()

--- a/parlai/core/dialog_teacher.py
+++ b/parlai/core/dialog_teacher.py
@@ -83,8 +83,8 @@ class DialogTeacher(Teacher):
         if self.epochDone:
             raise StopIteration()
 
-    @staticmethod
-    def internal_states():
+    @classmethod
+    def internal_states(cls):
         return super().internal_states() + ['lastY']
 
     def share(self):

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -550,6 +550,13 @@ class BatchWorld(World):
 
     def batch_observe(self, index, batch_actions, index_acting):
         batch_observations = []
+        a = self.world.get_agents()[index]
+
+        if (batch_actions is not None and len(batch_actions) > 0 and
+                hasattr(a, 'batch_observe')) and index != index_acting:
+            # if there's anything that needs to be batched, do it here
+            a.batch_observe(batch_actions)
+
         for i, w in enumerate(self.worlds):
             agents = w.get_agents()
             observation = None

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -550,12 +550,6 @@ class BatchWorld(World):
 
     def batch_observe(self, index, batch_actions, index_acting):
         batch_observations = []
-        a = self.world.get_agents()[index]
-
-        if (batch_actions is not None and len(batch_actions) > 0 and
-                hasattr(a, 'batch_observe')) and index != index_acting:
-            # if there's anything that needs to be batched, do it here
-            a.batch_observe(batch_actions)
 
         for i, w in enumerate(self.worlds):
             agents = w.get_agents()
@@ -572,6 +566,13 @@ class BatchWorld(World):
             if observation is None:
                 raise ValueError('Agents should return what they observed.')
             batch_observations.append(observation)
+
+        a = self.world.get_agents()[index]
+        if (batch_actions is not None and len(batch_actions) > 0 and
+                hasattr(a, 'batch_observe')) and index != index_acting:
+            # if there's anything that needs to be batched, do it here
+            a.batch_observe(batch_observations)
+
         return batch_observations
 
     def batch_act(self, index, batch_observation):

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -562,16 +562,17 @@ class BatchWorld(World):
             else:
                 if index == index_acting: return None # don't observe yourself talking
                 observation = validate(batch_actions[i])
-            observation = agents[index].observe(observation)
-            if observation is None:
-                raise ValueError('Agents should return what they observed.')
             batch_observations.append(observation)
 
         a = self.world.get_agents()[index]
         if (batch_actions is not None and len(batch_actions) > 0 and
-                hasattr(a, 'batch_observe')) and index != index_acting:
-            # if there's anything that needs to be batched, do it here
-            a.batch_observe(batch_observations)
+                hasattr(a, 'batch_observe')):
+            batch_observations = a.batch_observe(batch_observations)
+        else:
+            batch_observations = [w.get_agents()[index].observe(o) for w, o in zip(self.worlds, batch_observations)]
+
+        if batch_observations is None or any([o is None for o in batch_observations]):
+            raise ValueError('Agents should return what they observed.')
 
         return batch_observations
 


### PR DESCRIPTION
Call `batch_observe`, if available, before `observe` is called. The reason that this is not used **instead** of `observe` is for better backwards compatibility, as well as making it easy to reuse the nice things in the `observe` method in some super classes. 

(Maybe we should call it `batch_preobserve` instead?)