### PR TITLE
Improving message send semantics

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -897,6 +897,7 @@ class MTurkManager():
         """Send a message through the socket manager,
         update conversation state
         """
+        data = data.copy()
         data['type'] = data_model.MESSAGE_TYPE_MESSAGE
         # Force messages to have a unique ID
         if 'message_id' not in data:
@@ -924,6 +925,7 @@ class MTurkManager():
         if agent is not None:
             agent.state.messages.append(packet.data)
         self.socket_manager.queue_packet(packet)
+        return data['message_id']
 
     def send_command(self, receiver_id, assignment_id, data, blocking=True,
                      ack_func=None):

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -897,7 +897,7 @@ class MTurkManager():
         """Send a message through the socket manager,
         update conversation state
         """
-        data = data.copy()
+        data = data.copy()  # Ensure data packet is sent in current state
         data['type'] = data_model.MESSAGE_TYPE_MESSAGE
         # Force messages to have a unique ID
         if 'message_id' not in data:


### PR DESCRIPTION
Fixes #521 

In order to make sure that the content being sent via `send_message` isn't altered after the fact, the function now duplicates the data dict (the action) at the start of the call, thus the queued packet can't be edited externally.