### PR TITLE
various updates

### DIFF
--- a/examples/display_data.py
+++ b/examples/display_data.py
@@ -22,6 +22,14 @@ def display_data(opt):
     agent = RepeatLabelAgent(opt)
     world = create_task(opt, agent)
 
+    try:
+        # print dataset size if available
+        print('[loaded {} episodes with a total of {} examples]'.format(
+            world.num_episodes(), world.num_examples()
+        ))
+    except:
+        pass
+
     # Show some example dialogs.
     with world:
         for _ in range(opt['num_examples']):

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -7,7 +7,7 @@
 from parlai.core.agents import Agent
 from parlai.core.dict import DictionaryAgent
 from parlai.core.utils import maintain_dialog_history
-from .modules import Seq2seq
+from .modules import Seq2seq, RandomProjection
 
 import torch
 from torch.autograd import Variable
@@ -120,13 +120,14 @@ class Seq2seqAgent(Agent):
                                 'be used with default params except learning '
                                 'rate (as specified by -lr).')
         agent.add_argument('-emb', '--embedding-type', default='random',
-                           choices=['random'],
+                           choices=['random', 'glove', 'glove-fixed',
+                                    'fasttext', 'fasttext-fixed'],
                            help='Choose between different strategies '
                                 'for word embeddings. Default is random, '
-                                'but can also preinitialize from Glove.'
+                                'but can also preinitialize from Glove or '
+                                'Fasttext.'
                                 'Preinitialized embeddings can also be fixed '
-                                'so they are not updated during training. '
-                                'NOTE: glove init currently disabled.')
+                                'so they are not updated during training.')
         agent.add_argument('-lm', '--language-model', default='none',
                            choices=['none', 'only', 'both'],
                            help='Enabled language modeling training on the '
@@ -202,6 +203,39 @@ class Seq2seqAgent(Agent):
                                  end_idx=self.END_IDX,
                                  longest_label=self.states.get('longest_label', 1))
 
+            if opt['embedding_type'] != 'random':
+                # set up preinitialized embeddings
+                try:
+                    import torchtext.vocab as vocab
+                except ModuleNotFoundError as ex:
+                    print('Please install torch text with `pip install torchtext`')
+                    raise ex
+                if opt['embedding_type'].startswith('glove'):
+                    init = 'glove'
+                    embs = vocab.GloVe(name='840B', dim=300)
+                elif opt['embedding_type'].startswith('fasttext'):
+                    init = 'fasttext'
+                    embs = vocab.FastText(language='en')
+                else:
+                    raise RuntimeError('embedding type not implemented')
+
+                if opt['embeddingsize'] != 300:
+                    rp = torch.Tensor(300, opt['embeddingsize']).normal_()
+                    t = lambda x: torch.mm(x.unsqueeze(0), rp)
+                else:
+                    t = lambda x: x
+                cnt = 0
+                for w, i in self.dict.tok2ind.items():
+                    if w in embs.stoi:
+                        vec = t(embs.vectors[embs.stoi[w]])
+                        self.model.decoder.lt.weight.data[i] = vec
+                        cnt += 1
+                        if opt['lookuptable'] in ['unique', 'dec_out']:
+                            # also set encoder lt, since it's not shared
+                            self.model.encoder.lt.weight.data[i] = vec
+                print('Seq2seq: initialized embeddings for {} tokens from {}.'
+                      ''.format(cnt, init))
+
             if self.states:
                 # set loaded states if applicable
                 self.model.load_state_dict(self.states['model'])
@@ -239,7 +273,14 @@ class Seq2seqAgent(Agent):
             if opt['optimizer'] == 'sgd':
                 kwargs['momentum'] = 0.95
                 kwargs['nesterov'] = True
-            self.optimizer = optim_class(self.model.parameters(), **kwargs)
+
+            if opt['embedding_type'].endswith('fixed'):
+                print('Seq2seq: fixing embedding weights.')
+                self.model.decoder.lt.weight.requires_grad = False
+                self.model.encoder.lt.weight.requires_grad = False
+                if opt['lookuptable'] in ['dec_out', 'all']:
+                    self.model.decoder.e2s.weight.requires_grad = False
+            self.optimizer = optim_class([p for p in self.model.parameters() if p.requires_grad], **kwargs)
             if self.states:
                 if self.states['optimizer_type'] != opt['optimizer']:
                     print('WARNING: not loading optim state since optim class '
@@ -351,9 +392,9 @@ class Seq2seqAgent(Agent):
             loss.backward()
             self.update_params()
             losskey = 'loss' if not lm else 'lmloss'
-            loss_dict = {losskey: loss.mul(len(xs)).data}
-            perpkey = 'perplexity' if not lm else 'lm_perplexity'
-            loss_dict[perpkey] = (2**loss).mul(len(xs)).data
+            loss_dict = {losskey: loss.data}
+            perpkey = 'ppl' if not lm else 'lmppl'
+            loss_dict[perpkey] = loss.exp().data
         else:
             self.model.eval()
             predictions, scores, text_cand_inds = self.model(xs, ys, cands,

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -136,7 +136,7 @@ class Metrics(object):
         self.metrics['cnt'] = 0
         self.metrics['correct'] = 0
         self.metrics['f1'] = 0.0
-        self.custom_metrics = ['mean_rank', 'loss']
+        self.custom_metrics = ['mean_rank', 'loss', 'lmloss', 'ppl']
         for k in self.custom_metrics:
             self.metrics[k] = 0.0
             self.metrics[k + '_cnt'] = 0

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -104,13 +104,16 @@ def round_sigfigs(x, sigfigs=4):
     try:
         if x == 0:
             return 0
-        if x in [float('inf'), float('-inf'), float('NaN')]:
-            return x
         return round(x, -math.floor(math.log10(abs(x)) - sigfigs + 1))
     except (RuntimeError, TypeError):
         # handle 1D torch tensors
         # if anything else breaks here please file an issue on Github
         return round_sigfigs(x[0], sigfigs)
+    except (ValueError, OverflowError) as ex:
+        if x in [float('inf'), float('-inf')] or x != x:  # inf or nan
+            return x
+        else:
+            raise ex
 
 
 def flatten(teacher, context_length=-1, include_labels=True):


### PR DESCRIPTION
1) print size of dataset if available when using display_data
2) use a random projection instead of a linear layer for changing dimensionality in seq2seq. this saw slow convergence when initialized using the normal distrubtion with mean=0, std=1, but faster when std=0.1 (expected it to be faster since fewer params for the model to learn). this was using opensubtitles:task10k, esz=300, hs=600 (so need to downscale RNN output from 600 to 300)
3) added option to initialize embedding weights from glove or fasttext, and to fix the weights. initial experiments (using the above settings) do not improve convergence, but on larger data it might. partial tuning options could be explored as well.
4) fix metric reporting in seq2seq
5) fix metric class printing out tensor instead of float when value is `nan` or `inf`
6) add option to dictionary to lowercase everything
7) speed up opensubtitles first-init using lists instead of strings for concatenation, modify regularizer slightly to denote ellipses better and to remove extra inter-word whitespace