### PR TITLE
move self.stream to fixed data teacher

### DIFF
--- a/parlai/core/dialog_teacher.py
+++ b/parlai/core/dialog_teacher.py
@@ -39,7 +39,6 @@ class DialogTeacher(FixedDataTeacher):
 
         self.startTime = time.time()
         self.training = self.datatype.startswith('train')
-        self.stream = 'stream' in self.datatype.split(':')
 
         # first initialize any shared objects
         data_class = StreamDialogData if self.stream else DialogData

--- a/parlai/core/fixed_data_teacher.py
+++ b/parlai/core/fixed_data_teacher.py
@@ -46,6 +46,7 @@ class FixedDataTeacher(Teacher):
         self.episode_idx = self.data_offset - self.step_size
         self.episode_done = True
         self.epochDone = False
+        self.stream = 'stream' in self.datatype.split(':')
         try:
             if (self.episode_idx + self.step_size >= len(self) and not self.random):
                 self.epochDone = True


### PR DESCRIPTION
fix bug introduced in #397 where `python examples/display_data.py -t babi:task1k:1` failed