### PR TITLE
Status partner disconnect early

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -157,7 +157,7 @@ class ParlaiParser(argparse.ArgumentParser):
                  'unlimited.'
         )
         mturk.add_argument(
-            '--min-messages', dest='min-messages',
+            '--min-messages', dest='min_messages',
             default=0, type=int,
             help='number of messages required to be sent by MTurk agent when '
                  'considering whether to approve a HIT in the event of a '

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -159,8 +159,9 @@ class ParlaiParser(argparse.ArgumentParser):
         mturk.add_argument(
             '--min-messages', dest='min-messages',
             default=0, type=int,
-            help='number of messages required to be sent by MTurk agent in the '
-                 'event of a partner disconnect. If the number of messages '
+            help='number of messages required to be sent by MTurk agent when '
+                 'considering whether to approve a HIT in the event of a '
+                 'partner disconnect. I.e. if the number of messages '
                  'exceeds this number, the turker can submit the HIT.'
         )
 

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -156,6 +156,13 @@ class ParlaiParser(argparse.ArgumentParser):
             help='number of HITs that can be launched at the same time, 0 is '
                  'unlimited.'
         )
+        mturk.add_argument(
+            '--min-messages', dest='min-messages',
+            default=0, type=int,
+            help='number of messages required to be sent by MTurk agent in the '
+                 'event of a partner disconnect. If the number of messages '
+                 'exceeds this number, the turker can submit the HIT.'
+        )
 
         mturk.set_defaults(is_sandbox=True)
         mturk.set_defaults(is_debug=False)

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -1249,10 +1249,8 @@ class MTurkManager():
         results = []
         for assignment in assignments:
             assignment_id = assignment['AssignmentId']
-            res = client.approve_assignment(AssignmentId=assignment_id,
+            client.approve_assignment(AssignmentId=assignment_id,
                                       OverrideRejection=override_rejection)
-            results.append(res)
-        return results
 
     def block_worker(self, worker_id, reason):
         """Block a worker by id using the mturk client, passes reason along"""

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -1246,7 +1246,6 @@ class MTurkManager():
         """
         client = mturk_utils.get_mturk_client(self.is_sandbox)
         assignments = self.get_assignments_for_hit(hit_id)
-        results = []
         for assignment in assignments:
             assignment_id = assignment['AssignmentId']
             client.approve_assignment(AssignmentId=assignment_id,

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -74,6 +74,7 @@ class MTurkManager():
         self.required_hits = math.ceil(
             self.num_conversations * len(self.mturk_agent_ids) * HIT_MULT
         )
+        self.minimum_messages = opt.get('min_messages', 0)
         self.socket_manager = None
         self.is_test = is_test
         self.is_unique = False
@@ -290,7 +291,10 @@ class MTurkManager():
         elif not agent.state.is_final():
             # Update the assignment state
             agent.some_agent_disconnected = True
-            agent.state.status = AssignState.STATUS_PARTNER_DISCONNECT
+            if len(agent.state.messages) < self.minimum_messages:
+                agent.state.status = AssignState.STATUS_PARTNER_DISCONNECT_EARLY
+            else:
+                agent.state.status = AssignState.STATUS_PARTNER_DISCONNECT
 
             # Create and send the command
             data = agent.get_inactive_command_data()
@@ -1242,10 +1246,13 @@ class MTurkManager():
         """
         client = mturk_utils.get_mturk_client(self.is_sandbox)
         assignments = self.get_assignments_for_hit(hit_id)
+        results = []
         for assignment in assignments:
-            assignmend_id = assignment['AssignmentId']
-            client.approve_assignment(AssignmentId=assignment_id,
+            assignment_id = assignment['AssignmentId']
+            res = client.approve_assignment(AssignmentId=assignment_id,
                                       OverrideRejection=override_rejection)
+            results.append(res)
+        return results
 
     def block_worker(self, worker_id, reason):
         """Block a worker by id using the mturk client, passes reason along"""

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -291,7 +291,8 @@ class MTurkManager():
         elif not agent.state.is_final():
             # Update the assignment state
             agent.some_agent_disconnected = True
-            if len(agent.state.messages) < self.minimum_messages:
+            agent_messages = [m for m in agent.state.messages if m['id'] == agent.id]
+            if len(agent_messages) < self.minimum_messages:
                 agent.state.status = AssignState.STATUS_PARTNER_DISCONNECT_EARLY
             else:
                 agent.state.status = AssignState.STATUS_PARTNER_DISCONNECT

--- a/parlai/mturk/core/worker_state.py
+++ b/parlai/mturk/core/worker_state.py
@@ -82,9 +82,10 @@ class AssignState():
         elif self.status == self.STATUS_PARTNER_DISCONNECT_EARLY:
             command = data_model.COMMAND_INACTIVE_HIT
             text = ('One of your partners disconnected in the middle of the '
-                    'HIT. Unfortunately, you did not complete enough of the '
-                    'task to submit the HIT. Please return this HIT and '
-                    'accept a new one.')
+                    'HIT. We won\'t penalize you for their disconnect, but you '
+                    'did not complete enough of the task to submit the HIT. '
+                    'Please return this HIT and accept a new one if you would '
+                    'like to try again.')
         elif self.status == self.STATUS_RETURNED:
             text = ('You disconnected from this HIT and then returned '
                     'it. As we have marked the HIT as returned, it is no '

--- a/parlai/mturk/core/worker_state.py
+++ b/parlai/mturk/core/worker_state.py
@@ -21,6 +21,7 @@ class AssignState():
     STATUS_DONE = 'done'
     STATUS_DISCONNECT = 'disconnect'
     STATUS_PARTNER_DISCONNECT = 'partner disconnect'
+    STATUS_PARTNER_DISCONNECT_EARLY = 'partner disconnect early'
     STATUS_EXPIRED = 'expired'
     STATUS_RETURNED = 'returned'
 
@@ -45,6 +46,7 @@ class AssignState():
         return (self.status == self.STATUS_DISCONNECT or
                 self.status == self.STATUS_DONE or
                 self.status == self.STATUS_PARTNER_DISCONNECT or
+                self.status == self.STATUS_PARTNER_DISCONNECT_EARLY or
                 self.status == self.STATUS_RETURNED or
                 self.status == self.STATUS_EXPIRED)
 
@@ -77,6 +79,12 @@ class AssignState():
             text = ('One of your partners disconnected in the middle of the '
                     'HIT. We won\'t penalize you for their disconnect, so '
                     'please use the button below to mark the HIT as complete.')
+        elif self.status == self.STATUS_PARTNER_DISCONNECT_EARLY:
+            command = data_model.COMMAND_INACTIVE_HIT
+            text = ('One of your partners disconnected in the middle of the '
+                    'HIT. Unfortunately, you did not complete enough of the '
+                    'task to submit the HIT. Please return this HIT and '
+                    'accept a new one.')
         elif self.status == self.STATUS_RETURNED:
             text = ('You disconnected from this HIT and then returned '
                     'it. As we have marked the HIT as returned, it is no '


### PR DESCRIPTION
This PR allows you to specify a minimum number of messages required to be sent by the turker before accepting their HIT if their partner disconnects from the chat