### PR TITLE
More flexible eligibility functions

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -236,8 +236,16 @@ class MTurkManager():
         only listed a maximum of one time. In sandbox this is overridden for
         testing purposes, and the same worker can be returned more than once
         """
-        workers = [w for w in self.worker_pool
-                   if not w.hit_is_returned and eligibility_function(w)]
+        if callable(eligibility_function):
+            workers = [w for w in self.worker_pool
+                       if not w.hit_is_returned and eligibility_function(w)]
+        else:
+            pool = [w for w in self.worker_pool if not w.hit_is_returned]
+            if eligibility_function['multiple'] is True:
+                workers = eligibility_function['func'](pool)
+            else:
+                workers = [w for w in pool if eligibility_function['func'](w)]
+
         unique_workers = []
         unique_worker_ids = []
         for w in workers:
@@ -737,7 +745,39 @@ class MTurkManager():
         in the pool to start an instance of the task. Continue doing this
         until the desired number of conversations is had.
         """
-
+        if callable(eligibility_function):
+            # Convert legacy eligibility_functions to the new format
+            eligibility_function = {
+                'multiple': False,
+                'func': eligibility_function,
+            }
+        else:
+            # Ensure the eligibility function is valid
+            if 'func' not in eligibility_function:
+                shared_utils.print_and_log(
+                    logging.CRITICAL,
+                    "eligibility_function has no 'func'. Cancelling."
+                )
+                raise Exception(
+                    'eligibility_function dict must contain a `func` field '
+                    'containing the actual function.'
+                )
+            elif not callable(eligibility_function['func']):
+                shared_utils.print_and_log(
+                    logging.CRITICAL,
+                    "eligibility_function['func'] not a function. Cancelling."
+                )
+                raise Exception(
+                    "eligibility_function['func'] must contain a function. "
+                    "If eligibility_function['multiple'] is set, it should "
+                    "filter through the list of workers and only return those "
+                    "that are currently eligible to participate. If it is not "
+                    "set, it should take in a single worker and return whether"
+                    " or not they are eligible."
+                )
+            if 'multiple' not in eligibility_function:
+                eligibility_function['multiple'] = False
+        
         def _task_function(opt, workers, conversation_id):
             """Wait for workers to join the world, then run task function"""
             shared_utils.print_and_log(

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -236,15 +236,11 @@ class MTurkManager():
         only listed a maximum of one time. In sandbox this is overridden for
         testing purposes, and the same worker can be returned more than once
         """
-        if callable(eligibility_function):
-            workers = [w for w in self.worker_pool
-                       if not w.hit_is_returned and eligibility_function(w)]
+        pool = [w for w in self.worker_pool if not w.hit_is_returned]
+        if eligibility_function['multiple'] is True:
+            workers = eligibility_function['func'](pool)
         else:
-            pool = [w for w in self.worker_pool if not w.hit_is_returned]
-            if eligibility_function['multiple'] is True:
-                workers = eligibility_function['func'](pool)
-            else:
-                workers = [w for w in pool if eligibility_function['func'](w)]
+            workers = [w for w in pool if eligibility_function['func'](w)]
 
         unique_workers = []
         unique_worker_ids = []
@@ -777,7 +773,7 @@ class MTurkManager():
                 )
             if 'multiple' not in eligibility_function:
                 eligibility_function['multiple'] = False
-        
+
         def _task_function(opt, workers, conversation_id):
             """Wait for workers to join the world, then run task function"""
             shared_utils.print_and_log(

--- a/parlai/mturk/tasks/multi_agent_dialog/run.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/run.py
@@ -57,6 +57,11 @@ def main():
         def check_worker_eligibility(worker):
             return True
 
+        eligibility_function = {
+            'func': check_worker_eligibility,
+            'multiple': False,
+        }
+
         def assign_worker_roles(workers):
             for index, worker in enumerate(workers):
                 worker.id = mturk_agent_ids[index % len(mturk_agent_ids)]
@@ -81,7 +86,7 @@ def main():
             world.shutdown()
 
         mturk_manager.start_task(
-            eligibility_function=check_worker_eligibility,
+            eligibility_function=eligibility_function,
             assign_role_function=assign_worker_roles,
             task_function=run_conversation
         )

--- a/parlai/mturk/tasks/qa_data_collection/run.py
+++ b/parlai/mturk/tasks/qa_data_collection/run.py
@@ -50,8 +50,13 @@ def main():
 
         mturk_manager.ready_to_accept_workers()
 
-        def check_worker_eligibility(worker):
-            return True
+        def check_workers_eligibility(workers):
+            return workers
+
+        eligibility_function = {
+            'func': check_workers_eligibility,
+            'multiple': True,
+        }
 
         def assign_worker_roles(worker):
             worker[0].id = mturk_agent_id
@@ -72,7 +77,7 @@ def main():
             world.review_work()
 
         mturk_manager.start_task(
-            eligibility_function=check_worker_eligibility,
+            eligibility_function=eligibility_function,
             assign_role_function=assign_worker_roles,
             task_function=run_conversation
         )


### PR DESCRIPTION
Introduces a new option for eligibility functions that take in the whole worker pool and can output whatever workers are eligible. This allows for eligibility to be determined in relation to other workers in the pool, which provides for more complex control over pairings between workers. 

Updates two of the demos to the new format to provide exposure to it, one using the new model for the old functionality (multi_agent_dialog) and one using the new functionality (qa_data_collection)