### PR TITLE
Some quality of life improvements for ParlAI MTurk

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -401,6 +401,8 @@ class MTurkManager():
 
     def _handle_mturk_message(self, pkt):
         assignment_id = pkt.assignment_id
+        if assignment_id not in self.assignment_to_worker_id:
+            return
         worker_id = self.assignment_to_worker_id[assignment_id]
         mturk_event_type = pkt.data['text']
         agent = self._get_agent(worker_id, assignment_id)
@@ -666,6 +668,10 @@ class MTurkManager():
             )
         self.task_files_to_copy.append(
             os.path.join(task_directory_path, 'html', 'cover_page.html'))
+        for file_name in os.listdir(os.path.join(task_directory_path, 'html')):
+            self.task_files_to_copy.append(os.path.join(
+                task_directory_path, 'html', file_name
+            ))
         for mturk_agent_id in self.mturk_agent_ids + ['onboarding']:
             self.task_files_to_copy.append(os.path.join(
                 task_directory_path,
@@ -676,7 +682,7 @@ class MTurkManager():
         # Setup the server with a likely-unique app-name
         task_name = '{}-{}'.format(str(uuid.uuid4())[:8], self.opt['task'])
         self.server_task_name = \
-            ''.join(e for e in task_name if e.isalnum() or e == '-')
+            ''.join(e for e in task_name.lower() if e.isalnum() or e == '-')
         self.server_url = server_utils.setup_server(self.server_task_name,
                                                     self.task_files_to_copy)
         shared_utils.print_and_log(logging.INFO, self.server_url)

--- a/parlai/mturk/core/server/html/core.html
+++ b/parlai/mturk/core/server/html/core.html
@@ -757,7 +757,9 @@
       'data': null
     };
 
-    socket.emit(SOCKET_ROUTE_PACKET_STRING, hb, function() {last_local_heartbeat=Date.now();});
+    socket.emit(SOCKET_ROUTE_PACKET_STRING, hb, function() {
+      last_local_heartbeat=Date.now();
+    });
 
     // Check to see if we've disconnected from the server
     if (last_local_heartbeat != null &&

--- a/parlai/mturk/core/server/html/core.html
+++ b/parlai/mturk/core/server/html/core.html
@@ -108,7 +108,8 @@
   var STATUS_ACK = 'ack';
   var STATUS_INIT = 'init';
   var STATUS_SENT = 'sent';
-  var SERVER_HEARTBEAT_TIMEOUT = 8000 // 8 Seconds before we assume we died
+  var SERVER_HEARTBEAT_TIMEOUT = 80000 // 80 Sec before we think manager died
+  var LOCAL_HEARTBEAT_TIMEOUT = 16000 // 16 Seconds before we assume we died
 
   /* ================= State variables ================= */
 
@@ -125,6 +126,7 @@
   var blocking_id = null;
   var blocking_sent_time = null;
   var last_server_heartbeat = null;
+  var last_local_heartbeat = null;
   var displayed_messages = [];
 
   var is_cover_page = ("{{is_cover_page}}" === 'true') ? true : false;
@@ -331,7 +333,7 @@
   /* ================= UI handlers ================= */
 
   // On window resize, ensure that the UI is properly displayed
-  $(window).resize(function() {
+  function window_resize() {
     log("The window was resized", 4);
     // Set the text input width to match the bottom width minus space
     // for the done button
@@ -342,7 +344,8 @@
     var left_height = $("div#left-pane").height();
     var text_height = $("div#right-bottom-pane").outerHeight()
     $("div#right-top-pane").height((left_height - text_height) - 20);
-  });
+  }
+  $(window).resize(window_resize);
 
   // Handling keypress event for enter detection
   $(document).keypress(function(e) {
@@ -630,6 +633,7 @@
     }
   }
 
+  {% block handle_new_message %}
   // Handles an incoming message
   function handle_new_message(new_message_id, message) {
     var agent_id = message.id;
@@ -648,6 +652,7 @@
       add_message_to_conversation(agent_id, message_text, true);
     }
   }
+  {% endblock %}
 
   // Handle submitting a message
   $("button#id_send_msg_button").on('click', function () {
@@ -752,11 +757,11 @@
       'data': null
     };
 
-    socket.emit(SOCKET_ROUTE_PACKET_STRING, hb);
+    socket.emit(SOCKET_ROUTE_PACKET_STRING, hb, function() {last_local_heartbeat=Date.now();});
 
     // Check to see if we've disconnected from the server
-    if (last_server_heartbeat != null &&
-        Date.now() - last_server_heartbeat > SERVER_HEARTBEAT_TIMEOUT) {
+    if (last_local_heartbeat != null &&
+        Date.now() - last_local_heartbeat > LOCAL_HEARTBEAT_TIMEOUT) {
       close_socket();
       set_inactive_text('You have disconnected from the server, \
         please return this HIT and take a new one if you want to keep \

--- a/parlai/mturk/core/server/server.js
+++ b/parlai/mturk/core/server/server.js
@@ -209,7 +209,9 @@ app.get('/chat_index', async function (req, res) {
 
       // Load custom pages by the mturk_agent_id if the custom pages exist
       var custom_index_page = mturk_agent_id + '_index.html';
+      console.log('custom_index_page:' + custom_index_page)
       if (fs.existsSync(task_directory_name+'/'+custom_index_page)) {
+        console.log('rendering custom page:' + custom_index_page)
         res.render(custom_index_page, template_context);
       } else {
         res.render('mturk_index.html', template_context);

--- a/parlai/mturk/core/server/server.js
+++ b/parlai/mturk/core/server/server.js
@@ -209,9 +209,7 @@ app.get('/chat_index', async function (req, res) {
 
       // Load custom pages by the mturk_agent_id if the custom pages exist
       var custom_index_page = mturk_agent_id + '_index.html';
-      console.log('custom_index_page:' + custom_index_page)
       if (fs.existsSync(task_directory_name+'/'+custom_index_page)) {
-        console.log('rendering custom page:' + custom_index_page)
         res.render(custom_index_page, template_context);
       } else {
         res.render('mturk_index.html', template_context);


### PR DESCRIPTION
Fixes broken handling of non-blocking MTurk agents

Fixes server breaking from receiving messages from older amazon SNS queues

Fixes proper loading of custom html files on run

Makes agent-side disconnects more lenient, as if they are connected to heroku but haven't received a heartbeat from the manager they aren't considered dead unless the manager confirms it. Prevents telling someone they disconnected when we were the ones who disconnected.

Lets `handle_new_message` be directly overridable

Makes resize_window not an anonymous function so that it can be indirectly overridden in additional javascript