### PR TITLE
Mturk max connections

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -147,6 +147,12 @@ class ParlaiParser(argparse.ArgumentParser):
             default=0, type=int,
             help='number of concurrent conversations that one mturk worker '
                  'is able to be involved in, 0 is unlimited')
+        mturk.add_argument(
+            '--max-connections', dest='max_connections',
+            default=30, type=int,
+            help='number of HITs that can be launched at the same time, 0 is '
+                 'unlimited.'
+        )
 
         mturk.set_defaults(is_sandbox=True)
         mturk.set_defaults(is_debug=False)

--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -51,6 +51,10 @@ class MessengerAgent(Agent):
         """Put data into the message queue if it hasn't already been seen"""
         mid = message['message']['mid']
         seq = message['message']['seq']
+        if 'text' not in message['message']:
+            print('Msg: {} could not be extracted to text format'.format(
+                message['message']))
+            return
         text = message['message']['text']
         if text is None:
             text = message['message']['payload']

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -57,6 +57,9 @@ class MTurkManager():
         agent_ids that will participate in each conversation
         """
         self.opt = opt
+        if self.opt['unique_worker'] or \
+                self.opt['unique_qual_name'] is not None:
+            self.opt['allowed_conversations'] = 1
         self.server_url = None
         self.topic_arn = None
         self.port = 443
@@ -91,6 +94,7 @@ class MTurkManager():
         self.accepting_workers = True
         self._load_disconnects()
         self.assignment_to_worker_id = {}
+        self.qualifications = None
 
     def _init_logs(self):
         """Initialize logging settings from the opt"""
@@ -629,11 +633,27 @@ class MTurkManager():
             '\nYou are going to allow workers from Amazon Mechanical Turk to '
             'be an agent in ParlAI.\nDuring this process, Internet connection '
             'is required, and you should turn off your computer\'s auto-sleep '
-            'feature.\nEnough HITs will be created to fulfill {} times the '
-            'number of conversations requested, extra HITs will be expired '
-            'once the desired conversations {}.'.format(HIT_MULT, fin_word),
-            should_print=True
+            'feature.',
+            should_print=True,
         )
+        if self.opt['max_connections'] == 0:
+            shared_utils.print_and_log(
+                logging.INFO,
+                'Enough HITs will be created to fulfill {} times the '
+                'number of conversations requested, extra HITs will be expired'
+                ' once the desired conversations {}.'
+                ''.format(HIT_MULT, fin_word),
+                should_print=True,
+            )
+        else:
+            shared_utils.print_and_log(
+                logging.INFO,
+                'Enough HITs will be launched over time '
+                'up to a max of {} times the amount requested until the '
+                'desired number of conversations {}.'
+                ''.format(HIT_MULT, fin_word),
+                should_print=True,
+            )
         input('Please press Enter to continue... ')
         shared_utils.print_and_log(logging.NOTSET, '', True)
 
@@ -800,6 +820,12 @@ class MTurkManager():
             # Count if it's a completed conversation
             if self._no_workers_incomplete(workers):
                 self.completed_conversations += 1
+            if self.opt['max_connections'] != 0:  # If using a conv cap
+                for w in workers:
+                    if w.state.status in [
+                            AssignState.STATUS_DONE,
+                            AssignState.STATUS_PARTNER_DISCONNECT]:
+                        self.create_additional_hits(1)
 
         while True:
             # Loop forever starting task worlds until desired convos are had
@@ -1001,12 +1027,10 @@ class MTurkManager():
             if not_done_message in e.response['Error']['Message']:
                 return MTurkAgent.ASSIGNMENT_NOT_DONE
 
-    def create_additional_hits(self, num_hits, qualifications=None):
-        """Handle creation for a specific number of hits/assignments
-        Put created HIT ids into the hit_id_list
-        """
-        shared_utils.print_and_log(logging.INFO,
-                                   'Creating {} hits...'.format(num_hits))
+    def get_qualification_list(self, qualifications=None):
+        if self.qualifications is not None:
+            return self.qualifications
+
         if qualifications is None:
             qualifications = []
 
@@ -1043,6 +1067,18 @@ class MTurkManager():
                 'Comparator': 'DoesNotExist',
                 'RequiredToPreview': True
             })
+
+        self.qualifications = qualifications
+        return qualifications
+
+    def create_additional_hits(self, num_hits, qualifications=None):
+        """Handle creation for a specific number of hits/assignments
+        Put created HIT ids into the hit_id_list
+        """
+        shared_utils.print_and_log(logging.INFO,
+                                   'Creating {} hits...'.format(num_hits))
+
+        qualifications = self.get_qualification_list(qualifications)
 
         hit_type_id = mturk_utils.create_hit_type(
             hit_title=self.opt['hit_title'],
@@ -1083,10 +1119,16 @@ class MTurkManager():
         """Create hits based on the managers current config, return hit url"""
         shared_utils.print_and_log(logging.INFO, 'Creating HITs...', True)
 
-        mturk_page_url = self.create_additional_hits(
-            num_hits=self.required_hits,
-            qualifications=qualifications,
-        )
+        if self.opt['max_connections'] == 0:
+            mturk_page_url = self.create_additional_hits(
+                num_hits=self.required_hits,
+                qualifications=qualifications,
+            )
+        else:
+            mturk_page_url = self.create_additional_hits(
+                num_hits=self.opt['max_connections'],
+                qualifications=qualifications,
+            )
 
         shared_utils.print_and_log(logging.INFO,
                                    'Link to HIT: {}\n'.format(mturk_page_url),


### PR DESCRIPTION
Adds a new option for a maximum number of connections (defaulted to 30). This option now launches HITs gradually to meet the number requested rather than all at once. This gates the maximum number of people who can be connected to your server at once.

Changes qualification semantics such that now they're set by the first qualifications you launch with. Followup should move this into its own function to prevent confusion about how the qualifications parameter functions.

Also ensures that unique workers don't slip by the uniqueness clause by opening multiple HITs at once.

Also updates the delete_hits script to be able to be interrupted during its search, this way if your latest HIT died you can immediately go kill it

Doesn't add docs... Will add those in a followup