### PR TITLE
Add 'taskntalk' to task list and create teachers for accessing it.

### DIFF
--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -193,6 +193,13 @@ task_list = [
         "description": "Open-domain QA dataset with question-answer-evidence triples, from Joshi et al. '17. Link: https://arxiv.org/abs/1705.03551"
     },
     {
+        "id": "TaskNTalk",
+        "display_name": "Task N' Talk",
+        "task": "taskntalk",
+        "tags": [ "All",  "Goal" ],
+        "description": "Dataset of synthetic shapes described by attributes, for agents to play a cooperative QA game, from Kottur et al. '17. Link: https://arxiv.org/abs/1706.08502"
+    },
+    {
         "id": "Ubuntu",
         "display_name": "Ubuntu",
         "task": "ubuntu",

--- a/parlai/tasks/taskntalk/__init__.py
+++ b/parlai/tasks/taskntalk/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/tasks/taskntalk/__init__.py
+++ b/parlai/tasks/taskntalk/__init__.py
@@ -1,5 +1,3 @@
-# Copyright (c) 2017-present, Facebook, Inc.
-# All rights reserved.
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/tasks/taskntalk/agents.py
+++ b/parlai/tasks/taskntalk/agents.py
@@ -3,14 +3,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
+from parlai.core.agents import Teacher
+from .build import build
 
-import itertools
 import json
 import os
 import random
-
-from parlai.core.agents import Teacher
-from .build import build
 
 
 def _path(opt, task_size='small'):
@@ -34,18 +32,12 @@ class TaskNTalkTeacher(Teacher):
         super().__init__(opt, shared)
         # store datatype
         self.datatype = opt['datatype']
-
-        # task_size can be 'small' and 'large'
-        self.task_size = opt.get('task', 'taskntalk:small')
-        self.opt['datafile'] = _path(opt, self.task_size)
-
-        # setup data if it hasn't been provided in shared
-        if shared is not None:
-            self._setup_data(data_path)
+        if not shared:
+            self._setup_data(self.opt['datafile'])
         else:
             self.data = shared['data']
             self.task_defn = shared['task_defn']
-        self.batch_size = opt.get('batchsize', 1)
+            self.task_index = shared['task_index']
 
     def _setup_data(self, data_path):
         # loads data
@@ -53,13 +45,16 @@ class TaskNTalkTeacher(Teacher):
         with open(data_path) as data_file:
             json_data = json.load(data_file)
             self.data = json_data['data']
-            random.shuffle(self.data)
             self.task_defn = json_data['task_defn']
+        # images are [color, shape, style] lists (example: ['red', 'square', 'dotted'])
+        self.task_index = {'color': 0, 'shape': 1, 'style': 2}
+        random.shuffle(self.data)
 
     def share(self):
         shared = super().share()
         shared['data'] = self.data
         shared['task_defn'] = self.task_defn
+        shared['task_index'] = self.task_index
         return shared
 
     def __len__(self):
@@ -68,31 +63,35 @@ class TaskNTalkTeacher(Teacher):
     def observe(self, observation):
         """Process observation for metrics."""
         self.observation = observation
-        # todo (karandesai) : update metrics
+        # TODO(kd): update metrics
         return observation
 
     def act(self):
-        # pick random example if training, else  fetch all data
-        if self.datatype == 'train':
-            # select random images
-            indices = [random.randint(0, len(self.data) - 1)
-                       for _ in range(self.batch_size)]
-            images = [self.data[index] for index in indices]
-
-            # select random tasks
-            indices = [random.randint(0, len(self.task_defn) - 1)
-                       for _ in range(self.batch_size)]
-            tasks = [self.task_defn[index] for index in indices]
-            action = {
-                'image': images,
-                'text': tasks,
-                'episode_done': True
-            }
-        else:
-            all_data = list(itertools.product(self.data, self.task_defn))
-            action = {
-                'image': [imtask_tuple[0] for imtask_tuple in all_data],
-                'text': [imtask_tuple[1] for imtask_tuple in all_data],
-                'episode_done': True
-            }
+        # TODO(kd): fetch all data for valid/test
+        # select random image and task
+        image = random.choice(self.data)
+        task  = random.choice(self.task_defn)
+        labels = [image[self.task_index[attr]] for attr in task]
+        action = {
+            'image': ' '.join(image),
+            'text': ' '.join(task),
+            'labels': [' '.join(labels)],
+            'episode_done': True
+        }
         return action
+
+
+class SmallTeacher(TaskNTalkTeacher):
+    def __init__(self, opt, shared=None):
+        opt['datafile'] = _path(opt, 'small')
+        super().__init__(opt, shared)
+
+
+class LargeTeacher(TaskNTalkTeacher):
+    def __init__(self, opt, shared=None):
+        opt['datafile'] = _path(opt, 'large')
+        super().__init__(opt, shared)
+
+
+class DefaultTeacher(SmallTeacher):
+    pass

--- a/parlai/tasks/taskntalk/agents.py
+++ b/parlai/tasks/taskntalk/agents.py
@@ -1,5 +1,3 @@
-# Copyright (c) 2017-present, Facebook, Inc.
-# All rights reserved.
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
@@ -37,6 +35,7 @@ class TaskNTalkTeacher(Teacher):
     """
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
+        self.id = 'taskntalk'
         if not shared:
             self._setup_data(self.opt['datafile'])
         else:

--- a/parlai/tasks/taskntalk/agents.py
+++ b/parlai/tasks/taskntalk/agents.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import itertools
+import json
+import os
+import random
+
+from parlai.core.agents import Teacher
+from .build import build
+
+
+def _path(opt, task_size='small'):
+    # ensure data is built
+    build(opt)
+    dt = opt['datatype'].split(':')[0]
+
+    if dt == 'train':
+        file_name = 'train.json'
+    elif dt == 'valid' or dt == 'test':
+        file_name = 'valid.json'
+    else:
+        raise RuntimeError('Not valid datatype.')
+
+    data_path = os.path.join(opt['datapath'], 'taskntalk', task_size, file_name)
+    return data_path
+
+
+class TaskNTalkTeacher(Teacher):
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
+        # store datatype
+        self.datatype = opt['datatype']
+
+        # task_size can be 'small' and 'large'
+        self.task_size = opt.get('task', 'taskntalk:small')
+        self.opt['datafile'] = _path(opt, self.task_size)
+
+        # setup data if it hasn't been provided in shared
+        if shared is not None:
+            self._setup_data(data_path)
+        else:
+            self.data = shared['data']
+            self.task_defn = shared['task_defn']
+        self.batch_size = opt.get('batchsize', 1)
+
+    def _setup_data(self, data_path):
+        # loads data
+        print('loading: ' + data_path)
+        with open(data_path) as data_file:
+            json_data = json.load(data_file)
+            self.data = json_data['data']
+            random.shuffle(self.data)
+            self.task_defn = json_data['task_defn']
+
+    def share(self):
+        shared = super().share()
+        shared['data'] = self.data
+        shared['task_defn'] = self.task_defn
+        return shared
+
+    def __len__(self):
+        return len(self.data)
+
+    def observe(self, observation):
+        """Process observation for metrics."""
+        self.observation = observation
+        # todo (karandesai) : update metrics
+        return observation
+
+    def act(self):
+        # pick random example if training, else  fetch all data
+        if self.datatype == 'train':
+            # select random images
+            indices = [random.randint(0, len(self.data) - 1)
+                       for _ in range(self.batch_size)]
+            images = [self.data[index] for index in indices]
+
+            # select random tasks
+            indices = [random.randint(0, len(self.task_defn) - 1)
+                       for _ in range(self.batch_size)]
+            tasks = [self.task_defn[index] for index in indices]
+            action = {
+                'image': images,
+                'text': tasks,
+                'episode_done': True
+            }
+        else:
+            all_data = list(itertools.product(self.data, self.task_defn))
+            action = {
+                'image': [imtask_tuple[0] for imtask_tuple in all_data],
+                'text': [imtask_tuple[1] for imtask_tuple in all_data],
+                'episode_done': True
+            }
+        return action

--- a/parlai/tasks/taskntalk/build.py
+++ b/parlai/tasks/taskntalk/build.py
@@ -1,5 +1,3 @@
-# Copyright (c) 2017-present, Facebook, Inc.
-# All rights reserved.
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/tasks/taskntalk/build.py
+++ b/parlai/tasks/taskntalk/build.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import itertools
+import json
+import os
+import random
+
+import parlai.core.build_data as build_data
+
+
+def build(opt):
+    """Create train and validation data for synthetic shapes described by attributes."""
+    dpath = os.path.join(opt['datapath'], 'shapes_small')
+
+    if not build_data.built(dpath):
+        print('[building data: ' + dpath + ']')
+
+        # save training and validation data
+        to_save = {
+            'attributes': ['color', 'shape', 'style'],
+            'task_defn': [[0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1]],
+        }
+        split_data = {}
+
+        # small dataset properties
+        properties = {
+            'color': ['red', 'green', 'blue', 'purple'],
+            'shape': ['square', 'triangle', 'circle', 'star'],
+            'style': ['dotted', 'solid', 'filled', 'dashed']
+        }
+        to_save['properties'] = properties
+        # properties.values() not used directly to maintain order
+        data_verbose = list(itertools.product(*[properties[key] for key in to_save['attributes']]))
+
+        # randomly select train and rest of it is valid
+        split_data['valid'] = random.sample(data_verbose, int(0.8 * len(data_verbose)))
+        split_data['train'] = [s for s in data_verbose if s not in split_data['val']]
+
+        to_save['data'] = split_data['train']
+        with open(os.path.join(dpath, 'shapes_small', 'train.json'), 'w') as outfile:
+            json.dump(to_save, outfile, indent=4, separators=(',', ': '), sort_keys=True)
+
+        to_save['data'] = split_data['valid']
+        with open(os.path.join(dpath, 'shapes_small', 'valid.json'), 'w') as outfile:
+            json.dump(to_save, outfile, indent=4, separators=(',', ': '), sort_keys=True)
+
+        # large dataset properties
+        properties = {
+            'color': ['red', 'green', 'blue', 'purple', 'yellow', 'cyan', 'orange', 'teal'],
+            'shape': ['square', 'triangle', 'circle', 'star', 'heart', 'pentagon', 'hexagon', 'ring'],
+            'style': ['dotted', 'solid', 'filled', 'dashed', 'hstripe', 'vstripe', 'hgrad', 'vgrad']
+        }
+        to_save['properties'] = properties
+        data_verbose = list(itertools.product(*[properties[key] for key in to_save['attributes']]))
+        split_data['valid'] = random.sample(data_verbose, int(0.8 * len(data_verbose)))
+        split_data['train'] = [s for s in data_verbose if s not in split_data['val']]
+
+        to_save['data'] = split_data['train']
+        with open(os.path.join(dpath, 'shapes_large', 'train.json'), 'w') as outfile:
+            json.dump(to_save, outfile, indent=4, separators=(',', ': '), sort_keys=True)
+
+        to_save['data'] = split_data['valid']
+        with open(os.path.join(dpath, 'shapes_large', 'valid.json'), 'w') as outfile:
+            json.dump(to_save, outfile, indent=4, separators=(',', ': '), sort_keys=True)
+
+        # Mark the data as built.
+        build_data.mark_done(dpath)

--- a/parlai/tasks/taskntalk/build.py
+++ b/parlai/tasks/taskntalk/build.py
@@ -18,8 +18,6 @@ def build(opt):
 
     if not build_data.built(dpath):
         print('[building data: ' + dpath + ']')
-        if build_data.built(dpath):
-            build_data.remove_dir(dpath)
         build_data.make_dir(os.path.join(dpath, 'large'))
         build_data.make_dir(os.path.join(dpath, 'small'))
 

--- a/parlai/tasks/taskntalk/build.py
+++ b/parlai/tasks/taskntalk/build.py
@@ -14,10 +14,14 @@ import parlai.core.build_data as build_data
 
 def build(opt):
     """Create train and validation data for synthetic shapes described by attributes."""
-    dpath = os.path.join(opt['datapath'], 'shapes_small')
+    dpath = os.path.join(opt['datapath'], 'taskntalk')
 
     if not build_data.built(dpath):
         print('[building data: ' + dpath + ']')
+        if build_data.built(dpath):
+            build_data.remove_dir(dpath)
+        build_data.make_dir(os.path.join(dpath, 'large'))
+        build_data.make_dir(os.path.join(dpath, 'small'))
 
         # save training and validation data
         to_save = {
@@ -40,33 +44,33 @@ def build(opt):
 
         # randomly select train and rest of it is valid
         split_data['valid'] = random.sample(data_verbose, int(0.8 * len(data_verbose)))
-        split_data['train'] = [s for s in data_verbose if s not in split_data['val']]
+        split_data['train'] = [s for s in data_verbose if s not in split_data['valid']]
 
         to_save['data'] = split_data['train']
-        with open(os.path.join(dpath, 'shapes_small', 'train.json'), 'w') as outfile:
+        with open(os.path.join(dpath, 'small', 'train.json'), 'w') as outfile:
             json.dump(to_save, outfile, indent=4, separators=(',', ': '), sort_keys=True)
 
         to_save['data'] = split_data['valid']
-        with open(os.path.join(dpath, 'shapes_small', 'valid.json'), 'w') as outfile:
+        with open(os.path.join(dpath, 'small', 'valid.json'), 'w') as outfile:
             json.dump(to_save, outfile, indent=4, separators=(',', ': '), sort_keys=True)
 
         # large dataset properties
         properties = {
             'color': ['red', 'green', 'blue', 'purple', 'yellow', 'cyan', 'orange', 'teal'],
-            'shape': ['square', 'triangle', 'circle', 'star', 'heart', 'pentagon', 'hexagon', 'ring'],
+            'shape': ['square', 'triangle', 'circle', 'star', 'heart', 'spade', 'club', 'diamond'],
             'style': ['dotted', 'solid', 'filled', 'dashed', 'hstripe', 'vstripe', 'hgrad', 'vgrad']
         }
         to_save['properties'] = properties
         data_verbose = list(itertools.product(*[properties[key] for key in to_save['attributes']]))
         split_data['valid'] = random.sample(data_verbose, int(0.8 * len(data_verbose)))
-        split_data['train'] = [s for s in data_verbose if s not in split_data['val']]
+        split_data['train'] = [s for s in data_verbose if s not in split_data['valid']]
 
         to_save['data'] = split_data['train']
-        with open(os.path.join(dpath, 'shapes_large', 'train.json'), 'w') as outfile:
+        with open(os.path.join(dpath, 'large', 'train.json'), 'w') as outfile:
             json.dump(to_save, outfile, indent=4, separators=(',', ': '), sort_keys=True)
 
         to_save['data'] = split_data['valid']
-        with open(os.path.join(dpath, 'shapes_large', 'valid.json'), 'w') as outfile:
+        with open(os.path.join(dpath, 'large', 'valid.json'), 'w') as outfile:
             json.dump(to_save, outfile, indent=4, separators=(',', ': '), sort_keys=True)
 
         # Mark the data as built.

--- a/parlai/tasks/taskntalk/build.py
+++ b/parlai/tasks/taskntalk/build.py
@@ -22,7 +22,9 @@ def build(opt):
         # save training and validation data
         to_save = {
             'attributes': ['color', 'shape', 'style'],
-            'task_defn': [[0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1]],
+            'task_defn': [['color', 'shape'], ['shape', 'color'],
+                          ['color', 'style'], ['style', 'color'],
+                          ['shape', 'style'], ['style', 'shape']]
         }
         split_data = {}
 


### PR DESCRIPTION
### Reference Issue #446

This PR adds `taskntalk` task to the current list of tasks in ParlAI. There are two types of datasets - small and large. Also, `TaskNTalkTeacher` is created for fetching examples from this dataset, although it lacks metric handling functionality (to be introduced later).

Here are few examples of `display_data.py` example:

```sh
$ python3 display_data.py -t taskntalk:small --num-examples 1
[ optional arguments: ] 
[  num_examples: 1 ]
[ Main ParlAI Arguments: ] 
[  image_mode: raw ]
[  datatype: train ]
[  numthreads: 1 ]
[  task: taskntalk ]
[  datapath: /home/kd/Documents/gt/parlai/data ]
[  download_path: /home/kd/Documents/gt/parlai/downloads ]
[ Batching Arguments: ] 
[  batchsize: 1 ]
[creating task(s): taskntalk]
loading: /home/kd/Documents/gt/parlai/data/taskntalk/small/train.json
blue square solid
color shape
[labels: blue square]
   [RepeatLabelAgent]: blue square
- - - - - - - - - - - - - - - - - - - - -
~~
```
Similar results for `-t taskntalk:large` and `-t taskntalk`. And for batchsize > 1:
```sh
$ python3 display_data.py -t taskntalk:small --num-examples 1 --batchsize 2 -dt valid
     --- similar as above, excluded for sanity ---
loading: /home/kd/Documents/gt/parlai/data/taskntalk/small/valid.json
[--batchsize 2--]
[batch world 0:]
blue triangle solid
color shape
[labels: blue triangle]
   [RepeatLabelAgent]: blue triangle
- - - - - - - - - - - - - - - - - - - - -
[batch world 1:]
green triangle dashed
color style
[labels: blue triangle]
   [RepeatLabelAgent]: green dashed
- - - - - - - - - - - - - - - - - - - - -
[--end of batch--]
```