### PR TITLE
Learning rate scheduler for language model

### DIFF
--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -145,6 +145,7 @@ class TrainLoop():
         valid_report, self.valid_world = run_eval(
             self.agent, opt, 'valid', opt['validation_max_exs'],
             valid_world=self.valid_world)
+        self.agent.receive_metrics(valid_report)
         if valid_report[opt['validation_metric']] > self.best_valid:
             self.best_valid = valid_report[opt['validation_metric']]
             self.impatience = 0

--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -145,7 +145,8 @@ class TrainLoop():
         valid_report, self.valid_world = run_eval(
             self.agent, opt, 'valid', opt['validation_max_exs'],
             valid_world=self.valid_world)
-        self.agent.receive_metrics(valid_report)
+        if hasattr(self.agent, 'receive_metrics'):
+            self.agent.receive_metrics(valid_report)
         if valid_report[opt['validation_metric']] > self.best_valid:
             self.best_valid = valid_report[opt['validation_metric']]
             self.impatience = 0

--- a/parlai/agents/language_model/language_model.py
+++ b/parlai/agents/language_model/language_model.py
@@ -79,6 +79,7 @@ class LanguageModelAgent(Agent):
         self.use_cuda = not opt.get('no_cuda') and torch.cuda.is_available()
         self.batchsize = opt.get('batchsize', 1)
         self.use_person_tokens = opt.get('person_tokens', True)
+        self.valid_metrics = None
 
         if shared:
             # set up shared properties
@@ -486,6 +487,14 @@ class LanguageModelAgent(Agent):
         if path is not None:
             self.save(path + '.shutdown_state')
         super().shutdown()
+
+    def receive_metrics(self, metrics_dict):
+        if self.valid_metrics is None:
+            self.valid_metrics = metrics_dict
+        else:
+            if 'loss' in self.valid_metrics:
+
+            pass
 
     def load(self, path):
         """Return opt and model states."""

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -53,7 +53,6 @@ class Agent(object):
         if not hasattr(self, 'opt'):
             self.opt = copy.deepcopy(opt)
         self.observation = None
-        self.metrics_dict = None
 
     def observe(self, observation):
         """Receive an observation/action dict."""

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -53,6 +53,7 @@ class Agent(object):
         if not hasattr(self, 'opt'):
             self.opt = copy.deepcopy(opt)
         self.observation = None
+        self.metrics_dict = None
 
     def observe(self, observation):
         """Receive an observation/action dict."""
@@ -99,6 +100,13 @@ class Agent(object):
 
     def shutdown(self):
         """Perform any final cleanup if needed."""
+        pass
+
+    def receive_metrics(self, metrics_dict):
+        """Send the agent a metrics dict.
+        This can be used, for example, to anneal the learning rate after the
+        validation loss has plateaued.
+        """
         pass
 
 

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -101,13 +101,6 @@ class Agent(object):
         """Perform any final cleanup if needed."""
         pass
 
-    def receive_metrics(self, metrics_dict):
-        """Send the agent a metrics dict.
-        This can be used, for example, to anneal the learning rate after the
-        validation loss has plateaued.
-        """
-        pass
-
 
 class Teacher(Agent):
     """Basic Teacher agent which keeps track of how many times it's received


### PR DESCRIPTION
1. Adds a function "receive_metrics" for Agent class which allows the agent to receive a dictionary
2. Calls this function after validation during the train_model loop
3. Implements this function in language_model so that the learning rate is decreased by a factor when the validation loss does not decrease. Defaults to 0.5
4. Also makes small change to "get_predictions" function in language_model so that it handles case when predictions are empty (this happens when there are no 'valid' examples in the batch)