### PR TITLE
Clean logging

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -115,7 +115,7 @@ class ParlaiParser(argparse.ArgumentParser):
             help='print and log all server interactions and messages')
         mturk.add_argument(
             '--verbose', dest='verbose', action='store_true',
-            help='print all messages sent from turkers')
+            help='print all messages sent to and from Turkers')
         mturk.add_argument(
             '--log-level', dest='log_level', type=int, default=20,
             help='importance level for what to put into the logs. the lower '

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -114,6 +114,9 @@ class ParlaiParser(argparse.ArgumentParser):
             '--debug', dest='is_debug', action='store_true',
             help='print and log all server interactions and messages')
         mturk.add_argument(
+            '--verbose', dest='verbose', action='store_true',
+            help='print all messages sent from turkers')
+        mturk.add_argument(
             '--log-level', dest='log_level', type=int, default=20,
             help='importance level for what to put into the logs. the lower '
                  'the level the more that gets logged. values are 0-50')
@@ -130,6 +133,7 @@ class ParlaiParser(argparse.ArgumentParser):
 
         mturk.set_defaults(is_sandbox=True)
         mturk.set_defaults(is_debug=False)
+        mturk.set_defaults(verbose=False)
 
     def add_parlai_args(self, args=None):
         default_downloads_path = os.path.join(self.parlai_home, 'downloads')

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -43,16 +43,18 @@ def class2str(value):
 
 
 class ParlaiParser(argparse.ArgumentParser):
-    """Pseudo-extension of ``argparse`` which sets a number of parameters for the
-    ParlAI framework. More options can be added specific to other modules by
-    passing this object and calling ``add_arg()`` or ``add_argument()`` on it.
+    """Pseudo-extension of ``argparse`` which sets a number of parameters
+    for the ParlAI framework. More options can be added specific to other
+    modules by passing this object and calling ``add_arg()`` or
+    ``add_argument()`` on it.
 
     For example, see ``parlai.core.dict.DictionaryAgent.add_cmdline_args``.
     """
 
-    def __init__(self, add_parlai_args=True, add_model_args=False, model_argv=None):
+    def __init__(self, add_parlai_args=True, add_model_args=False,
+                 model_argv=None):
         """Initializes the ParlAI argparser.
-        - add_parlai_args (default True) initializes the default arguments for the
+        - add_parlai_args (default True) initializes the default arguments for
         ParlAI package, including the data download paths and task arguments.
         - add_model_args (default False) initializes the default arguments for
         loading models, including initializing arguments from that model.
@@ -95,11 +97,13 @@ class ParlaiParser(argparse.ArgumentParser):
             '-nc', '--num-conversations', default=1, type=int,
             help='number of conversations you want to create for this task')
         mturk.add_argument(
-            '--unique', dest='unique_worker', default=False, action='store_true',
+            '--unique', dest='unique_worker', default=False,
+            action='store_true',
             help='enforce that no worker can work on your task twice')
         mturk.add_argument(
             '-r', '--reward', default=0.05, type=float,
-            help='reward for each worker for finishing the conversation, in US dollars')
+            help='reward for each worker for finishing the conversation, '
+                 'in US dollars')
         mturk.add_argument(
             '--sandbox', dest='is_sandbox', action='store_true',
             help='submit the HITs to MTurk sandbox site')
@@ -107,17 +111,25 @@ class ParlaiParser(argparse.ArgumentParser):
             '--live', dest='is_sandbox', action='store_false',
             help='submit the HITs to MTurk live site')
         mturk.add_argument(
-            '--verbose', dest='verbose', action='store_true',
-            help='print out all messages sent/received in all conversations')
+            '--debug', dest='is_debug', action='store_true',
+            help='print and log all server interactions and messages')
         mturk.add_argument(
-            '--count-complete', dest='count_complete',  default=False, action='store_true',
-            help='continue until the requested number of conversations are completed rather than attempted')
+            '--log-level', dest='log_level', type=int, default=20,
+            help='importance level for what to put into the logs. the lower '
+                 'the level the more that gets logged. values are 0-50')
         mturk.add_argument(
-            '--allowed-conversations', dest='allowed_conversations',  default=0, type=int,
-            help='number of concurrent conversations that one mturk worker is able to be involved in, 0 is unlimited')
+            '--count-complete', dest='count_complete',
+            default=False, action='store_true',
+            help='continue until the requested number of conversations are '
+                 'completed rather than attempted')
+        mturk.add_argument(
+            '--allowed-conversations', dest='allowed_conversations',
+            default=0, type=int,
+            help='number of concurrent conversations that one mturk worker '
+                 'is able to be involved in, 0 is unlimited')
 
         mturk.set_defaults(is_sandbox=True)
-        mturk.set_defaults(verbose=False)
+        mturk.set_defaults(is_debug=False)
 
     def add_parlai_args(self, args=None):
         default_downloads_path = os.path.join(self.parlai_home, 'downloads')
