### PR TITLE
Messenger agents typing indicator functions

### DIFF
--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -54,6 +54,10 @@ class MessengerAgent(Agent):
                 '{} could not be extracted to an observed message'.format(resp)
             )
 
+    def observe_typing_on(self):
+        """Allow agent to typing indicator"""
+        self.manager.message_socket.typing_on(self.id)
+
     def put_data(self, message):
         """Put data into the message queue if it hasn't already been seen"""
         mid = message['message']['mid']

--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -55,7 +55,7 @@ class MessengerAgent(Agent):
             )
 
     def observe_typing_on(self):
-        """Allow agent to typing indicator"""
+        """Allow agent to observe typing indicator"""
         self.manager.message_socket.typing_on(self.id)
 
     def put_data(self, message):

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -266,9 +266,10 @@ class MessengerManager():
                 self.observe_message(
                     agent_id,
                     "Please wait while we pair you with another person. "
-                    "If you wish to return to the Overworld, click *EXIT*",
+                    "If you wish to exit, click *EXIT*",
                     quick_replies=['EXIT']
                 )
+                self.message_socket.typing_on(agent_id)
         else:
             # If an agent is in a solo world, we can put a typing indicator
             # and mark the message as read
@@ -480,6 +481,22 @@ class MessengerManager():
                                 # put agent back in overworld
                                 agent_state.set_active_agent(
                                     agent_state.get_overworld_agent())
+                                # reset wait message state
+                                agent_state.stored_data['seen_wait_message'] = False
+                            elif time_in_pool and time.time() - time_in_pool \
+                                    > 30:
+                                # tell agent that a match is taking longer than
+                                # expected
+                                if not agent_state.stored_data.get('seen_wait_message') \
+                                        or not agent_state.stored_data['seen_wait_message']:
+                                    self.observe_message(
+                                        agent_state.messenger_id,
+                                        "Pairing is taking longer than expected. "
+                                        "If you wish to exit, click *EXIT*",
+                                        quick_replies=['EXIT']
+                                    )
+                                    self.message_socket.typing_on(agent_state.messenger_id)
+                                    agent_state.stored_data['seen_wait_message'] = True
 
                     needed_agents = self.max_agents_for[world_type]
                     if len(agent_pool) >= needed_agents:
@@ -496,6 +513,8 @@ class MessengerManager():
                             state.assign_agent_to_task(agent, task_id)
                             state.set_active_agent(agent)
                             agents.append(agent)
+                            # reset wait message state
+                            state.stored_data['seen_wait_message'] = False
                         assign_role_functions[world_type](agents)
                         # Allow task creator to filter out workers and run
                         # versions of the task that require fewer agents

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -266,7 +266,7 @@ class MessengerManager():
                 self.observe_message(
                     agent_id,
                     "Please wait while we pair you with another person. "
-                    "If you wish to exit, click *EXIT*",
+                    "If you wish to exit, click *EXIT*.",
                     quick_replies=['EXIT']
                 )
                 self.message_socket.typing_on(agent_id)
@@ -492,7 +492,7 @@ class MessengerManager():
                                     self.observe_message(
                                         agent_state.messenger_id,
                                         "Pairing is taking longer than expected. "
-                                        "If you wish to exit, click *EXIT*",
+                                        "If you wish to exit, click *EXIT*.",
                                         quick_replies=['EXIT']
                                     )
                                     self.message_socket.typing_on(agent_state.messenger_id)

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -266,8 +266,7 @@ class MessengerManager():
                 self.observe_message(
                     agent_id,
                     "Please wait while we pair you with another person. "
-                    "If you wish to exit, click *EXIT*.",
-                    quick_replies=['EXIT']
+                    "If you wish to exit, type *EXIT*."
                 )
                 self.message_socket.typing_on(agent_id)
         else:
@@ -492,8 +491,7 @@ class MessengerManager():
                                     self.observe_message(
                                         agent_state.messenger_id,
                                         "Pairing is taking longer than expected. "
-                                        "If you wish to exit, click *EXIT*.",
-                                        quick_replies=['EXIT']
+                                        "If you wish to exit, type *EXIT*.",
                                     )
                                     self.message_socket.typing_on(agent_state.messenger_id)
                                     agent_state.stored_data['seen_wait_message'] = True


### PR DESCRIPTION
1. Adds `observe_typing_on` for messenger agent to observe typing indicator
2. Rephrases message from onboarding world for pairing to be more generic / not reference overworld, added typing indicator
3. If an agent is in a pool for more than 30 seconds, we send a message that pairing is taking longer than expected and add a typing indicator.