### PR TITLE
Timeouts for waiting to pair in messenger

### DIFF
--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -24,7 +24,9 @@ class MessengerAgent(Agent):
         self.acted_packets = {}
         self.observed_packets = {}
         self.msg_queue = Queue()
-        self.return_data = None
+        self.stored_data = {}
+        # initialize stored data
+        self.set_stored_data()
 
     def observe(self, act):
         """Send an agent a message through the mturk manager"""
@@ -75,11 +77,11 @@ class MessengerAgent(Agent):
             }
             self.msg_queue.put(action)
 
-    def set_state_data(self):
+    def set_stored_data(self):
         """Gets agent state data from manager"""
         agent_state = self.manager.get_agent_state(self.id)
         if agent_state is not None:
-            self.return_data = agent_state.return_data
+            self.stored_data = agent_state.stored_data
 
     def get_new_act_message(self):
         """Get a new act message if one exists, return None otherwise"""

--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -24,6 +24,7 @@ class MessengerAgent(Agent):
         self.acted_packets = {}
         self.observed_packets = {}
         self.msg_queue = Queue()
+        self.return_data = None
 
     def observe(self, act):
         """Send an agent a message through the mturk manager"""
@@ -73,6 +74,12 @@ class MessengerAgent(Agent):
                 'id': self.disp_id,
             }
             self.msg_queue.put(action)
+
+    def set_state_data(self):
+        """Gets agent state data from manager"""
+        agent_state = self.manager.get_agent_state(self.id)
+        if agent_state is not None:
+            self.return_data = agent_state.return_data
 
     def get_new_act_message(self):
         """Get a new act message if one exists, return None otherwise"""

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -93,9 +93,8 @@ class MessengerManager():
             )
             # time agent entered agent_pool
             agent.time_in_pool.setdefault(world_type, time.time())
-            if world_type not in self.agent_pool:
-                self.agent_pool[world_type] = []
-            self.agent_pool[world_type].append(agent)
+            # add agent to pool
+            self.agent_pool.setdefault(world_type, []).append(agent)
 
     def remove_agent_from_pool(self, agent, world_type='default', mark_removed=True):
         """Remove agent from the pool"""

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -27,7 +27,7 @@ class AgentState():
         self.active_agent = overworld_agent
         self.task_id_to_agent = {}
         self.onboard_data = None
-        self.return_data = None
+        self.stored_data = {}
         self.time_in_pool = {}
 
     def get_active_agent(self):
@@ -110,10 +110,7 @@ class MessengerManager():
                     del agent.time_in_pool[world_type]
                 # maybe mark agent as removed
                 if mark_removed:
-                    if agent.return_data is None:
-                        agent.return_data = {'removed': True}
-                    else:
-                        agent.return_data.setdefault('removed', True)
+                    agent.stored_data['removed_from_pool']=True
 
     def _expire_all_conversations(self):
         """iterate through all sub-worlds and shut them down"""


### PR DESCRIPTION
1. Adds option to set a timeout for worlds while waiting for the needed number of agents. Once timed out, the agent is removed from the pool and returned to the overworld. The agent is marked as "removed" in the return_data field of AgentState. In order to access this data, I added a corresponding field and a function "set_state_data" to the MessengerAgent class. I could set other fields from AgentState to MessengerAgent here (like onboard_data etc.), but I wasn't sure of the use case--what do you think @JackUrb ?
2. Adds option to return to overworld while waiting 