### PR TITLE
small improvements to s2s

### DIFF
--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -158,6 +158,8 @@ class Encoder(nn.Module):
         xes = F.dropout(self.lt(xs), p=self.dropout, training=self.training)
         x_lens = [x for x in torch.sum((xs > 0).int(), dim=1).data]
         xes_packed = pack_padded_sequence(xes, x_lens, batch_first=True)
+        if not self.training:
+            import pdb; pdb.set_trace()
 
         zeros = self.zeros(xs)
         if zeros.size(1) != bsz:
@@ -220,9 +222,9 @@ class Decoder(nn.Module):
     def forward(self, xs, hidden, encoder_output, attn_mask=None):
         xes = F.dropout(self.lt(xs), p=self.dropout, training=self.training)
         xes = self.attention(xes, hidden, encoder_output, attn_mask)
-        output, hidden = self.rnn(xes, hidden)
+        output, new_hidden = self.rnn(xes, hidden)
         # TODO: add post-attention?
-        # output = self.attention(output, hidden, encoder_output, attn_mask)
+        # output = self.attention(output, new_hidden, encoder_output, attn_mask)
 
         e = F.dropout(self.o2e(output), p=self.dropout, training=self.training)
         scores = F.dropout(self.e2s(e), p=self.dropout, training=self.training)
@@ -230,7 +232,7 @@ class Decoder(nn.Module):
         _max_score, idx = scores.narrow(2, 1, scores.size(2) - 1).max(2)
         preds = idx.add_(1)
 
-        return preds, scores, hidden
+        return preds, scores, new_hidden
 
 
 class Ranker(nn.Module):
@@ -358,6 +360,9 @@ class Ranker(nn.Module):
 
 
 class Linear(nn.Module):
+    """Custom Linear layer which allows for sharing weights (e.g. with an
+    nn.Embedding layer).
+    """
     def __init__(self, in_features, out_features, bias=True,
                  shared_weight=None):
         super().__init__()
@@ -390,9 +395,10 @@ class Linear(nn.Module):
             self.bias.data.uniform_(-stdv, stdv)
 
     def forward(self, input):
-        # detach weight to prevent gradients from changing weight when shared
         weight = self.weight
         if self.shared:
+            # detach weight to prevent gradients from changing weight
+            # (but need to detach every time so weights are up to date)
             weight = weight.detach()
         return F.linear(input, weight, self.bias)
 

--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -107,6 +107,7 @@ class Seq2seq(nn.Module):
             if self.rank and cands is not None:
                 text_cand_inds = self.ranker(cands, valid_cands, start,
                                              hidden, enc_out, attn_mask)
+            import pdb; pdb.set_trace()
 
         if predictions:
             predictions = torch.cat(predictions, 1)
@@ -158,8 +159,6 @@ class Encoder(nn.Module):
         xes = F.dropout(self.lt(xs), p=self.dropout, training=self.training)
         x_lens = [x for x in torch.sum((xs > 0).int(), dim=1).data]
         xes_packed = pack_padded_sequence(xes, x_lens, batch_first=True)
-        if not self.training:
-            import pdb; pdb.set_trace()
 
         zeros = self.zeros(xs)
         if zeros.size(1) != bsz:

--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -107,7 +107,6 @@ class Seq2seq(nn.Module):
             if self.rank and cands is not None:
                 text_cand_inds = self.ranker(cands, valid_cands, start,
                                              hidden, enc_out, attn_mask)
-            import pdb; pdb.set_trace()
 
         if predictions:
             predictions = torch.cat(predictions, 1)

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -324,7 +324,8 @@ class Seq2seqAgent(Agent):
                 reply=self.answers[batch_idx],
                 historyLength=self.opt['history_length'],
                 useReplies=self.opt['history_replies'],
-                dict=self.dict)
+                dict=self.dict,
+                useStartEndIndices=False)
         else:
             obs['text2vec'] = deque(obs['text2vec'], self.opt['history_length'])
         self.observation = obs

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -298,7 +298,6 @@ class Seq2seqAgent(Agent):
     def reset(self):
         """Reset observation and episode_done."""
         self.observation = None
-        self.episode_done = True
 
     def share(self):
         """Share internal states between parent and child instances."""
@@ -318,7 +317,6 @@ class Seq2seqAgent(Agent):
         """Save observation for act.
         If multiple observations are from the same episode, concatenate them.
         """
-        self.episode_done = observation['episode_done']
         # shallow copy observation (deep copy can be expensive)
         obs = observation.copy()
         batch_idx = self.opt.get('batchindex', 0)


### PR DESCRIPTION
- calculate loss all at once instead of one token-index at a time (thanks @myleott)
- add gradient clipping
- remove start/end from around input (still use `start` to begin decoding and `end` to stop)
- add perplexity to train logging (2^loss when using cross entropy, right?)