### PR TITLE
Make truncation an option, fix runtime error from updated pytorch

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -51,7 +51,9 @@ class Seq2seqAgent(Agent):
                  'highest scoring one.')
         agent.add_argument('-tr', '--truncate', type='bool', default=True,
             help='truncate input & output lengths to speed up training ' +
-                 '(may reduce accuracy)')
+                 '(may reduce accuracy). This fixes all input and output ' +
+                 'to have a maximum length and to be similar in length to ' +
+                 'one another by throwing away extra tokens.')
 
     def __init__(self, opt, shared=None):
         # initialize defaults first

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -53,7 +53,8 @@ class Seq2seqAgent(Agent):
             help='truncate input & output lengths to speed up training ' +
                  '(may reduce accuracy). This fixes all input and output ' +
                  'to have a maximum length and to be similar in length to ' +
-                 'one another by throwing away extra tokens.')
+                 'one another by throwing away extra tokens. This reduces ' +
+                 'the total amount of padding in the batches.')
 
     def __init__(self, opt, shared=None):
         # initialize defaults first

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -220,7 +220,7 @@ class Seq2seqAgent(Agent):
         text_cand_inds = None
 
         # first encode context
-        xes = self.lt(xs).t()
+        xes = self.lt(xs).transpose(0, 1)
         if self.zeros.size(1) != batchsize:
             self.zeros.resize_(self.num_layers, batchsize, self.hidden_size).fill_(0)
         h0 = Variable(self.zeros)
@@ -312,7 +312,7 @@ class Seq2seqAgent(Agent):
                 output, hn = self.decoder(xes, hn)
                 preds, scores = self.hidden_to_idx(output, dropout=False)
 
-                xes = self.lt(preds.t())
+                xes = self.lt(preds.transpose(0, 1))
                 max_len += 1
                 for b in range(batchsize):
                     if not done[b]:


### PR DESCRIPTION
fix pytorch bug reported in #270
default to truncating long inputs, but can turn this off with -tr false