### PR TITLE
Threadpool for image loading in vqa v1

### DIFF
--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -7,11 +7,50 @@ import parlai.core.build_data as build_data
 
 import os
 import copy
-import numpy as np
+import h5py
 from PIL import Image
-from functools import lru_cache
+from functools import wraps
+from threading import Lock, Condition
 
 _greyscale = '  .,:;crsA23hHG#98&@'
+_cache_size = 84000
+
+def first_n_cache(function):
+    cache = {}
+    cache_monitor = CacheMonitor()
+
+    @wraps(function)
+    def wrapper(*args):
+        path = args[1]
+        if path in cache:
+            return cache[path]
+        else:
+            img = function(*args)
+            if img is not None and len(cache) < _cache_size:
+                cache_monitor.waitForCache()
+                cache[path] = img
+                cache_monitor.doneWithCache()
+            return img
+    return wrapper
+
+
+class CacheMonitor():
+    def __init__(self):
+        self.cache_lock = Lock()
+        self.cache_available = Condition(self.cache_lock)
+        self.cache_busy = False
+
+    def waitForCache(self):
+        with self.cache_lock:
+            while self.cache_busy:
+                self.cache_available.wait()
+            self.cache_busy = True
+
+    def doneWithCache(self):
+        with self.cache_lock:
+            self.cache_busy = False
+            self.cache_available.notify_all()
+
 
 class ImageLoader():
     """Extract image feature using pretrained CNN network.
@@ -19,6 +58,9 @@ class ImageLoader():
     def __init__(self, opt):
         self.opt = copy.deepcopy(opt)
         self.netCNN = None
+        im = opt['image_mode']
+        if im is not None and im not in ['none', 'raw', 'ascii']:
+            self.init_cnn()
 
     def init_cnn(self):
         """Lazy initialization of preprocessor model in case we don't need any image preprocessing."""
@@ -37,12 +79,12 @@ class ImageLoader():
         self.datatype = opt['datatype']
         self.image_mode = opt['image_mode']
 
-        opt['cuda'] = not opt['no_cuda'] and torch.cuda.is_available()
+        opt['cuda'] = not opt.get('no_cuda', False) and torch.cuda.is_available()
         self.use_cuda = opt['cuda']
 
         if self.use_cuda:
             print('[ Using CUDA ]')
-            torch.cuda.set_device(opt['gpu'])
+            torch.cuda.set_device(opt.get('gpu', 0))
 
         cnn_type, layer_num = self.image_mode_switcher()
 
@@ -75,7 +117,10 @@ class ImageLoader():
         self.netCNN.cuda()
 
     def save(self, feature, path):
