### PR TITLE
Running ParlAI MTurk + Messenger on local servers

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -164,6 +164,11 @@ class ParlaiParser(argparse.ArgumentParser):
                  'partner disconnect. I.e. if the number of messages '
                  'exceeds this number, the turker can submit the HIT.'
         )
+        mturk.add_argument(
+            '--local', dest='local', default=False, action='store_true',
+            help='Run the server locally on this server rather than setting up'
+                 ' a heroku server.'
+        )
 
         mturk.set_defaults(is_sandbox=True)
         mturk.set_defaults(is_debug=False)
@@ -187,6 +192,11 @@ class ParlaiParser(argparse.ArgumentParser):
         messenger.add_argument(
             '--password', dest='password', type=str, default=None,
             help='Require a password for entry to the bot')
+        messenger.add_argument(
+            '--local', dest='local', action='store_true', default=False,
+            help='Run the server locally on this server rather than setting up'
+                 ' a heroku server.'
+        )
 
         messenger.set_defaults(is_debug=False)
         messenger.set_defaults(verbose=False)

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -387,7 +387,7 @@ class MessengerManager():
         self.server_task_name = \
             ''.join(e for e in task_name.lower() if e.isalnum() or e == '-')
         self.server_url = server_utils.setup_server(
-            self.server_task_name, local=self.opt['local_server'])
+            self.server_task_name, local=self.opt['local'])
         shared_utils.print_and_log(
             logging.INFO,
             'Webhook address: {}/webhook'.format(self.server_url),
@@ -422,6 +422,8 @@ class MessengerManager():
             expanded_file_path = os.path.expanduser(access_token_file_path)
             with open(expanded_file_path, 'w+') as access_token_file:
                 access_token_file.write(self.app_token)
+        if (self.opt['local']):  # skip some hops for local stuff
+            self.server_url = "https://localhost"
         self.message_socket = MessageSocket(self.server_url, self.port,
                                             self.app_token,
                                             self._handle_webhook_event)
@@ -568,7 +570,8 @@ class MessengerManager():
         except BaseException:
             pass
         finally:
-            server_utils.delete_server(self.server_task_name)
+            server_utils.delete_server(self.server_task_name,
+                                       self.opt['local'])
 
     # Agent Interaction Functions #
 

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -378,6 +378,19 @@ class MessengerManager():
         input('Please press Enter to continue... ')
         shared_utils.print_and_log(logging.NOTSET, '', True)
 
+        if self.opt['local'] is True:
+            shared_utils.print_and_log(
+                logging.INFO,
+                "In order to run the server locally, you will need "
+                "to have a public HTTPS endpoint (SSL signed) running on "
+                "the server you are currently excecuting ParlAI on. Enter "
+                "that public URL hostname when prompted and ensure that the "
+                "port being used by ParlAI (usually 3000) has external "
+                "traffic routed to it.",
+                should_print=True,
+            )
+            input('Please press Enter to continue... ')
+
         shared_utils.print_and_log(logging.INFO,
                                    'Setting up Messenger webhook...',
                                    should_print=True)
@@ -422,9 +435,10 @@ class MessengerManager():
             expanded_file_path = os.path.expanduser(access_token_file_path)
             with open(expanded_file_path, 'w+') as access_token_file:
                 access_token_file.write(self.app_token)
+        socket_use_url = self.server_url
         if (self.opt['local']):  # skip some hops for local stuff
-            self.server_url = "https://localhost"
-        self.message_socket = MessageSocket(self.server_url, self.port,
+            socket_use_url = "https://localhost"
+        self.message_socket = MessageSocket(socket_use_url, self.port,
                                             self.app_token,
                                             self._handle_webhook_event)
 

--- a/parlai/messenger/core/server_utils.py
+++ b/parlai/messenger/core/server_utils.py
@@ -259,7 +259,8 @@ def setup_local_server(task_name):
 
     time.sleep(1)
     print('Server running locally with pid {}.'.format(server_process.pid))
-    host = input('Please enter the server addr, like https://hostname.com: ')
+    host = input(
+        'Please enter the public server address, like https://hostname.com: ')
     port = input('Please enter the port given above, likely 3000: ')
     return '{}:{}'.format(host, port)
 

--- a/parlai/messenger/core/server_utils.py
+++ b/parlai/messenger/core/server_utils.py
@@ -14,6 +14,7 @@ import sh
 import shlex
 import shutil
 import subprocess
+import time
 
 region_name = 'us-east-1'
 user_name = getpass.getuser()
@@ -21,7 +22,10 @@ user_name = getpass.getuser()
 parent_dir = os.path.dirname(os.path.abspath(__file__))
 server_source_directory_name = 'server'
 heroku_server_directory_name = 'heroku_server'
+local_server_directory_name = 'local_server'
 task_directory_name = 'task'
+
+server_process = None
 
 heroku_url = \
     'https://cli-assets.heroku.com/heroku-cli/channels/stable/heroku-cli'
@@ -225,11 +229,62 @@ def delete_heroku_server(task_name):
     ))
 
 
