### PR TITLE
bAbI+ dataset integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ tmp/
 *.pickle
 # Heroku things
 heroku-cli-*
+
+.idea

--- a/parlai/tasks/dialog_babi_plus/__init__.py
+++ b/parlai/tasks/dialog_babi_plus/__init__.py
@@ -1,0 +1,3 @@
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/tasks/dialog_babi_plus/agents.py
+++ b/parlai/tasks/dialog_babi_plus/agents.py
@@ -1,0 +1,36 @@
+import os
+
+from parlai.core.fbdialog_teacher import FbDialogTeacher
+from parlai.tasks.dialog_babi_plus.build import build
+
+tasks = {}
+
+tasks[1] = 'dialog-babi-plus-task1-API-calls'
+
+
+def _path(task, opt):
+    # Build the data if it doesn't exist.
+    build(opt)
+    prefix = os.path.join(opt['datapath'], 'dialog-bAbI-plus', 'dialog-bAbI-plus-tasks')
+    suffix = ''
+    dt = opt['datatype'].split(':')[0]
+    if dt == 'train':
+        suffix = 'trn'
+    elif dt == 'test':
+        suffix = 'tst'
+    elif dt == 'valid':
+        suffix = 'dev'
+    datafile = os.path.join(prefix,
+                            '{tsk}-{type}.txt'.format(tsk=tasks[int(task)], type=suffix))
+
+    cands_datafile = os.path.join(prefix, 'dialog-babi-candidates.txt')
+
+    return datafile, cands_datafile
+
+
+# Single task.
+class TaskTeacher(FbDialogTeacher):
+    def __init__(self, opt, shared=None):
+        paths = _path(opt['task'].split(':')[2], opt)
+        opt['datafile'], opt['cands_datafile'] = paths
+        super().__init__(opt, shared)

--- a/parlai/tasks/dialog_babi_plus/agents.py
+++ b/parlai/tasks/dialog_babi_plus/agents.py
@@ -28,6 +28,16 @@ def _path(task, opt):
     return datafile, cands_datafile
 
 
+# The knowledge base of facts that can be used to answer questions.
+class KBTeacher(FbDialogTeacher):
+    def __init__(self, opt, shared=None):
+        build(opt)
+        opt['datafile'] = os.path.join(opt['datapath'], 'dialog-bAbI-plus',
+                                       'dialog-bAbI-plus-tasks',
+                                       'dialog-babi-kb-all.txt')
+        super().__init__(opt, shared)
+
+
 # Single task.
 class TaskTeacher(FbDialogTeacher):
     def __init__(self, opt, shared=None):

--- a/parlai/tasks/dialog_babi_plus/agents.py
+++ b/parlai/tasks/dialog_babi_plus/agents.py
@@ -43,8 +43,9 @@ class KBTeacher(FbDialogTeacher):
 
 
 # Single task.
-class TaskTeacher(FbDialogTeacher):
+class DefaultTeacher(FbDialogTeacher):
     def __init__(self, opt, shared=None):
-        paths = _path(opt['task'].split(':')[2], opt)
+        default_task_id = 1
+        paths = _path(default_task_id, opt)
         opt['datafile'], opt['cands_datafile'] = paths
         super().__init__(opt, shared)

--- a/parlai/tasks/dialog_babi_plus/agents.py
+++ b/parlai/tasks/dialog_babi_plus/agents.py
@@ -1,3 +1,7 @@
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
 import os
 
 from parlai.core.fbdialog_teacher import FbDialogTeacher

--- a/parlai/tasks/dialog_babi_plus/build.py
+++ b/parlai/tasks/dialog_babi_plus/build.py
@@ -1,3 +1,7 @@
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
 import os
 
 from parlai.core import build_data

--- a/parlai/tasks/dialog_babi_plus/build.py
+++ b/parlai/tasks/dialog_babi_plus/build.py
@@ -1,0 +1,22 @@
+import os
+
+from parlai.core import build_data
+
+
+def build(opt):
+    dpath = os.path.join(opt['datapath'], 'dialog-bAbI-plus')
+    fname = "dialog-bAbI-plus.zip"
+    version = None
+
+    if not build_data.built(os.path.join(dpath, "dialog-bAbI-plus"), version_string=version):
+        print('[building data: ' + dpath + ']')
+        if build_data.built(dpath):
+            # An older version exists, so remove these outdated files.
+            build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        url = "https://drive.google.com/uc?export=download&id=0B2MvoQfXtqZmMTJqclpBdGN2bmc"
+        build_data.download(url, dpath, fname)
+        build_data.untar(dpath, fname)
+
+        build_data.mark_done(dpath, version)

--- a/parlai/tasks/dialog_babi_plus/build.py
+++ b/parlai/tasks/dialog_babi_plus/build.py
@@ -8,7 +8,7 @@ def build(opt):
     fname = "dialog-bAbI-plus.zip"
     version = None
 
-    if not build_data.built(os.path.join(dpath, "dialog-bAbI-plus"), version_string=version):
+    if not build_data.built(dpath, version_string=version):
         print('[building data: ' + dpath + ']')
         if build_data.built(dpath):
             # An older version exists, so remove these outdated files.

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -67,6 +67,13 @@ task_list = [
         "description": "Simulated dialogs of restaurant booking, from Bordes et al. '16. Link: https://arxiv.org/abs/1605.07683"
     },
     {
+        "id": "dialog-bAbI-plus",
+        "display_name": "Dialog bAbI+",
+        "task": "dialog_babi_plus",
+        "tags": ["All", "Goal"],
+        "description": "bAbI+ is an extension of the bAbI Task 1 dialogues with everyday incremental dialogue phenomena (hesitations, restarts, and corrections) which model the disfluencies and communication problems in everyday spoken interaction in real-world environments. See https://www.researchgate.net/publication/319128941_Challenging_Neural_Dialogue_Models_with_Natural_Data_Memory_Networks_Fail_on_Incremental_Phenomena, http://aclweb.org/anthology/D17-1235"
+    },
+    {
         "id": "FVQA",
         "display_name": "FVQA",
         "task": "fvqa",


### PR DESCRIPTION
# bAbI+ integration

## Description
The aim of the present pull-request is to add a new world in ParlAI based on the recently proposed dataset *bAbI+*. *bAbI+* is an extension of the bAbI Task 1 dialogues with everyday incremental dialogue phenomena (hesitations, restarts, and corrections) which model the disfluencies and communication problems in everyday spoken interaction in real-world environments. See [[1]](https://www.researchgate.net/publication/319128941_Challenging_Neural_Dialogue_Models_with_Natural_Data_Memory_Networks_Fail_on_Incremental_Phenomena), [[2]](http://aclweb.org/anthology/D17-1235) for additional information about the dataset.

## Contribution
In the following we report the main changes to the ParlAI codebase:
1. Added to the .gitignore Intellij IDEA related files;
2. Created dialog bAbI+ world which supports **only** the task API calls;
3. Added reference to dialog bAbI+ to the tasks list.

## Authors
- Prof. Oliver Lemon ([https://sites.google.com/site/olemon/](https://sites.google.com/site/olemon/))
- Igor Shalyminov (@ishalyminov)
- Alessandro Suglia (@aleSuglia)
