### PR TITLE
Add dict-build-first option to eval_model.py

### DIFF
--- a/examples/eval_model.py
+++ b/examples/eval_model.py
@@ -14,6 +14,7 @@ or
 from parlai.core.params import ParlaiParser
 from parlai.core.agents import create_agent
 from parlai.core.worlds import create_task
+import build_dict
 
 import random
 
@@ -24,8 +25,16 @@ def main():
     parser = ParlaiParser(True, True)
     parser.add_argument('-n', '--num-examples', default=100000000)
     parser.add_argument('-d', '--display-examples', type='bool', default=False)
+    parser.add_argument('-dbf', '--dict-build-first', type='bool', default=True)
     parser.set_defaults(datatype='valid')
     opt = parser.parse_args()
+        
+    if opt['dict_build_first'] and 'dict_file' in opt:
+        if opt['dict_file'] is None and opt.get('model_file'):
+            opt['dict_file'] = opt['model_file'] + '.dict'
+        print("[ building dictionary first... ]")
+        build_dict.build_dict(opt)
+
     # Create model and assign it to the specified task
     agent = create_agent(opt)
     world = create_task(opt, agent)


### PR DESCRIPTION
I added an option for using trained `model file`.

### Test 

```
// train and save memnn model with babi task
$ python examples/train_model.py -m "memnn" -t "babi:task1k:1" -e 10 -bs 32 --gpu 0 -mf /tmp/model_babi_task1k_1


// eval memnn without the model_file
$ python examples/eval_model.py -m "memnn" -t "babi:task1k:1"
...
{'total': 100, 'accuracy': 0.14, 'f1': 0.14, 'hits@k': {1: 0.14, 5: 0.78, 10: 1.0, 50: 1.0, 100: 1.0}}


// eval memnn with the model_file
$ python examples/eval_model.py -m "memnn" -t "babi:task1k:1" -mf /tmp/model_memnn_babi_task1k_1
...
{'total': 100, 'accuracy': 1.0, 'f1': 1.0, 'hits@k': {1: 1.0, 5: 1.0, 10: 1.0, 50: 1.0, 100: 1.0}}
```


