### PR TITLE
bug fix

### DIFF
--- a/projects/convai2/baselines/seq2seq/eval.py
+++ b/projects/convai2/baselines/seq2seq/eval.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
     parser.set_defaults(
         task='convai2:self',
         model='seq2seq',
-        model_file='models:convai2/seq2seq/convai2_self_seq2seq_model',
+        model_file='models:convai2/seq2seq/convai2_self_seq2seq_model/convai2_self_seq2seq_model',
         dict_file='models:convai2/seq2seq/dict_convai2_self/dict_convai2_self',
         datatype='valid',
         batchsize=128,


### PR DESCRIPTION
since each model needs to be in it's own folder for the current build marking to verify whether to download something, need to have the double name