### PR TITLE
Fix loading seq2seq model in cuda mode

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -311,6 +311,12 @@ class Seq2seqAgent(Agent):
                           'changed.')
                 else:
                     self.optimizer.load_state_dict(states['optimizer'])
+                    if self.use_cuda:
+                        for state in self.optimizer.state.values():
+                            for k, v in state.items():
+                                if isinstance(v, torch.Tensor):
+                                    state[k] = v.cuda()
+
             self.scheduler = optim.lr_scheduler.ReduceLROnPlateau(
                 self.optimizer, 'min', factor=0.5, patience=3, verbose=True)
 


### PR DESCRIPTION
This fixes a bug when loading an existing seq2seq model along with its optimizer: all tensors for the optimizer state are mapped to CPU when loaded, and the training then crashes because the optimizer uses CPU-stored tensors although the underlying model parameters are on GPU.