### PR TITLE
Improve loading time for images

### DIFF
--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -9,6 +9,7 @@ import os
 import copy
 import numpy as np
 from PIL import Image
+from functools import lru_cache
 
 _greyscale = '  .,:;crsA23hHG#98&@'
 
@@ -121,6 +122,7 @@ class ImageLoader():
             asc.append('\n')
         return ''.join(asc)
 
+    @lru_cache(maxsize=None)
     def load(self, path):
         opt = self.opt
         mode = opt.get('image_mode', 'raw')


### PR DESCRIPTION
By including an lru_cache, a task can load images into memory for quicker access in the future

This commit resolves #357, assuming one has enough memory for all the images seen during training