### PR TITLE
Fix create_task_world error for multiple agents.

### DIFF
--- a/examples/base_train.py
+++ b/examples/base_train.py
@@ -24,22 +24,25 @@ import time
 def main():
     # Get command line arguments
     parser = ParlaiParser()
-    parser.add_argument('-n', '--num-examples', default=10)
+    parser.add_argument('-n', '--num-iters', default=10, type=int)
+    parser.add_argument('-a', '--num-agents', default=1, type=int)
     opt = parser.parse_args()
 
-    agent = Agent(opt)
+    agents = []
+    for _ in range(opt['num_agents']):
+        agents.append(Agent(opt))
 
     opt['datatype'] = 'train'
-    world_train = create_task(opt, agent)
+    world_train = create_task(opt, agents)
 
     opt['datatype'] = 'valid'
-    world_valid = create_task(opt, agent)
+    world_valid = create_task(opt, agents)
 
     start = time.time()
     # train / valid loop
     for _ in range(1):
         print('[ training ]')
-        for _ in range(10):  # train for a bit
+        for _ in range(opt['num_iters']):  # train for a bit
             world_train.parley()
 
         print('[ training summary. ]')

--- a/examples/display_data.py
+++ b/examples/display_data.py
@@ -12,39 +12,15 @@ see a few of them:
 """
 
 from parlai.core.params import ParlaiParser
-from parlai.core.agents import Agent
 from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
 from parlai.core.worlds import create_task
 
 import random
 
-
-class RepeatTextAgent(Agent):
-    """Simple agent which repeats the text it receives."""
-    def __init__(self, opt, shared=None):
-        super().__init__(opt)
-        self.id = 'RepeatTextAgent'
-
-    def act(self):
-        obs = self.observation
-        if obs is None or 'text' not in obs:
-            return {'text': 'Nothing to repeat yet.'}
-        return {'id': self.getID(), 'text': obs['text']}
-
-
 def display_data(opt):
-    # create one repeat label agent and assign it to the specified task
-    agents = []
-    agents.append(RepeatLabelAgent(opt))
-
-    # since RepeatLabelAgent action has label in 'text', other agents
-    # should be `RepeatTextAgent`s
-    for _ in range(opt['num_agents'] - 1):
-        agents.append(RepeatTextAgent(opt))
-
-    # world will be `DialogPartnerWorld` for num_agents = 1
-    # (agent + task teacher), else it will be `MultiAgentDialogWorld`
-    world = create_task(opt, agents)
+    # create repeat label agent and assign it to the specified task
+    agent = RepeatLabelAgent(opt)
+    world = create_task(opt, agent)
 
     # Show some example dialogs.
     with world:
@@ -62,7 +38,6 @@ def main():
     # Get command line arguments
     parser = ParlaiParser()
     parser.add_argument('-n', '--num-examples', default=10, type=int)
-    parser.add_argument('-a', '--num-agents', default=1, type=int)
     opt = parser.parse_args()
 
     display_data(opt)

--- a/examples/display_data.py
+++ b/examples/display_data.py
@@ -12,15 +12,39 @@ see a few of them:
 """
 
 from parlai.core.params import ParlaiParser
+from parlai.core.agents import Agent
 from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
 from parlai.core.worlds import create_task
 
 import random
 
+
+class RepeatTextAgent(Agent):
+    """Simple agent which repeats the text it receives."""
+    def __init__(self, opt, shared=None):
+        super().__init__(opt)
+        self.id = 'RepeatTextAgent'
+
+    def act(self):
+        obs = self.observation
+        if obs is None or 'text' not in obs:
+            return {'text': 'Nothing to repeat yet.'}
+        return {'id': self.getID(), 'text': obs['text']}
+
+
 def display_data(opt):
