### PR TITLE
Using qualifications instead of assignments for uniqueness

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -633,7 +633,6 @@ class MTurkManager():
             'type': 'reward',
             'num_total_assignments': num_assignments,
             'reward': self.opt['reward'],  # in dollars
-            'unique': self.opt['unique_worker']
         }
         total_cost = mturk_utils.calculate_mturk_cost(payment_opt=payment_opt)
         if not mturk_utils.check_mturk_balance(
@@ -855,6 +854,8 @@ class MTurkManager():
         finally:
             server_utils.delete_server(self.server_task_name)
             mturk_utils.delete_sns_topic(self.topic_arn)
+            if self.opt['unique_worker']:
+                mturk_utils.delete_qualification(self.unique_qual_id)
             self._save_disconnects()
 
     # MTurk Agent Interaction Functions #
@@ -955,6 +956,11 @@ class MTurkManager():
     def mark_workers_done(self, workers):
         """Mark a group of workers as done to keep state consistent"""
         for worker in workers:
+            if self.opt['unique_worker']:
+                self.give_worker_qualification(
+                    worker.worker_id,
+                    self.unique_qual_name
+                )
             if not worker.state.is_final():
                 worker.state.status = AssignState.STATUS_DONE
 
@@ -1005,6 +1011,18 @@ class MTurkManager():
                 'RequiredToPreview': True
             })
 
+        if self.opt['unique_worker']:
+            self.unique_qual_name = self.task_group_id + '_max_submissions'
+            self.unique_qual_id = mturk_utils.find_or_create_qualification(
+                self.unique_qual_name,
+                'Prevents workers from completing a task too frequently'
+            )
+            qualifications.append({
+                'QualificationTypeId': self.unique_qual_id,
+                'Comparator': 'DoesNotExist',
+                'RequiredToPreview': True
+            })
+
         hit_type_id = mturk_utils.create_hit_type(
             hit_title=self.opt['hit_title'],
             hit_description='{} (ID: {})'.format(self.opt['hit_description'],
@@ -1030,27 +1048,14 @@ class MTurkManager():
             self.topic_arn
         )
 
-        if self.opt['unique_worker'] is True:
-            # Use a single hit with many assignments to allow
-            # workers to only work on the task once
+        for _i in range(num_hits):
             mturk_page_url, hit_id = mturk_utils.create_hit_with_hit_type(
                 page_url=mturk_chat_url,
                 hit_type_id=hit_type_id,
-                num_assignments=num_hits,
+                num_assignments=1,
                 is_sandbox=self.is_sandbox
             )
             self.hit_id_list.append(hit_id)
-        else:
-            # Create unique hits, allowing one worker to be able to handle many
-            # tasks without needing to be unique
-            for _i in range(num_hits):
-                mturk_page_url, hit_id = mturk_utils.create_hit_with_hit_type(
-                    page_url=mturk_chat_url,
-                    hit_type_id=hit_type_id,
-                    num_assignments=1,
-                    is_sandbox=self.is_sandbox
-                )
-                self.hit_id_list.append(hit_id)
         return mturk_page_url
 
     def create_hits(self, qualifications=None):

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -79,7 +79,6 @@ def calculate_mturk_cost(payment_opt):
         'type': 'reward',
         'num_total_assignments': 1,
         'reward': 0.05  # in dollars
-        'unique': False # Unique workers requires multiple assignments to 1 HIT
     }
 
     Example payment_opt format for paying bonus:
@@ -91,8 +90,6 @@ def calculate_mturk_cost(payment_opt):
     total_cost = 0
     if payment_opt['type'] == 'reward':
         mult = 1.2
-        if payment_opt['unique'] and payment_opt['num_total_assignments'] > 10:
-            mult = 1.4
         total_cost = \
             payment_opt['num_total_assignments'] * payment_opt['reward'] * mult
     elif payment_opt['type'] == 'bonus':


### PR DESCRIPTION
Right now using the `--unique` flag and needing more than 10 HITs incurs an additional 20% mturk fee. By switching to using qualifications rather than assignments to determine uniqueness, we cut that cost but keep the ability to have unique workers.

If the unique flag is set, a condition is added to the task that requires the worker doesn't have a special qualification that we create

When the worker is marked as done with the task, they get the special qualification, and then they can't do the task again.

When the manager is shut down, that special qualification is deleted.