### PR TITLE
Fix hdf5 file image features loading

### DIFF
--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -198,5 +198,5 @@ class ImageLoader():
             else:
                 with open(new_path):
                     hdf5_file = h5py.File(new_path, 'r')
-                    feature = hdf5_file['feature'][0]
+                    feature = hdf5_file['feature'].value
                 return feature


### PR DESCRIPTION
Ensure that a preprocessed image is loaded with the same dimensionality as an image procesed during training (i.e., before, this code eliminated a dimension of the data)