### PR TITLE
build_tools.untar() --> build_data.untar()

### DIFF
--- a/parlai/tasks/narrative_qa/build.py
+++ b/parlai/tasks/narrative_qa/build.py
@@ -101,7 +101,7 @@ def try_downloading(directory, row):
         gz_path = os.path.join(directory,
                                document_id + '.content.gz')
         shutil.move(story_path, gz_path)
-        build_tools.untar(gz_path)
+        build_data.untar(gz_path)
 
     return False
 


### PR DESCRIPTION
__build_tools__ is an undefined name.  __build_data.untar()__ is defined at:
* https://github.com/facebookresearch/ParlAI/blob/master/parlai/core/build_data.py#L133

Found via #266