### PR TITLE
Syncing worker state with MTurk when polling

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -1061,7 +1061,12 @@ class MTurkManager():
         client = mturk_utils.get_mturk_client(self.is_sandbox)
         try:
             response = client.get_assignment(AssignmentId=assignment_id)
-            return response['Assignment']['AssignmentStatus']
+            status = response['Assignment']['AssignmentStatus']
+            worker_id = self.assignment_to_worker_id[assignment_id]
+            agent = self._get_agent(worker_id, assignment_id)
+            if agent is not None and status == MTurkAgent.ASSIGNMENT_DONE:
+                agent.hit_is_complete = True
+            return status
         except ClientError as e:
             # If the assignment isn't done, asking for the assignment will fail
             not_done_message = ('This operation can be called with a status '


### PR DESCRIPTION
Workers were able to leave the shutdown pool before being marked as any particular state due to a time discrepancy between when Mturk would update its local state and when it would send out the notification of a state change. This led to some improper bookkeeping.

Now we update the state when a polling event occurs if that polling event should update the state.