### PR TITLE
Fixing MTurkAgent act() and observe() methods

### DIFF
--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -127,6 +127,7 @@ class MTurkManager():
             'method_name': 'get_new_messages',
             'task_group_id': self.task_group_id,
             'last_message_id': self.db_last_message_id,
+            'receiver_agent_id': '[World]'
         }
         response = requests.get(self.json_api_endpoint_url, params=params)
         try:
@@ -149,18 +150,20 @@ class MTurkManager():
                                                     task_group_id = self.task_group_id,
                                                     conversation_id = conversation_id,
                                                     sender_agent_id = new_message['id'],
+                                                    receiver_agent_id = new_message['receiver_agent_id'],
                                                     message_content = json.dumps(obs_act_dict)
                                                 )
                         self.db_session.add(new_message_in_local_db)
                         self.db_session.commit()
     
     # Only gets new messages from local db, which syncs with remote db every `polling_interval` seconds.
-    def get_new_messages(self, task_group_id, conversation_id, after_message_id, excluded_sender_agent_id=None, included_sender_agent_id=None):
+    def get_new_messages(self, task_group_id, conversation_id, receiver_agent_id, after_message_id, excluded_sender_agent_id=None, included_sender_agent_id=None):
         with local_db_lock:
             return _get_new_messages(
                 db_session=self.db_session,
                 task_group_id=task_group_id,
                 conversation_id=conversation_id,
+                receiver_agent_id=receiver_agent_id,
                 after_message_id=after_message_id,
                 excluded_sender_agent_id=excluded_sender_agent_id,
                 included_sender_agent_id=included_sender_agent_id,
@@ -362,6 +365,7 @@ class MTurkAgent(Agent):
             conversation_dict, new_last_message_id = self.manager.get_new_messages(
                 task_group_id=self.manager.task_group_id,
                 conversation_id=self.conversation_id,
+                receiver_agent_id='[World]',
                 after_message_id=self.last_message_id,
                 included_sender_agent_id=self.id
             )

--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -20,7 +20,7 @@ from parlai.mturk.core.setup_aws import setup_aws, calculate_mturk_cost, check_m
 import threading
 from parlai.mturk.core.data_model import Base, Message
 from parlai.mturk.core.data_model import get_new_messages as _get_new_messages
-from parlai.mturk.core.data_model import COMMAND_GET_NEW_MESSAGES, COMMAND_SEND_MESSAGE
+from parlai.mturk.core.data_model import COMMAND_GET_NEW_MESSAGES, COMMAND_SEND_MESSAGE, COMMAND_SUBMIT_HIT
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
@@ -427,13 +427,27 @@ class MTurkAgent(Agent):
             print("Unable to send email to worker ID: "+str(self.worker_id)+". Error: "+str(response['failure']))
             return False
 
-    def wait_for_hit_completion(self):
+    def wait_for_hit_completion(self, timeout=None): # Timeout in seconds
+        if timeout:
+            start_time = time.time()
         while self.manager.get_agent_work_status(assignment_id=self.assignment_id) != ASSIGNMENT_DONE:
+            if timeout:
+                current_time = time.time()
+                if (current_time - start_time) > timeout:
+                    print("Timed out waiting for Turker to complete the HIT.")
+                    self.hit_is_abandoned = True
+                    return False
             if debug:
                 print("Waiting for Turker to complete the HIT...")
             time.sleep(polling_interval)
         print('Conversation ID: ' + str(self.conversation_id) + ', Agent ID: ' + self.id + ' - HIT is done.')
 
-    def shutdown(self):
+    def shutdown(self, timeout=None): # Timeout in seconds
         if not self.hit_is_abandoned:
-            self.wait_for_hit_completion()
+            self.manager.send_new_command(
+                task_group_id=self.manager.task_group_id,
+                conversation_id=self.conversation_id,
+                receiver_agent_id=self.id,
+                command=COMMAND_SUBMIT_HIT
+            )
+            self.wait_for_hit_completion(timeout=timeout)

--- a/parlai/mturk/core/data_model.py
+++ b/parlai/mturk/core/data_model.py
@@ -24,6 +24,7 @@ engine = None
 
 COMMAND_GET_NEW_MESSAGES = 'COMMAND_GET_NEW_MESSAGES' # MTurk agent is expected to get new messages from server
 COMMAND_SEND_MESSAGE = 'COMMAND_SEND_MESSAGE' # MTurk agent is expected to send a new message to server
+COMMAND_SUBMIT_HIT = 'COMMAND_SUBMIT_HIT' # MTurk agent is expected to hit "DONE" button and submit the HIT
 
 def object_as_dict(obj):
     return {c.key: getattr(obj, c.key)

--- a/parlai/mturk/core/data_model.py
+++ b/parlai/mturk/core/data_model.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy import create_engine, func
 from sqlalchemy.pool import NullPool
+from sqlalchemy import inspect
 
 is_python_2 = False
 if sys.version_info[0] < 3:
@@ -21,14 +22,29 @@ if sys.version_info[0] < 3:
 Base = declarative_base()
 engine = None
 
+COMMAND_GET_NEW_MESSAGES = 'COMMAND_GET_NEW_MESSAGES' # MTurk agent is expected to get new messages from server
+COMMAND_SEND_MESSAGE = 'COMMAND_SEND_MESSAGE' # MTurk agent is expected to send a new message to server
+
+def object_as_dict(obj):
+    return {c.key: getattr(obj, c.key)
+            for c in inspect(obj).mapper.column_attrs}
 
 class Message(Base):
     __tablename__ = 'message'
     id = Column(Integer, primary_key=True)
     task_group_id = Column(String(255), index=True)  # We assign a new task_group_id for each HIT group
     conversation_id = Column(String(255), index=True)
-    agent_id = Column(String(255), index=True)
+    sender_agent_id = Column(String(255), index=True)
+    receiver_agent_id = Column(String(255), index=True, default=None)
     message_content = Column(UnicodeText)
+
+class Command(Base):
+    __tablename__ = 'command'
+    id = Column(Integer, primary_key=True)
+    task_group_id = Column(String(255), index=True)
+    conversation_id = Column(String(255), index=True)
+    receiver_agent_id = Column(String(255), index=True)
+    command = Column(String(255))
 
 class MTurkHITAgentAllocation(Base):
     __tablename__ = 'mturk_hit_agent_allocation'
@@ -53,10 +69,16 @@ def check_database_health():
 
         # Try insert new objects with current schema
         try:
-            test_message = Message(id=0, task_group_id='Test', conversation_id='Test', agent_id='Test', message_content='Test')
+            test_message = Message(id=0, task_group_id='Test', conversation_id='Test', sender_agent_id='Test', receiver_agent_id='Test', message_content='Test')
             session.add(test_message)
             session.commit()
             session.delete(test_message)
+            session.commit()
+
+            test_command = Command(id=0, task_group_id='Test', conversation_id='Test', receiver_agent_id='Test', command='Test')
+            session.add(test_command)
+            session.commit()
+            session.delete(test_command)
             session.commit()
 
             test_agent_allocation = MTurkHITAgentAllocation(id=0, task_group_id='Test', agent_id='Test', conversation_id='Test', assignment_id='Test', hit_id='Test', worker_id='Test')
@@ -99,7 +121,33 @@ def init_database():
     return engine, session_maker
 
 
-def send_new_message(db_session, task_group_id, conversation_id, agent_id, message_text=None, reward=None, episode_done=False):
+def send_new_command(db_session, task_group_id, conversation_id, receiver_agent_id, command):
+    new_command_object = Command(
+        task_group_id = task_group_id,
+        conversation_id = conversation_id,
+        receiver_agent_id = receiver_agent_id,
+        command = command
+    )
+    db_session.add(new_command_object)
+    db_session.commit()
+
+    return new_command_object
+
+
+def get_command(db_session, task_group_id, conversation_id, receiver_agent_id, after_command_id):
+    query = db_session.query(Command).filter(Command.task_group_id==task_group_id) \
+                                    .filter(Command.conversation_id==conversation_id) \
+                                    .filter(Command.receiver_agent_id==receiver_agent_id) \
+                                    .filter(Command.id > after_command_id) \
+                                    .order_by(Command.id)
+    command_object = query.first()
+    if command_object:
+        return command_object
+    else:
+        return None
+
+
+def send_new_message(db_session, task_group_id, conversation_id, sender_agent_id, receiver_agent_id, message_text=None, reward=None, episode_done=False):
     """
     Message format:
     {
@@ -114,7 +162,7 @@ def send_new_message(db_session, task_group_id, conversation_id, agent_id, messa
     # ParlAI observation/action dict fields:
     new_message = {
         "text": message_text,
-        "id": agent_id,
+        "id": sender_agent_id,
     }
     if reward:
         new_message['reward'] = reward
@@ -127,7 +175,8 @@ def send_new_message(db_session, task_group_id, conversation_id, agent_id, messa
     new_message_object = Message(
         task_group_id = task_group_id,
         conversation_id = conversation_id,
-        agent_id = agent_id,
+        sender_agent_id = sender_agent_id,
+        receiver_agent_id = receiver_agent_id,
         message_content = message_content
     )
     db_session.add(new_message_object)
@@ -136,39 +185,7 @@ def send_new_message(db_session, task_group_id, conversation_id, agent_id, messa
     return new_message_object
 
 
-def send_new_messages_in_bulk(db_session, new_messages):
-    """
-    Same message format as in send_new_message(), but also needs to include the following in each message:
-    task_group_id
-    conversation_id
-
-    NOTE: we don't need returned objects if we are sending new messages from the local ParlAI system, so no return for this method is fine
-    """
-
-    new_message_objects = []
-    for new_message in new_messages:
-        new_message_dict = {
-            "text": new_message['text'],
-            "id": new_message['id'],
-        }
-        if 'reward' in new_message:
-            new_message_dict['reward'] = new_message['reward']
-        new_message_dict['episode_done'] = new_message.get('episode_done', False)
-        message_content = json.dumps(new_message_dict)
-        if is_python_2:
-            message_content = unicode(message_content)
-        new_message_objects.append(Message(
-            task_group_id = new_message['task_group_id'],
-            conversation_id = new_message['conversation_id'],
-            agent_id = new_message['id'],
-            message_content = message_content
-        ))
-
-    db_session.bulk_save_objects(new_message_objects)
-    db_session.commit()
-
-
-def get_new_messages(db_session, task_group_id, conversation_id=None, after_message_id=None, excluded_agent_id=None, included_agent_id=None, populate_meta_info=False):
+def get_new_messages(db_session, task_group_id, receiver_agent_id=None, conversation_id=None, after_message_id=None, excluded_sender_agent_id=None, included_sender_agent_id=None, populate_meta_info=False):
     """
     Return:
     conversation_dict = {
@@ -191,23 +208,25 @@ def get_new_messages(db_session, task_group_id, conversation_id=None, after_mess
     if not after_message_id:
         after_message_id = -1
 
-    included_agent_ids = []
-    if included_agent_id:
-        included_agent_ids = [included_agent_id]
+    included_sender_agent_ids = []
+    if included_sender_agent_id:
+        included_sender_agent_ids = [included_sender_agent_id]
 
-    excluded_agent_ids = []
-    if excluded_agent_id:
-        excluded_agent_ids = [excluded_agent_id]
+    excluded_sender_agent_ids = []
+    if excluded_sender_agent_id:
+        excluded_sender_agent_ids = [excluded_sender_agent_id]
 
     last_message_id = None
 
     query = db_session.query(Message).filter(Message.task_group_id==task_group_id).filter(Message.id > after_message_id)
-    if len(included_agent_ids) > 0:
-        query = query.filter(Message.agent_id.in_(included_agent_ids))
-    if len(excluded_agent_ids) > 0:
-        query = query.filter(~Message.agent_id.in_(excluded_agent_ids))
+    if len(included_sender_agent_ids) > 0:
+        query = query.filter(Message.sender_agent_id.in_(included_sender_agent_ids))
+    if len(excluded_sender_agent_ids) > 0:
+        query = query.filter(~Message.sender_agent_id.in_(excluded_sender_agent_ids))
     if conversation_id:
         query = query.filter(Message.conversation_id==conversation_id)
+    if receiver_agent_id:
+        query = query.filter(Message.receiver_agent_id==receiver_agent_id)
     new_message_objects = query.order_by(Message.id)
     conversation_dict = {}
 
@@ -221,11 +240,12 @@ def get_new_messages(db_session, task_group_id, conversation_id=None, after_mess
 
         new_message_dict = {
             "text": text,
-            "id": new_message_object.agent_id,
+            "id": new_message_object.sender_agent_id,
         }
         if 'reward' in message_content:
             new_message_dict['reward'] = message_content['reward']
         new_message_dict['episode_done'] = message_content.get('episode_done', False)
+        new_message_dict['receiver_agent_id'] = new_message_object.receiver_agent_id
 
         if populate_meta_info:
             new_message_dict['message_id'] = new_message_object.id

--- a/parlai/mturk/core/data_model.py
+++ b/parlai/mturk/core/data_model.py
@@ -185,7 +185,7 @@ def send_new_message(db_session, task_group_id, conversation_id, sender_agent_id
     return new_message_object
 
 
-def get_new_messages(db_session, task_group_id, receiver_agent_id=None, conversation_id=None, after_message_id=None, excluded_sender_agent_id=None, included_sender_agent_id=None, populate_meta_info=False):
+def get_new_messages(db_session, task_group_id, receiver_agent_id, conversation_id=None, after_message_id=None, excluded_sender_agent_id=None, included_sender_agent_id=None, populate_meta_info=False):
     """
     Return:
     conversation_dict = {

--- a/parlai/mturk/core/handler_template.py
+++ b/parlai/mturk/core/handler_template.py
@@ -56,7 +56,6 @@ def chat_index(event, context):
 
         try:
             task_group_id = event['query']['task_group_id']
-            all_agent_ids = event['query']['all_agent_ids']
             cur_agent_id = event['query']['cur_agent_id']
             assignment_id = event['query']['assignmentId'] # from mturk
 
@@ -74,7 +73,6 @@ def chat_index(event, context):
                 template_context['hit_index'] = 'Pending'
                 template_context['assignment_index'] = 'Pending'
                 template_context['cur_agent_id'] = cur_agent_id
-                template_context['all_agent_ids'] = all_agent_ids
                 template_context['frame_height'] = frame_height
 
                 custom_index_page = cur_agent_id + '_index.html'
@@ -91,6 +89,44 @@ def get_hit_config(event, context):
         with open('hit_config.json', 'r') as hit_config_file:
             return json.loads(hit_config_file.read().replace('\n', ''))
 
+def send_new_command(event, context):
+    if event['method'] == 'POST':
+        params = event['body']
+        task_group_id = params['task_group_id']
+        conversation_id = params['conversation_id']
+        receiver_agent_id = params['receiver_agent_id']
+        command = params['command']
+
+        new_command_object = data_model.send_new_command(
+            db_session=db_session, 
+            task_group_id=task_group_id, 
+            conversation_id=conversation_id, 
+            receiver_agent_id=receiver_agent_id, 
+            command=command
+        )
+        
+        return json.dumps(data_model.object_as_dict(new_command_object))
+
+def get_command(event, context):
+    if event['method'] == 'GET':
+        task_group_id = event['query']['task_group_id']
+        conversation_id = event['query']['conversation_id']
+        receiver_agent_id = event['query']['receiver_agent_id']
+        last_command_id = int(event['query']['last_command_id'])
+
+        command_object = data_model.get_command(
+            db_session=db_session, 
+            task_group_id=task_group_id, 
+            conversation_id=conversation_id, 
+            receiver_agent_id=receiver_agent_id, 
+            after_command_id=last_command_id
+        )
+         
+        if command_object:   
+            return json.dumps(data_model.object_as_dict(command_object))
+        else:
+            return None
+
 def get_new_messages(event, context):
     if event['method'] == 'GET':
         """
@@ -98,24 +134,29 @@ def get_new_messages(event, context):
         Expects in GET query parameters:
         <task_group_id>
         <last_message_id>
+        <receiver_agent_id>
         <conversation_id> (optional)
-        <excluded_agent_id> (optional)
+        <excluded_sender_agent_id> (optional)
         """
         task_group_id = event['query']['task_group_id']
         last_message_id = int(event['query']['last_message_id'])
+        receiver_agent_id = None
+        if 'receiver_agent_id' in event['query']:
+            receiver_agent_id = event['query']['receiver_agent_id']
         conversation_id = None
         if 'conversation_id' in event['query']:
             conversation_id = event['query']['conversation_id']
-        excluded_agent_id = event['query'].get('excluded_agent_id', None)
-        included_agent_id = event['query'].get('included_agent_id', None)
+        excluded_sender_agent_id = event['query'].get('excluded_sender_agent_id', None)
+        included_sender_agent_id = event['query'].get('included_sender_agent_id', None)
 
         conversation_dict, new_last_message_id = data_model.get_new_messages(
             db_session=db_session, 
             task_group_id=task_group_id, 
+            receiver_agent_id=receiver_agent_id,
             conversation_id=conversation_id,
             after_message_id=last_message_id,
-            excluded_agent_id=excluded_agent_id,
-            included_agent_id=included_agent_id,
+            excluded_sender_agent_id=excluded_sender_agent_id,
+            included_sender_agent_id=included_sender_agent_id,
             populate_meta_info=True
         )
 
@@ -130,14 +171,11 @@ def get_new_messages(event, context):
 
 def send_new_message(event, context):
     if event['method'] == 'POST':
-        """
-        Send new message for this agent.
-        Expects <task_group_id>, <conversation_id>, <cur_agent_id> and <text> as POST body parameters
-        """
         params = event['body']
         task_group_id = params['task_group_id']
         conversation_id = params['conversation_id']
-        cur_agent_id = params['cur_agent_id']
+        sender_agent_id = params['sender_agent_id']
+        receiver_agent_id = params['receiver_agent_id'] if 'receiver_agent_id' in params else None
         message_text = params['text'] if 'text' in params else None
         reward = params['reward'] if 'reward' in params else None
         episode_done = params['episode_done']
@@ -146,7 +184,8 @@ def send_new_message(event, context):
             db_session=db_session, 
             task_group_id=task_group_id, 
             conversation_id=conversation_id, 
-            agent_id=cur_agent_id, 
+            sender_agent_id=sender_agent_id, 
+            receiver_agent_id=receiver_agent_id,
             message_text=message_text, 
             reward=reward,
             episode_done=episode_done
@@ -154,7 +193,7 @@ def send_new_message(event, context):
 
         new_message = { 
             "message_id": new_message_object.id,
-            "id": cur_agent_id,
+            "id": sender_agent_id,
             "text": message_text,
         }
         if reward:
@@ -163,19 +202,6 @@ def send_new_message(event, context):
         
         return json.dumps(new_message)
 
-def send_new_messages_in_bulk(event, context):
-    if event['method'] == 'POST':
-        """
-        Send new messages in bulk.
-        Expects <new_messages> as POST body parameters
-        """
-        params = event['body']
-        new_messages = params['new_messages']
-
-        data_model.send_new_messages_in_bulk(
-            db_session=db_session,
-            new_messages=new_messages
-        )
 
 def sync_hit_assignment_info(event, context):
     if event['method'] == 'POST':

--- a/parlai/mturk/core/handler_template.py
+++ b/parlai/mturk/core/handler_template.py
@@ -140,9 +140,7 @@ def get_new_messages(event, context):
         """
         task_group_id = event['query']['task_group_id']
         last_message_id = int(event['query']['last_message_id'])
-        receiver_agent_id = None
-        if 'receiver_agent_id' in event['query']:
-            receiver_agent_id = event['query']['receiver_agent_id']
+        receiver_agent_id = event['query']['receiver_agent_id']
         conversation_id = None
         if 'conversation_id' in event['query']:
             conversation_id = event['query']['conversation_id']
@@ -210,7 +208,6 @@ def sync_hit_assignment_info(event, context):
         """
         try:
             params = event['body']
-            print(params)
             task_group_id = params['task_group_id']
             agent_id = params['agent_id']
             num_assignments = params['num_assignments']

--- a/parlai/mturk/core/html/core.html
+++ b/parlai/mturk/core/html/core.html
@@ -108,9 +108,6 @@ of patent rights can be found in the PATENTS file in the same directory.
             $("div#message_thread").css("display", "");
             scroll_conversation_to_bottom();
         }
-        if (received_message_from_other_agents && (!task_done) && new_messages[new_messages.length-1]['id'] === previous_agent_id) {
-            wait_for_worker_input();
-        }
     }
 </script>
 {% endblock %}
@@ -136,9 +133,9 @@ of patent rights can be found in the PATENTS file in the same directory.
         update_UI_for_response_type('text_input');
         $("div#waiting-for-message").css("display", "none");
         $("input#id_text_input").focus();
-        // Pause polling, since we are waiting for the worker to say something
         if (polling_timer) {
             clearTimeout(polling_timer);
+            polling_timer = null;
         }
     }
 
@@ -228,28 +225,13 @@ of patent rights can be found in the PATENTS file in the same directory.
     var workerId = null;
     var conversation_id = null;
     var cur_agent_id = `{{cur_agent_id}}`;
-    var mturk_agent_ids = `{{mturk_agent_ids}}`;
-    if (mturk_agent_ids) {
-        mturk_agent_ids = JSON.parse(mturk_agent_ids);
-    }
-    var all_agent_ids = `{{all_agent_ids}}`;
-    var cur_agent_index = null;
-    var previous_agent_id = null;
-    if (all_agent_ids) {
-        all_agent_ids = JSON.parse(all_agent_ids);
-        cur_agent_index = all_agent_ids.indexOf(cur_agent_id);
-        if (cur_agent_index == 0) {
-            previous_agent_id = all_agent_ids[all_agent_ids.length-1];
-        } else {
-            previous_agent_id = all_agent_ids[cur_agent_index-1];
-        }
-    }
     var task_description = null;
     var is_sandbox = null;
     var mturk_submit_url = null;
     var num_hits = null;
     var num_assignments = null;
     var last_message_id = -1;
+    var last_command_id = -1;
     var polling_timer = null;
     var messages_processed = {};
     var messages_shown = {};
@@ -265,12 +247,13 @@ of patent rights can be found in the PATENTS file in the same directory.
         }
     }
 
-    function send_message(text, episode_done=false, callback_function=null) {
+    function send_message(text, receiver_agent_id=null, episode_done=false, callback_function=null) {
         var post_data_dict = {
             task_group_id: task_group_id,
             conversation_id: conversation_id,
-            cur_agent_id: cur_agent_id,
+            sender_agent_id: cur_agent_id,
         };
+        if (receiver_agent_id) post_data_dict['receiver_agent_id'] = receiver_agent_id;
         if (text) post_data_dict['text'] = text;
         post_data_dict['episode_done'] = episode_done;
         post_data_dict['method_name'] = 'send_new_message';
@@ -293,7 +276,7 @@ of patent rights can be found in the PATENTS file in the same directory.
     $("button#id_send_msg_button").click(function () {
         var text = $("input#id_text_input").val();
         if (!(text == '')) {
-            send_message(text, done_after_responding, function(data){
+            send_message(text, null, done_after_responding, function(data){
                 $("input#id_text_input").val("");
                 $("div#response-type-text-input").css("display", "none");
                 data = JSON.parse(data);
@@ -314,45 +297,81 @@ of patent rights can be found in the PATENTS file in the same directory.
                     $("div#waiting-for-message").css("display", "");
                 }
                 if (!polling_timer) {
-                    polling_for_new_messages();
+                    polling_for_command();
                 }
             });
         }
     });
 
-    // background thread that gets new messages from relay server periodically
-    function polling_for_new_messages() {
-      $.ajax({
-        url: '/prod/json',
-        data: {
-            method_name: 'get_new_messages',
-            task_group_id: task_group_id,
-            conversation_id: conversation_id,
-            last_message_id: last_message_id
-        },
-        timeout: 3000 // in milliseconds
-      }).retry({times: 1000, timeout: 3000}).then(
-        function(data) {
-            if (verbose_log) console.log(data);
-            data = JSON.parse(data);
-            conversation_dict = data['conversation_dict'];
-            if (!($.isEmptyObject(conversation_dict))) {
-                message_list = data['conversation_dict'][conversation_id];
-                // New messages are sorted by message id in message_list
-                for (var i = 0; i < message_list.length; i++) {
-                    message = message_list[i];
-                    var agent_id = message['id'];
-                    var message_id = parseInt(message['message_id']);
-                    if (message_id > last_message_id) {
-                        last_message_id = message_id;
+    function get_new_messages() {
+        $.ajax({
+            url: '/prod/json',
+            data: {
+                method_name: 'get_new_messages',
+                task_group_id: task_group_id,
+                conversation_id: conversation_id,
+                receiver_agent_id: cur_agent_id,
+                last_message_id: last_message_id,
+            },
+            timeout: 3000 // in milliseconds
+        }).retry({times: 1000, timeout: 3000}).then(
+            function(data) {
+                if (verbose_log) console.log(data);
+                data = JSON.parse(data);
+                conversation_dict = data['conversation_dict'];
+                if (!($.isEmptyObject(conversation_dict))) {
+                    message_list = data['conversation_dict'][conversation_id];
+                    // New messages are sorted by message id in message_list
+                    for (var i = 0; i < message_list.length; i++) {
+                        message = message_list[i];
+                        var agent_id = message['id'];
+                        var message_id = parseInt(message['message_id']);
+                        if (message_id > last_message_id) {
+                            last_message_id = message_id;
+                        }
                     }
+                    handle_new_messages(message_list);
+                    check_done(message_list);
                 }
-                handle_new_messages(message_list);
-                check_done(message_list);
             }
-            polling_timer = setTimeout(polling_for_new_messages, 1000);
-        }
-      );
+        );
+    }
+
+    // background thread that gets new messages from relay server periodically
+    function polling_for_command() {
+        $.ajax({
+            url: '/prod/json',
+            data: {
+                method_name: 'get_command',
+                task_group_id: task_group_id,
+                conversation_id: conversation_id,
+                receiver_agent_id: cur_agent_id,
+                last_command_id: last_command_id,
+            },
+            timeout: 3000 // in milliseconds
+        }).retry({times: 1000, timeout: 3000}).then(
+            function(data) {
+                if (verbose_log) console.log(data);
+                if (!(data === null)) {
+                    data = JSON.parse(data);
+
+                    new_last_command_id = data['id'];
+                    if (new_last_command_id > last_command_id) {
+                        last_command_id = new_last_command_id;
+                    }
+
+                    command = data['command'];
+                    if (command === 'COMMAND_GET_NEW_MESSAGES') {
+                        get_new_messages();
+                        polling_timer = setTimeout(polling_for_command, 1000);
+                    } else if (command === 'COMMAND_SEND_MESSAGE') {
+                        wait_for_worker_input();
+                    }
+                } else {
+                    polling_timer = setTimeout(polling_for_command, 1000);
+                }   
+            }
+        );
     }
 
     function update_UI_for_response_type(response_type) {
@@ -376,6 +395,7 @@ of patent rights can be found in the PATENTS file in the same directory.
         // Stop polling
         if (polling_timer) {
             clearTimeout(polling_timer);
+            polling_timer = null;
         }
         if (in_mturk_hit_page()) {
             $("input#mturk_submit_button").click();
@@ -410,14 +430,8 @@ of patent rights can be found in the PATENTS file in the same directory.
         $("span#task-description").html(task_description);
 
         // UI related
-        $("input#id_text_input").focus();
-        if (cur_agent_index == 0) {
-            update_UI_for_response_type('text_input');
-            $("div#waiting-for-message").css("display", "none");
-        } else {
-            update_UI_for_response_type('idle');
-            $("div#waiting-for-message").css("display", "");
-        }
+        update_UI_for_response_type('idle');
+        $("div#waiting-for-message").css("display", "");
         $("div#left-pane").removeClass('col-xs-12');
         $("div#left-pane").addClass('col-xs-4');
 
@@ -426,7 +440,7 @@ of patent rights can be found in the PATENTS file in the same directory.
         }
 
         $(window).resize();
-        polling_for_new_messages();
+        polling_for_command();
     }
 
     $(document).ready(function() {

--- a/parlai/mturk/core/html/core.html
+++ b/parlai/mturk/core/html/core.html
@@ -73,45 +73,6 @@ of patent rights can be found in the PATENTS file in the same directory.
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script src="https://cdn.rawgit.com/yf225/jquery-ajax-retry/master/dist/jquery.ajax-retry.min.js"></script>
 
-{% block handle_new_messages %}
-<script type="text/javascript">
-    function handle_new_messages(new_messages) {
-        for (var i = 0; i < new_messages.length; i++) {
-            var message = new_messages[i];
-            var agent_id = message['id'];
-            var message_id = parseInt(message['message_id']);
-            var message_text = message['text'].replace(/(?:\r\n|\r|\n)/g, '<br />');
-
-            if (!(message_id in messages_shown)) {
-                if (agent_id != cur_agent_id) {
-                    $('div#message_thread').append(`
-                        <div class="row" style="margin-left: 0; margin-right: 0">
-                            <div class="alert alert-warning" role="alert" style="float: left; display:table">
-                                <span style="font-size: 16px"><b>`+agent_id+`</b>: `+message_text+`</span>
-                            </div>
-                        </div>
-                    `);
-                    received_message_from_other_agents = true;
-                } else {
-                    $('div#message_thread').append(`
-                        <div class="row" style="margin-left: 0; margin-right: 0">
-                            <div class="alert alert-info" role="alert" style="float: right; display:table">
-                                <span style="font-size: 16px"><b>`+agent_id+`</b>: `+message_text+`</span>
-                            </div>
-                        </div>
-                    `);
-                }
-                messages_shown[message_id] = true;
-            }
-        }
-        if (new_messages.length > 0) {
-            $("div#message_thread").css("display", "");
-            scroll_conversation_to_bottom();
-        }
-    }
-</script>
-{% endblock %}
-
 <script type="text/javascript">
     /* ================= Utility functions ================= */
     function scroll_conversation_to_bottom() {
@@ -247,13 +208,48 @@ of patent rights can be found in the PATENTS file in the same directory.
         }
     }
 
-    function send_message(text, receiver_agent_id=null, episode_done=false, callback_function=null) {
+    function handle_new_messages(new_messages) {
+        for (var i = 0; i < new_messages.length; i++) {
+            var message = new_messages[i];
+            var agent_id = message['id'];
+            var message_id = parseInt(message['message_id']);
+            var message_text = message['text'].replace(/(?:\r\n|\r|\n)/g, '<br />');
+
+            if (!(message_id in messages_shown)) {
+                if (agent_id != cur_agent_id) {
+                    $('div#message_thread').append(`
+                        <div class="row" style="margin-left: 0; margin-right: 0">
+                            <div class="alert alert-warning" role="alert" style="float: left; display:table">
+                                <span style="font-size: 16px"><b>`+agent_id+`</b>: `+message_text+`</span>
+                            </div>
+                        </div>
+                    `);
+                    received_message_from_other_agents = true;
+                } else {
+                    $('div#message_thread').append(`
+                        <div class="row" style="margin-left: 0; margin-right: 0">
+                            <div class="alert alert-info" role="alert" style="float: right; display:table">
+                                <span style="font-size: 16px"><b>`+agent_id+`</b>: `+message_text+`</span>
+                            </div>
+                        </div>
+                    `);
+                }
+                messages_shown[message_id] = true;
+            }
+        }
+        if (new_messages.length > 0) {
+            $("div#message_thread").css("display", "");
+            scroll_conversation_to_bottom();
+        }
+    }
+
+    function send_message(text, receiver_agent_id, episode_done=false, callback_function=null) {
         var post_data_dict = {
             task_group_id: task_group_id,
             conversation_id: conversation_id,
             sender_agent_id: cur_agent_id,
+            receiver_agent_id: receiver_agent_id
         };
-        if (receiver_agent_id) post_data_dict['receiver_agent_id'] = receiver_agent_id;
         if (text) post_data_dict['text'] = text;
         post_data_dict['episode_done'] = episode_done;
         post_data_dict['method_name'] = 'send_new_message';
@@ -273,10 +269,10 @@ of patent rights can be found in the PATENTS file in the same directory.
         );
     }
 
-    $("button#id_send_msg_button").click(function () {
+    $("button#id_send_msg_button").on('click', function () {
         var text = $("input#id_text_input").val();
         if (!(text == '')) {
-            send_message(text, null, done_after_responding, function(data){
+            send_message(text, '[World]', done_after_responding, function(data){
                 $("input#id_text_input").val("");
                 $("div#response-type-text-input").css("display", "none");
                 data = JSON.parse(data);
@@ -337,7 +333,7 @@ of patent rights can be found in the PATENTS file in the same directory.
         );
     }
 
-    // background thread that gets new messages from relay server periodically
+    // background thread that checks new command periodically
     function polling_for_command() {
         $.ajax({
             url: '/prod/json',
@@ -387,7 +383,7 @@ of patent rights can be found in the PATENTS file in the same directory.
         $(window).resize();
     }
 
-    $("button#done-button").click(function() {
+    $("button#done-button").on('click', function() {
         all_done_callback();
     });
 
@@ -402,22 +398,8 @@ of patent rights can be found in the PATENTS file in the same directory.
         }
     }
 
-    function init_cover_page_additional() {}
-    function init_chat_page_additional() {}
-</script>
-
-{% block additional_scripts %}
-{% endblock %}
-
-{% block additional_init_scripts %}
-{% endblock %}
-
-<script type="text/javascript">
     function init_cover_page() {
         $("span#task-description").html(task_description);
-        if (init_cover_page_additional) {
-            init_cover_page_additional();
-        }
     }
 
     function init_chat_page() {
@@ -434,10 +416,6 @@ of patent rights can be found in the PATENTS file in the same directory.
         $("div#waiting-for-message").css("display", "");
         $("div#left-pane").removeClass('col-xs-12');
         $("div#left-pane").addClass('col-xs-4');
-
-        if (init_chat_page_additional) {
-            init_chat_page_additional();
-        }
 
         $(window).resize();
         polling_for_command();
@@ -463,5 +441,9 @@ of patent rights can be found in the PATENTS file in the same directory.
         });
     });
 </script>
+
+{% block additional_scripts %}
+{% endblock %}
+
 </body>
 </html>

--- a/parlai/mturk/core/html/core.html
+++ b/parlai/mturk/core/html/core.html
@@ -196,17 +196,8 @@ of patent rights can be found in the PATENTS file in the same directory.
     var polling_timer = null;
     var messages_processed = {};
     var messages_shown = {};
-    var done_after_responding = false;
-    var task_done = false;
 
     /* ================= Message handling ================= */
-    function check_done(new_messages) {
-        for (var i = 0; i < new_messages.length; i++) {
-            if (new_messages[i]['episode_done']) {
-                done_after_responding = true;
-            }
-        }
-    }
 
     function handle_new_messages(new_messages) {
         for (var i = 0; i < new_messages.length; i++) {
@@ -243,7 +234,7 @@ of patent rights can be found in the PATENTS file in the same directory.
         }
     }
 
-    function send_message(text, receiver_agent_id, episode_done=false, callback_function=null) {
+    function send_message(text, receiver_agent_id, callback_function=null) {
         var post_data_dict = {
             task_group_id: task_group_id,
             conversation_id: conversation_id,
@@ -251,7 +242,7 @@ of patent rights can be found in the PATENTS file in the same directory.
             receiver_agent_id: receiver_agent_id
         };
         if (text) post_data_dict['text'] = text;
-        post_data_dict['episode_done'] = episode_done;
+        post_data_dict['episode_done'] = false;
         post_data_dict['method_name'] = 'send_new_message';
         $.ajax({
             url: '/prod/json',
@@ -272,7 +263,7 @@ of patent rights can be found in the PATENTS file in the same directory.
     $("button#id_send_msg_button").on('click', function () {
         var text = $("input#id_text_input").val();
         if (!(text == '')) {
-            send_message(text, '[World]', done_after_responding, function(data){
+            send_message(text, '[World]', function(data){
                 $("input#id_text_input").val("");
                 $("div#response-type-text-input").css("display", "none");
                 data = JSON.parse(data);
@@ -284,14 +275,7 @@ of patent rights can be found in the PATENTS file in the same directory.
                 var new_messages = [];
                 new_messages.push(data);
                 handle_new_messages(new_messages);
-                if (done_after_responding) {
-                    update_UI_for_response_type('done');
-                    task_done = true;
-                    $("div#waiting-for-message").css("display", "none");
-                } else {
-                    check_done(new_messages);
-                    $("div#waiting-for-message").css("display", "");
-                }
+                $("div#waiting-for-message").css("display", "");
                 if (!polling_timer) {
                     polling_for_command();
                 }
@@ -327,7 +311,6 @@ of patent rights can be found in the PATENTS file in the same directory.
                         }
                     }
                     handle_new_messages(message_list);
-                    check_done(message_list);
                 }
             }
         );
@@ -362,6 +345,9 @@ of patent rights can be found in the PATENTS file in the same directory.
                         polling_timer = setTimeout(polling_for_command, 1000);
                     } else if (command === 'COMMAND_SEND_MESSAGE') {
                         wait_for_worker_input();
+                    } else if (command === 'COMMAND_SUBMIT_HIT') {
+                        update_UI_for_response_type('done');
+                        $("div#waiting-for-message").css("display", "none");
                     }
                 } else {
                     polling_timer = setTimeout(polling_for_command, 1000);

--- a/parlai/mturk/core/html/mturk_index.html
+++ b/parlai/mturk/core/html/mturk_index.html
@@ -24,7 +24,7 @@ Example 1: Overriding left_pane to display custom image instead:
 
 Example 2: Overriding handle_new_messages to only show messages from this agent
 
-{% block handle_new_messages %}
+{% block additional_scripts %}
 <script type="text/javascript">
     function handle_new_messages(new_messages) {
         for (var i = 0; i < new_messages.length; i++) {

--- a/parlai/mturk/core/worlds.py
+++ b/parlai/mturk/core/worlds.py
@@ -22,6 +22,14 @@ class MTurkWorld(World):
 
     def shutdown(self):
         self.mturk_agent.shutdown()
+        """
+        Use the following code if there are multiple MTurk agents:
+        
+        global shutdown_agent
+        def shutdown_agent(mturk_agent):
+            mturk_agent.shutdown()
+        Parallel(n_jobs=len(self.mturk_agents), backend='threading')(delayed(shutdown_agent)(agent) for agent in self.mturk_agents)
+        """
         
     def review_work(self):
         """Programmatically approve/reject the turker's work.

--- a/parlai/mturk/tasks/model_evaluator/run.py
+++ b/parlai/mturk/tasks/model_evaluator/run.py
@@ -35,8 +35,7 @@ def main():
     mturk_agent_id = 'Worker'
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_id],
-        all_agent_ids = [ModelEvaluatorWorld.evaluator_agent_id, mturk_agent_id] # In speaking order
+        mturk_agent_ids = [mturk_agent_id]
     )
     mturk_manager.init_aws(opt=opt)
     mturk_manager.start_new_run(opt=opt)

--- a/parlai/mturk/tasks/multi_agent_dialog/run.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/run.py
@@ -34,8 +34,7 @@ def main():
     human_agent_2_id = 'human_2'
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_1_id, mturk_agent_2_id],
-        all_agent_ids = [human_agent_1_id, human_agent_2_id, mturk_agent_1_id, mturk_agent_2_id] # In speaking order
+        mturk_agent_ids = [mturk_agent_1_id, mturk_agent_2_id]
     )
     mturk_manager.init_aws(opt=opt)
     mturk_manager.start_new_run(opt=opt)

--- a/parlai/mturk/tasks/multi_agent_dialog/run.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/run.py
@@ -7,8 +7,8 @@ import os
 import time
 from parlai.core.params import ParlaiParser
 from parlai.mturk.core.agents import MTurkAgent, MTurkManager
+from parlai.mturk.tasks.multi_agent_dialog.worlds import MTurkMultiAgentDialogWorld
 from parlai.agents.local_human.local_human import LocalHumanAgent
-from parlai.core.worlds import MultiAgentDialogWorld
 from task_config import task_config
 import copy
 from itertools import product
@@ -51,7 +51,7 @@ def main():
         human_agent_2 = LocalHumanAgent(opt=None)
         human_agent_2.id = human_agent_2_id
 
-        world = MultiAgentDialogWorld(opt=opt, agents=[human_agent_1, human_agent_2, mturk_agent_1, mturk_agent_2])
+        world = MTurkMultiAgentDialogWorld(opt=opt, agents=[human_agent_1, human_agent_2, mturk_agent_1, mturk_agent_2])
 
         while not world.episode_done():
             world.parley()

--- a/parlai/mturk/tasks/multi_agent_dialog/worlds.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/worlds.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+from parlai.core.worlds import MultiAgentDialogWorld
+from joblib import Parallel, delayed
+
+class MTurkMultiAgentDialogWorld(MultiAgentDialogWorld):
+    """Basic world where each agent gets a turn in a round-robin fashion,
+    receiving as input the actions of all other agents since that agent last
+    acted.
+    """
+    def shutdown(self):
+        """Shutdown all mturk agents in parallel, otherwise if one mturk agent
+        is disconnected then it could prevent other mturk agents from completing."""
+        global shutdown_agent
+        def shutdown_agent(mturk_agent):
+            mturk_agent.shutdown()
+        Parallel(n_jobs=len(self.agents), backend='threading')(delayed(shutdown_agent)(agent) for agent in self.agents)

--- a/parlai/mturk/tasks/qa_data_collection/run.py
+++ b/parlai/mturk/tasks/qa_data_collection/run.py
@@ -35,8 +35,7 @@ def main():
     mturk_agent_id = 'Worker'
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_id],
-        all_agent_ids = [QADataCollectionWorld.collector_agent_id, mturk_agent_id] # In speaking order
+        mturk_agent_ids = [mturk_agent_id]
     )
     mturk_manager.init_aws(opt=opt)
     mturk_manager.start_new_run(opt=opt)


### PR DESCRIPTION
Before this fix, the MTurk agent's actions are not purely driven by the world - instead all agents' messages will be broadcast to all other agents without the need to call observe() on them. However, now we would want to enable one-to-one communication between agents, and each message should have a targeted receiver agent that receives it by being called observe(). We would also want the MTurk agent to be purely driven by the world, and the world should decide when an MTurk agent can speak / listen / submit the HIT.

We achieve this by adding a layer on top of the MTurk agent's message-polling: instead of polling for new messages we will now poll for new commands, which are actions that the world expects the agent to do (the current commands are "get new messages", "send message", and "submit hit"). Upon receiving a new command the agent webpage will then call the API to get new messages or update the UI accordingly to let the worker take action. Locally on the world side, each call to an MTurk agent's act() and observe() would send a new command to the remote database to notify the agent webpage to update its UI. 