### PR TITLE
fixed calling 'v2t' method and prediction transform  in agent seq2seq

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -253,7 +253,7 @@ class Seq2seqAgent(Agent):
                 xes = self.lt(y).unsqueeze(0)
                 for b in range(batchsize):
                     # convert the output scores to tokens
-                    token = self.v2t([preds.data[b][0]])
+                    token = self.v2t([preds.data[b]])
                     output_lines[b].append(token)
 
             loss.backward()
@@ -315,12 +315,12 @@ class Seq2seqAgent(Agent):
                 output, hn = self.decoder(xes, hn)
                 preds, scores = self.hidden_to_idx(output, dropout=False)
 
-                xes = self.lt(preds.transpose(0, 1))
+                xes = self.lt(preds.unsqueeze(0))
                 max_len += 1
                 for b in range(batchsize):
                     if not done[b]:
                         # only add more tokens for examples that aren't done yet
-                        token = self.v2t(preds.data[b])
+                        token = self.v2t([preds.data[b]])
                         if token == self.END:
                             # if we produced END, we're done
                             done[b] = True


### PR DESCRIPTION
The method “v2t” should take a vector (utterable of ints); the
preds is a 1-D vector, the updated method ‘transpose’ didn’t work. ‘unsqueeze’
can make it fit the input form.

The two error before fixed when doing the example `python examples/train_model.py -m seq2seq -t babi:task1k:1 -bs 8 -e 1 -mf /tmp/model_s2s`: 

> Traceback (most recent call last):
>   File "examples/train_model.py", line 209, in <module>
>     main()
>   File "examples/train_model.py", line 204, in main
>     run_eval(agent, opt, 'valid', write_log=True)
>   File "examples/train_model.py", line 54, in run_eval
>     valid_world.parley()
>   File "/home/yuchu/ParlAI/parlai/core/worlds.py", line 597, in parley
>     batch_act = self.batch_act(index, batch_observations[index])
>   File "/home/yuchu/ParlAI/parlai/core/worlds.py", line 570, in batch_act
>     batch_actions = a.batch_act(batch_observation)
>   File "/home/yuchu/ParlAI/parlai/agents/seq2seq/seq2seq.py", line 446, in batch_act
>     predictions, text_cand_inds = self.predict(xs, ys, cands)
>   File "/home/yuchu/ParlAI/parlai/agents/seq2seq/seq2seq.py", line 318, in predict
>     xes = self.lt(preds.transpose(0, 1))
>   File "/home/yuchu/anaconda2/envs/python3/lib/python3.6/site-packages/torch/autograd/variable.py", line 733, in transpose
>     return Transpose.apply(self, dim1, dim2)
>   File "/home/yuchu/anaconda2/envs/python3/lib/python3.6/site-packages/torch/autograd/_functions/tensor.py", line 80, in forward
>     result = i.transpose(dim1, dim2)
> RuntimeError: dimension out of range (expected to be in range of [-1, 0], but got 1)
> 
> Traceback (most recent call last):
>   File "examples/train_model.py", line 209, in <module>
>     main()
>   File "examples/train_model.py", line 204, in main
>     run_eval(agent, opt, 'valid', write_log=True)
>   File "examples/train_model.py", line 54, in run_eval
>     valid_world.parley()
>   File "/home/yuchu/ParlAI/parlai/core/worlds.py", line 597, in parley
>     batch_act = self.batch_act(index, batch_observations[index])
>   File "/home/yuchu/ParlAI/parlai/core/worlds.py", line 570, in batch_act
>     batch_actions = a.batch_act(batch_observation)
>   File "/home/yuchu/ParlAI/parlai/agents/seq2seq/seq2seq.py", line 446, in batch_act
>     predictions, text_cand_inds = self.predict(xs, ys, cands)
>   File "/home/yuchu/ParlAI/parlai/agents/seq2seq/seq2seq.py", line 323, in predict
>     token = self.v2t(preds.data[b])
>   File "/home/yuchu/ParlAI/parlai/agents/seq2seq/seq2seq.py", line 163, in v2t
>     return self.dict.vec2txt(vec)
>   File "/home/yuchu/ParlAI/parlai/core/dict.py", line 371, in vec2txt
>     return delimiter.join(self[int(idx)] for idx in vector)
> TypeError: 'int' object is not iterable