### PR TITLE
Adds more descriptive tags to conversational logs

### DIFF
--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -261,7 +261,7 @@ class SocketManager():
         pkt = packet.as_dict()
         shared_utils.print_and_log(
             logging.DEBUG,
-            'Send packet: {}'.format(packet.data)
+            'Send packet: {}'.format(packet)
         )
 
         result = self._safe_send(json.dumps({


### PR DESCRIPTION
Also reduces repeated polling to MTurk services, and ensures that someone who reconnects on a double refresh without receiving their world on the first refresh will be able to get one on the second refresh.