### PR TITLE
Adds new logging, fixes dict key undefined bugs

### DIFF
--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -21,6 +21,7 @@ class Packet():
     """Class for holding information sent over a socket"""
 
     # Possible Packet Status
+    STATUS_NONE = -1
     STATUS_INIT = 0
     STATUS_SENT = 1
     STATUS_ACK = 2
@@ -539,6 +540,8 @@ class SocketManager():
 
     def get_status(self, packet_id):
         """Returns the status of a particular packet by id"""
+        if packet_id not in self.packet_map:
+            return Packet.STATUS_NONE
         return self.packet_map[packet_id].status
 
     def _safe_put(self, connection_id, item):


### PR DESCRIPTION
During some user discussions, these bugs were noted: 
- Not all messages have a defined 'id' (namely commands and system messages do not). This caused a bug when trying to use the message id
- At a certain point we should stop making new HITs to fill in the old ones. That point is when we are no longer accepting workers

I also added logs to some events that probably should be logged (blocking workers, approving and denying hits). 