### PR TITLE
Because we need more ways to catch errors

### DIFF
--- a/parlai/messenger/core/server/server.js
+++ b/parlai/messenger/core/server/server.js
@@ -59,8 +59,8 @@ function _send_message(event_name, event_data) {
             return true;
           }
           console.log("Repeat send of packet failed");
-          console.log(packet)
-          console.log(error2)
+          console.log(packet);
+          console.log(error2);
         });
       }, 500);
     });
@@ -92,8 +92,8 @@ wss.on('connection', function (socket) {
   });
 
   socket.on('error', (err) => {
-    console.log('Caught socket error')
-    console.log(err)
+    console.log('Caught socket error');
+    console.log(err);
   });
 
   socket.send(JSON.stringify(

--- a/parlai/messenger/core/server/server.js
+++ b/parlai/messenger/core/server/server.js
@@ -91,6 +91,11 @@ wss.on('connection', function (socket) {
     }
   });
 
+  socket.on('error', (err) => {
+    console.log('Caught socket error')
+    console.log(err)
+  });
+
   socket.send(JSON.stringify(
     {'type': 'conn_success', 'content': 'Socket is open!'}
   ), function ack(error) {return;});

--- a/parlai/mturk/core/server/server.js
+++ b/parlai/mturk/core/server/server.js
@@ -138,6 +138,11 @@ wss.on('connection', function (socket) {
     console.log('Client disconnected: ' + connection_id);
   });
 
+  socket.on('error', (err) => {
+    console.log('Caught socket error')
+    console.log(err)
+  });
+
   // handles routing a packet to the desired recipient
   socket.on('message', function (data) {
     data = JSON.parse(data)

--- a/parlai/mturk/core/server/server.js
+++ b/parlai/mturk/core/server/server.js
@@ -71,8 +71,8 @@ function _send_message(connection_id, event_name, event_data) {
           return;
         }
         console.log("Repeat send of packet failed");
-        console.log(packet)
-        console.log(error2)
+        console.log(packet);
+        console.log(error2);
       });
     }, 500);
   });
@@ -139,8 +139,8 @@ wss.on('connection', function (socket) {
   });
 
   socket.on('error', (err) => {
-    console.log('Caught socket error')
-    console.log(err)
+    console.log('Caught socket error');
+    console.log(err);
   });
 
   // handles routing a packet to the desired recipient


### PR DESCRIPTION
As described in https://github.com/websockets/ws/issues/1256 we need to be able to detect network errors on the socket. This was something introduced by the chrome browser over websockets recently and the app will crash if it's not handled.