### PR TITLE
MTurk testing fixes

### DIFF
--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -326,6 +326,10 @@ class MTurkAgent(Agent):
         self.manager.free_workers([self])
         return True
 
+    def reduce_state():
+        """Cleans up resources related to maintaining complete state"""
+        self.msg_queue = None
+
     def shutdown(self, timeout=None, direct_submit=False):
         """Shuts down a hit when it is completed"""
         # Timeout in seconds, after which the HIT will be expired automatically

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -122,18 +122,23 @@ class MTurkManager():
         """Update the number of bad disconnects for the given worker, block
         them if they've exceeded the disconnect limit
         """
-        self.worker_state[worker_id].disconnects += 1
-        self.disconnects.append({'time': time.time(), 'id': worker_id})
-        if self.worker_state[worker_id].disconnects > MAX_DISCONNECTS:
-            text = ('This worker has repeatedly disconnected from these tasks,'
+        if not self.is_sandbox:
+            self.worker_state[worker_id].disconnects += 1
+            self.disconnects.append({'time': time.time(), 'id': worker_id})
+            if self.worker_state[worker_id].disconnects > MAX_DISCONNECTS:
+                text = (
+                    'This worker has repeatedly disconnected from these tasks,'
                     ' which require constant connection to complete properly '
                     'as they involve interaction with other Turkers. They have'
                     ' been blocked to ensure a better experience for other '
-                    'workers who don\'t disconnect.')
-            self.block_worker(worker_id, text)
-            print_and_log('Worker {} was blocked - too many disconnects'.format(
-                worker_id
-            ))
+                    'workers who don\'t disconnect.'
+                )
+                self.block_worker(worker_id, text)
+                print_and_log(
+                    'Worker {} was blocked - too many disconnects'.format(
+                        worker_id
+                    )
+                )
 
     def _get_ids_from_pkt(self, pkt):
         """Get sender, assignment, and conv ids from a packet"""

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -188,6 +188,7 @@ class MTurkManager():
                 #This worker must've disconnected or expired, remove them
                 if assignment_id in self.mturk_agents[worker_id]:
                     del self.mturk_agents[worker_id][assignment_id]
+                self.socket_manager.close_channel(worker_id, assignment_id)
                 continue
             conversation_id = 'w_{}'.format(uuid.uuid4())
 


### PR DESCRIPTION
Handles a few bugs that have come up as the integration test is underway. 

The first left channels open that would never disconnect but would keep failing alive checks. This would only occur when a user got a message saying they should enter a task world, but they never actually made it to the task world and disconnected in the transition process.

The second came up when I was able to block myself accidentally while testing various disconnects

The third was related to cleaner memory management, leaving it up to the agent to handle state cleanup. This will be important when we consolidate WorkerState state into the MTurkAgent class