+def setup_local_server(task_name):
+    global server_process
+    print("Local Server: Collecting files...")
+
+    server_source_directory_path = \
+        os.path.join(parent_dir, server_source_directory_name)
+    local_server_directory_path = os.path.join(parent_dir, '{}_{}'.format(
+        local_server_directory_name,
+        task_name
+    ))
+
+    # Delete old server files
+    sh.rm(shlex.split('-rf ' + local_server_directory_path))
+
+    # Copy over a clean copy into the server directory
+    shutil.copytree(server_source_directory_path, local_server_directory_path)
+
+    print("Local: Starting server...")
+
+    os.chdir(local_server_directory_path)
+
+    packages_installed = subprocess.call(['npm', 'install'])
+    if packages_installed != 0:
+        raise Exception('please make sure npm is installed, otherwise view '
+                        'the above error for more info.')
+
+    server_process = subprocess.Popen(['node', 'server.js'])
+
+    time.sleep(1)
+    print('Server running locally with pid {}.'.format(server_process.pid))
+    host = input('Please enter the server addr, like https://hostname.com: ')
+    port = input('Please enter the port given above, likely 3000: ')
+    return '{}:{}'.format(host, port)
+
+
+def delete_local_server(task_name):
+    global server_process
+    print('Terminating server')
+    server_process.terminate()
+    server_process.wait()
+    print('Cleaning temp directory')
+    local_server_directory_path = os.path.join(parent_dir, '{}_{}'.format(
+        local_server_directory_name,
+        task_name
+    ))
+    sh.rm(shlex.split('-rf ' + local_server_directory_path))
+
+
 def setup_server(task_name, local=False):
     if local:
         return setup_local_server(task_name)
     return setup_heroku_server(task_name)
 
 
-def delete_server(task_name):
-    delete_heroku_server(task_name)
+def delete_server(task_name, local=False):
+    if local:
+        delete_local_server(task_name)
+    else:
+        delete_heroku_server(task_name)

--- a/parlai/messenger/core/server_utils.py
+++ b/parlai/messenger/core/server_utils.py
@@ -225,7 +225,9 @@ def delete_heroku_server(task_name):
     ))
 
 
-def setup_server(task_name):
+def setup_server(task_name, local=False):
+    if local:
+        return setup_local_server(task_name)
     return setup_heroku_server(task_name)
 
 

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -324,10 +324,11 @@ class MTurkManager():
 
     def _setup_socket(self, timeout_seconds=None):
         """Set up a socket_manager with defined callbacks"""
+        socket_server_url = self.server_url
         if (self.opt['local']):  # skip some hops for local stuff
-            self.server_url = "https://localhost"
+            socket_server_url = "https://localhost"
         self.socket_manager = SocketManager(
-            self.server_url,
+            socket_server_url,
             self.port,
             self._on_alive,
             self._on_new_message,
@@ -672,6 +673,19 @@ class MTurkManager():
             )
         input('Please press Enter to continue... ')
         shared_utils.print_and_log(logging.NOTSET, '', True)
+
+        if self.opt['local'] is True:
+            shared_utils.print_and_log(
+                logging.INFO,
+                "In order to run the server locally, you will need "
+                "to have a public HTTPS endpoint (SSL signed) running on "
+                "the server you are currently excecuting ParlAI on. Enter "
+                "that public URL hostname when prompted and ensure that the "
+                "port being used by ParlAI (usually 3000) has external "
+                "traffic routed to it.",
+                should_print=True,
+            )
+            input('Please press Enter to continue... ')
 
         mturk_utils.setup_aws_credentials()
 

--- a/parlai/mturk/core/server/html/core.html
+++ b/parlai/mturk/core/server/html/core.html
@@ -551,7 +551,11 @@
     setting_socket = true
     window.setTimeout(function() {setting_socket = false;}, 4000);
     var url = window.location;
-    socket = new WebSocket('wss://' + url.host);
+    if (url.hostname == 'localhost') {
+      socket = new WebSocket('ws://' + url.hostname + ':' + url.port);
+    } else {
+      socket = new WebSocket('wss://' + url.hostname + ':' + url.port);
+    }
 
     socket.onmessage = parse_socket_message;
 

--- a/parlai/mturk/core/server_utils.py
+++ b/parlai/mturk/core/server_utils.py
@@ -14,6 +14,7 @@ import sh
 import shlex
 import shutil
 import subprocess
