### PR TITLE
Don't error out on timeout calls in onboarding

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -267,17 +267,18 @@ class MTurkManager():
             agent.state.status = AssignState.STATUS_DISCONNECT
             # in conversation, inform others about disconnect
             conversation_id = agent.conversation_id
-            if agent in self.conv_to_agent[conversation_id]:
-                for other_agent in self.conv_to_agent[conversation_id]:
-                    if agent.assignment_id != other_agent.assignment_id:
-                        self._handle_partner_disconnect(
-                            other_agent.worker_id,
-                            other_agent.assignment_id
-                        )
-            if len(self.mturk_agent_ids) > 1:
-                # The user disconnected from inside a conversation with
-                # another turker, record this as bad behavoir
-                self._handle_bad_disconnect(worker_id)
+            if conversation_id in self.conv_to_agent:
+                if agent in self.conv_to_agent[conversation_id]:
+                    for other_agent in self.conv_to_agent[conversation_id]:
+                        if agent.assignment_id != other_agent.assignment_id:
+                            self._handle_partner_disconnect(
+                                other_agent.worker_id,
+                                other_agent.assignment_id
+                            )
+                if len(self.mturk_agent_ids) > 1:
+                    # The user disconnected from inside a conversation with
+                    # another turker, record this as bad behavoir
+                    self._handle_bad_disconnect(worker_id)
 
     def _handle_partner_disconnect(self, worker_id, assignment_id):
         """Send a message to a worker notifying them that a partner has


### PR DESCRIPTION
Actions should only be taken to clear a user out of their conversation and log them for a bad disconnect _if_ it actually was a bad disconnect.