### PR TITLE
improve logging for small files

### DIFF
--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -107,6 +107,7 @@ def download(url, path, fname, redownload=False):
         raise RuntimeWarning('Connection broken too many times. Stopped retrying.')
 
     if download and retry > 0:
+        logger.log(done, total_size, force=True)
         print()
         if done < total_size:
             raise RuntimeWarning('Received less data than specified in ' +

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -275,16 +275,21 @@ class ProgressLogger(object):
         self.should_humanize = should_humanize
 
     def humanize(self, num, suffix='B'):
-        for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
+        if num < 0:
+            return num
+        for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
             if abs(num) < 1024.0:
                 return "%3.1f%s%s" % (num, unit, suffix)
             num /= 1024.0
         return "%.1f%s%s" % (num, 'Yi', suffix)
 
-    def log(self, curr, total, width=40):
+    def log(self, curr, total, width=40, force=False):
         """Displays a bar showing the current progress."""
+        if curr == 0 and total == -1:
+            print('[ no data received for this file ]', end='\r')
+            return
         curr_time = time.time()
-        if curr_time - self.latest < self.throttle_speed:
+        if not force and curr_time - self.latest < self.throttle_speed:
             return
         else:
             self.latest = curr_time


### PR DESCRIPTION
For small files, the "throttle" wasn't being hit and the log was never updated. Now, it will always do one last log.

For empty downloads (maybe the source is throttling our connection to them? this appears to be happening for NarrativeQA's guggenheim stories in #487), you may not receive any data. Instead of printing just a newline as before, or `0B / -1B` with the other fix, now it will log that nothing was downloaded. 