### PR TITLE
Add dates to wiki dump; support hosting of full extracted articles

### DIFF
--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -366,7 +366,7 @@ task_list = [
         "display_name": "Wikipedia",
         "task": 'wikipedia',
         "tags": [ "All" ],
-        "description": "Dump of Wikipedia articles",
+        "description": "Dump of Wikipedia articles from 2/3/18",
         "notes": "Specify ':full' for the full articles to be returned, otherwise defaults to ':summary', which provides the first paragraphs. To put the article in the labels and the title in the text, specify ':key-value' at the end (for a title/content key-value association)"
     },
 ]

--- a/parlai/tasks/wikipedia/agents.py
+++ b/parlai/tasks/wikipedia/agents.py
@@ -3,7 +3,17 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
+'''
+    Provides a dump of Wikipedia articles from 2/3/18.
 
+    One can either load full articles, using 'wikipedia:full',
+    or simply load the first paragraphs of the articles,
+    using 'wikipedia:summary'
+
+    To put the article in the labels and the title in the text, specify
+    ':key-value' at the end (for a title/content key-value association)
+
+'''
 from parlai.core.teachers import DialogTeacher
 from .build import build
 
@@ -11,17 +21,14 @@ import json
 import os
 
 
-class AllTeacher(DialogTeacher):
+class FullTeacher(DialogTeacher):
     """Reads Wikipedia pages one at a time
     """
     def __init__(self, opt, shared=None):
         self.key_value = ':key-value' in opt['task']
         opt['task'] = 'wikipedia:all'
-        success = build(opt)
+        build(opt)
         self.opt = opt
-        if not success:
-            '''Need to extract the rest of the data'''
-            raise RuntimeError(self.get_instructions())
         opt['datafile'] = os.path.join(
             opt['datapath'],
             'wikipedia/full/wiki_full_extracted')
@@ -30,10 +37,9 @@ class AllTeacher(DialogTeacher):
 
     def setup_data(self, path):
         print('loading: ' + path)
-        if not os.path.exists(path):
-            '''Need to extract the rest of the data'''
-            raise RuntimeError(self.get_instructions())
         for subdir in os.listdir(path):
+            if subdir == 'README.md':
+                continue
             subdir_path = os.path.join(path, subdir)
             for wiki_file in os.listdir(subdir_path):
                 wiki_file_path = os.path.join(subdir_path, wiki_file)
@@ -47,7 +53,8 @@ class AllTeacher(DialogTeacher):
                         else:
                             yield (title + '\n' + text, None), True
 
-    def get_instructions(self):
+    def get_extraction_instructions(self):
+        '''If one wants to run extraction themselves on a raw wikipedia dump'''
         dpath = os.path.join(self.opt['datapath'], 'wikipedia', 'full')
         fname = 'enwiki-latest-pages-articles.xml.bz2'
         instructions = """

--- a/parlai/tasks/wikipedia/build.py
+++ b/parlai/tasks/wikipedia/build.py
@@ -8,34 +8,19 @@ import os
 
 
 def build(opt):
-    # get path to data directory
     dpath = os.path.join(opt['datapath'], 'wikipedia')
-
     task = opt.get('task', 'wikipedia:all')
     extract_full = task.split(':')[-1] == 'all'
     if extract_full:
         dpath = os.path.join(dpath, 'full')
+        fname = 'wiki_full_extracted.tgz'
     else:
         dpath = os.path.join(dpath, 'summary')
-    # check if data had been previously built
+        fname = "summaries.tgz"
     if not build_data.built(dpath):
         print('[building data: ' + dpath + ']')
-
         build_data.make_dir(dpath)
-
-        if extract_full:
-            # download the data.
-            fname = 'enwiki-latest-pages-articles.xml.bz2'
-            url = 'https://dumps.wikimedia.org/enwiki/latest/' + fname
-            build_data.download(url, dpath, fname)
-            # # mark the data as built
-            build_data.mark_done(dpath)
-            return False
-        else:
-            fname = "summaries.tgz"
-            url = "https://s3.amazonaws.com/fair-data/parlai/wikipedia/" + fname
-            build_data.download(url, dpath, fname)
-            build_data.untar(dpath, fname)
-            build_data.mark_done(dpath)
-            return True
-    return True
+        url = 'https://s3.amazonaws.com/fair-data/parlai/wikipedia/' + fname
+        build_data.download(url, dpath, fname)
+        build_data.untar(dpath, fname)
+        build_data.mark_done(dpath)


### PR DESCRIPTION
Here's the text from a `README.md` included in the full extracted article dump:


> 
> Copyright
> (c) 2017-present, Facebook, Inc.
> All rights reserved.
> This source code is licensed under the BSD-style license found in the
> LICENSE file in the root directory of this source tree. An additional grant
> of patent rights can be found in the PATENTS file in the same directory.
> 
> 
> The data in this extraction are taken from a Wikipedia dump from February 3rd, 2018 (found at this link: https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2), and are licensed under the Creative Commons Attribution-Share-Alike 3.0 License (https://creativecommons.org/licenses/by-sa/3.0/legalcode).
> 
> The extraction of the original xml files was performed using a wikipedia extractor (https://github.com/attardi/wikiextractor); to reproduce the extraction on the original Wikipedia xml data dump (and place the extracted files in ParlAI), one can run the following command (with the appropriate file path prefixes):
> 
> `mkdir -p /path/to/ParlAI/downloads  && git clone https://github.com/attardi/wikiextractor /path/to/ParlAI/downloads/wikiextract && cd /path/to/ParlAI/downloads/wikiextract && python WikiExtractor.py /path/to/enwiki-latest-pages-articles.xml.bz2 --filter_disambig_pages -o /path/to/ParlAI/data/wikipedia/full/wiki_extracted --json`
