### PR TITLE
Add task for COPA

### DIFF
--- a/parlai/tasks/copa/__init__.py
+++ b/parlai/tasks/copa/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/tasks/copa/agents.py
+++ b/parlai/tasks/copa/agents.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+from parlai.core.teachers import DialogTeacher
+from .build import build
+
+import xml.etree.ElementTree as ET
+import os
+import copy
+
+
+COPA = "COPA"
+COPA_RESOURCES_FOLDER_NAME = 'COPA-resources'
+COPA_DATASETS_FOLDER_NAME = 'datasets'
+COPA_DATASET_PREFIX = 'copa-'
+COPA_CAUSE_SUFFIX = "What was the CAUSE for this?"
+COPA_RESULT_SUFFIX = "What happened as a RESULT?"
+
+
+def _path(opt):
+    build(opt)
+
+    dt = opt['datatype'].split(':')[0]
+
+    if dt == 'train':
+        suffix = 'dev'
+    elif dt == 'valid':
+        raise RuntimeError('No validation dataset for COPA')
+    elif dt == 'test':
+        suffix = 'test'
+    else:
+        raise RuntimeError('Not valid datatype.')
+
+    data_path = os.path.join(opt['datapath'], COPA,
+                             COPA_RESOURCES_FOLDER_NAME,
+                             COPA_DATASETS_FOLDER_NAME,
+                             COPA_DATASET_PREFIX + suffix + '.xml')
+
+    return data_path
+
+
+class DefaultTeacher(DialogTeacher):
+    def __init__(self, opt, shared=None):
+        opt = copy.deepcopy(opt)
+        data_path = _path(opt)
+        opt['datafile'] = data_path
+        self.id = 'COPA'
+
+        super().__init__(opt, shared)
+
+    def setup_data(self, path):
+        print('loading: ' + path)
+
+        tree = ET.parse(path)
+        root = tree.getroot()
+
+        for child in root:
+            id = child.attrib['id']
+            asks_for = child.attrib['asks-for']
+            answer = child.attrib['most-plausible-alternative']
+
+            premise = child[0].text
+            alternative_one = child[1].text
+            alternative_two = child[2].text
+
+            if asks_for == "cause":
+                premise += " " + COPA_CAUSE_SUFFIX
+            else:
+                premise += " " + COPA_RESULT_SUFFIX
+
+            if answer == "1":
+                answer = [alternative_one]
+            else:
+                answer = [alternative_two]
+            answer_options = [alternative_one, alternative_two]
+
+            yield (premise, answer, None, answer_options), False

--- a/parlai/tasks/copa/agents.py
+++ b/parlai/tasks/copa/agents.py
@@ -77,4 +77,4 @@ class DefaultTeacher(DialogTeacher):
                 answer = [alternative_two]
             answer_options = [alternative_one, alternative_two]
 
-            yield (premise, answer, None, answer_options), False
+            yield (premise, answer, None, answer_options), True

--- a/parlai/tasks/copa/agents.py
+++ b/parlai/tasks/copa/agents.py
@@ -25,10 +25,8 @@ def _path(opt):
 
     dt = opt['datatype'].split(':')[0]
 
-    if dt == 'train':
+    if dt == 'train' or dt == 'valid':
         suffix = 'dev'
-    elif dt == 'valid':
-        raise RuntimeError('No validation dataset for COPA')
     elif dt == 'test':
         suffix = 'test'
     else:
@@ -58,7 +56,6 @@ class DefaultTeacher(DialogTeacher):
         root = tree.getroot()
 
         for child in root:
-            id = child.attrib['id']
             asks_for = child.attrib['asks-for']
             answer = child.attrib['most-plausible-alternative']
 

--- a/parlai/tasks/copa/build.py
+++ b/parlai/tasks/copa/build.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import parlai.core.build_data as build_data
+import os
+
+
+def build(opt):
+    dpath = os.path.join(opt['datapath'], 'COPA')
+    version = None
+
+    if not build_data.built(dpath, version_string=version):
+        print('[building data: ' + dpath + ']')
+
+        if build_data.built(dpath):
+            # an older version exists, so remove these outdated files.
+            build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # download the data.
+        fname = 'COPA-resources.tgz'
+        # dataset URL
+        url = 'http://people.ict.usc.edu/~gordon/downloads/' + fname
+        build_data.download(url, dpath, fname)
+
+        # uncompress it
+        build_data.untar(dpath, fname)
+
+        # mark the data as built
+        build_data.mark_done(dpath, version_string=version)

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -39,6 +39,13 @@ task_list = [
         "description": "Sentence completion given a few sentences as context from a children's book. From Hill et al., '16. Link: https://arxiv.org/abs/1511.02301"
     },
     {
+        "id": "COPA",
+        "display_name": "Choice of Plausible Alternatives",
+        "task": "copa",
+        "tags": [ "All",  "Reasoning" ],
+        "description": "The Choice Of Plausible Alternatives (COPA) evaluation provides researchers with a tool for assessing progress in open-domain commonsense causal reasoning. COPA consists of 1000 questions, split equally into development and test sets of 500 questions each. See http://people.ict.usc.edu/~gordon/copa.html for more information"
+    },
+    {
         "id": "CornellMovie",
         "display_name": "Cornell Movie",
         "task": "cornell_movie",


### PR DESCRIPTION
Resolves #414 

PR adds support for COPA task:

Output from `display_data.py`:

```
$ python examples/display_data.py -t copa --num-examples 1  
[ optional arguments: ] 
[  num_examples: 1 ]
[ Main ParlAI Arguments: ] 
[  task: copa ]
[  download_path: /home/apsdehal/projects/forks/ParlAI/downloads ]
[  datatype: train ]
[  image_mode: raw ]
[  numthreads: 1 ]
[  datapath: /home/apsdehal/projects/forks/ParlAI/data ]
[ Batching Arguments: ] 
[  batchsize: 1 ]
[creating task(s): copa]
loading: /home/apsdehal/projects/forks/ParlAI/data/COPA/COPA-resources/datasets/copa-dev.xml
[COPA]: My body cast a shadow over the grass. What was the CAUSE for this?
[labels: The sun was rising.]
[cands: The sun was rising.|The grass was cut.]
   [RepeatLabelAgent]: The sun was rising.
~~
```

Let me know of any changes required.