### PR TITLE
expose way to upload attachments in messenger

### DIFF
--- a/parlai/messenger/core/message_socket.py
+++ b/parlai/messenger/core/message_socket.py
@@ -8,7 +8,6 @@ import json
 import logging
 import os
 import requests
-from requests_toolbelt import MultipartEncoder
 import threading
 import time
 import websocket

--- a/parlai/messenger/core/message_socket.py
+++ b/parlai/messenger/core/message_socket.py
@@ -270,7 +270,7 @@ class MessageSocket():
             results.append(result)
         return results
 
-    def upload_attachment(self, payload):
+    def upload_fb_attachment(self, payload):
         """Uploads an attachment using the Attachment Upload API and returns
         an attachment ID.
         """
@@ -313,7 +313,7 @@ class MessageSocket():
         result = response.json()
         shared_utils.print_and_log(
             logging.INFO,
-            '"Facebook response from message send: {}"'.format(result)
+            '"Facebook response from attachment upload: {}"'.format(result)
         )
         return result
 

--- a/parlai/messenger/core/message_socket.py
+++ b/parlai/messenger/core/message_socket.py
@@ -6,7 +6,6 @@
 import errno
 import json
 import logging
-import os
 import requests
 import threading
 import time

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -542,7 +542,7 @@ class MessengerManager():
         """Send a payload through the message manager"""
         return self.message_socket.send_fb_payload(receiver_id, data)
 
-    def get_attachment_upload(self, payload):
+    def upload_attachment(self, payload):
         """Uploads an attachment and returns an attachment ID
         `payload` should be a dict of the format
         {'type': <TYPE>, 'url': <URL>} or
@@ -550,4 +550,4 @@ class MessengerManager():
         For example,
         {'type': 'image', 'filename': 'test.png', 'format': 'png'}
         """
-        return self.message_socket.upload_attachment(payload)
+        return self.message_socket.upload_fb_attachment(payload)

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -541,3 +541,13 @@ class MessengerManager():
     def observe_payload(self, receiver_id, data):
         """Send a payload through the message manager"""
         return self.message_socket.send_fb_payload(receiver_id, data)
+
+    def get_attachment_upload(self, payload):
+        """Uploads an attachment and returns an attachment ID
+        `payload` should be a dict of the format
+        {'type': <TYPE>, 'url': <URL>} or
+        {'type': <TYPE>, 'filename': <FILENAME>, 'format': <FILEFORMAT>}.
+        For example,
+        {'type': 'image', 'filename': 'test.png', 'format': 'png'}
+        """
+        return self.message_socket.upload_attachment(payload)


### PR DESCRIPTION
Exposes a way to upload attachments in messenger.
- Can use attachment_ID or URL to send media
- Can upload attachment via URL or filename to get attachment_ID