### PR TITLE
MTurk Qualifications

### DIFF
--- a/docs/source/mturk.rst
+++ b/docs/source/mturk.rst
@@ -135,10 +135,19 @@ Additional flags can be used for more specific purposes.
 - ``--count-complete`` only counts completed assignments towards the num_conversations requested. This may lead to more conversations being had than requested (and thus higher costs for instances where one Turker disconnects and we pay the other) but it ensures that if you request 1,000 conversations you end up with at least 1,000 completed data points.
 
 
+Handling Turker Disconnects
+---------------------------
+Sometimes you may find that a task you have created is leading to a lot of workers disconnecting in the middle of a conversation, or that a few people are disconnecting repeatedly. ParlAI MTurk offers two kinds of blocks to stop these workers from doing your hits.
+
+- soft blocks can be created by using the ``--block-qualification <name>`` flag with a name that you want to associate to your ParlAI tasks. Any user that hits the disconnect cap for a HIT with this flag active will not be able to participate in any HITs using this flag.
+
+- hard blocks can be used by setting the ``--hard-block`` flag. Soft blocks in general are preferred, as Turkers can be block-averse (as it may affect their reputation) and sometimes the disconnects are out of their control. This will prevent any Turkers that hit the disconnect cap with this flag active from participating in any of your future HITs of any type.
+
+
 Reviewing Turker's Work
 -----------------------
 
-After all HITs are completed, you will be provided a webpage link to review them.
+After all HITs are completed, you can review the work through Amazon's online interface. You can also programmatically review work using the commands available in the `MTurkManager` class.
 
 If you don't take any action in 4 weeks, all HITs will be auto-approved and Turkers will be paid.
 

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -117,9 +117,19 @@ class ParlaiParser(argparse.ArgumentParser):
             '--verbose', dest='verbose', action='store_true',
             help='print all messages sent to and from Turkers')
         mturk.add_argument(
+            '--hard-block', dest='hard_block', action='store_true',
+            default=False,
+            help='Hard block disconnecting Turkers from all of your HITs')
+        mturk.add_argument(
             '--log-level', dest='log_level', type=int, default=20,
             help='importance level for what to put into the logs. the lower '
                  'the level the more that gets logged. values are 0-50')
