### PR TITLE
Creating a script to delete orphan HITs

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -12,12 +12,11 @@ import time
 import uuid
 
 from botocore.exceptions import ClientError
-from datetime import datetime
 
 from parlai.mturk.core.server_utils import setup_server, delete_server
 from parlai.mturk.core.mturk_utils import calculate_mturk_cost, \
     check_mturk_balance, create_hit_type, create_hit_with_hit_type, \
-    get_mturk_client, setup_aws_credentials, create_hit_config
+    get_mturk_client, setup_aws_credentials, create_hit_config, expire_hit
 from parlai.mturk.core.worker_state import WorkerState, AssignState
 from parlai.mturk.core.socket_manager import Packet, SocketManager
 from parlai.mturk.core.agents import MTurkAgent
@@ -899,15 +898,6 @@ class MTurkManager():
             ' your laptop or put your computer into sleep or standby mode.)\n')
         return mturk_page_url
 
-    def expire_hit(self, hit_id):
-        """Expire given HIT from the MTurk side
-        Only works if the hit is in the "pending" state
-        """
-        client = get_mturk_client(self.is_sandbox)
-        # Update expiration to a time in the past, the HIT expires instantly
-        past_time = datetime(2015, 1, 1)
-        client.update_expiration_for_hit(HITId=hit_id, ExpireAt=past_time)
-
     def get_hit(self, hit_id):
         """Get hit from mturk by hit_id"""
         client = get_mturk_client(self.is_sandbox)
@@ -926,7 +916,7 @@ class MTurkManager():
         """
         print_and_log("Expiring all unassigned HITs...")
         for hit_id in self.hit_id_list:
-            self.expire_hit(hit_id)
+            expire_hit(self.is_sandbox, hit_id)
 
     def approve_work(self, assignment_id):
         """approve work for a given assignment through the mturk client"""

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -8,6 +8,8 @@ import boto3
 import botocore
 import os
 import json
+from datetime import datetime
+
 from botocore.exceptions import ClientError
 from botocore.exceptions import ProfileNotFound
 
@@ -298,3 +300,10 @@ def create_hit_with_hit_type(page_url, hit_type_id, num_assignments,
         hit_type_id
     )
     return hit_link, hit_id
+
+
+def expire_hit(is_sandbox, hit_id):
+    client = get_mturk_client(is_sandbox)
+    # Update expiration to a time in the past, the HIT expires instantly
+    past_time = datetime(2015, 1, 1)
+    client.update_expiration_for_hit(HITId=hit_id, ExpireAt=past_time)

--- a/parlai/mturk/core/scripts/delete_hits.py
+++ b/parlai/mturk/core/scripts/delete_hits.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import argparse
+import os
+import sys
+
+import parlai.mturk.core.mturk_utils as mturk_utils
+
+def main():
+    """This script should be used after some error occurs that leaves HITs live
+    while the ParlAI MTurk server down. This will search through live HITs and
+    list them by task ID, letting you close down HITs that do not link to 
+    any server and are thus irrecoverable.
+    """
+    parser = argparse.ArgumentParser(description='Delete HITs by expiring')
+    parser.add_argument('--sandbox', dest='sandbox', default=False,
+                        action='store_true', help='Delete HITs from sandbox')
+    opt = parser.parse_args()
+    sandbox = opt.sandbox
+    task_group_ids = []
+    group_to_hit = {}
+    hits = []
+    processed = 0
+    found = 0
+    spinner_vals = ['-','\\','|','/']
+    if sandbox:
+        print(
+            'About to query the SANDBOX server, these HITs will be active HITs'
+            ' from within the MTurk requester sandbox'
+        )
+    else:
+        print(
+            'About to query the LIVE server, these HITs will be active HITs '
+            'potentially being worked on by real Turkers right now'
+        )
+
+    print('Getting HITs from amazon MTurk server, please wait...\n')
+    mturk_utils.setup_aws_credentials()
+    client = mturk_utils.get_mturk_client(sandbox)
+    response = client.list_hits(MaxResults=100)
+    while (True):
+        processed += response['NumResults']
+        for hit in response['HITs']:
+            if hit['NumberOfAssignmentsAvailable'] == 0:
+                # Ignore hits with no assignable assignments
+                continue
+            if hit['HITStatus'] != 'Assignable' and \
+                    hit['HITStatus'] != 'Unassignable':
+                # Ignore completed hits
+                continue
+            question = hit['Question']
+            if 'ExternalURL' in question:
+                url = question.split('ExternalURL')[1]
+                group_id = url.split('task_group_id=')[1]
+                group_id = group_id.split('&')[0]
+                group_id = group_id.split('<')[0]
+                if group_id not in task_group_ids:
+                    group_to_hit[group_id] = []
+                    task_group_ids.append(group_id)
+                group_to_hit[group_id].append(hit['HITId'])
+                found += 1
+        sys.stdout.write(
+            '\r{} HITs processed, {} active hits found amongst {} tasks. {}   '
+            .format(
+                processed,
+                found,
+                len(task_group_ids),
+                spinner_vals[((int) (processed / 100)) % 4]
+            )
+        )
+        if 'NextToken' not in response:
+            break
+        response = client.list_hits(
+            NextToken=response['NextToken'],
+            MaxResults=100
+        )
+
+    print('\n\nTask group id - Active HITs')
+    for group_id in task_group_ids:
+        print('{} - {}'.format(group_id, len(group_to_hit[group_id])))
+
+    print(
+        'To clear a task, please enter the task group id of the task that you '
+        'want to expire the HITs for. To exit, enter nothing'
+    )
+
+    while True:
+        task_group_id = input("Enter task group id: ")
+        if len(task_group_id) == 0:
+            break
+        elif (task_group_id not in task_group_ids):
+            print('Sorry, the id you entered was not found, try again')
+        else:
+            num_hits = input(
+                'Confirm by entering the number of HITs that will be deleted: '
+            )
+            if '{}'.format(len(group_to_hit[task_group_id])) == num_hits:
+                hits_expired = 0
+                for hit_id in group_to_hit[task_group_id]:
+                    mturk_utils.expire_hit(sandbox, hit_id)
+                    hits_expired += 1
+                    sys.stdout.write('\rExpired hits {}'.format(hits_expired))
+                print('\nAll hits for group {} have been expired.'.format(
+                    task_group_id
+                ))
+            else:
+                print(
+                    'You entered {} but there are {} HITs to expire, please '
+                    'try again to confirm you are ending the right task'.format(
+                        num_hits,
+                        len(group_to_hit[task_group_id])
+                    )
+                )
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
When the MTurk run script dies in a fatal error and the HITs are not deleted, this cleanup script can be run to find and remove orphan scripts without having to manually do so.