### PR TITLE
Exception to alert user of possible mistake when providing label and label candidate

### DIFF
--- a/parlai/core/dialog_teacher.py
+++ b/parlai/core/dialog_teacher.py
@@ -228,10 +228,12 @@ class DialogData(object):
                     new_entry.append(None)
                 if len(entry) > 1:
                     # process labels if available
-                    if entry[1] is not None:
+                    if entry[1] is None:
+                        new_entry.append(None)
+                    elif hasattr(entry[1], '__iter__') and type(entry[1]) is not str:
                         new_entry.append(tuple(sys.intern(e) for e in entry[1]))
                     else:
-                        new_entry.append(None)
+                        raise TypeError('Must provide iterable over labels, not a single string.')
                     if len(entry) > 2:
                         # process reward if available
                         if entry[2] is not None:
@@ -239,19 +241,20 @@ class DialogData(object):
                         else:
                             new_entry.append(None)
                         if len(entry) > 3:
-                            if entry[3] is not None:
-                                # process label candidates if available
-                                if last_cands and entry[3] is last_cands:
-                                    # if cands are shared, say "same" so we
-                                    # don't store them again
-                                    new_entry.append(
-                                        sys.intern('same as last time'))
-                                else:
-                                    last_cands = entry[3]
-                                    new_entry.append(tuple(
-                                        sys.intern(e) for e in entry[3]))
-                            else:
+                            # process label candidates if available
+                            if entry[3] is None:
                                 new_entry.append(None)
+                            elif last_cands and entry[3] is last_cands:
+                                # if cands are shared, say "same" so we
+                                # don't store them again
+                                new_entry.append(
+                                    sys.intern('same as last time'))
+                            elif hasattr(entry[3], '__iter__') and type(entry[3]) is not str:
+                                last_cands = entry[3]
+                                new_entry.append(tuple(
+                                    sys.intern(e) for e in entry[3]))
+                            else:
+                                raise TypeError('Must provide iterable over label candidates, not a single string.')
                             if len(entry) > 4 and entry[4] is not None:
                                 new_entry.append(sys.intern(entry[4]))
 

--- a/parlai/core/dialog_teacher.py
+++ b/parlai/core/dialog_teacher.py
@@ -231,6 +231,7 @@ class DialogData(object):
                     if entry[1] is None:
                         new_entry.append(None)
                     elif hasattr(entry[1], '__iter__') and type(entry[1]) is not str:
+                        # make sure iterable over labels, not single string
                         new_entry.append(tuple(sys.intern(e) for e in entry[1]))
                     else:
                         raise TypeError('Must provide iterable over labels, not a single string.')
@@ -250,6 +251,7 @@ class DialogData(object):
                                 new_entry.append(
                                     sys.intern('same as last time'))
                             elif hasattr(entry[3], '__iter__') and type(entry[3]) is not str:
+                                # make sure iterable over candidates, not single string
                                 last_cands = entry[3]
                                 new_entry.append(tuple(
                                     sys.intern(e) for e in entry[3]))


### PR DESCRIPTION
Currently in DialogData if you make a mistake and a pass a string as a label instead of a list it iterates over the string and provides a list of labels that is, for example ['y','e','s'], instead of ['yes']. Same applies to label candidates. Added an exception to alert the user and prevent unnoticed mistakes.