### PR TITLE
Exception to alert user of possible mistake when providing label and label candidate

### DIFF
--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -106,7 +106,9 @@ def main():
 
     # Set up logger if directory provided
     if opt['tensorboard_dir']:
-        opt['logger'] = TensorboardLogger(opt['tensorboard_dir'])
+        logger = TensorboardLogger(opt['tensorboard_dir'])
+        opt['train_log'] = {}
+        opt['valid_log'] = {}
 
     # Create model and assign it to the specified task
     agent = create_agent(opt)
@@ -176,16 +178,17 @@ def main():
 
             # Log train values
             if opt['tensorboard_dir']:
-                opt['logger'].log_train(train_report, total_exs)
+                logger.log_train(train_report, total_exs)
+                logger.log_train(opt['train_log'], total_exs)
 
         if (opt['validation_every_n_secs'] > 0 and
                 validate_time.time() > opt['validation_every_n_secs']):
             valid_report = run_eval(agent, opt, 'valid', True, opt['validation_max_exs'])
 
             # Log valid values
-            print(valid_report)
             if opt['tensorboard_dir']:
-                opt['logger'].log_valid(valid_report, total_exs)
+                logger.log_valid(valid_report, total_exs)
+                logger.log_valid(opt['valid_log'], total_exs)
 
             if valid_report['accuracy'] > best_accuracy:
                 best_accuracy = valid_report['accuracy']

--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -32,7 +32,6 @@ import copy
 import importlib
 import math
 import os
-import tensorboard_logger
 
 
 def run_eval(agent, opt, datatype, still_training=False, max_exs=-1):
@@ -106,6 +105,12 @@ def main():
         build_dict.build_dict(opt)
     # XXX Set up tensorboard
     if opt['tensorboard_dir']:
+        try:
+            import tensorboard_logger
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError('Need to install tensorboard_logger: ' +
+                    'go to https://github.com/TeamHG-Memex/tensorboard_logger')
+
         opt['tensorboard'] = {}
         train_board = tensorboard_logger.Logger(
                 os.path.join(opt['tensorboard_dir'], 'train'), flush_secs=5)

--- a/parlai/core/dialog_teacher.py
+++ b/parlai/core/dialog_teacher.py
@@ -216,10 +216,12 @@ class DialogData(object):
                     new_entry.append(None)
                 if len(entry) > 1:
                     # process labels if available
-                    if entry[1] is not None:
+                    if entry[1] is None:
+                        new_entry.append(None)
+                    elif hasattr(entry[1], '__iter__') and type(entry[1]) is not str:
                         new_entry.append(tuple(sys.intern(e) for e in entry[1]))
                     else:
-                        new_entry.append(None)
+                        raise TypeError('Must provide iterable over labels, not a single string.')
                     if len(entry) > 2:
                         # process reward if available
                         if entry[2] is not None:
@@ -227,19 +229,20 @@ class DialogData(object):
                         else:
                             new_entry.append(None)
                         if len(entry) > 3:
-                            if entry[3] is not None:
-                                # process label candidates if available
-                                if last_cands and entry[3] is last_cands:
-                                    # if cands are shared, say "same" so we
-                                    # don't store them again
-                                    new_entry.append(
-                                        sys.intern('same as last time'))
-                                else:
-                                    last_cands = entry[3]
-                                    new_entry.append(tuple(
-                                        sys.intern(e) for e in entry[3]))
-                            else:
+                            # process label candidates if available
+                            if entry[3] is None:
                                 new_entry.append(None)
+                            elif last_cands and entry[3] is last_cands:
+                                # if cands are shared, say "same" so we
+                                # don't store them again
+                                new_entry.append(
+                                    sys.intern('same as last time'))
+                            elif hasattr(entry[3], '__iter__') and type(entry[3]) is not str:
+                                last_cands = entry[3]
+                                new_entry.append(tuple(
+                                    sys.intern(e) for e in entry[3]))
+                            else:
+                                raise TypeError('Must provide iterable over label candidates, not a single string.')
                             if len(entry) > 4 and entry[4] is not None:
                                 new_entry.append(sys.intern(entry[4]))
 

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -4,9 +4,11 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+import os
 import math
 import sys
 import time
+from numbers import Number
 
 
 class Predictor(object):
@@ -50,6 +52,35 @@ class Predictor(object):
         self.agent.observe(observation)
         reply = self.agent.act()
         return reply
+
+
+class TensorboardLogger(object):
+    def __init__(self, logdir):
+        try:
+            import tensorboard_logger
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError('Need to install tensorboard_logger: ' +
+                    'go to https://github.com/TeamHG-Memex/tensorboard_logger')
+
+        self.train_board = tensorboard_logger.Logger(
+                os.path.join(logdir, 'train'), flush_secs=5)
+        self.valid_board = tensorboard_logger.Logger(
+                os.path.join(logdir, 'valid'), flush_secs=5)
+
+    def log_train(self, values_dict, step):
+        self._log(self.train_board, values_dict, step)
+
+    def log_valid(self, values_dict, step):
+        self._log(self.valid_board, values_dict, step)
+
+    def _log(self, logger, values_dict, step):
+        for name in values_dict:
+            if isinstance(values_dict[name], Number):
+                logger.log_value(name, values_dict[name], step)
+
+    def __getstate__(self):
+        # Avoid storing or copying this object as part of another.
+        pass
 
 
 class Timer(object):

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -75,12 +75,8 @@ class TensorboardLogger(object):
 
     def _log(self, logger, values_dict, step):
         for name in values_dict:
-            if isinstance(values_dict[name], Number):
+            if type(values_dict[name]) is not dict:
                 logger.log_value(name, values_dict[name], step)
-
-    def __getstate__(self):
-        # Avoid storing or copying this object as part of another.
-        pass
 
 
 class Timer(object):

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -8,7 +8,6 @@ import os
 import math
 import sys
 import time
-from numbers import Number
 
 
 class Predictor(object):


### PR DESCRIPTION
Currently in DialogData if you make a mistake and a pass a string as a label instead of a list it iterates over the string and provides a list of labels that is, for example ['y','e','s'], instead of ['yes']. Same applies to label candidates. Added an exception to alert the user and prevent unnoticed mistakes.