### PR TITLE
add model-reported metrics, add dot attention & fix a few bugs in s2s

### DIFF
--- a/examples/interactive.py
+++ b/examples/interactive.py
@@ -25,7 +25,6 @@ def main():
 
     # Get command line arguments
     parser = ParlaiParser(True, True)
-    parser.add_argument('-n', '--num-examples', default=1000)
     parser.add_argument('-d', '--display-examples', type='bool', default=False)
     opt = parser.parse_args()
     opt['task'] = 'parlai.agents.local_human.local_human:LocalHumanAgent'
@@ -35,7 +34,7 @@ def main():
     world = create_task(opt, agent)
 
     # Show some example dialogs:
-    for k in range(int(opt['num_examples'])):
+    while True:
         world.parley()
         if opt['display_examples']:
             print("---")
@@ -43,7 +42,6 @@ def main():
         if world.epoch_done():
             print("EPOCH DONE")
             break
-    world.shutdown()
 
 if __name__ == '__main__':
     main()

--- a/examples/profile.py
+++ b/examples/profile.py
@@ -3,64 +3,72 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
-"""Run the pytorch profiler and prints the results.
+"""Run the python or pytorch profiler and prints the results.
 
 For example, to make sure that bAbI task 1 (1k exs) loads one can run and to
 see a few of them:
 `python examples/profile.py -t babi:task1k:1 -m seq2seq -e 0.1 --dict-file /tmp/dict`'
 """
 
+import cProfile
+import io
 import pdb
+import pstats
 import torch
 from train_model import setup_args as train_args
 from train_model import main as train
 
+
 def setup_args():
     parser = train_args()
     profile = parser.add_argument_group('Profiler Arguments')
-    profile.add_argument('--use-nvprof', type='bool', default=False,
-                         help='If True, uses nvprof (might incur high overhead'
-                              ' and assumes that the whole process is running '
-                              'inside nvprof), otherwise uses a custom '
-                              'CPU-only profiler (with negligible overhead). '
-                              'Default: False.')
-    profile.add_argument('--trace-path', type=str, default=None,
-                         help='A path of the CUDA checkpoint. If specified, it'
-                              ' will be left unmodified after profiling '
-                              'finishes, so it can be opened and inspected in '
-                              'nvvp. Otherwise it will be created in a '
-                              'temporary directory and removed after reading '
-                              'the results.')
+    profile.add_argument('--torch', type='bool', default=False,
+                         help='If true, use the torch profiler. Otherwise use '
+                              'use cProfile.')
     profile.add_argument('--debug', type='bool', default=False,
                          help='If true, enter debugger at end of run.')
     return parser
 
+
 def main(parser):
     opt = parser.parse_args()
-    with torch.autograd.profiler.profile(
-        use_nvprof=opt['use_nvprof'], trace_path=opt['trace_path']
-    ) as prof:
+
+    if opt['torch']:
+        with torch.autograd.profiler.profile() as prof:
+            train(parser)
+        print(prof.total_average())
+
+        sort_cpu = sorted(prof.key_averages(), key=lambda k: k.cpu_time)
+        sort_cuda = sorted(prof.key_averages(), key=lambda k: k.cuda_time)
+
+        def cpu():
+            for e in sort_cpu:
+                print(e)
+
+        def cuda():
+            for e in sort_cuda:
+                print(e)
+
+        cpu()
+
+        if opt['debug']:
+            print('`cpu()` prints out cpu-sorted list, '
+                  '`cuda()` prints cuda-sorted list')
+
+            pdb.set_trace()
+    else:
+        pr = cProfile.Profile()
+        pr.enable()
         train(parser)
-    print(prof.total_average())
+        pr.disable()
+        s = io.StringIO()
+        sortby = 'cumulative'
+        ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
+        ps.print_stats()
+        print(s.getvalue())
+        if opt['debug']:
+            pdb.set_trace()
 
-    sort_cpu = sorted(prof.key_averages(), key=lambda k: k.cpu_time)
-    sort_cuda = sorted(prof.key_averages(), key=lambda k: k.cuda_time)
-
-    def cpu():
-        for e in sort_cpu:
-            print(e)
-
-    def cuda():
-        for e in sort_cuda:
-            print(e)
-
-    cpu()
-
-    if opt['debug']:
-        print('`cpu()` prints out cpu-sorted list, '
-              '`cuda()` prints cuda-sorted list')
-
-        pdb.set_trace()
 
 if __name__ == '__main__':
     main(setup_args())

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -104,7 +104,7 @@ class Teacher(Agent):
 
     def __init__(self, opt, shared=None):
         if not hasattr(self, 'opt'):
-             self.opt = copy.deepcopy(opt)
+            self.opt = copy.deepcopy(opt)
         if not hasattr(self, 'id'):
             self.id = opt.get('task', 'teacher')
         if not hasattr(self, 'metrics'):
@@ -129,7 +129,7 @@ class Teacher(Agent):
     # return state/action dict based upon passed state
     def act(self):
         if self.observation is not None and 'text' in self.observation:
-            t = { 'text': 'Hello agent!' }
+            t = {'text': 'Hello agent!'}
         return t
 
     def epoch_done(self):
@@ -137,8 +137,7 @@ class Teacher(Agent):
 
     # Return transformed metrics showing total examples and accuracy if avail.
     def report(self):
-        report = self.metrics.report()
-        return report
+        return self.metrics.report()
 
     def reset(self):
         super().reset()

--- a/parlai/core/dialog_teacher.py
+++ b/parlai/core/dialog_teacher.py
@@ -97,7 +97,7 @@ class DialogTeacher(Teacher):
         return None
 
     def observe(self, observation):
-        """Process observation for metrics. """
+        """Process observation for metrics."""
         if self.lastY is not None:
             self.metrics.update(observation, self.lastY)
             self.lastY = None

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -11,7 +11,6 @@ import copy
 import numpy as np
 import nltk
 import os
-import re
 
 
 def escape(s):
@@ -236,7 +235,6 @@ class DictionaryAgent(Agent):
 
     def _sent_tokenize(self, text, building=False):
         """Uses nltk-trained PunktTokenizer for sentence tokenization"""
-        text = text.replace('|', ' ' if building else ' __pipe__ ')
         return self.sent_tok.tokenize(text)
 
     def _word_tokenize(self, text, building=False):

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -5,7 +5,6 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 import math
-import sys
 import time
 
 
@@ -82,8 +81,11 @@ class Timer(object):
             return self.total + time.time() - self.start
         return self.total
 
-
 def round_sigfigs(x, sigfigs=4):
-    if x == 0:
-        return 0
+    try:
+        if x == 0:
+            return 0
+    except RuntimeError:
+        # handle 1D torch tensors
+        x = x[0]
     return round(x, -math.floor(math.log10(abs(x)) - sigfigs + 1))


### PR DESCRIPTION
with this metric change, if the model returns any metrics (e.g. `{'text': my_guess, 'metrics': {'loss': loss}}`) then those metrics will be available in metrics instance. This allows a model to send back loss, perplexity, or any other calculations to be shown in the logs or used as a validation metric. Models cannot overwrite `accuracy` or `f1`.

Also added "dot" attention to seq2seq, fixed a few small bugs, added option to do language model training "only".