-    # create repeat label agent and assign it to the specified task
-    agent = RepeatLabelAgent(opt)
-    world = create_task(opt, agent)
+    # create one repeat label agent and assign it to the specified task
+    agents = []
+    agents.append(RepeatLabelAgent(opt))
+
+    # since RepeatLabelAgent action has label in 'text', other agents
+    # should be `RepeatTextAgent`s
+    for _ in range(opt['num_agents'] - 1):
+        agents.append(RepeatTextAgent(opt))
+
+    # world will be `DialogPartnerWorld` for num_agents = 1
+    # (agent + task teacher), else it will be `MultiAgentDialogWorld`
+    world = create_task(opt, agents)
 
     # Show some example dialogs.
     with world:
@@ -38,6 +62,7 @@ def main():
     # Get command line arguments
     parser = ParlaiParser()
     parser.add_argument('-n', '--num-examples', default=10, type=int)
+    parser.add_argument('-a', '--num-agents', default=1, type=int)
     opt = parser.parse_args()
 
     display_data(opt)

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -74,6 +74,9 @@ class Agent(object):
     def getID(self):
         return self.id
 
+    def epoch_done(self):
+        return False
+
     def reset(self):
         self.observation = None
 

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -301,8 +301,7 @@ class DialogPartnerWorld(World):
 
     def epoch_done(self):
         """Only the first agent indicates when the epoch is done."""
-        return (self.agents[0].epoch_done()
-                if hasattr(self.agents[0], 'epoch_done') else False)
+        return self.agents[0].epoch_done()
 
     def report(self, compute_time=False):
         if hasattr(self.agents[0], 'report'):
@@ -356,9 +355,8 @@ class MultiAgentDialogWorld(World):
     def epoch_done(self):
         done = False
         for a in self.agents:
-            if hasattr(a, 'epoch_done'):
-                if a.epoch_done():
-                    done = True
+            if a.epoch_done():
+                done = True
         return done
 
     def episode_done(self):
@@ -895,7 +893,10 @@ def _get_task_world(opt, user_agents):
     if '.' in sp[0]:
         # The case of opt['task'] = 'parlai.tasks.squad.agents:DefaultTeacher'
         # (i.e. specifying your own path directly, assumes DialogPartnerWorld)
-        world_class = DialogPartnerWorld
+        if len(task_agents + user_agents) == 2:
+            world_class = DialogPartnerWorld
+        else:
+            world_class = MultiAgentDialogWorld
     else:
         task = sp[0].lower()
         if len(sp) > 1:


### PR DESCRIPTION
Bug Description
============

Minimal snippet (import statements and other details omitted for brevity):
```python
agent1 = Agent(opt)
agent2 = Agent(opt)
world = create_task_world(opt, [agent1, agent2])
```

**Actual Behaviour:** `create_task_world` returns `DialogPartnerWorld` even if agents are more than 2.
```text
RuntimeError: There must be exactly two agents for this world.
```

**Desired Behaviour:** `world` should be an instance of `MultiAgentDialogWorld`.

Contribution
=========
- Fix this error by returning a `MultiAgentDialogWorld`.
- Fix `epoch_done` method of `MultiAgentDialogWorld` and make it similar to `DialogPartnerWorld`'s method of the same name.
- Modify ~`display_data.py`~ `base_train.py` example to allow specifying multiple agents, just to make sure this works. Old example usage works the same way (`python3 base_train.py -t taskname`)

Example Usage
============
```text
~$ python3 base_train.py -t taskntalk --num-iters 1 --num-agents 2
[ optional arguments: ] 
[  num_iters: 1 ]
[  num_agents: 2 ]
        ### other arguments omitted for brevity ###
[ training ]
agent received observation:
  {'episode_done': True, 'image': 'purple circle dashed', 'labels': ['purple circle'], 'text': 'color shape'}
agent sending message:
  {'text': 'hello, teacher!'}
agent received observation:
  {'text': 'hello, teacher!'}
agent sending message:
  {'text': 'hello, teacher!'}
[ training summary. ]
  {'total': 0}
[ validating ]
agent received observation:
  {'episode_done': True, 'image': 'red star dashed', 'labels': ['star red'], 'text': 'shape color'}
agent sending message:
  {'text': 'hello, teacher!'}
agent received observation:
  {'text': 'hello, teacher!'}
agent sending message:
  {'text': 'hello, teacher!'}
[ validation summary. ]
  {'total': 0}
finished in 0.0 s
```