### PR TITLE
fixed error in json format

### DIFF
--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -233,7 +233,7 @@ task_list = [
         "task": "ms_marco",
         "tags": [ "All",  "QA" ],
         "description": "A large scale Machine Reading Comprehension Dataset with questions sampled from real anonymized user queries and contexts from web documents. From Nguyen et al. '16. Link: https://arxiv.org/abs/1611.09268"
-    }
+    },
     {
         "id": "CLEVR",
         "display_name": "CLEVR",


### PR DESCRIPTION
Fixes "SyntaxError: invalid syntax", when running the examples in documentation relying on task_list.