### PR TITLE
Switching to batched assign role functions

### DIFF
--- a/parlai/mturk/tasks/model_evaluator/run.py
+++ b/parlai/mturk/tasks/model_evaluator/run.py
@@ -54,8 +54,8 @@ def main():
         def check_worker_eligibility(worker):
             return True
 
-        def get_worker_role(worker):
-            return mturk_agent_id
+        def assign_worker_roles(worker):
+            worker[0].id = mturk_agent_id
 
         global run_conversation
         def run_conversation(opt, workers):
@@ -72,7 +72,7 @@ def main():
 
         mturk_manager.start_task(
             eligibility_function=check_worker_eligibility,
-            role_function=get_worker_role,
+            assign_role_function=assign_worker_roles,
             task_function=run_conversation
         )
     except:

--- a/parlai/mturk/tasks/model_evaluator/run.py
+++ b/parlai/mturk/tasks/model_evaluator/run.py
@@ -4,7 +4,8 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 from parlai.core.params import ParlaiParser
-from parlai.mturk.tasks.model_evaluator.worlds import ModelEvaluatorWorld, ModelEvaluatorOnboardWorld
+from parlai.mturk.tasks.model_evaluator.worlds import \
+    ModelEvaluatorWorld, ModelEvaluatorOnboardWorld
 from parlai.mturk.core.mturk_manager import MTurkManager
 from task_config import task_config
 import time
@@ -62,8 +63,13 @@ def main():
             mturk_agent = workers[0]
 
             model_agent = IrBaselineAgent(opt=opt)
-            # Create the MTurk agent which provides a chat interface to the Turker
-            world = ModelEvaluatorWorld(opt=opt, model_agent=model_agent, task_opt=task_opt, mturk_agent=mturk_agent)
+
+            world = ModelEvaluatorWorld(
+                opt=opt,
+                model_agent=model_agent,
+                task_opt=task_opt,
+                mturk_agent=mturk_agent
+            )
 
             while not world.episode_done():
                 world.parley()

--- a/parlai/mturk/tasks/multi_agent_dialog/run.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/run.py
@@ -7,7 +7,8 @@ import os
 import time
 from parlai.core.params import ParlaiParser
 from parlai.mturk.core.mturk_manager import MTurkManager
-from parlai.mturk.tasks.multi_agent_dialog.worlds import MTurkMultiAgentDialogWorld, MTurkMultiAgentDialogOnboardWorld
+from parlai.mturk.tasks.multi_agent_dialog.worlds import \
+    MTurkMultiAgentDialogWorld, MTurkMultiAgentDialogOnboardWorld
 from parlai.agents.local_human.local_human import LocalHumanAgent
 from task_config import task_config
 import copy
@@ -45,7 +46,10 @@ def main():
         mturk_manager.create_hits()
 
         def run_onboard(worker):
-            world = MTurkMultiAgentDialogOnboardWorld(opt=opt, mturk_agent=worker)
+            world = MTurkMultiAgentDialogOnboardWorld(
+                opt=opt,
+                mturk_agent=worker
+            )
             while not world.episode_done():
                 world.parley()
             world.shutdown()

--- a/parlai/mturk/tasks/multi_agent_dialog/run.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/run.py
@@ -50,19 +50,16 @@ def main():
                 world.parley()
             world.shutdown()
 
-        mturk_manager.set_onboard_function(onboard_function=run_onboard) # Set onboard_function to None to skip onboarding
+        # You can set onboard_function to None to skip onboarding
+        mturk_manager.set_onboard_function(onboard_function=run_onboard)
         mturk_manager.ready_to_accept_workers()
 
         def check_worker_eligibility(worker):
             return True
 
-        global worker_count
-        worker_count = 0
-        def get_worker_role(worker):
-            global worker_count
-            worker_role = mturk_agent_ids[worker_count % len(mturk_agent_ids)]
-            worker_count += 1
-            return worker_role
+        def assign_worker_roles(workers):
+            for index, worker in enumerate(workers):
+                worker.id = mturk_agent_ids[index % len(mturk_agent_ids)]
 
         def run_conversation(mturk_manager, opt, workers):
             # Create mturk agents
@@ -73,7 +70,10 @@ def main():
             human_agent_1 = LocalHumanAgent(opt=None)
             human_agent_1.id = human_agent_1_id
 
-            world = MTurkMultiAgentDialogWorld(opt=opt, agents=[human_agent_1, mturk_agent_1, mturk_agent_2])
+            world = MTurkMultiAgentDialogWorld(
+                opt=opt,
+                agents=[human_agent_1, mturk_agent_1, mturk_agent_2]
+            )
 
             while not world.episode_done():
                 world.parley()
@@ -82,7 +82,7 @@ def main():
 
         mturk_manager.start_task(
             eligibility_function=check_worker_eligibility,
-            role_function=get_worker_role,
+            assign_role_function=assign_worker_roles,
             task_function=run_conversation
         )
 

--- a/parlai/mturk/tasks/qa_data_collection/run.py
+++ b/parlai/mturk/tasks/qa_data_collection/run.py
@@ -4,7 +4,8 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 from parlai.core.params import ParlaiParser
-from parlai.mturk.tasks.qa_data_collection.worlds import QADataCollectionOnboardWorld, QADataCollectionWorld
+from parlai.mturk.tasks.qa_data_collection.worlds import \
+    QADataCollectionOnboardWorld, QADataCollectionWorld
 from parlai.mturk.core.mturk_manager import MTurkManager
 from task_config import task_config
 import time
@@ -63,7 +64,11 @@ def main():
         def run_conversation(mturk_manager, opt, workers):
             task = task_class(task_opt)
             mturk_agent = workers[0]
-            world = QADataCollectionWorld(opt=opt, task=task, mturk_agent=mturk_agent)
+            world = QADataCollectionWorld(
+                opt=opt,
+                task=task,
+                mturk_agent=mturk_agent
+            )
             while not world.episode_done():
                 world.parley()
             world.shutdown()

--- a/parlai/mturk/tasks/qa_data_collection/run.py
+++ b/parlai/mturk/tasks/qa_data_collection/run.py
@@ -56,8 +56,8 @@ def main():
         def check_worker_eligibility(worker):
             return True
 
-        def get_worker_role(worker):
-            return mturk_agent_id
+        def assign_worker_roles(worker):
+            worker[0].id = mturk_agent_id
 
         global run_conversation
         def run_conversation(mturk_manager, opt, workers):
@@ -71,7 +71,7 @@ def main():
 
         mturk_manager.start_task(
             eligibility_function=check_worker_eligibility,
-            role_function=get_worker_role,
+            assign_role_function=assign_worker_roles,
             task_function=run_conversation
         )
     except:


### PR DESCRIPTION
Oftentimes it can be useful to know about all of the workers who are going to enter a conversation in order to assign each of them a role. This before was done with global variables, which is non-ideal. Now it happens in a single function call rather than one for each worker, allowing the implementation to make worker-based decisions on who gets what role.

This includes the change to the assign_role_function function within mturk_manager as well as updates to the 3 example tasks' run.py files