### PR TITLE
Fixing small bugs related to deleting unused resources

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -186,7 +186,8 @@ class MTurkManager():
                 self.worker_state[worker_id].assignments[assignment_id]
             if assignment.is_final():
                 #This worker must've disconnected or expired, remove them
-                del self.mturk_agents[worker_id][assignment_id]
+                if assignment_id in self.mturk_agents[worker_id]
+                    del self.mturk_agents[worker_id][assignment_id]
                 continue
             conversation_id = 'w_{}'.format(uuid.uuid4())
 
@@ -682,8 +683,7 @@ class MTurkManager():
                 assignment_id = worker.assignment_id
                 assign_state = \
                     self.worker_state[worker_id].assignments[assignment_id]
-                del assign_state.messages
-                del assign_state.last_command
+                assign_state.clear_messages()
             # Count if it's a completed conversation
             if self._no_workers_incomplete(workers):
                 self.completed_conversations += 1

--- a/parlai/mturk/core/worker_state.py
+++ b/parlai/mturk/core/worker_state.py
@@ -47,6 +47,10 @@ class AssignState():
             self.last_command,
         )
 
+    def clear_messages(self):
+        self.messages = []
+        self.last_command = None
+
     def log_reconnect(self, worker_id):
         """Log a reconnect of a given worker to this assignment"""
         print_and_log(


### PR DESCRIPTION
Using delete fixed memory related bugs, but it wasn't implemented cleanly, causing instances where resources that no longer existed were being cleaned. This fixes the issue by casing on existence for del or setting members to None or [] to allow the garbage collector to manage instead.