### PR TITLE
Better Turker interaction with initialization issues

### DIFF
--- a/parlai/mturk/core/server/html/core.html
+++ b/parlai/mturk/core/server/html/core.html
@@ -771,10 +771,19 @@
 
   /* =================== Initialization =================== */
 
+  function fail_initialize() {
+    $("div#ui-placeholder").html('Unable to initialize. We may be having \
+      issues with our chat servers. Please refresh the page, or if that \
+      isn\'t working return the HIT and try again later if you would like \
+      to work on this task.');
+    close_socket();
+  }
+
   // Initializes the chat page
   function init_chat_page() {
     if (is_init_page) {
       $("div#ui-placeholder").html("Initializing...");
+      setTimeout(fail_initialize, 10000);
     } else {
       init_chat_panel();
     }


### PR DESCRIPTION
Right now the initialization page hangs on "initializing" forever without letting the user know that an error may have occurred. In all cases it should be able to connect to the server and initialize within 10 seconds, so if it's unable to do so we now replace the text with a message informing the Turker that there is an issue. This should lead to better Turker experience and less "It hangs on initializing forever" comments during issues when the server goes down (or a person forgetfully sleeps their laptop while running the server).