### PR TITLE
Easier loading of models without specifying all their options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ parts/
 sdist/
 var/
 parlai_internal/
+parlai_external/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -40,8 +40,9 @@ This module also provides a utility method:
 from .metrics import Metrics
 import copy
 import importlib
+import pickle
 import random
-
+import os
 
 class Agent(object):
     """Base class for all other agents."""
@@ -294,6 +295,16 @@ def name_to_agent_class(name):
     class_name += 'Agent'
     return class_name
 
+def load_agent_module(opt):
+    optfile =  opt['model_file'] + '.opt'
+    if os.path.isfile(optfile):
+        with open(optfile, 'rb') as handle:
+           opt = pickle.load(handle)
+        model_class = get_agent_module(opt['model'])
+        return model_class(opt)
+    else:
+        return None
+        
 def get_agent_module(dir_name):
     if ':' in dir_name:
         s = dir_name.split(':')
@@ -315,7 +326,15 @@ def create_agent(opt):
     The input is either of the form ``parlai.agents.ir_baseline.agents:IrBaselineAgent``
     (i.e. the path followed by the class name) or else just ``ir_baseline`` which
     assumes the path above, and a class name suffixed with 'Agent'.
+    If ``model-file'' is available in the options this function can also attempt to load
+    the model from that location instead.
     """
+    if opt.get('model_file'):
+        # Attempt to load the model from the model file first (this way we do not even
+        # have to specify the model name as a parameter.
+        model = load_agent_module(opt)
+        if model is not None:
+            return model
     if opt.get('model'):
         model_class = get_agent_module(opt['model'])
         return model_class(opt)

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -326,8 +326,12 @@ def create_agent(opt):
     The input is either of the form ``parlai.agents.ir_baseline.agents:IrBaselineAgent``
     (i.e. the path followed by the class name) or else just ``ir_baseline`` which
     assumes the path above, and a class name suffixed with 'Agent'.
+
     If ``model-file'' is available in the options this function can also attempt to load
-    the model from that location instead.
+    the model from that location instead. This avoids having to specify all the other
+    options necessary to set up the model including its name as they are all loaded from
+    the options file if it exists (the file opt['model_file'] + '.opt' must exist and
+    contain a pickled dict containing the model's options).
     """
     if opt.get('model_file'):
         # Attempt to load the model from the model file first (this way we do not even


### PR DESCRIPTION
E.g. this allows to do

py examples/eval_model.py -t "<task_name>" -mf "<model_file_name>"

and this will just work, rather than having to specify all the other options for a model so it can create the class. this also ensure it sets it up just how it was saved and you dont mess anything up.