### PR TITLE
Pass opt to onboarding world in Messenger

### DIFF
--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -162,7 +162,7 @@ class MessengerManager():
                 )
                 return
 
-        def _overworld_function(opt, agent_id, task_id):
+        def _overworld_function(agent_id, task_id):
             """Wrapper function for maintaining an overworld"""
             agent_state = self._get_agent_state(agent_id)
             agent = agent_state.get_overworld_agent()
@@ -185,7 +185,7 @@ class MessengerManager():
         # Start the onboarding thread and run it
         overworld_thread = threading.Thread(
             target=_overworld_function,
-            args=(self.opt, agent_id, task_id),
+            args=(agent_id, task_id),
             name=task_id
         )
         overworld_thread.daemon = True

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -162,11 +162,11 @@ class MessengerManager():
                 )
                 return
 
-        def _overworld_function(agent_id, task_id):
+        def _overworld_function(opt, agent_id, task_id):
             """Wrapper function for maintaining an overworld"""
             agent_state = self._get_agent_state(agent_id)
             agent = agent_state.get_overworld_agent()
-            overworld = self.overworld_func(agent)
+            overworld = self.overworld_func(opt, agent)
 
             while self.running:
                 world_type = overworld.parley()
@@ -185,7 +185,7 @@ class MessengerManager():
         # Start the onboarding thread and run it
         overworld_thread = threading.Thread(
             target=_overworld_function,
-            args=(agent_id, task_id),
+            args=(self.opt, agent_id, task_id),
             name=task_id
         )
         overworld_thread.daemon = True

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -162,7 +162,7 @@ class MessengerManager():
                 )
                 return
 
-        def _overworld_function(agent_id, task_id):
+        def _overworld_function(opt, agent_id, task_id):
             """Wrapper function for maintaining an overworld"""
             agent_state = self._get_agent_state(agent_id)
             agent = agent_state.get_overworld_agent()
@@ -185,7 +185,7 @@ class MessengerManager():
         # Start the onboarding thread and run it
         overworld_thread = threading.Thread(
             target=_overworld_function,
-            args=(agent_id, task_id),
+            args=(self.opt, agent_id, task_id),
             name=task_id
         )
         overworld_thread.daemon = True
@@ -231,7 +231,7 @@ class MessengerManager():
         """Handle creating an onboarding thread and moving an agent through
         the onboarding process
         """
-        def _onboard_function(agent_id, world_type, task_id):
+        def _onboard_function(opt, agent_id, world_type, task_id):
             """Onboarding wrapper to set state to onboarding properly"""
             agent_state = self._get_agent_state(agent_id)
             data = None
@@ -241,7 +241,7 @@ class MessengerManager():
                 agent = self._create_agent(task_id, agent_id)
                 agent_state.set_active_agent(agent)
                 agent_state.assign_agent_to_task(agent, task_id)
-                data = self.onboard_functions[world_type](agent, task_id)
+                data = self.onboard_functions[world_type](opt, agent, task_id)
                 agent_state.onboard_data = data
                 agent_state.set_active_agent(None)
 
@@ -252,7 +252,7 @@ class MessengerManager():
         # Start the onboarding thread and run it
         onboard_thread = threading.Thread(
             target=_onboard_function,
-            args=(agent_id, world_type, task_id),
+            args=(self.opt, agent_id, world_type, task_id),
             name=task_id
         )
         onboard_thread.daemon = True

--- a/parlai/messenger/core/worlds.py
+++ b/parlai/messenger/core/worlds.py
@@ -30,7 +30,7 @@ class OnboardWorld(World):
         self.episodeDone = False
 
     @staticmethod
-    def run(agent, task_id):
+    def run(opt, agent, task_id):
         pass
 
     def parley(self):

--- a/parlai/messenger/tasks/chatbot/run.py
+++ b/parlai/messenger/tasks/chatbot/run.py
@@ -29,8 +29,8 @@ def main():
     messenger_manager.setup_server()
     messenger_manager.init_new_state()
 
-    def get_overworld(agent):
-        return MessengerOverworld(None, agent)
+    def get_overworld(opt, agent):
+        return MessengerOverworld(opt, agent)
 
     def assign_agent_role(agent):
         agent[0].disp_id = 'Agent'

--- a/parlai/messenger/tasks/overworld_demo/run.py
+++ b/parlai/messenger/tasks/overworld_demo/run.py
@@ -22,8 +22,8 @@ def main():
     messenger_manager.setup_server()
     messenger_manager.init_new_state()
 
-    def get_overworld(agent):
-        return MessengerOverworld(None, agent)
+    def get_overworld(opt, agent):
+        return MessengerOverworld(opt, agent)
 
     onboard_functions = {name: worlds[0].run for (name, worlds)
                          in MessengerOverworld.DEMOS.items()}

--- a/parlai/messenger/tasks/overworld_demo/worlds.py
+++ b/parlai/messenger/tasks/overworld_demo/worlds.py
@@ -14,8 +14,8 @@ class MessengerEchoOnboardWorld(OnboardWorld):
     onboarding worlds that only exist to send an introduction message.
     """
     @staticmethod
-    def run(agent, task_id):
-        world = MessengerEchoOnboardWorld(opt=None, agent=agent)
+    def run(opt, agent, task_id):
+        world = MessengerEchoOnboardWorld(opt=opt, agent=agent)
         while not world.episode_done():
             world.parley()
         world.shutdown()
@@ -81,10 +81,10 @@ class MessengerOnboardDataOnboardWorld(OnboardWorld):
         self.turn = 0
 
     @staticmethod
-    def run(agent, task_id):
+    def run(opt, agent, task_id):
         '''Runs an instance of the onboarding world. Data returned from
         here will be made available in the agent.onboard_data field'''
-        world = MessengerOnboardDataOnboardWorld(opt=None, agent=agent)
+        world = MessengerOnboardDataOnboardWorld(opt=opt, agent=agent)
         while not world.episode_done():
             world.parley()
         world.shutdown()
@@ -166,8 +166,8 @@ class MessengerChatOnboardWorld(OnboardWorld):
         self.turn = 0
 
     @staticmethod
-    def run(agent, task_id):
-        world = MessengerChatOnboardWorld(opt=None, agent=agent)
+    def run(opt, agent, task_id):
+        world = MessengerChatOnboardWorld(opt=opt, agent=agent)
         while not world.episode_done():
             world.parley()
         world.shutdown()

--- a/parlai/messenger/tasks/qa_data_collection/run.py
+++ b/parlai/messenger/tasks/qa_data_collection/run.py
@@ -33,8 +33,8 @@ def main():
     messenger_manager.setup_server()
     messenger_manager.init_new_state()
 
-    def get_overworld(agent):
-        return MessengerOverworld(None, agent)
+    def get_overworld(opt, agent):
+        return MessengerOverworld(opt, agent)
 
     def assign_agent_role(agent):
         agent[0].disp_id = 'Agent'


### PR DESCRIPTION
- Added ability to pass opt to onboarding world in messenger
- Changed overworld demo so that it initializes onboard world with opt instead of None (was not necessary to change QA data collection demo since there is no onboard world)
- Changed run function in OnboardWorld base class to take opt as an argument