### PR TITLE
bug where wrong pretrained word embedding is zeroed

### DIFF
--- a/parlai/agents/drqa/utils.py
+++ b/parlai/agents/drqa/utils.py
@@ -36,7 +36,7 @@ def load_embeddings(opt, word_dict):
                 embeddings[word_dict[w]].copy_(vec)
 
     # Zero NULL token
-    embeddings[word_dict['<NULL>']].fill_(0)
+    embeddings[word_dict['__NULL__']].fill_(0)
 
     return embeddings
 


### PR DESCRIPTION
word_dict['\<NULL>'] returns the index for \_\_UNK__ rather than \_\_NULL__ and thus the wrong embedding is being zeroed