### PR TITLE
Tensorboard logging/visualization

### DIFF
--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -106,7 +106,9 @@ def main():
 
     # Set up logger if directory provided
     if opt['tensorboard_dir']:
-        opt['logger'] = TensorboardLogger(opt['tensorboard_dir'])
+        logger = TensorboardLogger(opt['tensorboard_dir'])
+        opt['train_log'] = {}
+        opt['valid_log'] = {}
 
     # Create model and assign it to the specified task
     agent = create_agent(opt)
@@ -176,16 +178,17 @@ def main():
 
             # Log train values
             if opt['tensorboard_dir']:
-                opt['logger'].log_train(train_report, total_exs)
+                logger.log_train(train_report, total_exs)
+                logger.log_train(opt['train_log'], total_exs)
 
         if (opt['validation_every_n_secs'] > 0 and
                 validate_time.time() > opt['validation_every_n_secs']):
             valid_report = run_eval(agent, opt, 'valid', True, opt['validation_max_exs'])
 
             # Log valid values
-            print(valid_report)
             if opt['tensorboard_dir']:
-                opt['logger'].log_valid(valid_report, total_exs)
+                logger.log_valid(valid_report, total_exs)
+                logger.log_valid(opt['valid_log'], total_exs)
 
             if valid_report['accuracy'] > best_accuracy:
                 best_accuracy = valid_report['accuracy']

--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -32,7 +32,6 @@ import copy
 import importlib
 import math
 import os
-import tensorboard_logger
 
 
 def run_eval(agent, opt, datatype, still_training=False, max_exs=-1):
@@ -106,6 +105,12 @@ def main():
         build_dict.build_dict(opt)
     # XXX Set up tensorboard
     if opt['tensorboard_dir']:
+        try:
+            import tensorboard_logger
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError('Need to install tensorboard_logger: ' +
+                    'go to https://github.com/TeamHG-Memex/tensorboard_logger')
+
         opt['tensorboard'] = {}
         train_board = tensorboard_logger.Logger(
                 os.path.join(opt['tensorboard_dir'], 'train'), flush_secs=5)

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -4,9 +4,11 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+import os
 import math
 import sys
 import time
+from numbers import Number
 
 
 class Predictor(object):
@@ -50,6 +52,35 @@ class Predictor(object):
         self.agent.observe(observation)
         reply = self.agent.act()
         return reply
+
+
+class TensorboardLogger(object):
+    def __init__(self, logdir):
+        try:
+            import tensorboard_logger
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError('Need to install tensorboard_logger: ' +
+                    'go to https://github.com/TeamHG-Memex/tensorboard_logger')
+
+        self.train_board = tensorboard_logger.Logger(
+                os.path.join(logdir, 'train'), flush_secs=5)
+        self.valid_board = tensorboard_logger.Logger(
+                os.path.join(logdir, 'valid'), flush_secs=5)
+
+    def log_train(self, values_dict, step):
+        self._log(self.train_board, values_dict, step)
+
+    def log_valid(self, values_dict, step):
+        self._log(self.valid_board, values_dict, step)
+
+    def _log(self, logger, values_dict, step):
+        for name in values_dict:
+            if isinstance(values_dict[name], Number):
+                logger.log_value(name, values_dict[name], step)
+
+    def __getstate__(self):
+        # Avoid storing or copying this object as part of another.
+        pass
 
 
 class Timer(object):

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -75,12 +75,8 @@ class TensorboardLogger(object):
 
     def _log(self, logger, values_dict, step):
         for name in values_dict:
-            if isinstance(values_dict[name], Number):
+            if type(values_dict[name]) is not dict:
                 logger.log_value(name, values_dict[name], step)
-
-    def __getstate__(self):
-        # Avoid storing or copying this object as part of another.
-        pass
 
 
 class Timer(object):

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -8,7 +8,6 @@ import os
 import math
 import sys
 import time
-from numbers import Number
 
 
 class Predictor(object):


### PR DESCRIPTION
This is something I've been using, but I'm not sure if it should be merged to master. Since it could be useful to some, I'm placing it here. It's a modification to the train script that sets up a flag for allowing tensorboard logging, which can then be visualized (even remotely) with a tensorboard server . The train script only sets up the accuracy, but the agent can set up other values for logging by placing them in the opt['tensorboard'] dict, eg below.

![image](https://user-images.githubusercontent.com/10751509/28331756-3d04ed2a-6bc0-11e7-800e-7a99b9382b59.png)
