### PR TITLE
Fix on empty candidate IR Baseline

### DIFF
--- a/parlai/agents/ir_baseline/ir_baseline.py
+++ b/parlai/agents/ir_baseline/ir_baseline.py
@@ -60,6 +60,8 @@ stopwords = { 'i', 'a', 'an', 'are', 'about', 'as', 'at', 'be', 'by',
               'has', 'any', 'why', 'will'}
 
 def score_match(query_rep, text, length_penalty, dictionary=None, debug=False):
+    if text == "":
+        return 0
     if not dictionary:
        words = text.lower().split(' ')
     else:


### PR DESCRIPTION
Currently, ir_baseline computes a score for the empty string candidate (""), and divides by the norm (0); this fix ensures score_match does not divide by 0