### PR TITLE
Fbdialog updates

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -907,6 +907,7 @@ class FbDialogTeacher(DialogTeacher):
             x = ''
             reward = 0
             dialog_index = 0
+            last_conv_id = None
             for line in read:
                 line = line.strip().replace('\\n', '\n')
                 if len(line) == 0:
@@ -914,7 +915,7 @@ class FbDialogTeacher(DialogTeacher):
 
                 # first, get conversation index -- '1' means start of episode
                 space_idx = line.find(' ')
-                conv_id = line[:space_idx]
+                conv_id = int(line[:space_idx])
 
                 # split line into constituent parts, if available:
                 # x<tab>y<tab>reward<tab>label_candidates
@@ -933,7 +934,7 @@ class FbDialogTeacher(DialogTeacher):
                     split[2] = None
 
                 # now check if we're at a new episode
-                if conv_id == '1':
+                if last_conv_id is None or conv_id < last_conv_id:
                     dialog_index += 1
                     x = x.strip()
                     if x:
@@ -953,6 +954,7 @@ class FbDialogTeacher(DialogTeacher):
                         x = '{x}\n{next_x}'.format(x=x, next_x=split[0])
                     else:
                         x = split[0]
+                last_conv_id = conv_id
                 if len(split) > 2 and split[2]:
                     reward += float(split[2])
 

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -334,6 +334,13 @@ task_list = [
         "description": "2014 International Workshop on Spoken Language task, currently only includes en_de and de_en. From Cettolo et al. '12. Link: wit3.fbk.eu"
     },
     {
+        "id": "ConvAI2",
+        "display_name": "ConvAI2",
+        "task": "convai2",
+        "tags": [ "All", "ChitChat" ],
+        "description": "A chit-chat dataset based on PersonaChat (https://arxiv.org/abs/1801.07243) for a NIPS 2018 competition. Link: http://convai.io/."
+    },
+    {
         "id": "ConvAI_ChitChat",
         "display_name": "ConvAI_ChitChat",
         "task": "convai_chitchat",

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -15,8 +15,7 @@ class TestEvalModel(unittest.TestCase):
     """Basic tests on the eval_model.py example."""
 
     args = [
-        '--task', '#moviedd-reddit',
-        '--datatype', 'valid',
+        '--task', 'tasks.repeat:RepeatTeacher:10',
     ]
 
     parser = ParlaiParser()


### PR DESCRIPTION
- the fbdialog parser now resets the episode if the next id is less than the current, rather than 1

e.g.
```
1 hello world
2 second entry
3 third entry
2 new episode
```

this maintains the old behavior but also handles small bugs in numbering in the files

+ a few unit test fixes