+import time
 
 region_name = 'us-east-1'
 user_name = getpass.getuser()
@@ -21,7 +22,10 @@ user_name = getpass.getuser()
 parent_dir = os.path.dirname(os.path.abspath(__file__))
 server_source_directory_name = 'server'
 heroku_server_directory_name = 'heroku_server'
+local_server_directory_name = 'local_server'
 task_directory_name = 'task'
+
+server_process = None
 
 heroku_url = \
     'https://cli-assets.heroku.com/heroku-cli/channels/stable/heroku-cli'
@@ -211,12 +215,90 @@ def delete_heroku_server(task_name):
     ))
 
 
-def setup_server(task_name, task_files_to_copy):
+def setup_local_server(task_name, task_files_to_copy=None):
+    global server_process
+    print("Local Server: Collecting files...")
+
+    server_source_directory_path = \
+        os.path.join(parent_dir, server_source_directory_name)
+    local_server_directory_path = os.path.join(parent_dir, '{}_{}'.format(
+        local_server_directory_name,
+        task_name
+    ))
+
+    # Delete old server files
+    sh.rm(shlex.split('-rf ' + local_server_directory_path))
+
+    # Copy over a clean copy into the server directory
+    shutil.copytree(server_source_directory_path, local_server_directory_path)
+
+    # Consolidate task files
+    task_directory_path = \
+        os.path.join(local_server_directory_path, task_directory_name)
+    sh.mv(
+        os.path.join(local_server_directory_path, 'html'),
+        task_directory_path
+    )
+
+    hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
+    sh.mv(hit_config_file_path, task_directory_path)
+
+    for file_path in task_files_to_copy:
+        try:
+            shutil.copy2(file_path, task_directory_path)
+        except IsADirectoryError:  # noqa: F821 we don't support python2
+            dir_name = os.path.basename(os.path.normpath(file_path))
+            shutil.copytree(
+                file_path, os.path.join(task_directory_path, dir_name))
+        except FileNotFoundError:  # noqa: F821 we don't support python2
+            pass
+
+    print("Local: Starting server...")
+
+    os.chdir(local_server_directory_path)
+
+    packages_installed = subprocess.call(['npm', 'install'])
+    if packages_installed != 0:
+        raise Exception('please make sure npm is installed, otherwise view '
+                        'the above error for more info.')
+
+    server_process = subprocess.Popen(['node', 'server.js'])
+
+    time.sleep(1)
+    print('Server running locally with pid {}.'.format(server_process.pid))
+    host = input('Please enter the server addr, like https://hostname.com: ')
+    port = input('Please enter the port given above, likely 3000: ')
+    return '{}:{}'.format(host, port)
+
+
+def delete_local_server(task_name):
+    global server_process
+    print('Terminating server')
+    server_process.terminate()
+    server_process.wait()
+    print('Cleaning temp directory')
+
+    local_server_directory_path = os.path.join(parent_dir, '{}_{}'.format(
+        local_server_directory_name,
+        task_name
+    ))
+    sh.rm(shlex.split('-rf {}'.format(local_server_directory_path)))
+
+
+def setup_server(task_name, task_files_to_copy, local=False):
+    if local:
+        return setup_local_server(
+            task_name,
+            task_files_to_copy=task_files_to_copy
+        )
     return setup_heroku_server(
         task_name,
         task_files_to_copy=task_files_to_copy
     )
 
 
-def delete_server(task_name):
-    delete_heroku_server(task_name)
+def delete_server(task_name, local=False):
+    if local:
+        delete_local_server(task_name)
+    else:
+        delete_heroku_server(task_name)

--- a/parlai/mturk/core/server_utils.py
+++ b/parlai/mturk/core/server_utils.py
@@ -266,7 +266,8 @@ def setup_local_server(task_name, task_files_to_copy=None):
 
     time.sleep(1)
     print('Server running locally with pid {}.'.format(server_process.pid))
-    host = input('Please enter the server addr, like https://hostname.com: ')
+    host = input(
+        'Please enter the public server address, like https://hostname.com: ')
     port = input('Please enter the port given above, likely 3000: ')
     return '{}:{}'.format(host, port)
 


### PR DESCRIPTION
This is the implementation for being able to run ParlAI MTurk's node server on the same machine you are running ParlAI from. It successfully tracks on localhost (can connect, acts as a proper webserver, really quick to deploy/test MTurk), but unfortunately both MTurk and Messenger require SSL signed endpoints to be able to use the API for. This means that general users of the `--local` flag will need to set up SSL for their server before they're able to use this feature.

I've put messaging in here to inform users of this fact, as while it is an annoying restriction I can't find any feasible way around it.