### PR TITLE
Only import h5py when it is needed

### DIFF
--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -80,6 +80,12 @@ class ImageLoader():
         import torchvision.transforms as transforms
         import torch.nn as nn
 
+        try:
+            import h5py
+            self.h5py = h5py
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError('Need to install h5py')
+
         if 'image_mode' not in opt or 'image_size' not in opt:
             raise RuntimeError(
                 'Need to add image arguments to opt. See '
@@ -122,8 +128,7 @@ class ImageLoader():
 
     def save(self, feature, path):
         with open(path, 'w'):
-            import h5py
-            hdf5_file = h5py.File(path, 'w')
+            hdf5_file = self.h5py.File(path, 'w')
             hdf5_file.create_dataset('feature', data=feature)
             hdf5_file.close()
 
@@ -202,7 +207,6 @@ class ImageLoader():
                 return self.extract(Image.open(path).convert('RGB'), new_path)
             else:
                 with open(new_path):
-                    import h5py
-                    hdf5_file = h5py.File(new_path, 'r')
+                    hdf5_file = self.h5py.File(new_path, 'r')
                     feature = hdf5_file['feature'].value
                 return feature

--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -6,7 +6,6 @@
 import parlai.core.build_data as build_data
 
 import os
-import h5py
 from PIL import Image
 from functools import wraps
 from threading import Lock, Condition
@@ -123,6 +122,7 @@ class ImageLoader():
 
     def save(self, feature, path):
         with open(path, 'w'):
+            import h5py
             hdf5_file = h5py.File(path, 'w')
             hdf5_file.create_dataset('feature', data=feature)
             hdf5_file.close()
@@ -202,6 +202,7 @@ class ImageLoader():
                 return self.extract(Image.open(path).convert('RGB'), new_path)
             else:
                 with open(new_path):
+                    import h5py
                     hdf5_file = h5py.File(new_path, 'r')
                     feature = hdf5_file['feature'].value
                 return feature


### PR DESCRIPTION
h5py isn't always available and is generally not used within ParlAI. In order to ensure that the non image users don't need to run into potential h5py issues, this only imports it when it is used.