### PR TITLE
add eval_labels to world display, update moviedialog version

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -82,6 +82,9 @@ def display_messages(msgs):
         if msg.get('labels'):
             lines.append(space + ('[labels: {}]'.format(
                         '|'.join(msg['labels']))))
+        if msg.get('eval_labels'):
+            lines.append(space + ('[eval_labels: {}]'.format(
+                        '|'.join(msg['eval_labels']))))
         if msg.get('label_candidates'):
             cand_len = len(msg['label_candidates'])
             if cand_len <= 10:

--- a/parlai/tasks/moviedialog/build.py
+++ b/parlai/tasks/moviedialog/build.py
@@ -11,7 +11,7 @@ import os
 
 def build(opt):
     dpath = os.path.join(opt['datapath'], 'MovieDialog')
-    version = None
+    version = '1'
 
     if not build_data.built(dpath, version_string=version):
         print('[building data: ' + dpath + ']')


### PR DESCRIPTION
moviedialog's task 1 data has been updated, change the version to force a new download

unrelated, show eval_labels in world.display()