### PR TITLE
Allowing uniqueness between HITs

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -104,6 +104,10 @@ class ParlaiParser(argparse.ArgumentParser):
             action='store_true',
             help='enforce that no worker can work on your task twice')
         mturk.add_argument(
+            '--unique-qual-name', dest='unique_qual_name',
+            default=None, type=str,
+            help='qualification name to use for uniqueness between HITs')
+        mturk.add_argument(
             '-r', '--reward', default=0.05, type=float,
             help='reward for each worker for finishing the conversation, '
                  'in US dollars')


### PR DESCRIPTION
Adds an additional way to declare uniqueness which allows for uniqueness between hits. 

The `--unique-qual-name <name>` argument ensures that any HITs launched using `<name>` will only be exposed to workers that haven't completed *any* HITs launched with that same `<name>`.

Also adds new text to ensure that workers who get around MTurk's qualification reconciliation system and accept a second HIT when they aren't supposed to get the below messaging:
![screen shot 2018-02-07 at 10 28 13 am](https://user-images.githubusercontent.com/1276867/35924871-42e71542-0bf2-11e8-9346-54f97459011d.png)
