### PR TITLE
Updates MTurk code to utilize SNS functionality

### DIFF
--- a/docs/source/mturk.rst
+++ b/docs/source/mturk.rst
@@ -7,7 +7,7 @@
 
 Using Mechanical Turk
 =====================
-**Author**: Will Feng
+**Authors**: Will Feng, Jack Urbanek
 
 In ParlAI, you can use Amazon Mechanical Turk for **data collection**, **training** and **evaluation** of your dialog model.
 
@@ -18,7 +18,7 @@ The human Turkers communicate in observation/action dict format, the same as all
 .. figure:: _static/img/mturk-small.png
    :align: center
 
-   Example: Human Turker participating in a QA data collection task
+   *Example: Human Turker participating in a QA data collection task*
 
 Each MTurk task has at least one human Turker that connects to ParlAI via the Mechanical Turk Live Chat interface, encapsulated as an ``MTurkAgent`` object.
 
@@ -31,7 +31,8 @@ We provide a few examples of using Mechanical Turk with ParlAI:
 
 - `QA Data Collection <https://github.com/facebookresearch/ParlAI/blob/master/parlai/mturk/tasks/qa_data_collection/>`__: collect questions and answers from Turkers, given a random Wikipedia paragraph from SQuAD.
 - `Model Evaluator <https://github.com/facebookresearch/ParlAI/blob/master/parlai/mturk/tasks/model_evaluator/>`__: ask Turkers to evaluate the information retrieval baseline model on the Reddit movie dialog dataset.
-- `Multi-Agent Dialog <https://github.com/facebookresearch/ParlAI/blob/master/parlai/mturk/tasks/multi_agent_dialog/>`__: round-robin chat between two local human agents and two Turkers.
+- `Multi-Agent Dialog <https://github.com/facebookresearch/ParlAI/blob/master/parlai/mturk/tasks/multi_agent_dialog/>`__: round-robin chat between a local human agent and two Turkers.
+- `Deal or No Deal <https://github.com/facebookresearch/ParlAI/tree/master/parlai/mturk/tasks/dealnodeal/>`__: negotiation chat between two agents over how to fairly divide a fixed set of items when each agent values the items differently.
 
 Task 1: Collecting Data
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -70,9 +71,17 @@ After one turn, the task is finished, and the Turker's work is submitted for you
 Task 3: Multi-Agent Dialog
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-ParlAI supports dialogs between multiple agents, whether they are local ParlAI agents or human Turkers. In the `Multi-Agent Dialog task <https://github.com/facebookresearch/ParlAI/tree/master/parlai/mturk/tasks/multi_agent_dialog/>`__, two local human agents and two Turkers engage in a round-robin chat, until the first local human agent sends a message ending with ``[DONE]``, after which other agents will send a final message and the task is concluded.
+ParlAI supports dialogs between multiple agents, whether they are local ParlAI agents or human Turkers. In the `Multi-Agent Dialog task <https://github.com/facebookresearch/ParlAI/tree/master/parlai/mturk/tasks/multi_agent_dialog/>`__, one local human agents and two Turkers engage in a round-robin chat, until the first local human agent sends a message ending with ``[DONE]``, after which other agents will send a final message and the task is concluded.
 
 This task uses the ``MultiAgentDialogWorld`` which is already implemented in ``parlai.core.worlds``.
+
+Task 4: Advanced Functionality - Deal or No Deal
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ParlAI is able to support more than just generic chat. The `Deal or No Deal task <https://github.com/facebookresearch/ParlAI/tree/master/parlai/mturk/tasks/dealnodeal/>`__ provides additional functionality over the regular chat window to allow users to view the items they are dividing, select an allocation, and then submit a deal.
+
+This task leverages the ability to override base functionality of the core.html page using ``task_config.py`. Javascript is added here to replace the task description with additional buttons and UI elements that are required for the more complicated task. These trigger within an overridden handle_new_message function, which will only fire after an agent has entered the chat.
+In general it is easier/preferred to use a custom webpage as described in step 4 of "Creating Your Own Task", though this is an alternate that can be used if you specifically only want to show additional components in the task description pane of the chat window.
 
 
 Creating Your Own Task
@@ -101,21 +110,29 @@ If you have not used Mechanical Turk before, you will need an MTurk Requester Ac
 
 - MTurk also has a “Sandbox” which is a test version of the MTurk marketplace. You can use it to test publishing and completing tasks without paying any money. ParlAI supports the Sandbox. To use the Sandbox, you need to sign up for a `Sandbox account <http://requestersandbox.mturk.com/>`__. You will then also need to `link your AWS account <http://requestersandbox.mturk.com/developer>`__ to your Sandbox account. In order to test faster, you will also want to create a `Sandbox Worker account <http://workersandbox.mturk.com/>`__. You can then view tasks your publish from ParlAI and complete them yourself.
 
