### PR TITLE
Small fix in fbdialog_teacher

### DIFF
--- a/parlai/core/fbdialog_teacher.py
+++ b/parlai/core/fbdialog_teacher.py
@@ -180,7 +180,7 @@ class FbDialogTeacher(DialogTeacher):
                         x = '{x}\n{next_x}'.format(x=x, next_x=split[0])
                     else:
                         x = split[0]
-                if len(split) > 2:
+                if len(split) > 2 and split[2]:
                     reward += float(split[2])
 
                 if len(split) > 1 and split[1]:


### PR DESCRIPTION
Make sure there is a check that split[2] is not 'None' before casting it to a float