### PR TITLE
Pytorch data fixes

### DIFF
--- a/examples/build_pytorch_data.py
+++ b/examples/build_pytorch_data.py
@@ -70,13 +70,14 @@ def build_data(opt):
                         'have a datafile or `--datafile` is not set')
 
     pytorch_datafile = datafile + ".pytorch"
-    if opt.get('preprocess', True):
+    preprocess = opt.get('pytorch_preprocess', True)
+    if preprocess:
         pytorch_datafile += agent.getID()
     if os.path.isfile(pytorch_datafile):
         # Data already built
         print("[ pytorch data already built. ]")
         return pytorch_datafile
-    print('----------\n[ setting up pytorch data. ]\n----------')
+    print('----------\n[ setting up pytorch data, saving to {}. ]\n----------'.format(pytorch_datafile))
 
     num_eps = 0
     num_exs = 0
@@ -85,7 +86,6 @@ def build_data(opt):
     include_labels = opt.get('include_labels', True)
     context_length = opt.get('context_length', -1)
     context = deque(maxlen=context_length if context_length > 0 else None)
-    preprocess = opt.get('pytorch_preprocess', True)
     # pass examples to dictionary
     with open(pytorch_datafile, 'w') as pytorch_data:
         while not world_data.epoch_done():
@@ -130,9 +130,14 @@ def main():
                        help=('The file to be loaded, preprocessed, and saved'))
     build.add_argument('--pytorch_buildteacher', type=str, default='',
         help='Which teacher to use when building the pytorch data')
-    build.add_argument('--pytorch_preprocess', type=bool, default=True,
-        help='Whether the agent should preprocess the data while building'
+    preprocess = argparser.add_mutually_exclusive_group(required=False)
+    preprocess.add_argument('--pytorch_preprocess', dest='pytorch_preprocess', action='store_true',
+        help='Set if the agent should preprocess the data while building'
              'the pytorch data')
+    preprocess.add_argument('--no_pytorch_preprocess', dest='pytorch_preprocess', action='store_false',
+        help='Set if the agent should NOT preprocess the data while building'
+             'the pytorch data')
+    argparser.set_defaults(pytorch_preprocess=True)
     opt = argparser.parse_args()
     build_data(opt)
 

--- a/examples/build_pytorch_data.py
+++ b/examples/build_pytorch_data.py
@@ -130,14 +130,9 @@ def main():
                        help=('The file to be loaded, preprocessed, and saved'))
     build.add_argument('--pytorch_buildteacher', type=str, default='',
         help='Which teacher to use when building the pytorch data')
-    preprocess = argparser.add_mutually_exclusive_group(required=False)
-    preprocess.add_argument('--pytorch_preprocess', dest='pytorch_preprocess', action='store_true',
-        help='Set if the agent should preprocess the data while building'
+    build.add_argument('--pytorch_preprocess', type='bool', default=True,
+        help='Whether the agent should preprocess the data while building'
              'the pytorch data')
-    preprocess.add_argument('--no_pytorch_preprocess', dest='pytorch_preprocess', action='store_false',
-        help='Set if the agent should NOT preprocess the data while building'
-             'the pytorch data')
-    argparser.set_defaults(pytorch_preprocess=True)
     opt = argparser.parse_args()
     build_data(opt)
 

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -318,12 +318,15 @@ class Seq2seqAgent(Agent):
         # shallow copy observation (deep copy can be expensive)
         obs = observation.copy()
         batch_idx = self.opt.get('batchindex', 0)
-        obs['text2vec'] = maintain_dialog_history(
-            self.history, obs,
-            reply=self.answers[batch_idx],
-            historyLength=self.opt['history_length'],
-            useReplies=self.opt['history_replies'],
-            dict=self.dict)
+        if not obs.get('preprocessed', False):
+            obs['text2vec'] = maintain_dialog_history(
+                self.history, obs,
+                reply=self.answers[batch_idx],
+                historyLength=self.opt['history_length'],
+                useReplies=self.opt['history_replies'],
+                dict=self.dict)
+        else:
+            obs['text2vec'] = deque(obs['text2vec'], self.opt['history_length'])
         self.observation = obs
         self.answers[batch_idx] = None
         return obs

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -100,8 +100,6 @@ class StreamDataset(Dataset):
         self.data_gen = self._data_generator(self.datafile)
         self.length_datafile = self.datafile + ".length"
         self._load_lens()
-        self.indices_lock = None
-        self.indices_seen = None
 
     def __getitem__(self, index):
         while True:
@@ -179,7 +177,6 @@ class PytorchDataTeacher(FixedDialogTeacher):
                 collate_fn=collate_fn,
                 pin_memory=False,
                 drop_last=False,
-                # timeout=0
                 )
             self.lastYs = [None] * self.bsz
         else:

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -148,9 +148,14 @@ class PytorchDataTeacher(FixedDialogTeacher):
             help='how many workers the Pytorch dataloader should use')
         arg_group.add_argument('--pytorch_buildteacher', type=str, default='',
             help='Which teacher to use when building the pytorch data')
-        arg_group.add_argument('--pytorch_preprocess', type=bool, default=True,
-            help='Whether the agent should preprocess the data while building'
+        preprocess = argparser.add_mutually_exclusive_group(required=False)
+        preprocess.add_argument('--pytorch_preprocess', dest='pytorch_preprocess', action='store_true',
+            help='Set if the agent should preprocess the data while building'
                  'the pytorch data')
+        preprocess.add_argument('--no_pytorch_preprocess', dest='pytorch_preprocess', action='store_false',
+            help='Set if the agent should NOT preprocess the data while building'
+                 'the pytorch data')
+        argparser.set_defaults(pytorch_preprocess=True)
 
     def __init__(self, opt, shared=None):
         opt['batch_sort'] = False
@@ -170,7 +175,8 @@ class PytorchDataTeacher(FixedDialogTeacher):
                 collate_fn=collate_fn,
                 pin_memory=False,
                 drop_last=False,
-                timeout=0)
+                # timeout=0
+                )
             self.lastYs = [None] * self.bsz
         else:
             self.dataset = shared['dataset']

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -150,14 +150,9 @@ class PytorchDataTeacher(FixedDialogTeacher):
             help='how many workers the Pytorch dataloader should use')
         arg_group.add_argument('--pytorch_buildteacher', type=str, default='',
             help='Which teacher to use when building the pytorch data')
-        preprocess = argparser.add_mutually_exclusive_group(required=False)
-        preprocess.add_argument('--pytorch_preprocess', dest='pytorch_preprocess', action='store_true',
-            help='Set if the agent should preprocess the data while building'
+        arg_group.add_argument('--pytorch_preprocess', type='bool', default=True,
+            help='Whether the agent should preprocess the data while building'
                  'the pytorch data')
-        preprocess.add_argument('--no_pytorch_preprocess', dest='pytorch_preprocess', action='store_false',
-            help='Set if the agent should NOT preprocess the data while building'
-                 'the pytorch data')
-        argparser.set_defaults(pytorch_preprocess=True)
 
     def __init__(self, opt, shared=None):
         opt['batch_sort'] = False


### PR DESCRIPTION
A few minor fixes/improvements to the Pytorch Teacher

- fix preprocess command line arg so that it actually works (specify `--pytorch_preprocess` for preprocessing, `--no_pytorch_preprocess` for no preprocessing
- make sure seq2seq model doesnt preprocess twice
- fix StreamDataset `__getitem__` so that, when there are multiple workers (e.g. 4), they do not load the same example 4 times (as they each get their own copy of the StreamDataset).