### PR TITLE
MTurk improvements

### DIFF
--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -301,6 +301,11 @@ class MTurkAgent(Agent):
         self.hit_id = None
         self.worker_id = None
 
+        # Wait for MTurk-specific info
+        while not (self.assignment_id and self.hit_id and self.worker_id):
+            self.assignment_id, self.hit_id, self.worker_id = self.manager.get_hit_assignment_info(self.manager.task_group_id, self.conversation_id, self.id)
+            time.sleep(polling_interval)
+
     def observe(self, msg):
         if msg['id'] not in self.manager.mturk_agent_ids: # If the message sender is an mturk agent, then there is no need to upload this message to db since it's already been done on the message sender side.
             # We can't have all mturk agents upload this observed new message to server, otherwise there will be duplication.
@@ -316,10 +321,6 @@ class MTurkAgent(Agent):
                 )
 
     def act(self):
-        while not (self.assignment_id and self.hit_id and self.worker_id):
-            self.assignment_id, self.hit_id, self.worker_id = self.manager.get_hit_assignment_info(self.manager.task_group_id, self.conversation_id, self.id)
-            time.sleep(polling_interval)
-
         while True:
             conversation_dict, new_last_message_id = self.manager.get_new_messages(
                 task_group_id=self.manager.task_group_id,

--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -290,10 +290,10 @@ class MTurkManager():
 
 
 class MTurkAgent(Agent):
-    def __init__(self, id, manager, conversation_id, opt, shared=None):
+    def __init__(self, id, manager, hit_index, assignment_index, opt, shared=None):
         super().__init__(opt)
 
-        self.conversation_id = conversation_id
+        self.conversation_id = str(hit_index) + '_' + str(assignment_index)
         self.manager = manager
         self.id = id
         self.last_message_id = 0

--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -367,8 +367,10 @@ class MTurkAgent(Agent):
         response = self.manager.email_worker(worker_id=self.worker_id, subject=subject, message_text=message_text)
         if 'success' in response:
             print("Email sent to worker ID: "+str(self.worker_id)+": Subject: "+str(subject)+": Text: "+str(message_text))
+            return True
         elif 'failure' in response:
             print("Unable to send email to worker ID: "+str(self.worker_id)+". Error: "+str(response['failure']))
+            return False
 
     def wait_for_hit_completion(self):
         while self.manager.get_agent_work_status(assignment_id=self.assignment_id) != ASSIGNMENT_DONE:

--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -226,6 +226,7 @@ class MTurkManager():
                         hit_description=opt['hit_description'] + ' (ID: ' + self.task_group_id + ', Role: ' + mturk_agent_id + ')',
                         hit_keywords=opt['hit_keywords'],
                         hit_reward=opt['reward'],
+                        assignment_duration_in_seconds=opt.get('assignment_duration_in_seconds', 30 * 60), # Set to 30 minutes by default
                         is_sandbox=opt['is_sandbox']
                     )
                 all_agent_ids_string = str(self.all_agent_ids).replace("'", '''"''')

--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -36,7 +36,6 @@ ASSIGNMENT_APPROVED = 'Approved'
 ASSIGNMENT_REJECTED = 'Rejected'
 
 polling_interval = 1 # in seconds
-create_hit_type_lock = threading.Lock()
 local_db_lock = threading.Lock()
 debug = False
 
@@ -220,15 +219,14 @@ class MTurkManager():
         mturk_agent_HIT_url_dict = {}
         for mturk_agent_id in self.mturk_agent_ids:
             for hit_index in range(1, opt['num_hits']+1):
