### PR TITLE
Add 'override' opt to ParlAI parser

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -278,10 +278,12 @@ def load_agent_module(opt):
     if os.path.isfile(optfile):
         with open(optfile, 'rb') as handle:
            new_opt = pickle.load(handle)
-        # override in case the file has been moved.
-        new_opt['model_file'] = opt['model_file']
-        model_class = get_agent_module(new_opt['model'])
-        return model_class(new_opt)
+        # only override opts specified in 'override' dict
+        if new_opt.get('override'):
+            for k, v in new_opt['override']:
+                opt[k] = v
+        model_class = get_agent_module(opt['model'])
+        return model_class(opt)
     else:
         return None
 

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -73,6 +73,9 @@ class ParlaiParser(argparse.ArgumentParser):
 
         self.add_arg = self.add_argument
 
+        # remember which args were specified on the command line
+        self.cli_args = sys.argv
+
         if add_parlai_args:
             self.add_parlai_args(model_argv)
             self.add_image_args()
@@ -307,6 +310,13 @@ class ParlaiParser(argparse.ArgumentParser):
             os.environ['PARLAI_DOWNPATH'] = self.opt['download_path']
         if self.opt.get('datapath'):
             os.environ['PARLAI_DATAPATH'] = self.opt['datapath']
+
+        # set all arguments specified in commandline as overridable
+        override = {}
+        for k, v in self.opt.items():
+            if v in self.cli_args:
+                override[k] = v
+        self.opt['override'] = override
 
         if print_args:
             self.print_args()


### PR DESCRIPTION
- When ParlAI parser is instantiated, it remembers which arguments were specified on the command line. These arguments are saved in a dict stored in `opt['override']`.
- Models can add additional items to `opt['override']` 
- `load_agent_model` in `core/agents.py` loads opts saved in `opt['model_file'] + '.opt'`, but only overrides the ones specified in `opt['override']`