### PR TITLE
Creates example for qualifications, fixes qual bug

### DIFF
--- a/docs/source/mturk.rst
+++ b/docs/source/mturk.rst
@@ -33,6 +33,7 @@ We provide a few examples of using Mechanical Turk with ParlAI:
 - `Model Evaluator <https://github.com/facebookresearch/ParlAI/blob/master/parlai/mturk/tasks/model_evaluator/>`__: ask Turkers to evaluate the information retrieval baseline model on the Reddit movie dialog dataset.
 - `Multi-Agent Dialog <https://github.com/facebookresearch/ParlAI/blob/master/parlai/mturk/tasks/multi_agent_dialog/>`__: round-robin chat between a local human agent and two Turkers.
 - `Deal or No Deal <https://github.com/facebookresearch/ParlAI/tree/master/parlai/mturk/tasks/dealnodeal/>`__: negotiation chat between two agents over how to fairly divide a fixed set of items when each agent values the items differently.
+- `Qualification Flow Example <https://github.com/facebookresearch/ParlAI/tree/master/parlai/mturk/tasks/qualification_flow_example>`__: filter out workers from working on more instances of your task if they fail to complete a test instance properly.
 
 Task 1: Collecting Data
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -83,6 +84,13 @@ ParlAI is able to support more than just generic chat. The `Deal or No Deal task
 This task leverages the ability to override base functionality of the core.html page using ``task_config.py``. Javascript is added here to replace the task description with additional buttons and UI elements that are required for the more complicated task. These trigger within an overridden handle_new_message function, which will only fire after an agent has entered the chat.
 In general it is easier/preferred to use a custom webpage as described in step 4 of "Creating Your Own Task", though this is an alternate that can be used if you specifically only want to show additional components in the task description pane of the chat window.
 
+Task 5: Advanced Functionality - MTurk Qualification Flow
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ParlAI MTurk is able to support filtering users through a form of qualification system. The `Qualification Flow task <https://github.com/facebookresearch/ParlAI/tree/master/parlai/mturk/tasks/qualification_flow_example>`__ demos this functionality using a simple "addition" task.
+
+In this task, all users see a test version of the task on the first time they enter it and a real version every subsequent time, however users that fail to pass the test version are assigned a qualification that prevents them from working on the task again. Thus ParlAI users are able to filter out workers from the very beginning who don't necessarily meet the specifications you are going for.
+This is preferred to filtering out workers using the onboarding world for tasks that require a full instance's worth of work to verify a worker's readiness.
 
 Creating Your Own Task
 ----------------------

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -269,15 +269,16 @@ def give_worker_qualification(worker_id, qualification_id, value=None):
 
     if value is not None:
         client.associate_qualification_with_worker(
-            QualificationTypeId='string',
-            WorkerId='string',
+            QualificationTypeId=qualification_id,
+            WorkerId=worker_id,
             IntegerValue=value,
             SendNotification=False
         )
     else:
         client.associate_qualification_with_worker(
-            QualificationTypeId='string',
-            WorkerId='string',
+            QualificationTypeId=qualification_id,
+            WorkerId=worker_id,
+            IntegerValue=1,
             SendNotification=False
         )
 

