### PR TITLE
Allowing mturk game server to have folders

### DIFF
--- a/parlai/mturk/core/server/server.js
+++ b/parlai/mturk/core/server/server.js
@@ -245,4 +245,6 @@ app.get('/get_timestamp', function (req, res) {
   res.json({'timestamp': Date.now()}); // in milliseconds
 });
 
+app.use(express.static('task'))
+
 // ======================= </Routing> =======================

--- a/parlai/mturk/core/server_utils.py
+++ b/parlai/mturk/core/server_utils.py
@@ -98,6 +98,10 @@ def setup_heroku_server(task_name, task_files_to_copy=None):
     for file_path in task_files_to_copy:
         try:
             shutil.copy2(file_path, task_directory_path)
+        except IsADirectoryError:  # noqa: F821 we don't support python2
+            dir_name = os.path.basename(os.path.normpath(file_path))
+            shutil.copytree(
+                file_path, os.path.join(task_directory_path, dir_name))
         except FileNotFoundError:  # noqa: F821 we don't support python2
             pass
 


### PR DESCRIPTION
If a user wanted to upload additional scripts and such that depended on having a regular filesystem, they wouldn't be able to before. Now they are