### PR TITLE
Fix the way the training loss is calculated for seq2seq

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -387,8 +387,9 @@ class Seq2seqAgent(Agent):
             loss += self.criterion(scores.view(-1, scores.size(-1)), ys.view(-1))
             loss.backward()
             self.update_params()
-            loss_dict = {'loss': loss.mul(len(xs)).data[0]}
-            loss_dict['ppl'] = (math.e**loss).mul(len(xs)).data[0]
+            loss_dict = {'loss': loss.data[0]}
+            loss_dict['ppl'] = (math.e**loss).data[0]
+            #loss_dict['ppl'] = (math.e**loss).mul(len(xs)).data[0]
         else:
             self.model.eval()
             predictions, scores, text_cand_inds = self.model(xs, ys, cands,

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -389,7 +389,6 @@ class Seq2seqAgent(Agent):
             self.update_params()
             loss_dict = {'loss': loss.data[0]}
             loss_dict['ppl'] = (math.e**loss).data[0]
-            #loss_dict['ppl'] = (math.e**loss).mul(len(xs)).data[0]
         else:
             self.model.eval()
             predictions, scores, text_cand_inds = self.model(xs, ys, cands,


### PR DESCRIPTION
Now that the Metrics class keeps a separate "total" count for each metric, we no longer need to multiply the loss by the length of the input sequence in seq2seq. 