--- a/parlai/mturk/tasks/qualification_flow_example/__init__.py
+++ b/parlai/mturk/tasks/qualification_flow_example/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/mturk/tasks/qualification_flow_example/run.py
+++ b/parlai/mturk/tasks/qualification_flow_example/run.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+from parlai.core.params import ParlaiParser
+from parlai.mturk.tasks.qualification_flow_example.worlds import \
+    QualificationFlowOnboardWorld, QualificationFlowSoloWorld
+from parlai.mturk.core.mturk_manager import MTurkManager
+import parlai.mturk.core.mturk_utils as mturk_utils
+from task_config import task_config
+import os
+import random
+
+
+def main():
+    completed_workers = []
+    argparser = ParlaiParser(False, False)
+    argparser.add_parlai_data_path()
+    argparser.add_mturk_args()
+    opt = argparser.parse_args()
+    opt['task'] = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+    opt.update(task_config)
+
+    mturk_agent_id = 'Worker'
+    mturk_manager = MTurkManager(
+        opt=opt,
+        mturk_agent_ids=[mturk_agent_id]
+    )
+    mturk_manager.setup_server()
+    qual_name = 'ParlAIExcludeQual{}t{}'.format(
+        random.randint(10000, 99999), random.randint(10000, 99999))
+    qual_desc = (
+        'Qualification for a worker not correctly completing the '
+        'first iteration of a task. Used to filter to different task pools.'
+    )
+    qualification_id = \
+        mturk_utils.find_or_create_qualification(qual_name, qual_desc)
+    print('Created qualification: ', qualification_id)
+
+    def run_onboard(worker):
+        world = QualificationFlowOnboardWorld(opt, worker)
+        while not world.episode_done():
+            world.parley()
+        world.shutdown()
+
+    mturk_manager.set_onboard_function(onboard_function=run_onboard)
+
+    try:
+        mturk_manager.start_new_run()
+        agent_qualifications = [{
+            'QualificationTypeId': qualification_id,
+            'Comparator': 'DoesNotExist',
+            'RequiredToPreview': True
+        }]
+        mturk_manager.create_hits(qualifications=agent_qualifications)
+
+        mturk_manager.ready_to_accept_workers()
+
+        def check_worker_eligibility(worker):
+            return True
+
+        def assign_worker_roles(worker):
+            worker[0].id = mturk_agent_id
+
+        global run_conversation
+
+        def run_conversation(mturk_manager, opt, workers):
+            mturk_agent = workers[0]
+            world = QualificationFlowSoloWorld(
+                opt=opt,
+                mturk_agent=mturk_agent,
+                qualification_id=qualification_id,
+                firstTime=(mturk_agent.worker_id not in completed_workers),
+            )
+            while not world.episode_done():
+                world.parley()
+            completed_workers.append(mturk_agent.worker_id)
+            world.shutdown()
+            world.review_work()
+
+        mturk_manager.start_task(
+            eligibility_function=check_worker_eligibility,
+            assign_role_function=assign_worker_roles,
+            task_function=run_conversation
+        )
+    except BaseException:
+        raise
+    finally:
+        mturk_utils.delete_qualification(qualification_id)
+        mturk_manager.expire_all_unassigned_hits()
+        mturk_manager.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/parlai/mturk/tasks/qualification_flow_example/task_config.py
+++ b/parlai/mturk/tasks/qualification_flow_example/task_config.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+task_config = {}
+
+
+"""A short and descriptive title about the kind of task the HIT contains.
+On the Amazon Mechanical Turk web site, the HIT title appears in search results,
+and everywhere the HIT is mentioned.
+"""
+task_config['hit_title'] = 'Answer simple math questions'
+
+
+"""A description includes detailed information about the kind of task the HIT contains.
+On the Amazon Mechanical Turk web site, the HIT description appears in the expanded
+view of search results, and in the HIT and assignment screens.
+"""
+task_config['hit_description'] = 'Gives a few math questions to be answered.'
+
+
+"""One or more words or phrases that describe the HIT, separated by commas.
+On MTurk website, these words are used in searches to find HITs.
+"""
+task_config['hit_keywords'] = 'chat,math'
+
+
+"""A detailed task description that will be shown on the HIT task preview page
+and on the left side of the chat page. Supports HTML formatting.
+"""
+task_config['task_description'] = \
+'''\'\'\'
+In this task, you will be given a math question to answer. Please answer numerically.<br><br>
+Only take one task at a time <br><br>
+
+If you are ready, please click "Accept HIT" to start this task.
+\'\'\''''