-- ParlAI will connect to your AWS account and set up some supporting resources including a Lambda function, an API Gateway and an RDS database. It will also use your AWS account to connect to the MTurk API. In order to do this, it will require credentials to access your AWS account. To set this up, you will need to create an `IAM user <https://console.aws.amazon.com/iam/>`__ with programmatic access and an AdministratorAccess policy. You can learn more about how to set up IAM users `here <http://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html>`__. Once you have created the account, keep its access key and the secret key handy as you will need it next.
+- ParlAI's MTurk functionality requires a free heroku account which can be obtained `here <https://signup.heroku.com/>`__. Running any ParlAI MTurk operation will walk you through linking the two.
 
 Then, to run an MTurk task, first ensure that the task directory is in `parlai/mturk/tasks/ <https://github.com/facebookresearch/ParlAI/blob/master/parlai/mturk/tasks/>`__. Then, run its ``run.py`` file with proper flags:
 
-.. code-block:: python
+.. code-block:: console
 
-    python run.py -nh <num_hits> -na <num_assignments> -r <reward> [--sandbox]/[--live]
+    python run.py -nc <num_conversations> -r <reward> [--sandbox]/[--live]
 
-E.g. to create 2 HITs for the `QA Data Collection <https://github.com/facebookresearch/ParlAI/blob/master/parlai/mturk/tasks/qa_data_collection/>`__ example with 1 assignment per HIT and $0.05 per assignment in sandbox mode, first go into the task directory and then run:
+E.g. to create 2 conversations for the `QA Data Collection <https://github.com/facebookresearch/ParlAI/blob/master/parlai/mturk/tasks/qa_data_collection/>`__ example with a reward of $0.05 per assignment in sandbox mode, first go into the task directory and then run:
 
-.. code-block:: python
+.. code-block:: console
 
-    python run.py -nh 2 -na 1 -r 0.05 --sandbox
+    python run.py -nc 2 -r 0.05 --sandbox
 
 Please make sure to test your task in MTurk sandbox mode first (``--sandbox``) before pushing it live (``--live``).
+
+Additional flags can be used for more specific purposes.
+
+- ``--unique`` ensures that an Turker is only able to complete one assignment, thus ensuring each assignment is completed by a unique person.
+
+- ``--allowed-conversations <num>`` prevents a Turker from entering more than <num> conversations at once (by using multiple windows/tabs). This defaults to 0, which is unlimited.
+
+- ``--count-complete`` only counts completed assignments towards the num_conversations requested. This may lead to more conversations being had than requested (and thus higher costs for instances where one Turker disconnects and we pay the other) but it ensures that if you request 1,000 conversations you end up with at least 1,000 completed data points.
 
 
 Reviewing Turker's Work

--- a/docs/source/mturk.rst
+++ b/docs/source/mturk.rst
@@ -80,7 +80,7 @@ Task 4: Advanced Functionality - Deal or No Deal
 
 ParlAI is able to support more than just generic chat. The `Deal or No Deal task <https://github.com/facebookresearch/ParlAI/tree/master/parlai/mturk/tasks/dealnodeal/>`__ provides additional functionality over the regular chat window to allow users to view the items they are dividing, select an allocation, and then submit a deal.
 
