### PR TITLE
Fix: typo requireFileExists

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -337,7 +337,7 @@ def create_agent(opt, requireModelExists=False):
     if opt.get('model'):
         model_class = get_agent_module(opt['model'])
         model = model_class(opt) 
-        if requireFileExists and hasattr(model, 'load'):
+        if requireModelExists and hasattr(model, 'load'):
             # double check that we didn't forget to set model_file on loadable model
             print('WARNING: model_file unset but model has a `load` function.')            
         return model


### PR DESCRIPTION
A typo in parlai/core/agents which might cause failure in creating agent.