### PR TITLE
Add support for NarrativeQA

### DIFF
--- a/parlai/tasks/narrative_qa/__init__.py
+++ b/parlai/tasks/narrative_qa/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/tasks/narrative_qa/agents.py
+++ b/parlai/tasks/narrative_qa/agents.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+from parlai.core.teachers import DialogTeacher
+from .build import build
+
+import os
+import copy
+import csv
+import glob
+
+
+def _path(opt):
+    build(opt)
+
+    dt = opt['datatype'].split(':')[0]
+
+    if not (dt == 'train' or dt == 'valid' or dt == 'test'):
+        raise RuntimeError('Not valid datatype.')
+
+    suffix = dt
+
+    data_path = os.path.join(opt['datapath'], 'NarrativeQA',
+                             'narrative_qa', suffix)
+
+    return data_path
+
+
+class SummariesTeacher(DialogTeacher):
+    def __init__(self, opt, shared=None):
+        opt = copy.deepcopy(opt)
+        data_path = _path(opt)
+        opt['datafile'] = data_path
+        self.id = 'NarrativeQA'
+
+        super().__init__(opt, shared)
+
+    def setup_data(self, path):
+        print('loading data from: ' + path)
+
+        qa_path = os.path.join(path, 'qaps.csv')
+        summaries_path = os.path.join(path, 'summaries.csv')
+
+        qa_pairs = dict()
+
+        with open(qa_path, 'r') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                if row['document_id'] not in qa_pairs:
+                    qa_pairs[row['document_id']] = []
+                qa_pairs[row['document_id']].append(row)
+
+        with open(summaries_path, 'r') as f:
+            reader = csv.DictReader(f)
+
+            for row in reader:
+                info = 'Summary:  %s' % row['summary_tokenized']
+
+                for i, qa in enumerate(qa_pairs[row['document_id']]):
+                    question = qa['question_tokenized']
+                    answer1 = qa['answer1_tokenized']
+                    answer2 = qa['answer2_tokenized']
+
+                    if i == 0:
+                        # Prepend start info in first question
+                        yield (info + '\n' + question,
+                               [answer1, answer2]), True
+                    else:
+                        yield (question, [answer1, answer2]), False
+
+
+class DefaultTeacher(DialogTeacher):
+    def __init__(self, opt, shared=None):
+        opt = copy.deepcopy(opt)
+        data_path = _path(opt)
+        opt['datafile'] = data_path
+        self.id = 'NarrativeQA'
+
+        super().__init__(opt, shared)
+
+    def setup_data(self, path):
+        print('loading data from: ' + path)
+
+        qa_path = os.path.join(path, 'qaps.csv')
+        documents_path = os.path.join(path, 'documents.csv')
+
+        stories_base_path = os.path.join(path, '..', 'stories')
+        qa_pairs = dict()
+
+        print("%s stories found." %
+              len(glob.glob(os.path.join(stories_base_path, "*.content"))))
+
+        with open(qa_path, 'r') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                if row['document_id'] not in qa_pairs:
+                    qa_pairs[row['document_id']] = []
+                qa_pairs[row['document_id']].append(row)
+
+        with open(documents_path, 'r') as f:
+            reader = csv.DictReader(f)
+
+            for row in reader:
+                story_path = os.path.join(stories_base_path,
+                                          row['document_id'] + '.content')
+
+                if not os.path.exists(story_path):
+                    continue
+
+                story = None
+                with open(story_path, 'r', encoding='utf-8',
+                          errors='ignore') as f:
+                    story = f.read().strip()
+
+                info = 'Title:  %s' % row['wiki_title']
+                info += '\nKind: %s' % row['kind']
+                info += '\nStory url: %s' % row['story_url']
+                info += '\nStory start: %s' % row['story_start']
+                info += '\nStory end: %s' % row['story_end']
+                info += '\nStory: %s' % story
+
+                for i, qa in enumerate(qa_pairs[row['document_id']]):
+                    question = qa['question_tokenized']
+                    answer1 = qa['answer1_tokenized']
+                    answer2 = qa['answer2_tokenized']
+
+                    if i == 0:
+                        # Prepend start info in first question
+                        yield (info + '\n' + question, [
+                               answer1, answer2]), True
+                    else:
+                        yield (question, [answer1, answer2]), False

