### PR TITLE
Yield final x value in FBDialogTeacher

### DIFF
--- a/parlai/core/fbdialog_teacher.py
+++ b/parlai/core/fbdialog_teacher.py
@@ -203,3 +203,5 @@ class FbDialogTeacher(DialogTeacher):
                     # reset x in case there is unlabeled data still left
                     x = ''
                     reward = 0
+            if x:
+                yield [x, None, reward], start


### PR DESCRIPTION
Adds a condition to setup_data in FBDialogTeacher to yield the final line in a dataset if 'x' is non empty