### PR TITLE
Preventing endless alives after 8 seconds of disconnect

### DIFF
--- a/parlai/mturk/core/server/html/core.html
+++ b/parlai/mturk/core/server/html/core.html
@@ -816,6 +816,8 @@
       try {
         socket.close();
       } catch(e) {/* Socket already terminated */}
+      window.clearInterval(heartbeat_id);
+      last_server_heartbeat = null;
       setup_socket();
     }
 


### PR DESCRIPTION
Not clearing this timeout and last heartbeat would make the loop go endlessly until the user left. HITs would kick you out forever following 8 seconds of disconnection between the client and the ParlAI server.

Alives would instantly die because this would trigger before the response came in.