-                with create_hit_type_lock:
-                    hit_type_id = create_hit_type(
-                        hit_title=opt['hit_title'],
-                        hit_description=opt['hit_description'] + ' (ID: ' + self.task_group_id + ', Role: ' + mturk_agent_id + ')',
-                        hit_keywords=opt['hit_keywords'],
-                        hit_reward=opt['reward'],
-                        assignment_duration_in_seconds=opt.get('assignment_duration_in_seconds', 30 * 60), # Set to 30 minutes by default
-                        is_sandbox=opt['is_sandbox']
-                    )
+                hit_type_id = create_hit_type(
+                    hit_title=opt['hit_title'],
+                    hit_description=opt['hit_description'] + ' (ID: ' + self.task_group_id + ', Role: ' + mturk_agent_id + ')',
+                    hit_keywords=opt['hit_keywords'],
+                    hit_reward=opt['reward'],
+                    assignment_duration_in_seconds=opt.get('assignment_duration_in_seconds', 30 * 60), # Set to 30 minutes by default
+                    is_sandbox=opt['is_sandbox']
+                )
                 all_agent_ids_string = str(self.all_agent_ids).replace("'", '''"''')
                 mturk_chat_url = self.html_api_endpoint_url + "?method_name=chat_index&task_group_id="+str(self.task_group_id)+"&all_agent_ids="+all_agent_ids_string+"&cur_agent_id="+str(mturk_agent_id)
                 mturk_page_url = create_hit_with_hit_type(

--- a/parlai/mturk/core/setup_aws.py
+++ b/parlai/mturk/core/setup_aws.py
@@ -592,7 +592,7 @@ def get_mturk_client(is_sandbox):
         client = boto3.client(service_name = 'mturk', region_name='us-east-1')
     return client
 
-def create_hit_type(hit_title, hit_description, hit_keywords, hit_reward, is_sandbox):
+def create_hit_type(hit_title, hit_description, hit_keywords, hit_reward, assignment_duration_in_seconds, is_sandbox):
     client = boto3.client(
         service_name = 'mturk',
         region_name = 'us-east-1',
@@ -620,7 +620,7 @@ def create_hit_type(hit_title, hit_description, hit_keywords, hit_reward, is_san
     # Create the HIT type
     response = client.create_hit_type(
         AutoApprovalDelayInSeconds=4*7*24*3600, # auto-approve after 4 weeks
-        AssignmentDurationInSeconds=1800,
+        AssignmentDurationInSeconds=assignment_duration_in_seconds,
         Reward=str(hit_reward),
         Title=hit_title,
         Keywords=hit_keywords,

--- a/parlai/mturk/tasks/model_evaluator/run.py
+++ b/parlai/mturk/tasks/model_evaluator/run.py
@@ -12,7 +12,6 @@ import os
 import copy
 from itertools import product
 from joblib import Parallel, delayed
-import threading
 
 
 def main():
@@ -44,11 +43,9 @@ def main():
     
     global run_hit
     def run_hit(hit_index, assignment_index, opt, task_opt, mturk_manager):
-        conversation_id = str(hit_index) + '_' + str(assignment_index)
-
         model_agent = IrBaselineAgent(opt=opt)
         # Create the MTurk agent which provides a chat interface to the Turker
-        mturk_agent = MTurkAgent(id=mturk_agent_id, manager=mturk_manager, conversation_id=conversation_id, opt=opt)
+        mturk_agent = MTurkAgent(id=mturk_agent_id, manager=mturk_manager, hit_index=hit_index, assignment_index=assignment_index, opt=opt)
         world = ModelEvaluatorWorld(opt=opt, model_agent=model_agent, task_opt=task_opt, mturk_agent=mturk_agent)
 
         while not world.episode_done():

--- a/parlai/mturk/tasks/model_evaluator/run.py
+++ b/parlai/mturk/tasks/model_evaluator/run.py
@@ -12,6 +12,7 @@ import os
 import copy
 from itertools import product
 from joblib import Parallel, delayed
+import threading
 
 
 def main():
@@ -39,6 +40,7 @@ def main():
         all_agent_ids = [ModelEvaluatorWorld.evaluator_agent_id, mturk_agent_id] # In speaking order
     )
     mturk_manager.init_aws(opt=opt)
+    mturk_manager.start_new_run(opt=opt)
     
     global run_hit
     def run_hit(hit_index, assignment_index, opt, task_opt, mturk_manager):

--- a/parlai/mturk/tasks/model_evaluator/worlds.py
+++ b/parlai/mturk/tasks/model_evaluator/worlds.py
@@ -48,6 +48,6 @@ class ModelEvaluatorWorld(MTurkWorld):
     def shutdown(self):
         self.task_world.shutdown()
         self.mturk_agent.shutdown()
-        
+
     def review_work(self):
         pass

--- a/parlai/mturk/tasks/multi_agent_dialog/run.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/run.py
@@ -38,6 +38,7 @@ def main():
         all_agent_ids = [human_agent_1_id, human_agent_2_id, mturk_agent_1_id, mturk_agent_2_id] # In speaking order
     )
     mturk_manager.init_aws(opt=opt)
+    mturk_manager.start_new_run(opt=opt)
 
     global run_hit
     def run_hit(hit_index, assignment_index, opt, mturk_manager):

--- a/parlai/mturk/tasks/multi_agent_dialog/run.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/run.py
@@ -42,11 +42,9 @@ def main():
 
     global run_hit
     def run_hit(hit_index, assignment_index, opt, mturk_manager):
-        conversation_id = str(hit_index) + '_' + str(assignment_index)
-
         # Create mturk agents
-        mturk_agent_1 = MTurkAgent(id=mturk_agent_1_id, manager=mturk_manager, conversation_id=conversation_id, opt=opt)
-        mturk_agent_2 = MTurkAgent(id=mturk_agent_2_id, manager=mturk_manager, conversation_id=conversation_id, opt=opt)
+        mturk_agent_1 = MTurkAgent(id=mturk_agent_1_id, manager=mturk_manager, hit_index=hit_index, assignment_index=assignment_index, opt=opt)
+        mturk_agent_2 = MTurkAgent(id=mturk_agent_2_id, manager=mturk_manager, hit_index=hit_index, assignment_index=assignment_index, opt=opt)
 
         # Create the local human agents
         human_agent_1 = LocalHumanAgent(opt=None)

--- a/parlai/mturk/tasks/qa_data_collection/run.py
+++ b/parlai/mturk/tasks/qa_data_collection/run.py
@@ -39,6 +39,7 @@ def main():
         all_agent_ids = [QADataCollectionWorld.collector_agent_id, mturk_agent_id] # In speaking order
     )
     mturk_manager.init_aws(opt=opt)
+    mturk_manager.start_new_run(opt=opt)
 
     global run_hit
     def run_hit(hit_index, assignment_index, task_class, task_opt, opt, mturk_manager):

--- a/parlai/mturk/tasks/qa_data_collection/run.py
+++ b/parlai/mturk/tasks/qa_data_collection/run.py
@@ -43,11 +43,9 @@ def main():
 
     global run_hit
     def run_hit(hit_index, assignment_index, task_class, task_opt, opt, mturk_manager):
-        conversation_id = str(hit_index) + '_' + str(assignment_index)
-
         task = task_class(task_opt)
         # Create the MTurk agent which provides a chat interface to the Turker
-        mturk_agent = MTurkAgent(id=mturk_agent_id, manager=mturk_manager, conversation_id=conversation_id, opt=opt)
+        mturk_agent = MTurkAgent(id=mturk_agent_id, manager=mturk_manager, hit_index=hit_index, assignment_index=assignment_index, opt=opt)
         world = QADataCollectionWorld(opt=opt, task=task, mturk_agent=mturk_agent)
         while not world.episode_done():
             world.parley()


### PR DESCRIPTION
- Add email_worker() API to MTurkAgent
- Add start_new_run() method to allow creating HITs for new round without re-initializing AWS
- Allow setting `assignment_duration_in_seconds` (HIT expiration time) in opt dict
- Busy-wait for worker to accept HIT in MTurkAgent.__init__ method
- Hide implementation detail of conversation_id to prevent change, since the format for conversation_id is also hard-coded in other places
- Remove lock for create_hit_type() since it will only be called from one thread right now