### PR TITLE
remove extra linear layer from s2s when not needed

### DIFF
--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -199,7 +199,11 @@ class Decoder(nn.Module):
                              dropout=dropout, batch_first=True)
 
         # rnn output to embedding
-        self.o2e = nn.Linear(hidden_size, emb_size)
+        if hidden_size != emb_size:
+            self.o2e = nn.Linear(hidden_size, emb_size)
+        else:
+            # no need to learn the extra weights
+            self.o2e = lambda x: x
         # embedding to scores, use custom linear to possibly share weights
         shared_weight = self.lt.weight if share_output else None
         self.e2s = Linear(emb_size, num_features, bias=False,


### PR DESCRIPTION
maybe it would be better to replace the linear layer with some kind of random projection when hsz != esz? this sped up both exs/s and may speed up convergence to remove the linear layer (less computation, fewer params, easier to get the gradient to deeper layers)
  