@@ -127,17 +139,16 @@ class ParlaiParser(argparse.ArgumentParser):
             help='ParlAI task(s), e.g. "babi:Task1" or "babi,cbt"')
         parlai.add_argument(
             '--download-path', default=default_downloads_path,
-            help='path for non-data dependencies to store any needed files.' +
+            help='path for non-data dependencies to store any needed files.'
                  'defaults to {parlai_dir}/downloads')
         parlai.add_argument(
             '-dt', '--datatype', default='train',
             choices=['train', 'train:stream', 'train:ordered',
                 'train:ordered:stream', 'train:stream:ordered',
                 'valid', 'valid:stream', 'test', 'test:stream'],
-            help='choose from: train, train:ordered, valid, test. ' +
-                 'to stream data add ":stream" to any option ' +
-                 '(e.g., train:stream). ' +
-                 'by default: train is random with replacement, ' +
+            help='choose from: train, train:ordered, valid, test. to stream '
+                 'data add ":stream" to any option (e.g., train:stream). '
+                 'by default: train is random with replacement, '
                  'valid is ordered, test is ordered.')
         parlai.add_argument(
             '-im', '--image-mode', default='raw', type=str,
@@ -199,16 +210,18 @@ class ParlaiParser(argparse.ArgumentParser):
             if item == '-im' or item == '--image-mode':
                 image_mode = args[index + 1]
         if image_mode and image_mode != 'none':
-            parlai = self.add_argument_group('ParlAI Image Preprocessing Arguments')
+            parlai = \
+                self.add_argument_group('ParlAI Image Preprocessing Arguments')
             parlai.add_argument('--image-size', type=int, default=256,
                 help='')
             parlai.add_argument('--image-cropsize', type=int, default=224,
                 help='')
 
     def parse_args(self, args=None, namespace=None, print_args=True):
-        """Parses the provided arguments and returns a dictionary of the ``args``.
-        We specifically remove items with ``None`` as values in order to support
-        the style ``opt.get(key, default)``, which would otherwise return ``None``.
+        """Parses the provided arguments and returns a dictionary of the
+        ``args``. We specifically remove items with ``None`` as values in order
+        to support the style ``opt.get(key, default)``, which would otherwise
+        return ``None``.
         """
         self.args = super().parse_args(args=args)
         self.opt = vars(self.args)
@@ -235,7 +248,10 @@ class ParlaiParser(argparse.ArgumentParser):
         for key, value in self.opt.items():
             values[str(key)] = str(value)
         for group in self._action_groups:
-            group_dict={a.dest:getattr(self.args,a.dest,None) for a in group._group_actions}
+            group_dict = {
+                a.dest:getattr(self.args,a.dest,None)
+                for a in group._group_actions
+            }
             namespace = argparse.Namespace(**group_dict)
             count = 0
             for key in namespace.__dict__:

--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-
+import logging
 import threading
 import time
 from queue import Queue
@@ -13,8 +13,7 @@ import uuid
 from parlai.core.agents import Agent
 from parlai.mturk.core.worker_state import WorkerState, AssignState
 import parlai.mturk.core.data_model as data_model
-from parlai.mturk.core.shared_utils import print_and_log, THREAD_SHORT_SLEEP, \
-                                           THREAD_MTURK_POLLING_SLEEP
+import parlai.mturk.core.shared_utils as shared_utils
 
 # Special act messages for failure states
 MTURK_DISCONNECT_MESSAGE = '[DISCONNECT]' # Turker disconnected from conv
@@ -65,11 +64,13 @@ class MTurkAgent(Agent):
                 response = self.manager.get_hit(hit_id=self.hit_id)
                 # Amazon MTurk system acknowledges that the HIT is accepted
                 if response['HIT']['NumberOfAssignmentsPending'] == 1:
-                    print_and_log(('Worker has accepted the HIT '
-                                   '(acknowledged by MTurk API).'), False)
+                    shared_utils.print_and_log(
+                        logging.INFO,
+                        'Worker has accepted the HIT'
+                    )
                     self.hit_is_accepted = True
                     break
-            time.sleep(THREAD_MTURK_POLLING_SLEEP)
+            time.sleep(shared_utils.THREAD_MTURK_POLLING_SLEEP)
         while True:
             if self.hit_id:
                 response = self.manager.get_hit(hit_id=self.hit_id)
@@ -83,18 +84,32 @@ class MTurkAgent(Agent):
                     # available HITs consistent with the number of
                     # conversations left.
                     if self.is_in_task():
-                        print_and_log(('Worker has returned the HIT. Since '
+                        shared_utils.print_and_log(
+                            logging.INFO,
+                            'Worker {}_{} has returned the HIT {}. Since '
                             'the worker is already in a task conversation, '
-                            'we are expiring the HIT.'), False)
+                            'we are expiring the HIT.'.format(
+                                self.worker_id,
+                                self.assignment_id,
+                                self.hit_id
+                            )
+                        )
                         self.manager.expire_hit(hit_id=self.hit_id)
                     else:
-                        print_and_log(('Worker has returned the HIT. Since '
+                        shared_utils.print_and_log(
+                            logging.INFO,
+                            'Worker {}_{} has returned the HIT {}. Since '
                             'the worker is still in onboarding, we will not '
-                            'expire the HIT.'), False)
+                            'expire the HIT.'.format(
+                                self.worker_id,
+                                self.assignment_id,
+                                self.hit_id
+                            )
+                        )
                     # we will not be using this MTurkAgent object for another
                     # worker, so no need to check its status anymore
                     return
-            time.sleep(THREAD_MTURK_POLLING_SLEEP)
+            time.sleep(shared_utils.THREAD_MTURK_POLLING_SLEEP)
 
     def get_connection_id(self):
         """Returns an appropriate connection_id for this agent"""
@@ -102,7 +117,8 @@ class MTurkAgent(Agent):
 
     def log_reconnect(self):
         """Log a reconnect of this agent """
-        print_and_log(
+        shared_utils.print_and_log(
+            logging.DEBUG,
             'Agent ({})_({}) reconnected to {} with status {}'.format(
                 self.worker_id, self.assignment_id,
                 self.conversation_id, self.state.status
@@ -126,7 +142,7 @@ class MTurkAgent(Agent):
         while True:
             if self.state.status == desired_status:
                 break
-            time.sleep(THREAD_SHORT_SLEEP)
+            time.sleep(shared_utils.THREAD_SHORT_SLEEP)
 
     def is_in_task(self):
         """Use conversation_id to determine if an agent is in a task"""
@@ -197,7 +213,10 @@ class MTurkAgent(Agent):
                 if timeout:
                     current_time = time.time()
                     if (current_time - start_time) > timeout:
-                        print_and_log('{} is timeout.'.format(self.id), False)
+                        shared_utils.print_and_log(
+                            logging.INFO,
+                            '{} timed out before sending.'.format(self.id)
+                        )
                         self.manager.handle_turker_timeout(
                             self.worker_id,
                             self.assignment_id
@@ -208,7 +227,7 @@ class MTurkAgent(Agent):
                             'episode_done': True
                         }
                         return msg
-                time.sleep(THREAD_SHORT_SLEEP)
+                time.sleep(shared_utils.THREAD_SHORT_SLEEP)
 
     def change_conversation(self, conversation_id, agent_id, change_callback):
         """Handle changing a conversation for an agent, takes a callback for
@@ -238,10 +257,12 @@ class MTurkAgent(Agent):
             return True
 
     def _print_not_available_for(self, item):
-        print_and_log(
+        shared_utils.print_and_log(
+            logging.WARN,
             'Conversation ID: {}, Agent ID: {} - HIT '
             'is abandoned and thus not available for '
-            '{}.'.format(self.conversation_id, self.id, item)
+            '{}.'.format(self.conversation_id, self.id, item),
+            should_print=True
         )
 
     def approve_work(self):
@@ -252,13 +273,16 @@ class MTurkAgent(Agent):
             if self.manager.get_agent_work_status(self.assignment_id) == \
                     self.ASSIGNMENT_DONE:
                 self.manager.approve_work(assignment_id=self.assignment_id)
-                print_and_log(
+                shared_utils.print_and_log(
+                    logging.INFO,
                     'Conversation ID: {}, Agent ID: {} - HIT is '
                     'approved.'.format(self.conversation_id, self.id)
                 )
             else:
-                print_and_log('Cannot approve HIT. Reason: Turker hasn\'t '
-                              'completed the HIT yet.')
+                shared_utils.print_and_log(
+                    logging.WARN,
+                    'Cannot approve HIT. Turker hasn\'t completed the HIT yet.'
+                )
 
     def reject_work(self, reason='unspecified'):
         """Reject work after it has been submitted"""
@@ -268,19 +292,24 @@ class MTurkAgent(Agent):
             if self.manager.get_agent_work_status(self.assignment_id) == \
                     self.ASSIGNMENT_DONE:
                 self.manager.reject_work(self.assignment_id, reason)
-                print_and_log(
+                shared_utils.print_and_log(
+                    logging.INFO,
                     'Conversation ID: {}, Agent ID: {} - HIT is '
                     'rejected.'.format(self.conversation_id, self.id)
                 )
             else:
-                print_and_log('Cannot reject HIT. Reason: Turker hasn\'t '
-                              'completed the HIT yet.')
+                shared_utils.print_and_log(
+                    logging.WARN,
+                    'Cannot reject HIT. Turker hasn\'t completed the HIT yet.'
+                )
 
     def block_worker(self, reason='unspecified'):
         """Block a worker from our tasks"""
         self.manager.block_worker(worker_id=self.worker_id, reason=reason)
-        print_and_log(
-            'Blocked worker ID: {}. Reason: {}'.format(self.worker_id, reason)
+        shared_utils.print_and_log(
+            logging.WARN,
+            'Blocked worker ID: {}. Reason: {}'.format(self.worker_id, reason),
+            should_print=True
         )
 
     def pay_bonus(self, bonus_amount, reason='unspecified'):
@@ -299,8 +328,11 @@ class MTurkAgent(Agent):
                     unique_request_token=unique_request_token
                 )
             else:
-                print_and_log('Cannot pay bonus for HIT. Reason: Turker '
-                              'hasn\'t completed the HIT yet.')
+                shared_utils.print_and_log(
+                    logging.WARN,
+                    'Cannot pay bonus for HIT. Reason: Turker '
+                    'hasn\'t completed the HIT yet.'
+                )
 
     def email_worker(self, subject, message_text):
         """Sends an email to a worker, returns true on a successful send"""
@@ -310,7 +342,8 @@ class MTurkAgent(Agent):
             message_text=message_text
         )
         if 'success' in response:
-            print_and_log(
+            shared_utils.print_and_log(
+                logging.INFO,
                 'Email sent to worker ID: {}: Subject: {}: Text: {}'.format(
                     self.worker_id,
                     subject,
@@ -319,7 +352,8 @@ class MTurkAgent(Agent):
             )
             return True
         elif 'failure' in response:
-            print_and_log(
+            shared_utils.print_and_log(
+                logging.WARN,
                 "Unable to send email to worker ID: {}. Error: {}".format(
                     self.worker_id,
                     response['failure']
@@ -350,17 +384,29 @@ class MTurkAgent(Agent):
             if timeout:
                 current_time = time.time()
                 if (current_time - start_time) > timeout:
-                    print_and_log(
-                        "Timeout waiting for Turker to complete HIT."
+                    shared_utils.print_and_log(
+                        logging.INFO,
+                        "Timeout waiting for ({})_({}) to complete {}.".format(
+                            self.worker_id,
+                            self.assignment_id,
+                            self.conversation_id
+                        )
                     )
                     self.set_hit_is_abandoned()
                     return False
-            print_and_log('Waiting for ({})_({}) to complete {}...'.format(
-                self.worker_id, self.assignment_id, self.conversation_id
-            ), False)
-            time.sleep(THREAD_MTURK_POLLING_SLEEP)
-        print_and_log('Conversation ID: {}, Agent ID: {} - HIT is '
-                      'done.'.format(self.conversation_id, self.id))
+            shared_utils.print_and_log(
+                logging.DEBUG,
+                'Waiting for ({})_({}) to complete {}...'.format(
+                    self.worker_id, self.assignment_id, self.conversation_id
+                )
+            )
+            time.sleep(shared_utils.THREAD_MTURK_POLLING_SLEEP)
+        shared_utils.print_and_log(
+            logging.INFO,
+            'Conversation ID: {}, Agent ID: {} - HIT is done.'.format(
+                self.conversation_id, self.id
+            )
+        )
         self.manager.free_workers([self])
         return True
 

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -10,19 +10,17 @@ import pickle
 import threading
 import time
 import uuid
+import logging
 
 from botocore.exceptions import ClientError
 
-from parlai.mturk.core.server_utils import setup_server, delete_server
-from parlai.mturk.core.mturk_utils import calculate_mturk_cost, \
-    check_mturk_balance, create_hit_type, create_hit_with_hit_type, \
-    get_mturk_client, setup_aws_credentials, create_hit_config, expire_hit
-from parlai.mturk.core.worker_state import WorkerState, AssignState
-from parlai.mturk.core.socket_manager import Packet, SocketManager
 from parlai.mturk.core.agents import MTurkAgent
-from parlai.mturk.core.shared_utils import print_and_log, generate_event_id, \
-                                        THREAD_SHORT_SLEEP, THREAD_MEDIUM_SLEEP
+from parlai.mturk.core.socket_manager import Packet, SocketManager
+from parlai.mturk.core.worker_state import WorkerState, AssignState
 import parlai.mturk.core.data_model as data_model
+import parlai.mturk.core.mturk_utils as mturk_utils
+import parlai.mturk.core.server_utils as server_utils
+import parlai.mturk.core.shared_utils as shared_utils
 
 # Timeout before cancelling a world start
 WORLD_START_TIMEOUT = 11
@@ -133,10 +131,12 @@ class MTurkManager():
                     'workers who don\'t disconnect.'
                 )
                 self.block_worker(worker_id, text)
-                print_and_log(
+                shared_utils.print_and_log(
+                    logging.INFO,
                     'Worker {} was blocked - too many disconnects'.format(
                         worker_id
-                    )
+                    ),
+                    True
                 )
 
     def _get_agent_from_pkt(self, pkt):
@@ -301,7 +301,10 @@ class MTurkManager():
         alive packet. This asks the socket manager to open a new channel and
         then handles ensuring the worker state is consistent
         """
-        print_and_log('on_agent_alive: {}'.format(pkt), False)
+        shared_utils.print_and_log(
+            logging.DEBUG,
+            'on_agent_alive: {}'.format(pkt)
+        )
         worker_id = pkt.data['worker_id']
         hit_id = pkt.data['hit_id']
         assign_id = pkt.data['assignment_id']
@@ -318,9 +321,10 @@ class MTurkManager():
 
         if not assign_id:
             # invalid assignment_id is an auto-fail
-            print_and_log('Agent ({}) with no assign_id called alive'.format(
-                worker_id
-            ), False)
+            shared_utils.print_and_log(
+                logging.WARN,
+                'Agent ({}) with no assign_id called alive'.format(worker_id)
+            )
         elif not assign_id in curr_worker_state.agents:
             # First time this worker has connected under this assignment, init
             # new agent if we are still accepting workers
@@ -406,11 +410,14 @@ class MTurkManager():
             # This worker never registered, so we don't do anything
             return
 
-        print_and_log('Worker {} disconnected from {} in status {}'.format(
-            worker_id,
-            assignment_id,
-            agent.state.status
-        ))
+        shared_utils.print_and_log(
+            logging.DEBUG,
+            'Worker {} disconnected from {} in status {}'.format(
+                worker_id,
+                assignment_id,
+                agent.state.status
+            )
+        )
 
         if agent.state.status == AssignState.STATUS_NONE:
             # Agent never made it to onboarding, delete
@@ -525,7 +532,8 @@ class MTurkManager():
     def _log_missing_agent(self, worker_id, assignment_id):
         """Logs when an agent was expected to exist, yet for some reason it
         didn't. If these happen often there is a problem"""
-        print_and_log(
+        shared_utils.print_and_log(
+            logging.WARN,
             'Expected to have an agent for {}_{}, yet none was found'.format(
                 worker_id,
                 assignment_id
@@ -536,20 +544,23 @@ class MTurkManager():
 
     def setup_server(self, task_directory_path=None):
         """Prepare the MTurk server for the new HIT we would like to submit"""
-        completion_type = 'start'
+        fin_word = 'start'
         if self.opt['count_complete']:
-            completion_type = 'finish'
-        print_and_log('\nYou are going to allow workers from Amazon '
-              'Mechanical Turk to be an agent in ParlAI.\nDuring this '
-              'process, Internet connection is required, and you should '
-              'turn off your computer\'s auto-sleep feature.\n'
-              'Enough HITs will be created to fulfill {} times the number of '
-              'conversations requested, extra HITs will be expired once the '
-              'desired conversations {}.'.format(HIT_MULT, completion_type))
+            fin_word = 'finish'
+        shared_uils.print_and_log(
+            logging.INFO,
+            '\nYou are going to allow workers from Amazon Mechanical Turk to '
+            'be an agent in ParlAI.\nDuring this process, Internet connection '
+            'is required, and you should turn off your computer\'s auto-sleep '
+            'feature.\nEnough HITs will be created to fulfill {} times the '
+            'number of conversations requested, extra HITs will be expired '
+            'once the desired conversations {}.'.format(HIT_MULT, fin_word),
+            should_print=True
+        )
         key_input = input('Please press Enter to continue... ')
-        print_and_log('')
+        shared_utils.print_and_log(logging.NOTSET, '', True)
 
-        setup_aws_credentials()
+        mturk_utils.setup_aws_credentials()
 
         # See if there's enough money in the account to fund the HITs requested
         num_assignments = self.required_hits
@@ -559,14 +570,16 @@ class MTurkManager():
             'reward': self.opt['reward'],  # in dollars
             'unique': self.opt['unique_worker']
         }
-        total_cost = calculate_mturk_cost(payment_opt=payment_opt)
-        if not check_mturk_balance(balance_needed=total_cost,
-                                   is_sandbox=self.opt['is_sandbox']):
+        total_cost = mturk_utils.calculate_mturk_cost(payment_opt=payment_opt)
+        if not mturk_utils.check_mturk_balance(
+                balance_needed=total_cost,
+                is_sandbox=self.opt['is_sandbox']):
             raise SystemExit('Insufficient funds')
 
         if total_cost > 100 or self.opt['reward'] > 1:
             confirm_string = '$%.2f' % total_cost
-            print_and_log(
+            shared_utils.print_and_log(
+                logging.INFO,
                 'You are going to create {} HITs at {} per assignment, for a '
                 'total cost of {} after MTurk fees. Please enter "{}" to '
                 'confirm and continue, and anything else to cancel'.format(
@@ -574,14 +587,16 @@ class MTurkManager():
                     '$%.2f' % self.opt['reward'],
                     confirm_string,
                     confirm_string
-                )
+                ),
+                should_print=True
             )
             check = input('Enter here: ')
             if (check != confirm_string):
                 raise SystemExit('Cancelling')
 
-        print_and_log('Setting up MTurk server...')
-        create_hit_config(
+        shared_utils.print_and_log(logging.INFO, 'Setting up MTurk server...',
+                                   should_print=True)
+        mturk_utils.create_hit_config(
             task_description=self.opt['task_description'],
             unique_worker=self.opt['unique_worker'],
             is_sandbox=self.opt['is_sandbox']
@@ -610,15 +625,17 @@ class MTurkManager():
         task_name = '{}-{}'.format(str(uuid.uuid4())[:8], self.opt['task'])
         self.server_task_name = \
             ''.join(e for e in task_name if e.isalnum() or e == '-')
-        self.server_url = \
-            setup_server(self.server_task_name, self.task_files_to_copy)
-        print_and_log(self.server_url, False)
+        self.server_url = server_utils.setup_server(self.server_task_name,
+                                                    self.task_files_to_copy)
+        shared_utils.print_and_log(logging.INFO, self.server_url)
 
-        print_and_log("MTurk server setup done.\n")
+        shared_utils.print_and_log(logging.INFO, "MTurk server setup done.\n",
+                                   should_print=True)
 
     def ready_to_accept_workers(self):
         """Set up socket to start communicating to workers"""
-        print_and_log('Local: Setting up SocketIO...')
+        shared_utils.print_and_log(logging.INFO,
+                                   'Local: Setting up SocketIO...', True)
         self._setup_socket()
 
     def start_new_run(self):
@@ -657,7 +674,7 @@ class MTurkManager():
                     print('Timeout waiting for workers, move back to waiting')
                     self._move_workers_to_waiting(workers)
                     return
-                time.sleep(THREAD_SHORT_SLEEP)
+                time.sleep(shared_utils.THREAD_SHORT_SLEEP)
 
             print('All workers joined the conversation!')
             self.started_conversations += 1
@@ -717,7 +734,7 @@ class MTurkManager():
                 for thread in self.task_threads:
                     thread.join()
                 break
-            time.sleep(THREAD_MEDIUM_SLEEP)
+            time.sleep(shared_utils.THREAD_MEDIUM_SLEEP)
 
     def shutdown(self):
         """Handle any mturk client shutdown cleanup."""
@@ -729,7 +746,7 @@ class MTurkManager():
         for assignment_id in self.assignment_to_onboard_thread:
             self.assignment_to_onboard_thread[assignment_id].join()
         self._save_disconnects()
-        delete_server(self.server_task_name)
+        server_utils.delete_server(self.server_task_name)
 
     ### MTurk Agent Interaction Functions ###
 
@@ -777,7 +794,7 @@ class MTurkManager():
         # Force messages to have a unique ID
         if 'message_id' not in data:
             data['message_id'] = str(uuid.uuid4())
-        event_id = generate_event_id(receiver_id)
+        event_id = shared_utils.generate_event_id(receiver_id)
         packet = Packet(
             event_id,
             Packet.TYPE_MESSAGE,
@@ -801,7 +818,7 @@ class MTurkManager():
         update conversation state
         """
         data['type'] = data_model.MESSAGE_TYPE_COMMAND
-        event_id = generate_event_id(receiver_id)
+        event_id = shared_utils.generate_event_id(receiver_id)
         packet = Packet(
             event_id,
             Packet.TYPE_MESSAGE,
@@ -838,7 +855,7 @@ class MTurkManager():
 
     def get_agent_work_status(self, assignment_id):
         """Get the current status of an assignment's work"""
-        client = get_mturk_client(self.is_sandbox)
+        client = mturk_utils.get_mturk_client(self.is_sandbox)
         try:
             response = client.get_assignment(AssignmentId=assignment_id)
             return response['Assignment']['AssignmentStatus']
@@ -853,8 +870,9 @@ class MTurkManager():
         """Handle creation for a specific number of hits/assignments
         Put created HIT ids into the hit_id_list
         """
-        print_and_log('Creating {} hits...'.format(num_hits), False)
-        hit_type_id = create_hit_type(
+        shared_utils.print_and_log(logging.INFO,
+                                   'Creating {} hits...'.format(num_hits))
+        hit_type_id = mturk_utils.create_hit_type(
             hit_title=self.opt['hit_title'],
             hit_description='{} (ID: {})'.format(self.opt['hit_description'],
                                                  self.task_group_id),
@@ -868,13 +886,13 @@ class MTurkManager():
             self.server_url,
             self.task_group_id
         )
-        print_and_log(mturk_chat_url, False)
+        shared_utils.print_and_log(logging.INFO, mturk_chat_url)
         mturk_page_url = None
 
         if self.opt['unique_worker'] == True:
             # Use a single hit with many assignments to allow
             # workers to only work on the task once
-            mturk_page_url, hit_id = create_hit_with_hit_type(
+            mturk_page_url, hit_id = mturk_utils.create_hit_with_hit_type(
                 page_url=mturk_chat_url,
                 hit_type_id=hit_type_id,
                 num_assignments=num_hits,
@@ -885,7 +903,7 @@ class MTurkManager():
             # Create unique hits, allowing one worker to be able to handle many
             # tasks without needing to be unique
             for i in range(num_hits):
-                mturk_page_url, hit_id = create_hit_with_hit_type(
+                mturk_page_url, hit_id = mturk_utils.create_hit_with_hit_type(
                     page_url=mturk_chat_url,
                     hit_type_id=hit_type_id,
                     num_assignments=1,
@@ -896,45 +914,53 @@ class MTurkManager():
 
     def create_hits(self):
         """Create hits based on the managers current config, return hit url"""
-        print_and_log('Creating HITs...')
+        shared_utils.print_and_log(logging.INFO, 'Creating HITs...', True)
 
         mturk_page_url = self.create_additional_hits(
             num_hits=self.required_hits
         )
 
-        print_and_log('Link to HIT: {}\n'.format(mturk_page_url))
-        print_and_log('Waiting for Turkers to respond... (Please don\'t close'
-            ' your laptop or put your computer into sleep or standby mode.)\n')
+        shared_utils.print_and_log(logging.INFO,
+                                   'Link to HIT: {}\n'.format(mturk_page_url),
+                                   should_print=True)
+        shared_utils.print_and_log(
+            logging.INFO,
+            'Waiting for Turkers to respond... (Please don\'t close'
+            ' your laptop or put your computer into sleep or standby mode.)\n',
+            should_print=True
+        )
         return mturk_page_url
 
     def get_hit(self, hit_id):
         """Get hit from mturk by hit_id"""
-        client = get_mturk_client(self.is_sandbox)
+        client = mturk_utils.get_mturk_client(self.is_sandbox)
         return client.get_hit(HITId=hit_id)
 
     def get_assignment(self, assignment_id):
         """Gets assignment from mturk by assignment_id. Only works if the
         assignment is in a completed state
         """
-        client = get_mturk_client(self.is_sandbox)
+        client = mturk_utils.get_mturk_client(self.is_sandbox)
         return client.get_assignment(AssignmentId=assignment_id)
 
     def expire_all_unassigned_hits(self):
         """Move through the whole hit_id list and attempt to expire the
         HITs, though this only immediately expires those that aren't assigned.
         """
-        print_and_log("Expiring all unassigned HITs...")
+        shared_utils.print_and_log(logging.INFO,
+                                   'Expiring all unassigned HITs...',
+                                   should_print=True)
         for hit_id in self.hit_id_list:
-            expire_hit(self.is_sandbox, hit_id)
+            mturk_utils.expire_hit(self.is_sandbox, hit_id)
 
     def approve_work(self, assignment_id):
         """approve work for a given assignment through the mturk client"""
-        client = get_mturk_client(self.is_sandbox)
+        client = mturk_utils.get_mturk_client(self.is_sandbox)
         client.approve_assignment(AssignmentId=assignment_id)
 
     def reject_work(self, assignment_id, reason):
         """reject work for a given assignment through the mturk client"""
-        client = get_mturk_client(self.is_sandbox)
+        client = mturk_utils.get_mturk_client(self.is_sandbox)
         client.reject_assignment(
             AssignmentId=assignment_id,
             RequesterFeedback=reason
@@ -942,7 +968,7 @@ class MTurkManager():
 
     def block_worker(self, worker_id, reason):
         """Block a worker by id using the mturk client, passes reason along"""
-        client = get_mturk_client(self.is_sandbox)
+        client = mturk_utils.get_mturk_client(self.is_sandbox)
         client.create_worker_block(WorkerId=worker_id, Reason=reason)
 
     def pay_bonus(self, worker_id, bonus_amount, assignment_id, reason,
@@ -950,16 +976,20 @@ class MTurkManager():
         """Handles paying bonus to a turker, fails for insufficient funds.
         Returns True on success and False on failure
         """
-        total_cost = calculate_mturk_cost(
+        total_cost = mturk_utils.calculate_mturk_cost(
             payment_opt={'type': 'bonus', 'amount': bonus_amount}
         )
-        if not check_mturk_balance(balance_needed=total_cost,
-                                   is_sandbox=self.is_sandbox):
-            print_and_log('Cannot pay bonus. Reason: Insufficient funds'
-                          ' in your MTurk account.')
+        if not mturk_utils.check_mturk_balance(balance_needed=total_cost,
+                                               is_sandbox=self.is_sandbox):
+            shared_utils.print_and_log(
+                logging.WARN,
+                'Cannot pay bonus. Reason: Insufficient '
+                'funds in your MTurk account.',
+                should_print=True
+            )
             return False
 
-        client = get_mturk_client(self.is_sandbox)
+        client = mturk_utils.get_mturk_client(self.is_sandbox)
         # unique_request_token may be useful for handling future network errors
         client.send_bonus(
             WorkerId=worker_id,
@@ -968,15 +998,18 @@ class MTurkManager():
             Reason=reason,
             UniqueRequestToken=unique_request_token
         )
-        print_and_log('Paid ${} bonus to WorkerId: {}'.format(
-            bonus_amount,
-            worker_id
-        ))
+        shared_utils.print_and_log(
+            logging.INFO,
+            'Paid ${} bonus to WorkerId: {}'.format(
+                bonus_amount,
+                worker_id
+            )
+        )
         return True
 
     def email_worker(self, worker_id, subject, message_text):
         """Send an email to a worker through the mturk client"""
-        client = get_mturk_client(self.is_sandbox)
+        client = mturk_utils.get_mturk_client(self.is_sandbox)
         response = client.notify_workers(
             Subject=subject,
             MessageText=message_text,

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -45,7 +45,7 @@ class MTurkManager():
     between a world and the MTurk server.
     """
 
-    def __init__(self, opt, mturk_agent_ids):
+    def __init__(self, opt, mturk_agent_ids, is_test=False):
         """Create an MTurkManager using the given setup opts and a list of
         agent_ids that will participate in each conversation
         """
@@ -64,6 +64,7 @@ class MTurkManager():
             self.num_conversations * len(self.mturk_agent_ids) * HIT_MULT
         )
         self.socket_manager = None
+        self.is_test = is_test
         self._init_logs()
 
 
@@ -399,6 +400,11 @@ class MTurkManager():
         if agent is None:
             self._log_missing_agent(worker_id, assignment_id)
         elif not agent.state.is_final():
+            shared_utils.print_and_log(
+                logging.INFO,
+                'Manager received: '.format(pkt),
+                should_print=self.opt['verbose']
+            )
             # Push the message to the message thread to send on a reconnect
             agent.state.messages.append(pkt.data)
 
@@ -644,7 +650,8 @@ class MTurkManager():
     def ready_to_accept_workers(self):
         """Set up socket to start communicating to workers"""
         shared_utils.print_and_log(logging.INFO,
-                                   'Local: Setting up SocketIO...', True)
+                                   'Local: Setting up SocketIO...',
+                                   not self.is_test)
         self._setup_socket()
 
     def start_new_run(self):
@@ -974,7 +981,7 @@ class MTurkManager():
         """
         shared_utils.print_and_log(logging.INFO,
                                    'Expiring all unassigned HITs...',
-                                   should_print=True)
+                                   should_print=not self.is_test)
         for hit_id in self.hit_id_list:
             mturk_utils.expire_hit(self.is_sandbox, hit_id)
 

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -402,7 +402,7 @@ class MTurkManager():
         elif not agent.state.is_final():
             shared_utils.print_and_log(
                 logging.INFO,
-                'Manager received: '.format(pkt),
+                'Manager received: {}'.format(pkt),
                 should_print=self.opt['verbose']
             )
             # Push the message to the message thread to send on a reconnect
@@ -562,7 +562,7 @@ class MTurkManager():
         fin_word = 'start'
         if self.opt['count_complete']:
             fin_word = 'finish'
-        shared_uils.print_and_log(
+        shared_utils.print_and_log(
             logging.INFO,
             '\nYou are going to allow workers from Amazon Mechanical Turk to '
             'be an agent in ParlAI.\nDuring this process, Internet connection '
@@ -836,6 +836,12 @@ class MTurkManager():
             data,
             blocking=blocking,
             ack_func=ack_func
+        )
+
+        shared_utils.print_and_log(
+            logging.INFO,
+            'Manager sending: {}'.format(packet),
+            should_print=self.opt['verbose']
         )
         # Push outgoing message to the message thread to be able to resend
         # on a reconnect event

--- a/parlai/mturk/core/shared_utils.py
+++ b/parlai/mturk/core/shared_utils.py
@@ -14,8 +14,8 @@ THREAD_MEDIUM_SLEEP = 0.3
 # ThrottlingException might happen if we poll too frequently
 THREAD_MTURK_POLLING_SLEEP = 10
 
-logging_enabled = True
 logger = None
+logging_enabled = True
 debug = True
 log_level = logging.ERROR
 

--- a/parlai/mturk/core/shared_utils.py
+++ b/parlai/mturk/core/shared_utils.py
@@ -17,6 +17,7 @@ THREAD_MTURK_POLLING_SLEEP = 10
 logging_enabled = True
 logger = None
 debug = True
+log_level = logging.ERROR
 
 if logging_enabled:
     logging.basicConfig(
@@ -28,10 +29,19 @@ if logging_enabled:
     )
     logger = logging.getLogger('mturk')
 
+def set_log_level(new_level):
+    global log_level
+    log_level = new_level
 
-def print_and_log(message, should_print=True):
-    if logging_enabled:
-        logger.info(message)
+
+def set_is_debug(is_debug):
+    global debug
+    debug = is_debug
+
+
+def print_and_log(level, message, should_print=False):
+    if logging_enabled and level >= log_level:
+        logger.log(level, message)
     if should_print or debug: # Always print message in debug mode
         print(message)
 

--- a/parlai/mturk/core/test/integration_test/integration_test.py
+++ b/parlai/mturk/core/test/integration_test/integration_test.py
@@ -65,6 +65,7 @@ FAKE_WORKER_ID = 'FAKE_WORKER_ID_{}_{}'
 DISCONNECT_WAIT_TIME = SocketManager.DEF_SOCKET_TIMEOUT + 1.5
 
 completed_threads = {}
+start_times = {}
 
 def dummy(*args):
     pass
@@ -579,7 +580,7 @@ def test_solo_with_onboarding(opt, server_url):
     onboarding to ensure the agent is marked disconnected.
     """
     global completed_threads
-    print('Starting {}'.format(SOLO_ONBOARDING_TEST))
+    print('{} Starting'.format(SOLO_ONBOARDING_TEST))
     opt['task'] = SOLO_ONBOARDING_TEST
     hit_id = FAKE_HIT_ID.format(SOLO_ONBOARDING_TEST)
     assign_id_1 = FAKE_ASSIGNMENT_ID.format(SOLO_ONBOARDING_TEST, 1)
@@ -738,7 +739,7 @@ def test_solo_no_onboarding(opt, server_url):
     and is able to complete the task and be marked as completed
     """
     global completed_threads
-    print('Starting {}'.format(SOLO_NO_ONBOARDING_TEST))
+    print('{} Starting'.format(SOLO_NO_ONBOARDING_TEST))
     opt['task'] = SOLO_NO_ONBOARDING_TEST
     hit_id = FAKE_HIT_ID.format(SOLO_NO_ONBOARDING_TEST)
     assign_id = FAKE_ASSIGNMENT_ID.format(SOLO_NO_ONBOARDING_TEST, 1)
@@ -824,7 +825,7 @@ def test_solo_refresh_in_middle(opt, server_url):
     properly restored
     """
     global completed_threads
-    print('Starting {}'.format(SOLO_REFRESH_TEST))
+    print('{} Starting'.format(SOLO_REFRESH_TEST))
     opt['task'] = SOLO_REFRESH_TEST
     hit_id = FAKE_HIT_ID.format(SOLO_REFRESH_TEST)
     assign_id = FAKE_ASSIGNMENT_ID.format(SOLO_REFRESH_TEST, 1)
@@ -838,7 +839,8 @@ def test_solo_refresh_in_middle(opt, server_url):
     mturk_agent_id = AGENT_1_ID
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_id]
+        mturk_agent_ids=[mturk_agent_id],
+        is_test=True
     )
     mturk_manager.server_url = server_url
     mturk_manager.start_new_run()
@@ -935,7 +937,7 @@ def test_duo_with_onboarding(opt, server_url):
     able to join after the conversation starts, as the HIT should be expired
     """
     global completed_threads
-    print('Starting {}'.format(DUO_ONBOARDING_TEST))
+    print('{} Starting'.format(DUO_ONBOARDING_TEST))
     opt['task'] = DUO_ONBOARDING_TEST
     hit_id = FAKE_HIT_ID.format(DUO_ONBOARDING_TEST)
     assign_id_1 = FAKE_ASSIGNMENT_ID.format(DUO_ONBOARDING_TEST, 1)
@@ -959,7 +961,8 @@ def test_duo_with_onboarding(opt, server_url):
     mturk_agent_id_2 = AGENT_2_ID
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_id_1, mturk_agent_id_2]
+        mturk_agent_ids=[mturk_agent_id_1, mturk_agent_id_2],
+        is_test=True
     )
     mturk_manager.server_url = server_url
     mturk_manager.start_new_run()
@@ -1148,7 +1151,7 @@ def test_duo_no_onboarding(opt, server_url):
     agent returns to waiting
     """
     global completed_threads
-    print('Starting {}'.format(DUO_NO_ONBOARDING_TEST))
+    print('{} Starting'.format(DUO_NO_ONBOARDING_TEST))
     opt['task'] = DUO_NO_ONBOARDING_TEST
     opt['count_complete'] = True
     hit_id = FAKE_HIT_ID.format(DUO_NO_ONBOARDING_TEST)
@@ -1174,7 +1177,8 @@ def test_duo_no_onboarding(opt, server_url):
     mturk_agent_id_2 = AGENT_2_ID
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_id_1, mturk_agent_id_2]
+        mturk_agent_ids=[mturk_agent_id_1, mturk_agent_id_2],
+        is_test=True
     )
     mturk_manager.server_url = server_url
     mturk_manager.start_new_run()
@@ -1413,7 +1417,7 @@ def test_duo_valid_reconnects(opt, server_url):
     state, as well as completing a task after a reconnect.
     """
     global completed_threads
-    print('Starting {}'.format(DUO_VALID_RECONNECT_TEST))
+    print('{} Starting'.format(DUO_VALID_RECONNECT_TEST))
     opt['task'] = DUO_VALID_RECONNECT_TEST
     hit_id = FAKE_HIT_ID.format(DUO_VALID_RECONNECT_TEST)
     assign_id_1 = FAKE_ASSIGNMENT_ID.format(DUO_VALID_RECONNECT_TEST, 1)
@@ -1433,7 +1437,8 @@ def test_duo_valid_reconnects(opt, server_url):
     mturk_agent_id_2 = AGENT_2_ID
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_id_1, mturk_agent_id_2]
+        mturk_agent_ids=[mturk_agent_id_1, mturk_agent_id_2],
+        is_test=True
     )
     mturk_manager.server_url = server_url
     mturk_manager.start_new_run()
@@ -1620,7 +1625,7 @@ def test_duo_one_disconnect(opt, server_url):
     a partner disconnect or after a disconnect.
     """
     global completed_threads
-    print('Starting {}'.format(DUO_ONE_DISCONNECT_TEST))
+    print('{} Starting'.format(DUO_ONE_DISCONNECT_TEST))
     opt['task'] = DUO_ONE_DISCONNECT_TEST
     hit_id = FAKE_HIT_ID.format(DUO_ONE_DISCONNECT_TEST)
     assign_id_1 = FAKE_ASSIGNMENT_ID.format(DUO_ONE_DISCONNECT_TEST, 1)
@@ -1641,7 +1646,8 @@ def test_duo_one_disconnect(opt, server_url):
     mturk_agent_id_2 = AGENT_2_ID
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_id_1, mturk_agent_id_2]
+        mturk_agent_ids=[mturk_agent_id_1, mturk_agent_id_2],
+        is_test=True
     )
     mturk_manager.server_url = server_url
     mturk_manager.start_new_run()
@@ -1823,7 +1829,7 @@ def test_count_complete(opt, server_url):
     count_complete flag.
     """
     global completed_threads
-    print('Starting {}'.format(COUNT_COMPLETE_TEST))
+    print('{} Starting'.format(COUNT_COMPLETE_TEST))
     opt['task'] = COUNT_COMPLETE_TEST
     opt['count_complete'] = True
     opt['num_conversations'] = 1
@@ -1839,7 +1845,8 @@ def test_count_complete(opt, server_url):
 
     mturk_agent_id = AGENT_1_ID
     mturk_manager = MTurkManager(opt=opt,
-                                 mturk_agent_ids = [mturk_agent_id])
+                                 mturk_agent_ids=[mturk_agent_id],
+                                 is_test=True)
     mturk_manager.server_url = server_url
     mturk_manager.start_new_run()
     task_group_id = mturk_manager.task_group_id
@@ -1978,7 +1985,7 @@ def test_expire_hit(opt, server_url):
     one in onboarding and sending 3 to waiting, then ensuring that the
     remaining waiting worker gets expired"""
     global completed_threads
-    print('Starting {}'.format(EXPIRE_HIT_TEST))
+    print('{} Starting'.format(EXPIRE_HIT_TEST))
     opt['task'] = EXPIRE_HIT_TEST
     opt['count_complete'] = True
     hit_id = FAKE_HIT_ID.format(EXPIRE_HIT_TEST)
@@ -2006,7 +2013,8 @@ def test_expire_hit(opt, server_url):
     mturk_agent_id_2 = AGENT_2_ID
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_id_1, mturk_agent_id_2]
+        mturk_agent_ids=[mturk_agent_id_1, mturk_agent_id_2],
+        is_test=True
     )
     mturk_manager.server_url = server_url
     mturk_manager.start_new_run()
@@ -2241,7 +2249,7 @@ def test_allowed_conversations(opt, server_url):
     they're allowed to start it after finishing the first
     """
     global completed_threads
-    print('Starting {}'.format(ALLOWED_CONVERSATION_TEST))
+    print('{} Starting'.format(ALLOWED_CONVERSATION_TEST))
     opt['allowed_conversations'] = 1
     opt['num_conversations'] = 2
     opt['task'] = ALLOWED_CONVERSATION_TEST
@@ -2258,7 +2266,8 @@ def test_allowed_conversations(opt, server_url):
     mturk_agent_id = AGENT_1_ID
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_id]
+        mturk_agent_ids=[mturk_agent_id],
+        is_test=True
     )
     mturk_manager.server_url = server_url
     mturk_manager.start_new_run()
@@ -2376,7 +2385,7 @@ def test_unique_workers_in_conversation(opt, server_url):
     when not in the sandbox
     """
     global completed_threads
-    print('Starting {}'.format(UNIQUE_CONVERSATION_TEST))
+    print('{} Starting'.format(UNIQUE_CONVERSATION_TEST))
     opt['task'] = UNIQUE_CONVERSATION_TEST
     opt['is_sandbox'] = False
     opt['count_complete'] = True
@@ -2399,7 +2408,8 @@ def test_unique_workers_in_conversation(opt, server_url):
     mturk_agent_id_2 = AGENT_2_ID
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_id_1, mturk_agent_id_2]
+        mturk_agent_ids=[mturk_agent_id_1, mturk_agent_id_2],
+        is_test=True
     )
     mturk_manager.server_url = server_url
     mturk_manager.start_new_run()
@@ -2598,20 +2608,21 @@ def test_unique_workers_in_conversation(opt, server_url):
     completed_threads[UNIQUE_CONVERSATION_TEST] = True
 
 
-# Map of tests to run to their testing function
+# Map of tests to run to their testing function, slowest tests first reduces
+# overall runtime
 TESTS = {
-    SOCKET_TEST: test_socket_manager,
-    SOLO_ONBOARDING_TEST: test_solo_with_onboarding,
-    SOLO_NO_ONBOARDING_TEST: test_solo_no_onboarding,
-    SOLO_REFRESH_TEST: test_solo_refresh_in_middle,
-    DUO_ONBOARDING_TEST: test_duo_with_onboarding,
     DUO_NO_ONBOARDING_TEST: test_duo_no_onboarding,
-    DUO_VALID_RECONNECT_TEST: test_duo_valid_reconnects,
-    DUO_ONE_DISCONNECT_TEST: test_duo_one_disconnect,
-    COUNT_COMPLETE_TEST: test_count_complete,
+    SOLO_ONBOARDING_TEST: test_solo_with_onboarding,
+    DUO_ONBOARDING_TEST: test_duo_with_onboarding,
     EXPIRE_HIT_TEST: test_expire_hit,
+    DUO_ONE_DISCONNECT_TEST: test_duo_one_disconnect,
+    DUO_VALID_RECONNECT_TEST: test_duo_valid_reconnects,
+    UNIQUE_CONVERSATION_TEST: test_unique_workers_in_conversation,
     ALLOWED_CONVERSATION_TEST: test_allowed_conversations,
-    UNIQUE_CONVERSATION_TEST: test_unique_workers_in_conversation
+    SOLO_REFRESH_TEST: test_solo_refresh_in_middle,
+    SOLO_NO_ONBOARDING_TEST: test_solo_no_onboarding,
+    COUNT_COMPLETE_TEST: test_count_complete,
+    SOCKET_TEST: test_socket_manager
 }
 
 # Runtime threads, MAX_THREADS is used on initial pass, RETEST_THREADS is used
@@ -2621,6 +2632,7 @@ MAX_THREADS = 8
 RETEST_THREADS = 2
 
 def run_tests(tests_to_run, max_threads, base_opt, server_url):
+    global start_time
     failed_tests = []
     threads = {}
     for test_name in tests_to_run:
@@ -2631,24 +2643,43 @@ def run_tests(tests_to_run, max_threads, base_opt, server_url):
                     new_threads[n] = threads[n]
                 else:
                     if n in completed_threads:
-                        print("{} Passed".format(n))
+                        print("{} Passed. Runtime - {} Seconds".format(
+                            n,
+                            time.time() - start_times[n]
+                        ))
                     else:
-                        print("{} FAILED".format(n))
+                        print("{} Failed. Runtime - {} Seconds".format(
+                            n,
+                            time.time() - start_times[n]
+                        ))
                         failed_tests.append(n)
             threads = new_threads
             time.sleep(1)
         new_thread = threading.Thread(target=TESTS[test_name],
                                       args=(base_opt.copy(), server_url))
         new_thread.start()
+        start_times[test_name] = time.time()
         threads[test_name] = new_thread
         time.sleep(0.25)
-    for thread_name in threads:
-        threads[thread_name].join()
-        if thread_name in completed_threads:
-            print("{} Passed".format(thread_name))
-        else:
-            print("{} FAILED".format(thread_name))
-            failed_tests.append(thread_name)
+    while len(threads) > 0:
+        new_threads = {}
+        for n in threads:
+            if threads[n].isAlive():
+                new_threads[n] = threads[n]
+            else:
+                if n in completed_threads:
+                    print("{} Passed. Runtime - {} Seconds".format(
+                        n,
+                        time.time() - start_times[n]
+                    ))
+                else:
+                    print("{} Failed. Runtime - {} Seconds".format(
+                        n,
+                        time.time() - start_times[n]
+                    ))
+                    failed_tests.append(n)
+        threads = new_threads
+        time.sleep(1)
     return failed_tests
 
 

--- a/parlai/mturk/core/worker_state.py
+++ b/parlai/mturk/core/worker_state.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-from parlai.mturk.core.shared_utils import print_and_log
 import parlai.mturk.core.data_model as data_model
 
 class AssignState():


### PR DESCRIPTION
Made some changes to logging within MTurk code to allow for more control of what gets logged and what gets printed.

`--log-level N` will ensure only messages above importance level N (as defined in logging's importance enums) are logged
`--verbose` is now actually respected, and will print messages to and from Turkers even when not printing everything
`--debug` now prints everything, which is what we were familiar with before this change