### PR TITLE
No longer crash with unexpected message formats

### DIFF
--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -51,6 +51,10 @@ class MessengerAgent(Agent):
         """Put data into the message queue if it hasn't already been seen"""
         mid = message['message']['mid']
         seq = message['message']['seq']
+        if 'text' not in message['message']:
+            print('Msg: {} could not be extracted to text format'.format(
+                message['message']))
+            return
         text = message['message']['text']
         if text is None:
             text = message['message']['payload']


### PR DESCRIPTION
Until we are able to handle sticker and photo messages, as well as attachments, this provides a failsafe to ensure a world doesn't crash just because it receives a message type that can't be processed by the agent yet.