### PR TITLE
fixes to teachers and batching

### DIFF
--- a/parlai/agents/fairseq/fairseq_py/__init__.py
+++ b/parlai/agents/fairseq/fairseq_py/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/agents/fairseq/fairseq_py/scripts/__init__.py
+++ b/parlai/agents/fairseq/fairseq_py/scripts/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/agents/fairseq/fairseq_py/tests/__init__.py
+++ b/parlai/agents/fairseq/fairseq_py/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -162,6 +162,10 @@ class MultiTaskTeacher(Teacher):
     def __init__(self, opt, shared=None):
         self.tasks = []
         self.opt = opt
+
+        opt['batch_sort'] = False
+        print('WARNING: batch_sort disabled for multitasking')
+
         self.id = opt['task']
         if shared and 'tasks' in shared:
             self.tasks = [create_agent_from_shared(t) for t in shared['tasks']]

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -151,6 +151,14 @@ class FixedDialogTeacher(Teacher):
                 clen = opt.get('context_length', -1)
                 incl = opt.get('include_labels', True)
 
+                if ordered_teacher.num_examples() > 1000000:  # one million
+                    print('WARNING: this dataset is large, and batch sorting '
+                          'may use too much RAM or take too long to set up. '
+                          'Consider disabling batch sorting, setting '
+                          'context-length to a small integer (if this dataset '
+                          'has episodes of multiple examples), or streaming '
+                          'the data using a streamed data mode if supported.')
+
                 flatdata = flatten(ordered_teacher,
                                    context_length=clen, include_labels=incl)
                 self.sorted_data = sort_data(flatdata)

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -142,7 +142,8 @@ def flatten(teacher, context_length=-1, include_labels=True):
                           'limit the length of each flattened example, '
                           'disabling batch sorting / flattening by setting '
                           '--batch-sort false, or switching to data streaming '
-                          'using --datatype {type}:stream to read from disk.')
+                          'using --datatype {type}:stream to read from disk '
+                          'if it is supported for your dataset.')
 
 
 def sort_data(data, key='text_label', method='spaces'):

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -378,6 +378,8 @@ class MultiWorld(World):
     """
 
     def __init__(self, opt, agents=None, shared=None):
+        opt['batch_sort'] = False
+        print('WARNING: batch_sort disabled for multitasking')
         super().__init__(opt)
         self.worlds = []
         for index, k in enumerate(opt['task'].split(',')):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,10 +14,13 @@ class TestInit(unittest.TestCase):
     def test_init_everywhere(self):
         from parlai.core.params import ParlaiParser
         opt = ParlaiParser().parse_args()
-        for root, subfolder, files in os.walk(os.path.join(opt['parlai_home'], 'parlai')):
+        for root, _subfolder, files in os.walk(os.path.join(opt['parlai_home'], 'parlai')):
             if not root.endswith('__pycache__'):
                 if os.path.basename(root) == 'html':
                     # skip mturk core's html folder--not a python module
+                    continue
+                if '/clib' in root:
+                    # skip fairseq's clib
                     continue
                 assert '__init__.py' in files, 'Dir {} is missing __init__.py'.format(root)
 


### PR DESCRIPTION
- disabled batch sorting during multitasking since we don't have support for it to actually help (currently it's mixing sub-batches of different lengths)
- print a warning for large datasets if batch sorting enabled
- prevent accidentally initializing non-batched version of teacher in addition to batched version (and not using it, just causing a slowdown in loading)