--- a/parlai/tasks/narrative_qa/build.py
+++ b/parlai/tasks/narrative_qa/build.py
@@ -1,0 +1,143 @@
+
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import parlai.core.build_data as build_data
+import os
+import subprocess
+import shutil
+import csv
+import stat
+
+
+# TODO: Shift this back to deepmind's repo once PR #1 on it merges
+NARRATIVE_QA_DOWNLOAD_URL = 'https://github.com/apsdehal/narrativeqa/archive/master.zip'
+
+
+def get_rows_for_set(reader, req_set):
+    selected_rows = [row for row in reader if row['set'].strip() == req_set]
+    return selected_rows
+
+
+def read_csv_to_dict_list(filepath):
+    f = open(filepath, 'r')
+    return csv.DictReader(f, delimiter=','), f
+
+
+def write_dict_list_to_csv(dict_list, filepath):
+    keys = list(dict_list[0].keys())
+
+    with open(filepath, 'w') as f:
+        writer = csv.DictWriter(f, fieldnames=keys)
+        writer.writeheader()
+
+        for row in dict_list:
+            writer.writerow(row)
+
+
+def divide_csv_into_sets(csv_filepath, sets=['train', 'valid', 'test']):
+    reader, fh = read_csv_to_dict_list(csv_filepath)
+
+    base_filename = os.path.basename(csv_filepath).split('.')[0]
+    base_path = os.path.dirname(csv_filepath)
+
+    for s in sets:
+        path = os.path.join(base_path,
+                            base_filename + '_' + s + '.csv')
+        fh.seek(0)
+        rows = get_rows_for_set(reader, s)
+        write_dict_list_to_csv(rows, path)
+
+    fh.close()
+
+
+def make_folders(base_path, sets=['train', 'valid', 'test']):
+    for s in sets:
+        path = os.path.join(base_path, s)
+        if not os.path.exists(path):
+            os.mkdir(path)
+
+
+def move_files(base_path, sets=['train', 'valid', 'test']):
+    source = os.listdir(base_path)
+
+    for f in source:
+        for s in sets:
+            if f.endswith('_' + s + '.csv'):
+                final_name = f[:-(len('_' + s + '.csv'))] + '.csv'
+                f = os.path.join(base_path, f)
+                shutil.move(f, os.path.join(base_path, s, final_name))
+
+
+def build(opt):
+    dpath = os.path.join(opt['datapath'], 'NarrativeQA')
+    version = None
+
+    if not build_data.built(dpath, version_string=version):
+        print('[building data: ' + dpath + ']')
+
+        if build_data.built(dpath):
+            # an older version exists, so remove these outdated files.
+            build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # download the data.
+        fname = 'narrative_qa.zip'
+        # dataset URL
+        url = NARRATIVE_QA_DOWNLOAD_URL
+        build_data.download(url, dpath, fname)
+
+        # uncompress it
+        build_data.untar(dpath, fname)
+
+        print('downloading stories now')
+        base_path = os.path.join(dpath, 'narrativeqa-master')
+        # download all of the stories
+        story_script_path = os.path.join(base_path,
+                                         'download_stories.sh')
+
+        # add proper permissions
+        st = os.stat(story_script_path)
+        os.chmod(story_script_path, st.st_mode | stat.S_IEXEC)
+
+        try:
+            subprocess.check_output(story_script_path)
+        except subprocess.CalledProcessError:
+            raise RuntimeError('Error in downloading stories')
+
+        # move from tmp to stories
+        tmp_stories_path = os.path.join(base_path,
+                                        'tmp')
+        new_stories_path = os.path.join(base_path,
+                                        'stories')
+        shutil.move(tmp_stories_path, new_stories_path)
+
+        # divide into train, valid and test for summaries
+        summaries_csv_path = os.path.join(base_path, 'third_party',
+                                          'wikipedia', 'summaries.csv')
+        new_path = os.path.join(base_path, 'summaries.csv')
+        shutil.move(summaries_csv_path, new_path)
+
+        divide_csv_into_sets(new_path)
+
+        # divide into sets for questions
+        questions_path = os.path.join(base_path, 'qaps.csv')
+        divide_csv_into_sets(questions_path)
+
+        # divide into sets for documents
+        documents_path = os.path.join(base_path, 'documents.csv')
+        divide_csv_into_sets(documents_path)
+
+        # move specific set's files into their set's folder
+        make_folders(base_path)
+        move_files(base_path)
+
+        # move narrativeqa-master to narrative_qa
+        new_path = os.path.join(dpath, 'narrative_qa')
+        shutil.move(base_path, new_path)
+
+        # mark the data as built
+        build_data.mark_done(dpath, version_string=version)

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -151,6 +151,14 @@ task_list = [
         "description": "A dataset designed for use in the development and evaluation of machine learning models for sentence understanding. Each example contains a premise and hypothesis. Model has to predict whether premise and hypothesis entail, contradict or are neutral to each other. From Williams et al. '17. Link: https://arxiv.org/abs/1704.05426"
     },
     {
+        "id": "NarrativeQA",
+        "display_name": "NarrativeQA",
+        "task": "narrative_qa",
+        "tags": [ "All",  "QA" ],
+        "description": "A dataset and set of tasks in which the reader must answer questions about stories by reading entire books or movie scripts. From Kočiský et. al. '17. Link: https://arxiv.org/abs/1712.07040'",
+        "notes": "You can access summaries only task for NarrativeQA by using task 'narrative_qa:summaries'. By default, only stories are provided."
+    },
+    {
         "id": "OpenSubtitles",
         "display_name": "Open Subtitles",
         "task": "opensubtitles",

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -211,6 +211,29 @@ class TestData(unittest.TestCase):
 
         shutil.rmtree(self.TMP_PATH)
 
+    def test_narrative_qa(self):
+        from parlai.core.params import ParlaiParser
+        from parlai.tasks.narrative_qa.agents import DefaultTeacher, SummariesTeacher
+
+        opt = ParlaiParser().parse_args(args=self.args)
+        for dt in ['train', 'valid', 'test']:
+            opt['datatype'] = dt
+
+            teacher = DefaultTeacher(opt)
+            reply = teacher.act()
+            check(opt, reply)
+
+        shutil.rmtree(self.TMP_PATH)
+
+        for dt in ['train', 'valid', 'test']:
+            opt['datatype'] = dt
+
+            teacher = SummariesTeacher(opt)
+            reply = teacher.act()
+            check(opt, reply)
+
+        shutil.rmtree(self.TMP_PATH)
+
     def test_opensubtitles(self):
         from parlai.core.params import ParlaiParser
         from parlai.tasks.opensubtitles.agents import DefaultTeacher


### PR DESCRIPTION
Resolves #475 

- Adds two tasks, one for summaries and one for stories, `narrative_qa` and `narrative_qa:summaries`
- Downloads all of the stories while building, so may take some time during downloading
- Provides both answer references as possible answer_labels
- In case a story is missing (unable to download), it is skipped.
- download_tests file has been update to reflect both stories and summaries download test
- For convenience, creates train, valid and test folders and creates separate CSVs for each of them
- Uses apsdehal's fork with some fixes for now, should be changed to deepmind's original repo after PR 1 on that repo is merged