-This task leverages the ability to override base functionality of the core.html page using ``task_config.py`. Javascript is added here to replace the task description with additional buttons and UI elements that are required for the more complicated task. These trigger within an overridden handle_new_message function, which will only fire after an agent has entered the chat.
+This task leverages the ability to override base functionality of the core.html page using ``task_config.py``. Javascript is added here to replace the task description with additional buttons and UI elements that are required for the more complicated task. These trigger within an overridden handle_new_message function, which will only fire after an agent has entered the chat.
 In general it is easier/preferred to use a custom webpage as described in step 4 of "Creating Your Own Task", though this is an alternate that can be used if you specifically only want to show additional components in the task description pane of the chat window.
 
 

--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -41,77 +41,15 @@ class MTurkAgent(Agent):
         self.hit_id = hit_id
         self.worker_id = worker_id
         self.some_agent_disconnected = False
-        self.hit_is_abandoned = False
         self.hit_is_expired = False
-        self.hit_is_accepted = False # state from Amazon MTurk system
+        self.hit_is_abandoned = False # state from Amazon MTurk system
         self.hit_is_returned = False # state from Amazon MTurk system
+        self.hit_is_complete = False # state from Amazon MTurk system
         self.disconnected = False
         self.task_group_id = manager.task_group_id
         self.message_request_time = None
 
         self.msg_queue = Queue()
-
-        # TODO-1 replace with code that subscribes to notifs to update status
-        # self.check_hit_status_thread = threading.Thread(
-        #    target=self._check_hit_status)
-        # self.check_hit_status_thread.daemon = True
-        # self.check_hit_status_thread.start()
-
-    def _check_hit_status(self):
-        """Monitor and update the HIT status by polling"""
-        # TODO-1 replace with code that subscribes to notifs to update status
-        # Check if HIT is accepted
-        while True:
-            if self.hit_id:
-                response = self.manager.get_hit(hit_id=self.hit_id)
-                # Amazon MTurk system acknowledges that the HIT is accepted
-                if response['HIT']['NumberOfAssignmentsPending'] == 1:
-                    shared_utils.print_and_log(
-                        logging.INFO,
-                        'Worker has accepted the HIT'
-                    )
-                    self.hit_is_accepted = True
-                    break
-            time.sleep(shared_utils.THREAD_MTURK_POLLING_SLEEP)
-        while True:
-            if self.hit_id:
-                response = self.manager.get_hit(hit_id=self.hit_id)
-                # HIT is returned
-                if response['HIT']['NumberOfAssignmentsAvailable'] == 1:
-                    self.hit_is_returned = True
-                    # If the worker is still in onboarding, then we don't need
-                    # to expire the HIT.
-                    # If the worker is already in a conversation, then we
-                    # should expire the HIT to keep the total number of
-                    # available HITs consistent with the number of
-                    # conversations left.
-                    if self.is_in_task():
-                        shared_utils.print_and_log(
-                            logging.INFO,
-                            'Worker {}_{} has returned the HIT {}. Since '
-                            'the worker is already in a task conversation, '
-                            'we are expiring the HIT.'.format(
-                                self.worker_id,
-                                self.assignment_id,
-                                self.hit_id
-                            )
-                        )
-                        self.manager.expire_hit(hit_id=self.hit_id)
-                    else:
-                        shared_utils.print_and_log(
-                            logging.INFO,
-                            'Worker {}_{} has returned the HIT {}. Since '
-                            'the worker is still in onboarding, we will not '
-                            'expire the HIT.'.format(
-                                self.worker_id,
-                                self.assignment_id,
-                                self.hit_id
-                            )
-                        )
-                    # we will not be using this MTurkAgent object for another
-                    # worker, so no need to check its status anymore
-                    return
-            time.sleep(shared_utils.THREAD_MTURK_POLLING_SLEEP)
 
     def get_connection_id(self):
         """Returns an appropriate connection_id for this agent"""
@@ -397,10 +335,18 @@ class MTurkAgent(Agent):
                 self.manager.free_workers([self])
                 return True
             start_time = time.time()
-        while self.manager.get_agent_work_status(self.assignment_id) != \
+        iters = (shared_utils.THREAD_MTURK_POLLING_SLEEP /
+                 shared_utils.THREAD_SHORT_SLEEP)
+        i = 0
+        while not self.hit_is_complete and i < iters:
+            time.sleep(shared_utils.THREAD_SHORT_SLEEP)
+            i += 1
+        while not self.hit_is_complete and \
+                self.manager.get_agent_work_status(self.assignment_id) != \
                 self.ASSIGNMENT_DONE:
             # Check if the Turker already returned/disconnected
             if self.hit_is_returned or self.disconnected:
+                self.manager.free_workers([self])
                 return False
             if timeout:
                 current_time = time.time()
@@ -414,6 +360,7 @@ class MTurkAgent(Agent):
                         )
                     )
                     self.set_hit_is_abandoned()
+                    self.manager.free_workers([self])
                     return False
             shared_utils.print_and_log(
                 logging.DEBUG,
@@ -421,7 +368,11 @@ class MTurkAgent(Agent):
                     self.worker_id, self.assignment_id, self.conversation_id
                 )
             )
-            time.sleep(shared_utils.THREAD_MTURK_POLLING_SLEEP)
+            i = 0
+            while not self.hit_is_complete and i < iters:
+                time.sleep(shared_utils.THREAD_SHORT_SLEEP)
+                i += 1
+
         shared_utils.print_and_log(
             logging.INFO,
             'Conversation ID: {}, Agent ID: {} - HIT is done.'.format(

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -698,7 +698,7 @@ class MTurkManager():
         self.task_group_id = '{}_{}'.format(self.opt['task'], self.run_id)
         self._init_state()
         self.topic_arn = mturk_utils.setup_sns_topic(
-            self.server_task_name,
+            self.opt['task'],
             self.server_url,
             self.task_group_id
         )

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -319,7 +319,6 @@ def setup_sns_topic(task_name, server_url, task_group_id):
     response = client.get_topic_attributes(
         TopicArn=arn
     )
-    print(response)
     policy_json = '''{{
     "Version": "2008-10-17",
     "Id": "{}/MTurkOnlyPolicy",
@@ -334,7 +333,6 @@ def setup_sns_topic(task_name, server_url, task_group_id):
             "Resource": "{}"
         }}
     ]}}'''.format(arn,arn)
-    print(policy_json)
     client.set_topic_attributes(
         TopicArn=arn,
         AttributeName='Policy',
@@ -356,8 +354,6 @@ def subscribe_to_hits(hit_type_id, is_sandbox, sns_arn):
         },
         Active=True
     )
-    print("subscribed to hits!")
-    print(response)
 
 def send_test_notif(topic_arn, event_type):
     client = get_mturk_client(True)
@@ -371,7 +367,6 @@ def send_test_notif(topic_arn, event_type):
         },
         TestEventType=event_type
     )
-    print(response)
 
 def delete_sns_topic(topic_arn):
     client = boto3.client('sns', region_name='us-east-1',)

--- a/parlai/mturk/core/server/package.json
+++ b/parlai/mturk/core/server/package.json
@@ -22,6 +22,7 @@
     "pg-hstore": "2.3.2",
     "sequelize": "4.4.2",
     "socket.io": "2.0.3",
-    "wait-until": "0.0.2"
+    "wait-until": "0.0.2",
+    "request": "2.82.0"
   }
 }

--- a/parlai/mturk/core/server/server.js
+++ b/parlai/mturk/core/server/server.js
@@ -11,6 +11,7 @@ const express = require('express');
 const fs = require("fs");
 const nunjucks = require('nunjucks');
 const socketIO = require('socket.io');
+var request = require('request');
 
 const task_directory_name = 'task'
 
@@ -18,12 +19,113 @@ const PORT = process.env.PORT || 3000;
 
 // Initialize app
 const app = express()
+app.use(bodyParser.text());
+app.use(bodyParser.urlencoded({
+    extended: true
+}));
 app.use(bodyParser.json());
 
 nunjucks.configure(task_directory_name, {
     autoescape: true,
     express: app
 });
+
+// ======================= <Socket> =======================
+
+// Start a socket
+const io = socketIO(
+  app.listen(PORT, () => console.log(`Listening on ${ PORT }`))
+);
+
+// Track connections
+var connection_id_to_room_id = {};
+var room_id_to_connection_id = {};
+var NOTIF_ID = 'MTURK_NOTIFICATIONS'
+var global_socket = null;
+
+// Handles sending a message through the socket
+function _send_message(socket, connection_id, event_name, event_data) {
+  // Find the room the connection exists in
+  var connection_room_id = connection_id_to_room_id[connection_id];
+  // Server does not have information about this worker. Should wait for this
+  // worker's agent_alive event instead.
+  if (!connection_room_id) {
+    console.log('Connection room id for ' + connection_id +
+      ' doesn\'t exist! Skipping message.')
+    return;
+  }
+  // Send the message through
+  socket.broadcast.in(connection_room_id).emit(event_name, event_data);
+}
+
+// Connection ids differ when they are heading to or from the world, these
+// functions let the rest of message sending logic remain consistent
+function _get_to_conn_id(data) {
+  var reciever_id = data['receiver_id'];
+  if (reciever_id && reciever_id.startsWith('[World')) {
+    return reciever_id;
+  } else {
+    return reciever_id + '_' + data['assignment_id'];
+  }
+}
+
+function _get_from_conn_id(data) {
+  var sender_id = data['sender_id'];
+  if (sender_id && sender_id.startsWith('[World')) {
+    return sender_id;
+  } else {
+    return sender_id + '_' + data['assignment_id'];
+  }
+}
+
+// Register handlers
+io.on('connection', function (socket) {
+  console.log('Client connected');
+  global_socket = socket;
+
+  // Disconnects are logged
+  socket.on('disconnect', function () {
+    var connection_id = room_id_to_connection_id[socket.id];
+    console.log('Client disconnected: ' + connection_id);
+  });
+
+  // Agent alive events are handled by registering the agent to a connection_id
+  // and then forwarding the alive to the world if it came from a client
+  socket.on('agent alive', function (data, ack) {
+    var sender_id = data['sender_id'];
+    var in_connection_id = _get_from_conn_id(data);
+    var out_connection_id = _get_to_conn_id(data);
+    console.log('agent alive', data);
+    connection_id_to_room_id[in_connection_id] = socket.id;
+    room_id_to_connection_id[socket.id] = in_connection_id;
+    console.log('connection_id ' + in_connection_id + ' registered');
+
+    // Send alive packets to the world, but not from the world
+    if (!(sender_id && sender_id.startsWith('[World'))) {
+      _send_message(socket, out_connection_id, 'new packet', data);
+    }
+    // Acknowledge that the message was recieved
+    if(ack) {
+      ack('agent_alive');
+    }
+  });
+
+  // handles routing a packet to the desired recipient
+  socket.on('route packet', function (data, ack) {
+    console.log('route packet', data);
+    var out_connection_id = _get_to_conn_id(data);
+
+    _send_message(socket, out_connection_id, 'new packet', data);
+    // Acknowledge if required
+    if(ack) {
+      ack('route packet');
+    }
+  });
+
+  socket.emit('socket_open', 'Socket is open!');
+});
+
+// ======================= </Socket> =======================
 
 // ======================= <Routing> =======================
 
@@ -32,6 +134,29 @@ function _load_hit_config() {
   var content = fs.readFileSync(task_directory_name+'/hit_config.json');
   return JSON.parse(content);
 }
+
+
+app.post('/sns_posts', async function (req, res, next) {
+  res.end('Successful POST');
+  console.log(req);
+  if (req.headers['x-amz-sns-message-type'] == 'SubscriptionConfirmation') {
+    var content = JSON.parse(req.body);
+    console.log(content);
+    var confirm_url = content.SubscribeURL;
+    request(confirm_url, function (error, response, body) {
+      if (!error && response.statusCode == 200) {
+        console.log(body)
+      }
+    })
+  } else {
+    console.log(req.query['task_group_id']);
+    var task_group_id = req.query['task_group_id'];
+    var world_id = '[World_' + task_group_id + ']';
+    var content = JSON.parse(req.body);
+    console.log(content);
+    _send_message(global_socket, world_id, 'new packet', content);
+  }
+});
 
 // Renders the chat page by setting up the template_context given the
 // sent params for the request
@@ -84,97 +209,3 @@ app.get('/get_timestamp', function (req, res) {
 });
 
 // ======================= </Routing> =======================
-
-// ======================= <Socket> =======================
-
-// Start a socket
-const io = socketIO(
-  app.listen(PORT, () => console.log(`Listening on ${ PORT }`))
-);
-
-// Track connections
-var connection_id_to_room_id = {};
-var room_id_to_connection_id = {};
-
-// Handles sending a message through the socket
-function _send_message(socket, connection_id, event_name, event_data) {
-  // Find the room the connection exists in
-  var connection_room_id = connection_id_to_room_id[connection_id];
-  // Server does not have information about this worker. Should wait for this
-  // worker's agent_alive event instead.
-  if (!connection_room_id) {
-    console.log('Connection room id for ' + connection_id +
-      ' doesn\'t exist! Skipping message.')
-    return;
-  }
-  // Send the message through
-  socket.broadcast.in(connection_room_id).emit(event_name, event_data);
-}
-
-// Connection ids differ when they are heading to or from the world, these
-// functions let the rest of message sending logic remain consistent
-function _get_to_conn_id(data) {
-  var reciever_id = data['receiver_id'];
-  if (reciever_id && reciever_id.startsWith('[World')) {
-    return reciever_id;
-  } else {
-    return reciever_id + '_' + data['assignment_id'];
-  }
-}
-
-function _get_from_conn_id(data) {
-  var sender_id = data['sender_id'];
-  if (sender_id && sender_id.startsWith('[World')) {
-    return sender_id;
-  } else {
-    return sender_id + '_' + data['assignment_id'];
-  }
-}
-
-// Register handlers
-io.on('connection', function (socket) {
-  console.log('Client connected');
-
-  // Disconnects are logged
-  socket.on('disconnect', function () {
-    var connection_id = room_id_to_connection_id[socket.id];
-    console.log('Client disconnected: ' + connection_id);
-  });
-
-  // Agent alive events are handled by registering the agent to a connection_id
-  // and then forwarding the alive to the world if it came from a client
-  socket.on('agent alive', function (data, ack) {
-    var sender_id = data['sender_id'];
-    var in_connection_id = _get_from_conn_id(data);
-    var out_connection_id = _get_to_conn_id(data);
-    console.log('agent alive', data);
-    connection_id_to_room_id[in_connection_id] = socket.id;
-    room_id_to_connection_id[socket.id] = in_connection_id;
-    console.log('connection_id ' + in_connection_id + ' registered');
-
-    // Send alive packets to the world, but not from the world
-    if (!(sender_id && sender_id.startsWith('[World'))) {
-      _send_message(socket, out_connection_id, 'new packet', data);
-    }
-    // Acknowledge that the message was recieved
-    if(ack) {
-      ack('agent_alive');
-    }
-  });
-
-  // handles routing a packet to the desired recipient
-  socket.on('route packet', function (data, ack) {
-    console.log('route packet', data);
-    var out_connection_id = _get_to_conn_id(data);
-
-    _send_message(socket, out_connection_id, 'new packet', data);
-    // Acknowledge if required
-    if(ack) {
-      ack('route packet');
-    }
-  });
-
-  socket.emit('socket_open', 'Socket is open!');
-});
-
-// ======================= </Socket> =======================

--- a/parlai/mturk/core/server/server.js
+++ b/parlai/mturk/core/server/server.js
@@ -141,7 +141,6 @@ app.post('/sns_posts', async function (req, res, next) {
   console.log(req);
   if (req.headers['x-amz-sns-message-type'] == 'SubscriptionConfirmation') {
     var content = JSON.parse(req.body);
-    console.log(content);
     var confirm_url = content.SubscribeURL;
     request(confirm_url, function (error, response, body) {
       if (!error && response.statusCode == 200) {
@@ -149,12 +148,33 @@ app.post('/sns_posts', async function (req, res, next) {
       }
     })
   } else {
-    console.log(req.query['task_group_id']);
     var task_group_id = req.query['task_group_id'];
     var world_id = '[World_' + task_group_id + ']';
     var content = JSON.parse(req.body);
     console.log(content);
-    _send_message(global_socket, world_id, 'new packet', content);
+    if (content['MessageId'] != '') {
+      var message_id = content['MessageId'];
+      var sender_id = 'AmazonMTurk';
+      var message = JSON.parse(content['Message']);
+      console.log(message);
+      var event_type = message['Events'][0]['EventType'];
+      var assignment_id = message['Events'][0]['AssignmentId'];
+      var data = {
+        text: event_type,
+        id: sender_id,
+        message_id: message_id
+      };
+      var msg = {
+        id: message_id,
+        type: 'message',
+        sender_id: sender_id,
+        assignment_id: assignment_id,
+        conversation_id: 'AmazonSNS',
+        receiver_id: world_id,
+        data: data
+      };
+      _send_message(global_socket, world_id, 'new packet', msg);
+    }
   }
 });
 

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -69,20 +69,28 @@ class Packet():
         """Create a packet from the dictionary that would
         be recieved over a socket
         """
-        packet_id = packet['id']
-        packet_type = packet['type']
-        sender_id = packet['sender_id']
-        receiver_id = packet['receiver_id']
-        assignment_id = packet['assignment_id']
-        data = None
-        if 'data' in packet:
-            data = packet['data']
-        else:
-            data = ''
-        conversation_id = packet['conversation_id']
+        try:
+            packet_id = packet['id']
+            packet_type = packet['type']
+            sender_id = packet['sender_id']
+            receiver_id = packet['receiver_id']
+            assignment_id = packet['assignment_id']
+            data = None
+            if 'data' in packet:
+                data = packet['data']
+            else:
+                data = ''
+            conversation_id = packet['conversation_id']
 
-        return Packet(packet_id, packet_type, sender_id, receiver_id,
-            assignment_id, data, conversation_id)
+            return Packet(packet_id, packet_type, sender_id, receiver_id,
+                assignment_id, data, conversation_id)
+        except:
+            print_and_log(
+                logging.WARN,
+                'Could not create a valid packet out of the dictionary'
+                'provided: {}'.format(packet)
+            )
+            return None
 
     def as_dict(self):
         """Convert a packet into a form that can be pushed over a socket"""
@@ -275,6 +283,8 @@ class SocketManager():
             """Incoming message handler for ACKs, ALIVEs, HEARTBEATs,
             and MESSAGEs"""
             packet = Packet.from_dict(args[0])
+            if packet is None:
+                return
             packet_id = packet.id
             packet_type = packet.type
             connection_id = packet.get_sender_connection_id()

--- a/parlai/mturk/core/test/integration_test/integration_test.py
+++ b/parlai/mturk/core/test/integration_test/integration_test.py
@@ -2643,18 +2643,18 @@ def test_unique_workers_in_conversation(opt, server_url):
 # Map of tests to run to their testing function, slowest tests first reduces
 # overall runtime
 TESTS = {
-    # DUO_NO_ONBOARDING_TEST: test_duo_no_onboarding,
-    # SOLO_ONBOARDING_TEST: test_solo_with_onboarding,
-    # DUO_ONBOARDING_TEST: test_duo_with_onboarding,
-    # EXPIRE_HIT_TEST: test_expire_hit,
-    # DUO_ONE_DISCONNECT_TEST: test_duo_one_disconnect,
-    # DUO_VALID_RECONNECT_TEST: test_duo_valid_reconnects,
-    # UNIQUE_CONVERSATION_TEST: test_unique_workers_in_conversation,
-    # ALLOWED_CONVERSATION_TEST: test_allowed_conversations,
-    # SOLO_REFRESH_TEST: test_solo_refresh_in_middle,
-    # SOLO_NO_ONBOARDING_TEST: test_solo_no_onboarding,
-    # COUNT_COMPLETE_TEST: test_count_complete,
-    # SOCKET_TEST: test_socket_manager,
+    DUO_NO_ONBOARDING_TEST: test_duo_no_onboarding,
+    SOLO_ONBOARDING_TEST: test_solo_with_onboarding,
+    DUO_ONBOARDING_TEST: test_duo_with_onboarding,
+    EXPIRE_HIT_TEST: test_expire_hit,
+    DUO_ONE_DISCONNECT_TEST: test_duo_one_disconnect,
+    DUO_VALID_RECONNECT_TEST: test_duo_valid_reconnects,
+    UNIQUE_CONVERSATION_TEST: test_unique_workers_in_conversation,
+    ALLOWED_CONVERSATION_TEST: test_allowed_conversations,
+    SOLO_REFRESH_TEST: test_solo_refresh_in_middle,
+    SOLO_NO_ONBOARDING_TEST: test_solo_no_onboarding,
+    COUNT_COMPLETE_TEST: test_count_complete,
+    SOCKET_TEST: test_socket_manager,
     AMAZON_SNS_TEST: test_sns_service,
 }
 

--- a/parlai/mturk/core/test/integration_test/integration_test.py
+++ b/parlai/mturk/core/test/integration_test/integration_test.py
@@ -25,6 +25,7 @@ from parlai.mturk.core.socket_manager import Packet, SocketManager
 from parlai.mturk.core.worker_state import WorkerState, AssignState
 from parlai.mturk.core.agents import MTURK_DISCONNECT_MESSAGE
 import parlai.mturk.core.data_model as data_model
+import parlai.mturk.core.mturk_utils as mturk_utils
 from parlai.mturk.core.mturk_utils import create_hit_config
 from socketIO_client_nexus import SocketIO
 import time
@@ -58,6 +59,7 @@ COUNT_COMPLETE_TEST = 'COUNT_COMPLETE_TEST'
 EXPIRE_HIT_TEST = 'EXPIRE_HIT_TEST'
 ALLOWED_CONVERSATION_TEST = 'ALLOWED_CONVERSATION_TEST'
 UNIQUE_CONVERSATION_TEST = 'UNIQUE_CONVERSATION_TEST'
+AMAZON_SNS_TEST = 'AMAZON_SNS_TEST'
 
 FAKE_ASSIGNMENT_ID = 'FAKE_ASSIGNMENT_ID_{}_{}'
 FAKE_WORKER_ID = 'FAKE_WORKER_ID_{}_{}'
@@ -406,6 +408,36 @@ def check_new_agent_setup(agent, mturk_manager,
     assert mturk_manager.socket_manager.socket_is_open(connection_id), \
         'The socket manager didn\'t open a socket for this agent'
 
+
+def test_sns_service(opt, server_url):
+    global completed_threads
+    task_name = AMAZON_SNS_TEST
+    task_group_id = AMAZON_SNS_TEST
+    def world_on_alive(pkt):
+        print("Alive {}".format(pkt))
+
+    def world_on_new_message(pkt):
+        print("Message {}".format(pkt))
+
+    def world_on_socket_dead(worker_id, assign_id):
+        print("Dead {}".format(pkt))
+
+    socket_manager = SocketManager(
+        server_url,
+        PORT,
+        world_on_alive,
+        world_on_new_message,
+        world_on_socket_dead,
+        task_group_id
+    )
+
+    mturk_utils.setup_aws_credentials()
+    arn = mturk_utils.setup_sns_topic(task_name, server_url, task_group_id)
+    mturk_utils.send_test_notif(arn, 'AssignmentAbandoned')
+    mturk_utils.send_test_notif(arn, 'AssignmentReturned')
+    mturk_utils.send_test_notif(arn, 'AssignmentSubmitted')
+    mturk_utils.delete_sns_topic(arn)
+    completed_threads[AMAZON_SNS_TEST] = True
 
 def test_socket_manager(opt, server_url):
     global completed_threads
@@ -2611,18 +2643,19 @@ def test_unique_workers_in_conversation(opt, server_url):
 # Map of tests to run to their testing function, slowest tests first reduces
 # overall runtime
 TESTS = {
-    DUO_NO_ONBOARDING_TEST: test_duo_no_onboarding,
-    SOLO_ONBOARDING_TEST: test_solo_with_onboarding,
-    DUO_ONBOARDING_TEST: test_duo_with_onboarding,
-    EXPIRE_HIT_TEST: test_expire_hit,
-    DUO_ONE_DISCONNECT_TEST: test_duo_one_disconnect,
-    DUO_VALID_RECONNECT_TEST: test_duo_valid_reconnects,
-    UNIQUE_CONVERSATION_TEST: test_unique_workers_in_conversation,
-    ALLOWED_CONVERSATION_TEST: test_allowed_conversations,
-    SOLO_REFRESH_TEST: test_solo_refresh_in_middle,
-    SOLO_NO_ONBOARDING_TEST: test_solo_no_onboarding,
-    COUNT_COMPLETE_TEST: test_count_complete,
-    SOCKET_TEST: test_socket_manager
+    # DUO_NO_ONBOARDING_TEST: test_duo_no_onboarding,
+    # SOLO_ONBOARDING_TEST: test_solo_with_onboarding,
+    # DUO_ONBOARDING_TEST: test_duo_with_onboarding,
+    # EXPIRE_HIT_TEST: test_expire_hit,
+    # DUO_ONE_DISCONNECT_TEST: test_duo_one_disconnect,
+    # DUO_VALID_RECONNECT_TEST: test_duo_valid_reconnects,
+    # UNIQUE_CONVERSATION_TEST: test_unique_workers_in_conversation,
+    # ALLOWED_CONVERSATION_TEST: test_allowed_conversations,
+    # SOLO_REFRESH_TEST: test_solo_refresh_in_middle,
+    # SOLO_NO_ONBOARDING_TEST: test_solo_no_onboarding,
+    # COUNT_COMPLETE_TEST: test_count_complete,
+    # SOCKET_TEST: test_socket_manager,
+    AMAZON_SNS_TEST: test_sns_service,
 }
 
 # Runtime threads, MAX_THREADS is used on initial pass, RETEST_THREADS is used


### PR DESCRIPTION
Amazon mechanical turk recently released an API for receiving notification messages for assignment lifecycle events. These notifications can be delivered directly to the heroku server, and then pushed forward to the terminal that is running the collection script. Thus we have a non-polling (and also faster) workflow for updating assignment state, though we still poll at a reduced rate to ensure that we catch up if a message is somehow lost.

This also includes updates to our MTurk docs.