### PR TITLE
Pytorch teacher batch cache

### DIFF
--- a/examples/build_pytorch_data.py
+++ b/examples/build_pytorch_data.py
@@ -50,7 +50,7 @@ def build_data(opt):
             df += '.pytorch' + (agent.getID() if opt.get('pytorch_preprocess', True) else '')
         if not os.path.isfile(df):
             raise Exception('Tried to find data but it is not built, please'
-                            'specify `--pytorch_buildteacher`')
+                            'specify `--pytorch-buildteacher`')
         else:
             return df
 
@@ -66,7 +66,7 @@ def build_data(opt):
 
     datafile = teacher.datafile if hasattr(teacher, 'datafile') else opt.get('datafile')
     if not datafile:
-        raise Exception('Tried to build data but either `pytorch_buildteacher` does not '
+        raise Exception('Tried to build data but either `pytorch-buildteacher` does not '
                         'have a datafile or `--datafile` is not set')
 
     pytorch_datafile = datafile + ".pytorch"
@@ -128,9 +128,9 @@ def main():
     build = argparser.add_argument_group('Data Building Args')
     build.add_argument('--datafile',
                        help=('The file to be loaded, preprocessed, and saved'))
-    build.add_argument('--pytorch_buildteacher', type=str, default='',
+    build.add_argument('--pytorch-buildteacher', type=str, default='',
         help='Which teacher to use when building the pytorch data')
-    build.add_argument('--pytorch_preprocess', type='bool', default=True,
+    build.add_argument('--pytorch-preprocess', type='bool', default=True,
         help='Whether the agent should preprocess the data while building'
              'the pytorch data')
     opt = argparser.parse_args()

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -20,10 +20,10 @@
           happens automatically, and requires one of the following:
             - `--datafile` set to the either the built .pytorch data file
                 or the data file used to build the pytorch data file
-            - `--pytorch_buildteacher` set to the task teacher that will be/was used
+            - `--pytorch-buildteacher` set to the task teacher that will be/was used
                 to build the pytorch data (by passing observations to the agent)
         - If building the dictionary for the first time, please specify
-          the `--pytorch_buildteacher` so that the dictionary can be built appropriately
+          the `--pytorch-buildteacher` so that the dictionary can be built appropriately
 
     Briefly, to use the PytorchDataTeacher, specify `-t pytorch_teacher`
     when training.
@@ -33,22 +33,22 @@
 
     1. Ensure that an appropriate teacher exists that can read the data
        currently saved and produce an action dict for an agent (this will be
-       the `pytorch_buildteacher`)
+       the `pytorch-buildteacher`)
     2. Build the data so that it can be used by the PytorchDataTeacher
         - This can be accomplished in 2 ways:
-            1. Specify a `pytorch_buildteacher`, `datafile` (where the data currently
+            1. Specify a `pytorch-buildteacher`, `datafile` (where the data currently
                is, and what will be used to build the data), and `datatype`
                (e.g. train, valid, etc) when calling either `build_pytorch_data`
                or calling `train_model.py`. If one is training a model, the data
                 will be built automatically in `train_model.py`.
-            2. Implement the `pytorch_buildteacher` such that it saves the appropriate
+            2. Implement the `pytorch-buildteacher` such that it saves the appropriate
                datafile in its `datafile` attribute (i.e. `self.datafile`) given
-               the datatype, and then specify the `pytorch_buildteacher` when calling
+               the datatype, and then specify the `pytorch-buildteacher` when calling
                either `build_pytorch_data.py` or `train_model.py`
 
-    Additionally, if `pytorch_preprocess` is set to `True`, then the model specified
+    Additionally, if `pytorch-preprocess` is set to `True`, then the model specified
     in the command line params will have its `observe` function called on the
-    `pytorch_buildteacher`'s action, and the data will be saved for that model
+    `pytorch-buildteacher`'s action, and the data will be saved for that model
     specifically.
 
     Here's an example of what would need to be done for `bAbI` 10k task 1,
@@ -59,18 +59,18 @@
        `Task1kTeacher`)
     2. If `Task1kTeacher` saves the datafile in it's attributes, use one of the
        following 2 commands:
-       - `python examples/train_model.py -t pytorch_teacher --pytorch_buildteacher \
-         babi:task10k:1 -m seq2seq -mf /tmp/pytorch_data_build --pytorch_preprocess 1`
+       - `python examples/train_model.py -t pytorch_teacher --pytorch-buildteacher \
+         babi:task10k:1 -m seq2seq -mf /tmp/pytorch_data_build --pytorch-preprocess 1`
             - if one would like to train the model after building the data
        - `python examples/build_pytorch_data.py -m seq2seq \
-         --pytorch_buildteacher babi:task10k:1 --pytorch_preprocess 1`
+         --pytorch-buildteacher babi:task10k:1 --pytorch-preprocess 1`
     3. If you would like to specify a specific datafile to build, e.g. a
        validation file, you could do either of the following:
-       - `python examples/train_model.py -t pytorch_teacher --pytorch_buildteacher \
+       - `python examples/train_model.py -t pytorch_teacher --pytorch-buildteacher \
          babi:task10k:1 --datafile data/bAbI/tasks_1-20_v1-2/en-valid-10k-nosf/qa1_valid.txt \
-         -dt valid -m seq2seq -mf /tmp/pytorch_data_build --pytorch_preprocess 1`
+         -dt valid -m seq2seq -mf /tmp/pytorch_data_build --pytorch-preprocess 1`
        - `python examples/build_pytorch_data.py -m seq2seq \
-         --pytorch_buildteacher babi:task10k:1 --pytorch_preprocess 1 \
+         --pytorch-buildteacher babi:task10k:1 --pytorch-preprocess 1 \
          --datafile data/bAbI/tasks_1-20_v1-2/en-valid-10k-nosf/qa1_valid.txt`
 
 """
@@ -206,13 +206,8 @@ def batch_cache(function):
         # If Loader, put episodes in cache
         if isinstance(caller, LoaderProcess):
             with add_to_cache_cv:
-                counter = 0
                 while get_cache_size() >= max_cache_size and len(get_available_buckets(bsz)) >= bsz:
                     cache_filled_cv.notify_all()
-                    counter += 1
-                    if counter < 64:
-                        print("notified teachers")
-
                     add_to_cache_cv.wait()
             idx_and_batch = function(*args)
             if idx_and_batch is None:
@@ -230,15 +225,10 @@ def batch_cache(function):
                     return teacher.batch_idx + 1, batch
                 available_buckets = get_available_buckets(bsz)
                 with cache_filled_cv:
-                    counter = 0
                     while get_cache_size() <= min_cache_size or len(available_buckets) == 0:
                         add_to_cache_cv.notify()
-                        counter += 1
-                        if counter < 64 == 0:
-                            print("notified loader")
                         cache_filled_cv.wait()
                         available_buckets = get_available_buckets(bsz)
-
                 batch = None
                 if len(available_buckets) != 0:
                     # Pick length index at random
@@ -294,7 +284,7 @@ class LoaderProcess(Thread):
             drop_last=False,
             )
         self.data = enumerate(self.dataloader)
-        self.batch_cache_type = opt.get('batch_cache')
+        self.batch_cache_type = opt.get('batch_sort_cache')
         self.batch_length_range = opt.get('batch_length_range')
 
     def run(self):
@@ -372,15 +362,16 @@ class PytorchDataTeacher(FixedDialogTeacher):
             help='datafile for pytorch data loader')
         arg_group.add_argument('-nw', '--numworkers', type=int, default=4,
             help='how many workers the Pytorch dataloader should use')
-        arg_group.add_argument('--pytorch_buildteacher', type=str, default='',
+        arg_group.add_argument('--pytorch-buildteacher', type=str, default='',
             help='Which teacher to use when building the pytorch data')
-        arg_group.add_argument('--pytorch_preprocess', type='bool', default=True,
+        arg_group.add_argument('--pytorch-preprocess', type='bool', default=True,
             help='Whether the agent should preprocess the data while building'
                  'the pytorch data')
-        arg_group.add_argument('--batch_cache', type=str,
+        arg_group.add_argument('--batch-sort-cache', type=str,
             choices=['pop', 'index', 'none'], default='none',
-            help='Whether to build up cache of batches of similar size')
-        arg_group.add_argument('--batch_length_range', type=int, default=5,
+            help='Whether to have batches of similarly sized episodes, and how'
+            'to build up the cache')
+        arg_group.add_argument('--batch-length-range', type=int, default=5,
             help='degree of variation of size allowed in batch')
 
     def __init__(self, opt, shared=None):
@@ -388,7 +379,7 @@ class PytorchDataTeacher(FixedDialogTeacher):
         super().__init__(opt, shared)
         self.use_batch_act = self.bsz > 1
         self.num_workers = opt['numworkers']
-        self.batch_cache_type = opt.get('batch_cache')
+        self.batch_cache_type = opt.get('batch_sort_cache')
         # One can specify a collate function to use for preparing a batch
         collate_fn = opt.get('collate_fn', default_collate)
         if not shared:

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -79,8 +79,6 @@ from examples.build_pytorch_data import build_data
 
 import json
 import math
-import copy
-import time
 import random
 from functools import wraps
 try:
@@ -414,8 +412,7 @@ class PytorchDataTeacher(FixedDialogTeacher):
             self.pytorch_dataloader = shared['pytorch_dataloader']
             self.lastYs = shared['lastYs']
 
-        self.num_batches = math.ceil(self.num_examples()/self.bsz)
-
+        self.num_batches = math.ceil(self.dataset.num_episodes()/self.bsz)
         self.reset()
 
     def reset(self):


### PR DESCRIPTION
Adds a batch sort capability to the pytorch data teacher. Accomplishes this via building up a cache of episodes with a background process, and picking out batches from the cache. 

There are two caching methods:
- 'pop' - this pops batches out of the cache into a separate "batches" list, that can be polled later once all of the batches have been loaded
-'index' - this keeps episodes in the `{length : episode_list}` dictionary, and simply grabs batches from there