+        mturk.add_argument(
+            '--block-qualification', dest='block_qualification', default='',
+            help='Qualification to use for soft blocking users. By default '
+                 'turkers are never blocked, though setting this will allow '
+                 'you to filter out turkers that have disconnected too many '
+                 'times on previous HITs where this qualification was set.')
         mturk.add_argument(
             '--count-complete', dest='count_complete',
             default=False, action='store_true',

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -151,13 +151,20 @@ class MTurkManager():
                     self.block_worker(worker_id, text)
                     shared_utils.print_and_log(
                         logging.INFO,
-                        'Worker {} was blocked - too many disconnects'.format(
+                        'Worker {} blocked - too many disconnects'.format(
                             worker_id
                         ),
                         True
                     )
                 elif self.opt['block_qualification'] != '':
                     self.soft_block_worker(worker_id)
+                    shared_utils.print_and_log(
+                        logging.INFO,
+                        'Worker {} soft blocked - too many disconnects'.format(
+                            worker_id
+                        ),
+                        True
+                    )
 
     def _get_agent_from_pkt(self, pkt):
         """Get sender, assignment, and conv ids from a packet"""
@@ -1106,19 +1113,30 @@ class MTurkManager():
         """Give a worker a particular qualification"""
         qual_id = mturk_utils.find_qualification(qual_name)
         if qual_id is False or qual_id is None:
-            print(
+            shared_utils.print_and_log(
+                logging.WARN,
                 'Could not give worker {} qualification {}, as the '
                 'qualification could not be found to exist.'
+                ''.format(worker_id, qual_name),
+                should_print=True
             )
             return
         mturk_utils.give_worker_qualification(worker_id, qual_id, qual_value)
 
     def create_qualification(self, qualification_name, description,
                              can_exist=True):
+        """Create a new qualification. If can_exist is set, simply return
+        the ID of the existing qualification rather than throw an error
+        """
         if not can_exist:
             qual_id = mturk_utils.find_qualification(qualification_name)
             if qual_id is not None:
-                print('Could not create qualification, as it existed')
+                shared_utils.print_and_log(
+                    logging.WARN,
+                    'Could not create qualification {}, as it existed'
+                    ''.format(qualification_name),
+                    should_print=True
+                )
                 return None
         return mturk_utils.find_or_create_qualification(
             qualification_name,

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -174,8 +174,117 @@ def get_mturk_client(is_sandbox):
     return client
 
 
+def delete_qualification(qualification_id):
+    """Deletes a qualification by name"""
+    client = boto3.client(
+        service_name='mturk',
+        region_name='us-east-1',
+        endpoint_url='https://mturk-requester-sandbox.us-east-1.amazonaws.com'
+    )
+    client.delete_qualification_type(
+        QualificationTypeId=qualification_id
+    )
+
+
+def find_qualification(qualification_name, must_be_owned=True):
+    """Query amazon to find the existing qualification name, return the Id,
+    otherwise return none.
+    If must_be_owned is true, it only returns qualifications owned by the user.
+    Will return False if it finds another's qualification
+    """
+    client = boto3.client(
+        service_name='mturk',
+        region_name='us-east-1',
+        endpoint_url='https://mturk-requester-sandbox.us-east-1.amazonaws.com'
+    )
+
+    # Search for the qualification owned by the current user
+    response = client.list_qualification_types(
+        Query=qualification_name,
+        MustBeRequestable=True,
+        MustBeOwnedByCaller=True,
+    )
+
+    for qualification in response['QualificationTypes']:
+        if qualification['Name'] == qualification_name:
+            return qualification['QualificationTypeId']
+
+    # Qualification was not found to exist, check to see if someone else has it
+    response = client.list_qualification_types(
+        Query=qualification_name,
+        MustBeRequestable=True,
+        MustBeOwnedByCaller=False,
+    )
+
+    for qualification in response['QualificationTypes']:
+        if qualification['Name'] == qualification_name:
+            if must_be_owned:
+                print(
+                    'Sorry, the qualification name {} is already owned, '
+                    'please use a different name for your qualification.'
+                    ''.format(qualification_name)
+                )
+                return False
+            return qualification['QualificationTypeId']
+    return None
+
+
+def find_or_create_qualification(qualification_name, description,
+                                 must_be_owned=True):
+    """Query amazon to find the existing qualification name, return the Id. If
+    it exists and must_be_owned is true but we don't own it, this prints an
+    error and returns none. If it doesn't exist, the qualification is created
+    """
+    qual_id = find_qualification(
+        qualification_name,
+        must_be_owned=must_be_owned
+    )
+
+    if qual_id is False:
+        return None
+    if qual_id is not None:
+        return qual_id
+
+    # Create the qualification, as it doesn't exist yet
+    client = boto3.client(
+        service_name='mturk',
+        region_name='us-east-1',
+        endpoint_url='https://mturk-requester-sandbox.us-east-1.amazonaws.com'
+    )
+    response = client.create_qualification_type(
+        Name=qualification_name,
+        Description=description,
+        QualificationTypeStatus='Active',
+    )
+    return response['QualificationType']['QualificationTypeId']
+
+
+def give_worker_qualification(worker_id, qualification_id, value=None):
+    """Gives a qualification to the given worker"""
+    client = boto3.client(
+        service_name='mturk',
+        region_name='us-east-1',
+        endpoint_url='https://mturk-requester-sandbox.us-east-1.amazonaws.com'
+    )
+
+    if value is not None:
+        client.associate_qualification_with_worker(
+            QualificationTypeId='string',
+            WorkerId='string',
+            IntegerValue=value,
+            SendNotification=False
+        )
+    else:
+        client.associate_qualification_with_worker(
+            QualificationTypeId='string',
+            WorkerId='string',
+            SendNotification=False
+        )
+
+
 def create_hit_type(hit_title, hit_description, hit_keywords, hit_reward,
-                    assignment_duration_in_seconds, is_sandbox):
+                    assignment_duration_in_seconds, is_sandbox,
+                    qualifications=None):
     """Create a HIT type to be used to generate HITs of the requested params"""
     client = boto3.client(
         service_name='mturk',
@@ -200,6 +309,8 @@ def create_hit_type(hit_title, hit_description, hit_keywords, hit_reward,
         ],
         'RequiredToPreview': True
     }]
+    if qualifications is not None:
+        localRequirements += qualifications
 
     # Create the HIT type
     response = client.create_hit_type(

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -175,7 +175,7 @@ def get_mturk_client(is_sandbox):
 
 
 def delete_qualification(qualification_id):
-    """Deletes a qualification by name"""
+    """Deletes a qualification by id"""
     client = boto3.client(
         service_name='mturk',
         region_name='us-east-1',
@@ -260,7 +260,7 @@ def find_or_create_qualification(qualification_name, description,
 
 
 def give_worker_qualification(worker_id, qualification_id, value=None):
-    """Gives a qualification to the given worker"""
+    """Give a qualification to the given worker"""
     client = boto3.client(
         service_name='mturk',
         region_name='us-east-1',

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -64,7 +64,6 @@ class Packet():
         self.ack_func = ack_func
         self.status = self.STATUS_INIT
         self.time = None
-        self.alive = False
 
     @staticmethod
     def from_dict(packet):
@@ -196,6 +195,7 @@ class SocketManager():
         self.run = {}
         self.last_heartbeat = {}
         self.packet_map = {}
+        self.alive = False
 
         # setup the socket
         self._setup_socket()

--- a/parlai/mturk/core/test/integration_test/integration_test.py
+++ b/parlai/mturk/core/test/integration_test/integration_test.py
@@ -56,7 +56,6 @@ EXPIRE_HIT_TEST = 'EXPIRE_HIT_TEST'
 ALLOWED_CONVERSATION_TEST = 'ALLOWED_CONVERSATION_TEST'
 UNIQUE_CONVERSATION_TEST = 'UNIQUE_CONVERSATION_TEST'
 AMAZON_SNS_TEST = 'AMAZON_SNS_TEST'
-AMAZON_QUALIFICATION_TEST = 'AMAZON_QUALIFICATION_TEST'
 
 FAKE_ASSIGNMENT_ID = 'FAKE_ASSIGNMENT_ID_{}_{}'
 FAKE_WORKER_ID = 'FAKE_WORKER_ID_{}_{}'
@@ -456,10 +455,6 @@ def test_sns_service(opt, server_url):
     mturk_utils.delete_sns_topic(arn)
 
     completed_threads[AMAZON_SNS_TEST] = True
-
-
-def test_qualifications(opt, server_url):
-    completed_threads[AMAZON_QUALIFICATION_TEST] = True
 
 
 def test_socket_manager(opt, server_url):

--- a/parlai/mturk/core/test/integration_test/integration_test.py
+++ b/parlai/mturk/core/test/integration_test/integration_test.py
@@ -22,7 +22,7 @@ from parlai.mturk.core.test.integration_test.worlds import TestOnboardWorld, \
 from parlai.mturk.core.mturk_manager import MTurkManager, WORLD_START_TIMEOUT
 from parlai.mturk.core.server_utils import setup_server, delete_server
 from parlai.mturk.core.socket_manager import Packet, SocketManager
-from parlai.mturk.core.worker_state import WorkerState, AssignState
+from parlai.mturk.core.worker_state import AssignState
 from parlai.mturk.core.agents import MTURK_DISCONNECT_MESSAGE
 import parlai.mturk.core.data_model as data_model
 import parlai.mturk.core.mturk_utils as mturk_utils
@@ -30,12 +30,8 @@ from parlai.mturk.core.mturk_utils import create_hit_config
 from socketIO_client_nexus import SocketIO
 import time
 import os
-import importlib
-import copy
 import uuid
 import threading
-from itertools import product
-from joblib import Parallel, delayed
 
 TEST_TASK_DESCRIPTION = 'This is a test task description'
 MTURK_AGENT_IDS = ['TEST_USER_1', 'TEST_USER_2']
@@ -60,6 +56,7 @@ EXPIRE_HIT_TEST = 'EXPIRE_HIT_TEST'
 ALLOWED_CONVERSATION_TEST = 'ALLOWED_CONVERSATION_TEST'
 UNIQUE_CONVERSATION_TEST = 'UNIQUE_CONVERSATION_TEST'
 AMAZON_SNS_TEST = 'AMAZON_SNS_TEST'
+AMAZON_QUALIFICATION_TEST = 'AMAZON_QUALIFICATION_TEST'
 
 FAKE_ASSIGNMENT_ID = 'FAKE_ASSIGNMENT_ID_{}_{}'
 FAKE_WORKER_ID = 'FAKE_WORKER_ID_{}_{}'
@@ -69,8 +66,10 @@ DISCONNECT_WAIT_TIME = SocketManager.DEF_SOCKET_TIMEOUT + 1.5
 completed_threads = {}
 start_times = {}
 
+
 def dummy(*args):
     pass
+
 
 class MockAgent(object):
     """Class that pretends to be an MTurk agent interacting through the
@@ -144,12 +143,16 @@ class MockAgent(object):
 
     def setup_socket(self, server_url, message_handler):
         """Sets up a socket for an agent"""
+
         def on_socket_open(*args):
             self.send_alive()
+
         def on_new_message(*args):
             message_handler(args[0])
+
         def on_disconnect(*args):
             self.disconnected = True
+
         self.socketIO = SocketIO(server_url, PORT)
         # Register Handlers
         self.socketIO.on(data_model.SOCKET_OPEN_STRING, on_socket_open)
@@ -167,7 +170,7 @@ class MockAgent(object):
             'id': str(uuid.uuid4()),
             'receiver_id': '[World_' + self.task_group_id + ']',
             'assignment_id': self.assignment_id,
-            'sender_id' : self.worker_id,
+            'sender_id': self.worker_id,
             'conversation_id': self.conversation_id,
             'type': Packet.TYPE_HEARTBEAT,
             'data': None
@@ -258,6 +261,7 @@ def run_solo_world(opt, mturk_manager, is_onboarded):
             workers[0].id = MTURK_SOLO_WORKER
 
         global run_conversation
+
         def run_conversation(mturk_manager, opt, workers):
             task = opt['task']
             mturk_agent = workers[0]
@@ -271,7 +275,7 @@ def run_solo_world(opt, mturk_manager, is_onboarded):
             assign_role_function=assign_worker_roles,
             task_function=run_conversation
         )
-    except:
+    except Exception:
         raise
     finally:
         pass
@@ -303,6 +307,7 @@ def run_duo_world(opt, mturk_manager, is_onboarded):
                 worker.id = MTURK_DUO_WORKER
 
         global run_conversation
+
         def run_conversation(mturk_manager, opt, workers):
             world = TestDuoWorld(opt=opt, agents=workers)
             while not world.episode_done():
@@ -314,7 +319,7 @@ def run_duo_world(opt, mturk_manager, is_onboarded):
             assign_role_function=assign_worker_roles,
             task_function=run_conversation
         )
-    except:
+    except Exception:
         raise
     finally:
         pass
@@ -411,33 +416,51 @@ def check_new_agent_setup(agent, mturk_manager,
 
 def test_sns_service(opt, server_url):
     global completed_threads
+    print('{} Starting'.format(AMAZON_SNS_TEST))
     task_name = AMAZON_SNS_TEST
     task_group_id = AMAZON_SNS_TEST
-    def world_on_alive(pkt):
-        print("Alive {}".format(pkt))
+    messages = 0
 
     def world_on_new_message(pkt):
-        print("Message {}".format(pkt))
-
-    def world_on_socket_dead(worker_id, assign_id):
-        print("Dead {}".format(pkt))
+        nonlocal messages  # noqa: E999 we don't support python2
+        messages += 1
 
     socket_manager = SocketManager(
         server_url,
         PORT,
-        world_on_alive,
+        dummy,
         world_on_new_message,
-        world_on_socket_dead,
+        dummy,
         task_group_id
     )
+
+    # Wait for manager to spin up
+    last_time = time.time()
+    while not socket_manager.alive:
+        time.sleep(0.2)
+        assert time.time() - last_time < 10, \
+            'Timed out wating for socket_manager to spin up'
 
     mturk_utils.setup_aws_credentials()
     arn = mturk_utils.setup_sns_topic(task_name, server_url, task_group_id)
     mturk_utils.send_test_notif(arn, 'AssignmentAbandoned')
     mturk_utils.send_test_notif(arn, 'AssignmentReturned')
     mturk_utils.send_test_notif(arn, 'AssignmentSubmitted')
+    last_time = time.time()
+    while messages != 3:
+        # Wait for manager to catch up
+        time.sleep(0.2)
+        assert time.time() - last_time < 30, \
+            'Timed out wating for amazon message'
+
     mturk_utils.delete_sns_topic(arn)
+
     completed_threads[AMAZON_SNS_TEST] = True
+
+
+def test_qualifications(opt, server_url):
+    completed_threads[AMAZON_QUALIFICATION_TEST] = True
+
 
 def test_socket_manager(opt, server_url):
     global completed_threads
@@ -458,7 +481,7 @@ def test_socket_manager(opt, server_url):
         assign_id = pkt.data['assignment_id']
         assert assign_id == ASSIGN_1_ID, 'Assign id was {}'.format(assign_id)
         conversation_id = pkt.data['conversation_id']
-        assert conversation_id == None, \
+        assert conversation_id is None, \
             'Conversation id was {}'.format(conversation_id)
         # Start a channel
         socket_manager.open_channel(worker_id, assign_id)
@@ -630,7 +653,7 @@ def test_solo_with_onboarding(opt, server_url):
     mturk_agent_id = AGENT_1_ID
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_id]
+        mturk_agent_ids=[mturk_agent_id]
     )
     mturk_manager.server_url = server_url
     mturk_manager.start_new_run()
@@ -691,7 +714,7 @@ def test_solo_with_onboarding(opt, server_url):
         'Agent disconnected in onboarding didn\'t get inactive hit'
     assert assign_state.status == AssignState.STATUS_DISCONNECT, \
         'Disconnected agent not marked as so in state'
-    assert mturk_manager_assign.disconnected == True, \
+    assert mturk_manager_assign.disconnected is True, \
         'Disconnected agent not marked as so in agent'
 
     # Connect with a new agent and finish onboarding
@@ -754,7 +777,7 @@ def test_solo_with_onboarding(opt, server_url):
     check_status(assign_state.status, AssignState.STATUS_DONE)
     wait_for_state_time(DISCONNECT_WAIT_TIME, mturk_manager)
     check_status(assign_state.status, AssignState.STATUS_DONE)
-    assert mturk_manager_assign.disconnected == False, \
+    assert mturk_manager_assign.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
     assert not mturk_manager.socket_manager.socket_is_open(connection_id_1), \
         'The socket manager didn\'t close the socket upon failure of ' \
@@ -785,7 +808,7 @@ def test_solo_no_onboarding(opt, server_url):
     mturk_agent_id = AGENT_1_ID
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids = [mturk_agent_id]
+        mturk_agent_ids=[mturk_agent_id]
     )
     mturk_manager.server_url = server_url
     mturk_manager.start_new_run()
@@ -818,7 +841,8 @@ def test_solo_no_onboarding(opt, server_url):
     wait_for_state_time(2, mturk_manager)
 
     # Assert that the state was properly set up
-    check_new_agent_setup(test_agent, mturk_manager, AssignState.STATUS_IN_TASK)
+    check_new_agent_setup(test_agent, mturk_manager,
+                          AssignState.STATUS_IN_TASK)
     mturk_manager_assign = \
         mturk_manager.mturk_workers[worker_id].agents[assign_id]
     assign_state = mturk_manager_assign.state
@@ -846,7 +870,7 @@ def test_solo_no_onboarding(opt, server_url):
     check_status(assign_state.status, AssignState.STATUS_DONE)
     assert len(assign_state.messages) == 0, \
         'Messages were not cleared upon completion of the task'
-    assert mturk_manager_assign.disconnected == False, \
+    assert mturk_manager_assign.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
     assert message_num == 2, 'Not all messages were successfully processed'
     completed_threads[SOLO_NO_ONBOARDING_TEST] = True
@@ -906,7 +930,8 @@ def test_solo_refresh_in_middle(opt, server_url):
     wait_for_state_time(2, mturk_manager)
 
     # Assert that the state was properly set up
-    check_new_agent_setup(test_agent, mturk_manager, AssignState.STATUS_IN_TASK)
+    check_new_agent_setup(test_agent, mturk_manager,
+                          AssignState.STATUS_IN_TASK)
     mturk_manager_assign = \
         mturk_manager.mturk_workers[worker_id].agents[assign_id]
     assign_state = mturk_manager_assign.state
@@ -958,7 +983,7 @@ def test_solo_refresh_in_middle(opt, server_url):
     check_status(assign_state.status, AssignState.STATUS_DONE)
     assert len(assign_state.messages) == 0, \
         'Messages were not cleared upon completion of the task'
-    assert mturk_manager_assign.disconnected == False, \
+    assert mturk_manager_assign.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
     completed_threads[SOLO_REFRESH_TEST] = True
 
@@ -1007,6 +1032,7 @@ def test_duo_with_onboarding(opt, server_url):
     # create and set up the two agents
     test_agent_1 = MockAgent(opt, hit_id, assign_id_1,
                              worker_id_1, task_group_id)
+
     def msg_callback_1(packet):
         nonlocal message_num
         nonlocal test_agent_1
@@ -1024,6 +1050,7 @@ def test_duo_with_onboarding(opt, server_url):
 
     test_agent_2 = MockAgent(opt, hit_id, assign_id_2,
                              worker_id_2, task_group_id)
+
     def msg_callback_2(packet):
         nonlocal message_num
         nonlocal test_agent_2
@@ -1163,14 +1190,17 @@ def test_duo_with_onboarding(opt, server_url):
     check_status(assign_state_2.status, AssignState.STATUS_DONE)
     assert mturk_manager.completed_conversations == 1, \
         'Complete conversation not marked as complete'
-    assert mturk_manager_assign_1.disconnected == False, \
+    assert mturk_manager_assign_1.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
-    assert mturk_manager_assign_2.disconnected == False, \
+    assert mturk_manager_assign_2.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
     assert not mturk_manager.socket_manager.socket_is_open(connection_id_1), \
         'The socket manager didn\'t close the socket upon completion of the ' \
         'task, though it should have'
     assert not mturk_manager.socket_manager.socket_is_open(connection_id_2), \
+        'The socket manager didn\'t close the socket upon completion of the ' \
+        'task, though it should have'
+    assert not mturk_manager.socket_manager.socket_is_open(connection_id_3), \
         'The socket manager didn\'t close the socket upon completion of the ' \
         'task, though it should have'
     completed_threads[DUO_ONBOARDING_TEST] = True
@@ -1223,6 +1253,7 @@ def test_duo_no_onboarding(opt, server_url):
     # create and set up an agent to disconnect when paired
     test_agent_3 = MockAgent(opt, hit_id, assign_id_3,
                              worker_id_3, task_group_id)
+
     def msg_callback_3(packet):
         nonlocal message_num
         nonlocal test_agent_3
@@ -1262,6 +1293,7 @@ def test_duo_no_onboarding(opt, server_url):
     # create and set up an agent to disconnect when returned to waiting
     test_agent_4 = MockAgent(opt, hit_id, assign_id_4,
                              worker_id_4, task_group_id)
+
     def msg_callback_4(packet):
         nonlocal message_num
         nonlocal test_agent_4
@@ -1312,6 +1344,7 @@ def test_duo_no_onboarding(opt, server_url):
     # create and set up the first successful agent
     test_agent_1 = MockAgent(opt, hit_id, assign_id_1,
                              worker_id_1, task_group_id)
+
     def msg_callback_1(packet):
         nonlocal message_num
         nonlocal test_agent_1
@@ -1353,6 +1386,7 @@ def test_duo_no_onboarding(opt, server_url):
     # Set up the second agent
     test_agent_2 = MockAgent(opt, hit_id, assign_id_2,
                              worker_id_2, task_group_id)
+
     def msg_callback_2(packet):
         nonlocal message_num
         nonlocal test_agent_2
@@ -1423,7 +1457,6 @@ def test_duo_no_onboarding(opt, server_url):
     test_agent_2.always_beat = False
     wait_for_state_time(3, mturk_manager)
 
-
     check_status(assign_state_1.status, AssignState.STATUS_DONE)
     check_status(assign_state_2.status, AssignState.STATUS_DONE)
     wait_for_state_time(DISCONNECT_WAIT_TIME, mturk_manager)
@@ -1431,14 +1464,20 @@ def test_duo_no_onboarding(opt, server_url):
     check_status(assign_state_2.status, AssignState.STATUS_DONE)
     assert mturk_manager.completed_conversations == 1, \
         'Complete conversation not marked as complete'
-    assert mturk_manager_assign_1.disconnected == False, \
+    assert mturk_manager_assign_1.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
-    assert mturk_manager_assign_2.disconnected == False, \
+    assert mturk_manager_assign_2.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
     assert not mturk_manager.socket_manager.socket_is_open(connection_id_1), \
         'The socket manager didn\'t close the socket upon completion of the ' \
         'task, though it should have'
     assert not mturk_manager.socket_manager.socket_is_open(connection_id_2), \
+        'The socket manager didn\'t close the socket upon completion of the ' \
+        'task, though it should have'
+    assert not mturk_manager.socket_manager.socket_is_open(connection_id_3), \
+        'The socket manager didn\'t close the socket upon completion of the ' \
+        'task, though it should have'
+    assert not mturk_manager.socket_manager.socket_is_open(connection_id_4), \
         'The socket manager didn\'t close the socket upon completion of the ' \
         'task, though it should have'
     completed_threads[DUO_NO_ONBOARDING_TEST] = True
@@ -1483,6 +1522,7 @@ def test_duo_valid_reconnects(opt, server_url):
     # create and set up the first agent
     test_agent_1 = MockAgent(opt, hit_id, assign_id_1,
                              worker_id_1, task_group_id)
+
     def msg_callback_1(packet):
         nonlocal message_num
         nonlocal test_agent_1
@@ -1539,6 +1579,7 @@ def test_duo_valid_reconnects(opt, server_url):
     # Set up the second agent
     test_agent_2 = MockAgent(opt, hit_id, assign_id_2,
                              worker_id_2, task_group_id)
+
     def msg_callback_2(packet):
         nonlocal message_num
         nonlocal test_agent_2
@@ -1638,9 +1679,9 @@ def test_duo_valid_reconnects(opt, server_url):
     check_status(assign_state_2.status, AssignState.STATUS_DONE)
     assert mturk_manager.completed_conversations == 1, \
         'Complete conversation not marked as complete'
-    assert mturk_manager_assign_1.disconnected == False, \
+    assert mturk_manager_assign_1.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
-    assert mturk_manager_assign_2.disconnected == False, \
+    assert mturk_manager_assign_2.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
     assert not mturk_manager.socket_manager.socket_is_open(connection_id_1), \
         'The socket manager didn\'t close the socket upon completion of the ' \
@@ -1692,6 +1733,7 @@ def test_duo_one_disconnect(opt, server_url):
     # create and set up the first agent
     test_agent_1 = MockAgent(opt, hit_id, assign_id_1,
                              worker_id_1, task_group_id)
+
     def msg_callback_1(packet):
         nonlocal message_num
         nonlocal test_agent_1
@@ -1740,6 +1782,7 @@ def test_duo_one_disconnect(opt, server_url):
     # Set up the second agent
     test_agent_2 = MockAgent(opt, hit_id, assign_id_2,
                              worker_id_2, task_group_id)
+
     def msg_callback_2(packet):
         nonlocal message_num
         nonlocal test_agent_2
@@ -1836,16 +1879,15 @@ def test_duo_one_disconnect(opt, server_url):
     second_agent.always_beat = False
     wait_for_state_time(DISCONNECT_WAIT_TIME, mturk_manager)
 
-
     check_status(mturk_second_agent.state.status,
-        AssignState.STATUS_PARTNER_DISCONNECT)
+                 AssignState.STATUS_PARTNER_DISCONNECT)
     check_status(mturk_first_agent.state.status,
-        AssignState.STATUS_DISCONNECT)
+                 AssignState.STATUS_DISCONNECT)
     assert mturk_manager.completed_conversations == 0, \
         'Incomplete conversation marked as complete'
-    assert mturk_second_agent.disconnected == False, \
+    assert mturk_second_agent.disconnected is False, \
         'MTurk manager improperly marked the connected agent as disconnected'
-    assert mturk_first_agent.disconnected == True, \
+    assert mturk_first_agent.disconnected is True, \
         'MTurk did not mark the disconnected agent as so'
     assert not mturk_manager.socket_manager.socket_is_open(connection_id_1), \
         'The socket manager didn\'t close the socket upon failure of the ' \
@@ -1998,9 +2040,9 @@ def test_count_complete(opt, server_url):
         'Messages were not cleared upon completion of the task'
     assert len(assign_state_2.messages) == 0, \
         'Messages were not cleared upon completion of the task'
-    assert mturk_manager_assign_1.disconnected == False, \
+    assert mturk_manager_assign_1.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
-    assert mturk_manager_assign_2.disconnected == False, \
+    assert mturk_manager_assign_2.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
     assert mturk_manager.started_conversations == 2, \
         'At least one conversation wasn\'t successfully logged'
@@ -2059,6 +2101,7 @@ def test_expire_hit(opt, server_url):
     # create and set up the two agents
     test_agent_1 = MockAgent(opt, hit_id, assign_id_1,
                              worker_id_1, task_group_id)
+
     def msg_callback_1(packet):
         nonlocal message_num
         nonlocal test_agent_1
@@ -2076,6 +2119,7 @@ def test_expire_hit(opt, server_url):
 
     test_agent_2 = MockAgent(opt, hit_id, assign_id_2,
                              worker_id_2, task_group_id)
+
     def msg_callback_2(packet):
         nonlocal message_num
         nonlocal test_agent_2
@@ -2098,7 +2142,6 @@ def test_expire_hit(opt, server_url):
         nonlocal last_command_3
         if packet.data['type'] == data_model.MESSAGE_TYPE_COMMAND:
             last_command_3 = packet
-
 
     test_agent_4 = MockAgent(opt, hit_id, assign_id_4,
                              worker_id_4, task_group_id)
@@ -2240,7 +2283,6 @@ def test_expire_hit(opt, server_url):
     test_agent_3.always_beat = False
     test_agent_4.always_beat = False
 
-
     check_status(assign_state_1.status, AssignState.STATUS_DONE)
     check_status(assign_state_2.status, AssignState.STATUS_DONE)
     wait_for_state_time(DISCONNECT_WAIT_TIME, mturk_manager)
@@ -2248,17 +2290,17 @@ def test_expire_hit(opt, server_url):
     check_status(assign_state_2.status, AssignState.STATUS_DONE)
     assert mturk_manager.completed_conversations == 1, \
         'Complete conversation not marked as complete'
-    assert mturk_manager_assign_1.disconnected == False, \
+    assert mturk_manager_assign_1.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
-    assert mturk_manager_assign_2.disconnected == False, \
+    assert mturk_manager_assign_2.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
-    assert mturk_manager_assign_3.disconnected == False, \
+    assert mturk_manager_assign_3.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
-    assert mturk_manager_assign_4.disconnected == False, \
+    assert mturk_manager_assign_4.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
-    assert mturk_manager_assign_3.hit_is_expired == True, \
+    assert mturk_manager_assign_3.hit_is_expired is True, \
         'MTurk manager failed to mark agent as expired'
-    assert mturk_manager_assign_4.hit_is_expired == True, \
+    assert mturk_manager_assign_4.hit_is_expired is True, \
         'MTurk manager failed to mark agent as expired'
     assert not mturk_manager.socket_manager.socket_is_open(connection_id_1), \
         'The socket manager didn\'t close the socket upon completion of the ' \
@@ -2332,7 +2374,8 @@ def test_allowed_conversations(opt, server_url):
     wait_for_state_time(2, mturk_manager)
 
     # Assert that the state was properly set up
-    check_new_agent_setup(test_agent, mturk_manager, AssignState.STATUS_IN_TASK)
+    check_new_agent_setup(test_agent, mturk_manager,
+                          AssignState.STATUS_IN_TASK)
     mturk_manager_assign = \
         mturk_manager.mturk_workers[worker_id].agents[assign_id]
     assign_state = mturk_manager_assign.state
@@ -2377,7 +2420,8 @@ def test_allowed_conversations(opt, server_url):
     wait_for_state_time(2, mturk_manager)
 
     # Assert that the state was properly set up
-    check_new_agent_setup(test_agent_2, mturk_manager, AssignState.STATUS_IN_TASK)
+    check_new_agent_setup(test_agent_2, mturk_manager,
+                          AssignState.STATUS_IN_TASK)
     mturk_manager_assign_2 = \
         mturk_manager.mturk_workers[worker_id].agents[assign_id_2]
     assign_state_2 = mturk_manager_assign_2.state
@@ -2401,12 +2445,11 @@ def test_allowed_conversations(opt, server_url):
     wait_for_state_time(2, mturk_manager)
     check_status(assign_state_2.status, AssignState.STATUS_DONE)
 
-
     wait_for_state_time(DISCONNECT_WAIT_TIME, mturk_manager)
     check_status(assign_state.status, AssignState.STATUS_DONE)
     assert len(assign_state.messages) == 0, \
         'Messages were not cleared upon completion of the task'
-    assert mturk_manager_assign.disconnected == False, \
+    assert mturk_manager_assign.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
     assert message_num == 2, 'Not all messages were successfully processed'
     completed_threads[ALLOWED_CONVERSATION_TEST] = True
@@ -2454,6 +2497,7 @@ def test_unique_workers_in_conversation(opt, server_url):
     # create and set up the two agents for the one worker
     test_agent_1 = MockAgent(opt, hit_id, assign_id_1,
                              worker_id_1, task_group_id)
+
     def msg_callback_1(packet):
         nonlocal message_num
         nonlocal test_agent_1
@@ -2495,6 +2539,7 @@ def test_unique_workers_in_conversation(opt, server_url):
     # Set up the second agent
     test_agent_2 = MockAgent(opt, hit_id, assign_id_2,
                              worker_id_1, task_group_id)
+
     def msg_callback_2(packet):
         nonlocal message_num
         nonlocal test_agent_2
@@ -2533,6 +2578,7 @@ def test_unique_workers_in_conversation(opt, server_url):
     # Create third agent
     test_agent_3 = MockAgent(opt, hit_id, assign_id_3,
                              worker_id_2, task_group_id)
+
     def msg_callback_3(packet):
         nonlocal message_num
         nonlocal test_agent_3
@@ -2567,15 +2613,12 @@ def test_unique_workers_in_conversation(opt, server_url):
 
     in_agent = None
     in_assign = None
-    out_agent = None
     out_assign = None
     if assign_state_1.status == AssignState.STATUS_IN_TASK:
         in_agent = test_agent_1
         in_assign = mturk_manager_assign_1
-        out_agent = test_agent_2
         out_assign = mturk_manager_assign_2
     elif assign_state_2.status == AssignState.STATUS_IN_TASK:
-        out_agent = test_agent_1
         out_assign = mturk_manager_assign_1
         in_agent = test_agent_2
         in_assign = mturk_manager_assign_2
@@ -2622,11 +2665,11 @@ def test_unique_workers_in_conversation(opt, server_url):
     check_status(assign_state_3.status, AssignState.STATUS_DONE)
     assert mturk_manager.completed_conversations == 1, \
         'Complete conversation not marked as complete'
-    assert in_assign.disconnected == False, \
+    assert in_assign.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
-    assert out_assign.disconnected == False, \
+    assert out_assign.disconnected is False, \
         'MTurk manager improperly marked the agent as disconnected'
-    assert out_assign.hit_is_expired == True, \
+    assert out_assign.hit_is_expired is True, \
         'Expired HIT was not marked as such'
     assert not mturk_manager.socket_manager.socket_is_open(connection_id_1), \
         'The socket manager didn\'t close the socket upon completion of the ' \
@@ -2663,6 +2706,7 @@ TESTS = {
 # the expected times for updating state
 MAX_THREADS = 8
 RETEST_THREADS = 2
+
 
 def run_tests(tests_to_run, max_threads, base_opt, server_url):
     global start_time
@@ -2726,7 +2770,7 @@ def main():
     base_opt['num_conversations'] = 1
     base_opt['count_complete'] = False
     task_name, server_url = handle_setup(base_opt)
-    print ("Setup time: {} seconds".format(time.time() - start_time))
+    print("Setup time: {} seconds".format(time.time() - start_time))
     start_time = time.time()
     try:
         failed_tests = run_tests(TESTS, MAX_THREADS, base_opt, server_url)
@@ -2738,7 +2782,7 @@ def main():
             flakey_tests = {}
             for test_name in failed_tests:
                 flakey_tests[test_name] = TESTS[test_name]
-            failed_tests = run_tests(flakey_tests, RETEST_THREADS, \
+            failed_tests = run_tests(flakey_tests, RETEST_THREADS,
                                      base_opt, server_url)
             if len(failed_tests) == 0:
                 print("All tests passed, ParlAI MTurk is functioning")
@@ -2747,10 +2791,11 @@ def main():
 
         test_duration = time.time() - start_time
         print("Test duration: {} seconds".format(test_duration))
-    except:
+    except Exception:
         raise
     finally:
         handle_shutdown(task_name)
+
 
 if __name__ == '__main__':
     mturk_utils.setup_aws_credentials()


### PR DESCRIPTION
Introduces qualifications to ParlAI's mechanical turk functionality. While currently they're only used internally to 'soft ban' users by assigning them a qualification that excludes them from being able to complete HITs with that set, it can also be used to make workflows that require and specify arbitrary qualifications, including the capability to create new qualifications during world creation or evaluation.

Also fixes some clowniness I noticed in the server that was breaking the (formerly incomplete) SNS test. 