### PR TITLE
Setting default display id for ParlAI-Messenger

### DIFF
--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -17,6 +17,7 @@ class MessengerAgent(Agent):
         super().__init__(opt)
         self.manager = manager
         self.id = messenger_psid
+        self.disp_id = 'NewUser'
         self.task_id = task_id
         self.active = True
         self.message_request_time = None


### PR DESCRIPTION
Prevents an initialization crash from sending a message without having a preset ID from the world