--- a/parlai/mturk/tasks/qualification_flow_example/worlds.py
+++ b/parlai/mturk/tasks/qualification_flow_example/worlds.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+from parlai.core.worlds import validate
+from parlai.mturk.core.worlds import MTurkOnboardWorld, MTurkTaskWorld
+import parlai.mturk.core.mturk_utils as mturk_utils
+
+import random
+
+class QualificationFlowOnboardWorld(MTurkOnboardWorld):
+    def parley(self):
+        ad = {}
+        ad['id'] = 'System'
+        ad['text'] = (
+            'This demo displays the functionality of using qualifications to '
+            'filter the workers who are able to do your tasks. The first task '
+            'you will get will check to see if you pass the bar that the task '
+            'requires against a prepared test set. If you pass, the next task '
+            'will be a real one rather than the test one.'
+            '\n'
+            'Send anything to get started.'
+        )
+        self.mturk_agent.observe(ad)
+        self.mturk_agent.act()
+        self.episodeDone = True
+
+
+class QualificationFlowSoloWorld(MTurkTaskWorld):
+    """
+    World that asks a user 5 math questions, first from a test set if the user
+    is entering for the first time, and then randomly for all subsequent times
+
+    Users who don't get enough correct in the test set are assigned a
+    qualification that blocks them from completing more HITs during shutdown
+
+    Demos functionality of filtering workers with just one running world.
+
+    Similar results could be achieved by using two worlds where the first acts
+    as just a filter and gives either a passing or failing qualification. The
+    second would require the passing qualification. The first world could then
+    be runnable using the --unique flag.
+    """
+    test_set = [
+        ['What is 1+1?', '2'],
+        ['What is 3+2?', '5'],
+        ['What is 6+6?', '12'],
+        ['What is 5-3?', '2'],
+        ['What is 6*4?', '24'],
+    ]
+
+    collector_agent_id = 'System'
+
+    def __init__(self, opt, mturk_agent, qualification_id, firstTime):
+        self.mturk_agent = mturk_agent
+        self.firstTime = firstTime
+        if not firstTime:
+            self.questions = self.generate_questions(5)
+        else:
+            self.questions = self.test_set
+        self.episodeDone = False
+        self.correct = 0
+        self.curr_question = 0
+        self.qualification_id = qualification_id
+
+    def generate_questions(self, num):
+        questions = []
+        for _ in range(num):
+            num1 = random.randint(1, 20)
+            num2 = random.randint(3, 16)
+            questions.append([
+                'What is {} + {}?'.format(num1, num2),
+                '{}'.format(num1 + num2)
+            ])
+        return questions
+
+    def parley(self):
+        if self.curr_question == len(self.questions):
+            ad = {
+                'episode_done': True,
+                'id': self.__class__.collector_agent_id,
+                'text': 'Thank you for your answers!',
+            }
+            self.mturk_agent.observe(validate(ad))
+            self.episodeDone = True
+        else:
+            ad = {
+                'episode_done': True,
+                'id': self.__class__.collector_agent_id,
+                'text': self.questions[self.curr_question][0],
+            }
+            self.mturk_agent.observe(validate(ad))
+            answer = self.mturk_agent.act()
+            if answer == self.questions[self.curr_question][1]:
+                self.correct += 1
+            self.curr_question += 1
+
+    def episode_done(self):
+        return self.episodeDone
+
+    def report(self):
+        pass
+
+    def shutdown(self):
+        """
+        Here is where the filtering occurs. If a worker hasn't successfully
+        answered all the questions correctly, they are given the qualification
+        that marks that they should be blocked from this task.
+        """
+        if self.firstTime and self.correct != len(self.questions):
+                mturk_utils.give_worker_qualification(
+                    self.mturk_agent.worker_id,
+                    self.qualification_id
+                )
+        self.mturk_agent.shutdown()
+
+    def review_work(self):
+        pass


### PR DESCRIPTION
Introduces a demo of the parlai mturk qualification feature that shows the most basic instance of what is possible. Future extensions may include demonstrating how to use a primer task to filter workers into different tiers that get different kinds of tasks.

Fixes a small bug that prevented people from properly using the parlai-user facing api for qualifications.