### PR TITLE
Improve compatibility with PyTorch master (0.4)

### DIFF
--- a/parlai/agents/coopgame_agent/coopgame_agent.py
+++ b/parlai/agents/coopgame_agent/coopgame_agent.py
@@ -116,7 +116,7 @@ class CooperativeGameAgent(Agent):
     def detokenize(self, vec):
         """Convert a ``torch.autograd.Variable`` of tokens into a string."""
         text_tokens = vec
-        if type(text_tokens) == Variable:
+        if isinstance(text_tokens, Variable):
             text_tokens = list(text_tokens.data)
         return self.dict.vec2txt(text_tokens)
 

--- a/parlai/agents/ibm_seq2seq/ibm_seq2seq.py
+++ b/parlai/agents/ibm_seq2seq/ibm_seq2seq.py
@@ -259,7 +259,7 @@ class IbmSeq2seqAgent(Agent):
 
     def v2t(self, vec):
         """Convert token indices to string of tokens."""
-        if type(vec) == Variable:
+        if isinstance(vec, Variable):
             vec = vec.data
         new_vec = []
         for i in vec:

--- a/parlai/agents/language_model/language_model.py
+++ b/parlai/agents/language_model/language_model.py
@@ -328,7 +328,7 @@ class LanguageModelAgent(Agent):
 
     def repackage_hidden(self, h):
         """Wraps hidden states in new Variables, to detach them from their history."""
-        if type(h) == Variable:
+        if isinstance(h, Variable):
             return Variable(h.data)
         else:
             return tuple(self.repackage_hidden(v) for v in h)

--- a/parlai/agents/memnn/modules.py
+++ b/parlai/agents/memnn/modules.py
@@ -49,7 +49,7 @@ class MemNN(nn.Module):
         memory_lengths = memory_lengths.data
         memories = memories.data
         if self.extra_features_slots > 0:
-            num_nonempty_memories = memory_lengths.ne(0).sum()
+            num_nonempty_memories = int(memory_lengths.ne(0).long().sum())
             updated_memories = memories.new(memories.numel() + num_nonempty_memories * self.extra_features_slots)
             src_offset = 0
             dst_offset = 0
@@ -96,6 +96,9 @@ class Embed(nn.Embedding):
         indices = indices.data
         if lengths.dim() == 1 or lengths.size(1) == 1:
             lengths_mat = lengths_mat.squeeze().unsqueeze(0)
+
+        if lengths_mat.dim() == 1:
+            raise RuntimeError(lengths.shape)
 
         input = torch.LongTensor(lengths_mat.size(0), lengths_mat.size(1), torch.max(lengths_mat))
         pad = self.padding_idx if self.padding_idx is not None else 0

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -346,7 +346,7 @@ class Seq2seqAgent(Agent):
 
     def v2t(self, vec):
         """Convert token indices to string of tokens."""
-        if type(vec) == Variable:
+        if isinstance(vec, Variable):
             vec = vec.data
         new_vec = []
         for i in vec:

--- a/parlai/agents/starspace/starspace.py
+++ b/parlai/agents/starspace/starspace.py
@@ -214,7 +214,7 @@ class StarspaceAgent(Agent):
 
     def v2t(self, vec):
         """Convert token indices to string of tokens."""
-        if type(vec) == Variable:
+        if isinstance(vec, Variable):
             vec = vec.data
         new_vec = []
         for i in vec:

--- a/parlai/core/thread_utils.py
+++ b/parlai/core/thread_utils.py
@@ -48,7 +48,7 @@ class SharedTable(MutableMapping):
         if init_dict:
             sizes = {typ: 0 for typ in self.types.keys()}
             for k, v in init_dict.items():
-                if 'Tensor' in str(type(v)):
+                if is_tensor(v):
                     # add tensor to tensor dict--don't try to put in rawarray
                     self.tensors[k] = v
                     continue
@@ -149,3 +149,10 @@ class SharedTable(MutableMapping):
 
     def get_lock(self):
         return self.lock
+
+
+def is_tensor(v):
+    if type(v).__module__.startswith('torch'):
+        import torch
+        return torch.is_tensor(v)
+    return False


### PR DESCRIPTION
 - Use isinstance instead of exact type checks
 - Use torch.is_tensor instead of string matching the type

The test_train_model.py script still fails. I think it's due to
var.squeeze() returning a 0-d value in a place  where it used to return
a 1-d 1-element value.