### PR TITLE
Fix transition from onboarding world to a task world when no redirect necessary

### DIFF
--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -14,6 +14,7 @@ from botocore.exceptions import ProfileNotFound
 
 region_name = 'us-east-1'
 aws_profile_name = 'parlai_mturk'
+client = None
 
 parent_dir = os.path.dirname(os.path.abspath(__file__))
 mturk_hit_frame_height = 650
@@ -163,14 +164,17 @@ def create_hit_config(task_description, unique_worker, is_sandbox):
 
 def get_mturk_client(is_sandbox):
     """Returns the appropriate mturk client given sandbox option"""
-    client = boto3.client(
-        service_name='mturk',
-        region_name='us-east-1',
-        endpoint_url='https://mturk-requester-sandbox.us-east-1.amazonaws.com'
-    )
-    # Region is always us-east-1
-    if not is_sandbox:
-        client = boto3.client(service_name='mturk', region_name='us-east-1')
+    global client
+    if client is None:
+        client = boto3.client(
+            service_name='mturk',
+            region_name='us-east-1',
+            endpoint_url='https://mturk-requester-sandbox.us-east-1.amazonaws.com'
+        )
+        # Region is always us-east-1
+        if not is_sandbox:
+            client = \
+                boto3.client(service_name='mturk', region_name='us-east-1')
     return client
 
 

--- a/parlai/mturk/core/server/html/core.html
+++ b/parlai/mturk/core/server/html/core.html
@@ -460,6 +460,22 @@
 
   /* ================= Socket handling ================= */
 
+  // way to send alive packets when expected to
+  function send_alive() {
+    send_packet(
+        TYPE_ALIVE,
+        {
+          hit_id: hit_id,
+          assignment_id: assignment_id,
+          worker_id: worker_id,
+          conversation_id: conversation_id
+        },
+        true,
+        true,
+        null
+    );
+  }
+
   // Sets up and registers the socket and the callbacks
   function setup_socket() {
     var host = window.location.hostname;
@@ -468,18 +484,7 @@
     // When the socket opens, we must tell it that we're alive
     socket.on(SOCKET_OPEN_STRING, function() {
       log('Server connected.', 2);
-      send_packet(
-          TYPE_ALIVE,
-          {
-            hit_id: hit_id,
-            assignment_id: assignment_id,
-            worker_id: worker_id,
-            conversation_id: conversation_id
-          },
-          true,
-          true,
-          null
-      );
+      send_alive();
     });
 
     // Log disconnect
@@ -625,10 +630,14 @@
         conversation_id = new_conversation_id;
         agent_id = new_agent_id;
         show_waiting_world();
+        // No redirect, so tell the world we're here
+        send_alive();
       } else {
         // Update the conversation id
         conversation_id = new_conversation_id;
         agent_id = new_agent_id;
+        // No redirect, so tell the world we're here
+        send_alive();
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/facebookresearch/ParlAI/issues/509.

The issue was rooted in the fact that the server was expecting an alive message to fully change the state, an error in onboarding to task world switches introduced in #500.