-        np.save(path, feature)
+        with open(path, 'w'):
+            hdf5_file = h5py.File(path, 'w')
+            hdf5_file.create_dataset('feature', data=feature)
+            hdf5_file.close()
 
     def image_mode_switcher(self):
         switcher = {
@@ -122,7 +167,7 @@ class ImageLoader():
             asc.append('\n')
         return ''.join(asc)
 
-    @lru_cache(maxsize=None)
+    @first_n_cache
     def load(self, path):
         opt = self.opt
         mode = opt.get('image_mode', 'raw')
@@ -145,10 +190,13 @@ class ImageLoader():
                 build_data.make_dir(dpath)
 
             imagefn = imagefn.split('.')[0]
-            imagefn = imagefn + '.npy'
+            imagefn = imagefn + '.hdf5'
             new_path = os.path.join(prepath, mode, imagefn)
 
             if not os.path.isfile(new_path):
                 return self.extract(Image.open(path).convert('RGB'), new_path)
             else:
-                return np.load(new_path)
+                with open(new_path):
+                    hdf5_file = h5py.File(new_path, 'r')
+                    feature = hdf5_file['feature'][0]
+                return feature

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -827,7 +827,7 @@ def create_task(opt, user_agents):
     # Single threaded or hogwild task creation (the latter creates multiple threads).
     # Check datatype for train, because we need to do single-threaded for
     # valid and test in order to guarantee exactly one epoch of training.
-    if opt.get('numthreads', 1) == 1 or 'train' not in opt['datatype']:
+    if opt.get('numthreads', 1) == 1 or 'train' not in opt['datatype'] or opt.get('batchsize', 1) > 1:
         if ',' not in opt['task']:
             # Single task
             world = create_task_world(opt, user_agents)

--- a/parlai/tasks/vqa_v1/agents.py
+++ b/parlai/tasks/vqa_v1/agents.py
@@ -11,6 +11,9 @@ from .build import build, buildImage
 import json
 import random
 import os
+from threading import Thread
+import queue
+import concurrent.futures
 
 
 def _path(opt):
@@ -44,6 +47,25 @@ def _path(opt):
     return data_path, annotation_path, image_path
 
 
+class MasterLoader(Thread):
+    def __init__(self, opt):
+        Thread.__init__(self, daemon=True)
+        num_masters = opt.get('batchsize', 1)
+        self.request_queues = {i: queue.Queue() for i in range(num_masters)}
+        self.num_threads = opt.get('numthreads', 8)
+        self.request_queue = queue.Queue()
+
+    def __len__(self):
+        return len(self.ques['questions'])
+
+    def run(self):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self.num_threads) as executor:
+            while True:
+                teacher, load_fn, data_req = self.request_queue.get()
+                future = executor.submit(load_fn, data_req)
+                teacher.receive(future)
+
+
 class OeTeacher(Teacher):
     """
     VQA Open-Ended teacher, which loads the json vqa data and implements its
@@ -53,25 +75,50 @@ class OeTeacher(Teacher):
         super().__init__(opt, shared)
         self.datatype = opt['datatype']
         data_path, annotation_path, self.image_path = _path(opt)
+        self.image_mode = opt.get('image_mode', 'none')
 
         if shared and 'ques' in shared:
             self.ques = shared['ques']
             if 'annotation' in shared:
                 self.annotation = shared['annotation']
             self.image_loader = shared['image_loader']
+            self.master_loader = shared['master_loader']
         else:
             self._setup_data(data_path, annotation_path)
             self.image_loader = ImageLoader(opt)
+            self.master_loader = MasterLoader(opt)
+            self.master_loader.start()
 
         # for ordered data in batch mode (especially, for validation and
         # testing), each teacher in the batch gets a start index and a step
         # size so they all process disparate sets of the data
         self.step_size = opt.get('batchsize', 1)
         self.data_offset = opt.get('batchindex', 0)
+        self.example_queue = queue.Queue()
         self.reset()
+        if self.image_mode != 'none':
+            self.submit_example_request()
+
 
     def __len__(self):
         return len(self.ques['questions'])
+
+    def submit_example_request(self):
+        if self.datatype == 'train':
+            self.episode_idx = random.randrange(len(self))
+        else:
+            self.episode_idx = (self.episode_idx + self.step_size) % len(self)
+            if self.episode_idx == len(self) - self.step_size:
+                self.epochDone = True
+
+        image_id = self.ques['questions'][self.episode_idx]['image_id']
+        img_path = self.image_path + '%012d.jpg' % (image_id)
+        self.master_loader.request_queue.put(
+            (self, self.image_loader.load, img_path))
+
+    def receive(self, future):
+        data = future.result()
+        self.example_queue.put(data)
 
     def reset(self):
         # Reset the dialog so that it is at the start of the epoch,
@@ -79,6 +126,7 @@ class OeTeacher(Teacher):
         super().reset()
         self.lastY = None
         self.episode_idx = self.data_offset - self.step_size
+        self.example_queue = queue.Queue()
 
     def observe(self, observation):
         """Process observation for metrics."""
@@ -88,21 +136,13 @@ class OeTeacher(Teacher):
         return observation
 
     def act(self):
-        if self.datatype == 'train':
-            self.episode_idx = random.randrange(len(self))
-        else:
-            self.episode_idx = (self.episode_idx + self.step_size) % len(self)
-            if self.episode_idx == len(self) - self.step_size:
-                self.epochDone = True
-
         qa = self.ques['questions'][self.episode_idx]
         question = qa['question']
-        image_id = qa['image_id']
-
-        img_path = self.image_path + '%012d.jpg' % (image_id)
-
+        image = None
+        if self.image_mode != 'none':
+            image = self.example_queue.get()
         action = {
-            'image': self.image_loader.load(img_path),
+            'image': image,
             'text': question,
             'episode_done': True
         }
@@ -114,6 +154,8 @@ class OeTeacher(Teacher):
         if self.datatype.startswith('train'):
             action['labels'] = self.lastY
 
+        # Submit for next example before returning
+        self.submit_example_request()
         return action
 
     def share(self):
@@ -122,6 +164,7 @@ class OeTeacher(Teacher):
         if hasattr(self, 'annotation'):
             shared['annotation'] = self.annotation
         shared['image_loader'] = self.image_loader
+        shared['master_loader'] = self.master_loader
         return shared
 
     def _setup_data(self, data_path, annotation_path):

--- a/parlai/tasks/vqa_v1/agents.py
+++ b/parlai/tasks/vqa_v1/agents.py
@@ -51,7 +51,6 @@ class MasterLoader(Thread):
     def __init__(self, opt):
         Thread.__init__(self, daemon=True)
         num_masters = opt.get('batchsize', 1)
-        self.request_queues = {i: queue.Queue() for i in range(num_masters)}
         self.num_threads = opt.get('numthreads', 8)
         self.request_queue = queue.Queue()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ nltk
 numpy
 Pillow
 pyzmq
+h5py


### PR DESCRIPTION
1. Adds a thread pool for loading images for VQA v1.
2. Switches saving resnet features from numpy pickles to hdf5 files
3. Converts lru_cache in image_featurizers to a first_n cache of size 84k (around 32gb for hdf5 features)
4. Allows numthreads and batchsize to both be specified and lead to creation of a BatchWorld rather than HogwildWorld.