### PR TITLE
Add free automated flake8 testing on all pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+cache: pip
+python:
+    # - 2.7.13
+    - 3.6
+install:
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # add other tests here
+notifications:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
The owner of the this repo would need to go to https://travis-ci.com/profile and flip the repository switch on to enable free automated flake8 testing on each pull request.

flake8 testing of https://github.com/facebookresearch/ParlAI on Python 3.6.2

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./parlai/agents/hred/data_iterator.py:241:45: E999 SyntaxError: invalid syntax
        print 'Data Iterator Evaluate Mode: ', self.evaluate_mode
                                            ^

./parlai/agents/hred/utils.py:151:15: F821 undefined name 'xrange'
    for dx in xrange(sizeX):
              ^

./parlai/agents/hred/utils.py:190:15: F821 undefined name 'xrange'
    for dx in xrange(sizeX):
              ^

./parlai/mturk/core/data_model.py:174:27: F821 undefined name 'unicode'
        message_content = unicode(message_content)
                          ^

./parlai/mturk/core/handler_template.py:24:34: F821 undefined name 'rds_host'
data_model.setup_database_engine(rds_host, rds_db_name, rds_username, rds_password)
                                 ^

./parlai/mturk/core/handler_template.py:24:44: F821 undefined name 'rds_db_name'
data_model.setup_database_engine(rds_host, rds_db_name, rds_username, rds_password)
                                           ^

./parlai/mturk/core/handler_template.py:24:57: F821 undefined name 'rds_username'
data_model.setup_database_engine(rds_host, rds_db_name, rds_username, rds_password)
                                                        ^

./parlai/mturk/core/handler_template.py:24:71: F821 undefined name 'rds_password'
data_model.setup_database_engine(rds_host, rds_db_name, rds_username, rds_password)
                                                                      ^

./parlai/mturk/core/handler_template.py:76:52: F821 undefined name 'frame_height'
                template_context['frame_height'] = frame_height
                                                   ^

./parlai/tasks/booktest/agents.py:68:16: F821 undefined name 'obs'
        return obs
               ^

./parlai/tasks/wikiqa/build.py:24:28: F821 undefined name 'lq'
                s = '1 ' + lq + '\t' + ans.lstrip('|') + '\t\t' + cands.lstrip('|')
                           ^

./parlai/tasks/wikiqa/build.py:24:40: F821 undefined name 'ans'
                s = '1 ' + lq + '\t' + ans.lstrip('|') + '\t\t' + cands.lstrip('|')
                                       ^

./parlai/tasks/wikiqa/build.py:24:67: F821 undefined name 'cands'
                s = '1 ' + lq + '\t' + ans.lstrip('|') + '\t\t' + cands.lstrip('|')
                                                                  ^

./parlai/tasks/wikiqa/build.py:25:54: F821 undefined name 'ans'
                if (dtype.find('filtered') == -1) or ans != '':
                                                     ^

1     E999 SyntaxError: invalid syntax
13    F821 undefined name 'xrange'
14
```