### PR TITLE
LM interactive fix

### DIFF
--- a/parlai/agents/language_model/language_model.py
+++ b/parlai/agents/language_model/language_model.py
@@ -227,7 +227,7 @@ class LanguageModelAgent(Agent):
         obs = observation.copy()
         seq_len = self.opt['seq_len']
         is_training = True
-        if 'eval_labels' in obs:
+        if 'labels' not in obs:
             is_training = False
 
         if is_training:


### PR DESCRIPTION
In interactive mode, LM defaults to training mode since eval_labels are not present, so predictions are not produced. This fixes that