### PR TITLE
Decoupling message receives from message sends

### DIFF
--- a/parlai/messenger/core/message_sender.py
+++ b/parlai/messenger/core/message_sender.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+import json
+import logging
+import requests
+
+import parlai.mturk.core.shared_utils as shared_utils
+
+MAX_QUICK_REPLIES = 10
+MAX_TEXT_CHARS = 640
+MAX_QUICK_REPLY_TITLE_CHARS = 20
+MAX_POSTBACK_CHARS = 1000
+
+
+# Arbitrary attachments can be created as long as they adhere to the docs
+# developers.facebook.com/docs/messenger-platform/send-messages/templates
+
+# Message builders
+def create_attachment(payload):
+    """Create a simple url-based attachment"""
+    # TODO support data-based attachments?
+    assert payload['type'] in ['image', 'video', 'file', 'audio'], \
+        'unsupported attachment type'
+    assert ('url' in payload or 'attachment_id' in payload), \
+        'unsupported attachment method: must contain url or attachment_id'
+    if 'url' in payload:
+        return {'type': payload['type'],
+                'payload': {'url': payload['url']}}
+    elif 'attachment_id' in payload:
+        return {'type': payload['type'],
+                'payload': {'attachment_id': payload['attachment_id']}}
+
+
+def create_reply_option(title, payload=''):
+    """Create a quick reply option. Takes in display title and optionally extra
+    custom data.
+    """
+    assert len(title) <= MAX_QUICK_REPLY_TITLE_CHARS, (
+        'Quick reply title length {} greater than the max of {}'.format(
+            len(title), MAX_QUICK_REPLY_TITLE_CHARS
+        )
+    )
+    assert len(payload) <= MAX_POSTBACK_CHARS, (
+        'Payload length {} greater than the max of {}'.format(
+            len(payload), MAX_POSTBACK_CHARS
+        )
+    )
+    return {'content_type': 'text', 'title': title, 'payload': payload}
+
+
+def create_text_message(text, quick_replies=None):
+    """Return a list of text messages from the given text. If the message is
+    too long it is split into multiple messages.
+    quick_replies should be a list of options made with create_reply_option.
+    """
+    def _message(text_content, replies):
+        payload = {'text': text_content[:MAX_TEXT_CHARS]}
+        if replies:
+            payload['quick_replies'] = replies
+        return payload
+
+    tokens = [s[:MAX_TEXT_CHARS] for s in text.split(' ')]
+    splits = []
+    cutoff = 0
+    curr_length = 0
+    if quick_replies:
+        assert len(quick_replies) <= MAX_QUICK_REPLIES, (
+            'Number of quick replies {} greater than the max of {}'.format(
+                len(quick_replies), MAX_QUICK_REPLIES
+            )
+        )
+    for i in range(len(tokens)):
+        if (curr_length + len(tokens[i]) > MAX_TEXT_CHARS):
+            splits.append(_message(' '.join(tokens[cutoff:i]), None))
+            cutoff = i + 1
+            curr_length = 0
+        curr_length += len(tokens[i]) + 1
+    if cutoff < len(tokens):
+        splits.append(_message(' '.join(tokens[cutoff:]), quick_replies))
+    return splits
+
+
+def create_attachment_message(attachment_item, quick_replies=None):
+    """Create a message list made with only an attachment.
+    quick_replies should be a list of options made with create_reply_option.
+    """
+    payload = {'attachment': attachment_item}
+    if quick_replies:
+        assert len(quick_replies) <= MAX_QUICK_REPLIES, (
+            'Number of quick replies {} greater than the max of {}'.format(
+                len(quick_replies), MAX_QUICK_REPLIES
+            )
+        )
+        payload['quick_replies'] = quick_replies
+    return [payload]
+
+
+def create_list_element(element):
+    assert 'title' in element, 'List elems must have a title'
+    ret_elem = {
+        'title': element['title'],
+        'subtitle': '',
+        'default_action': {
+            'type': 'postback',
+            'title': element['title'],
+            'payload': element['title'],
+        }
+    }
+    if 'subtitle' in element:
+        ret_elem['subtitle'] = element['subtitle']
+    return ret_elem
+
+
+def create_compact_list_message(raw_elems):
+    elements = [create_list_element(elem) for elem in raw_elems]
+    return {
+        'type': 'template',
+        'payload': {
+            'template_type': 'list',
+            'top_element_style': 'COMPACT',
+            'elements': elements,
+        }
+    }
+
+
+class MessageSender():
+    """MesageSender is a wrapper around the facebook messenger requests that
+    simplifies the process of sending content.
+    """
+
+    """MessageSocket is a wrapper around websocket to simplify message sends
+    and receives into parlai from FB messenger.
+    """
+
+    def __init__(self, secret_token):
+        """
+        server_url:           url at which the server is to be run
+        port:                 port for the socket to operate on
+        message_callback:     function to be called on incoming message objects
+                              format: message_callback(self, data)
+        """
+        self.auth_args = {'access_token': secret_token}
+
+    def send_sender_action(self, receiver_id, action):
+        api_address = 'https://graph.facebook.com/v2.6/me/messages'
+        message = {
+            'recipient': {
+                'id': receiver_id
+            },
+            "sender_action": action,
+        }
+        requests.post(
+            api_address,
+            params=self.auth_args,
+            json=message,
+        )
+
+    def send_read(self, receiver_id):
+        self.send_sender_action(receiver_id, "mark_seen")
+
+    def typing_on(self, receiver_id):
+        self.send_sender_action(receiver_id, "typing_on")
+
+    def send_fb_payload(self, receiver_id, payload):
+        """Sends a payload to messenger, processes it if we can"""
+        api_address = 'https://graph.facebook.com/v2.6/me/messages'
+        if payload['type'] == 'list':
+            data = create_compact_list_message(payload['data'])
+        elif payload['type'] in ['image', 'video', 'file', 'audio']:
+            data = create_attachment(payload)
+        else:
+            data = payload['data']
+        message = {
+            "messaging_type": 'RESPONSE',
+            "recipient": {
+                "id": receiver_id
+            },
+            "message": {
+                "attachment": data,
+            }
+        }
+        response = requests.post(
+            api_address,
+            params=self.auth_args,
+            json=message,
+        )
+        result = response.json()
+        shared_utils.print_and_log(
+            logging.INFO,
+            '"Facebook response from message send: {}"'.format(result)
+        )
+        return result
+
+    def send_fb_message(self, receiver_id, message, is_response,
+                        quick_replies=None):
+        """Sends a message directly to messenger"""
+        api_address = 'https://graph.facebook.com/v2.6/me/messages'
+        if quick_replies is not None:
+            quick_replies = [create_reply_option(x, x) for x in quick_replies]
+        ms = create_text_message(message, quick_replies)
+        results = []
+        for m in ms:
+            if m['text'] == '':
+                continue  # Skip blank messages
+            payload = {
+                "messaging_type": 'RESPONSE' if is_response else 'UPDATE',
+                "recipient": {
+                    "id": receiver_id
+                },
+                "message": m
+            }
+            response = requests.post(
+                api_address,
+                params=self.auth_args,
+                json=payload
+            )
+            result = response.json()
+            shared_utils.print_and_log(
+                logging.INFO,
+                '"Facebook response from message send: {}"'.format(result)
+            )
+            results.append(result)
+        return results
+
+    def upload_fb_attachment(self, payload):
+        """Uploads an attachment using the Attachment Upload API and returns
+        an attachment ID.
+        """
+        api_address = 'https://graph.facebook.com/v2.6/me/message_attachments'
+        assert payload['type'] in ['image', 'video', 'file', 'audio'], \
+            'unsupported attachment type'
+        if 'url' in payload:
+            message = {
+                "message": {
+                    "attachment": {
+                        "type": payload['type'],
+                        "payload": {
+                            "is_reusable": "true",
+                            "url": payload['url']
+                        }
+                    }
+                }
+            }
+            response = requests.post(
+                api_address,
+                params=self.auth_args,
+                json=message,
+            )
+        elif 'filename' in payload:
+            message = {
+                "attachment": {
+                    "type": payload['type'],
+                    "payload": {
+                        "is_reusable": "true",
+                    }
+                }
+            }
+            filedata = {
+                "filedata": (
+                    payload['filename'],
+                    open(payload['filename'], 'rb'),
+                    payload['type'] + '/' + payload['format']
+                )
+            }
+            response = requests.post(
+                api_address,
+                params=self.auth_args,
+                data={"message": json.dumps(message)},
+                files=filedata
+            )
+        result = response.json()
+        shared_utils.print_and_log(
+            logging.INFO,
+            '"Facebook response from attachment upload: {}"'.format(result)
+        )
+        return result

--- a/parlai/messenger/core/message_sender.py
+++ b/parlai/messenger/core/message_sender.py
@@ -131,10 +131,6 @@ class MessageSender():
     simplifies the process of sending content.
     """
 
-    """MessageSocket is a wrapper around websocket to simplify message sends
-    and receives into parlai from FB messenger.
-    """
-
     def __init__(self, secret_token):
         """
         server_url:           url at which the server is to be run

--- a/parlai/messenger/core/message_socket.py
+++ b/parlai/messenger/core/message_socket.py
@@ -6,137 +6,22 @@
 import errno
 import json
 import logging
-import requests
 import threading
 import time
 import websocket
 
 import parlai.mturk.core.shared_utils as shared_utils
 
-MAX_QUICK_REPLIES = 10
-MAX_TEXT_CHARS = 640
-MAX_QUICK_REPLY_TITLE_CHARS = 20
-MAX_POSTBACK_CHARS = 1000
 SOCKET_TIMEOUT = 6
-
-# Arbitrary attachments can be created as long as they adhere to the docs
-# developers.facebook.com/docs/messenger-platform/send-messages/templates
-
-# Message builders
-def create_attachment(payload):
-    """Create a simple url-based attachment"""
-    # TODO support data-based attachments?
-    assert payload['type'] in ['image', 'video', 'file', 'audio'], \
-        'unsupported attachment type'
-    assert ('url' in payload or 'attachment_id' in payload), \
-        'unsupported attachment method: must contain url or attachment_id'
-    if 'url' in payload:
-        return {'type': payload['type'],
-                'payload': {'url': payload['url']}}
-    elif 'attachment_id' in payload:
-        return {'type': payload['type'],
-                'payload': {'attachment_id': payload['attachment_id']}}
-
-
-def create_reply_option(title, payload=''):
-    """Create a quick reply option. Takes in display title and optionally extra
-    custom data.
-    """
-    assert len(title) <= MAX_QUICK_REPLY_TITLE_CHARS, (
-        'Quick reply title length {} greater than the max of {}'.format(
-            len(title), MAX_QUICK_REPLY_TITLE_CHARS
-        )
-    )
-    assert len(payload) <= MAX_POSTBACK_CHARS, (
-        'Payload length {} greater than the max of {}'.format(
-            len(payload), MAX_POSTBACK_CHARS
-        )
-    )
-    return {'content_type': 'text', 'title': title, 'payload': payload}
-
-
-def create_text_message(text, quick_replies=None):
-    """Return a list of text messages from the given text. If the message is
-    too long it is split into multiple messages.
-    quick_replies should be a list of options made with create_reply_option.
-    """
-    def _message(text_content, replies):
-        payload = {'text': text_content[:MAX_TEXT_CHARS]}
-        if replies:
-            payload['quick_replies'] = replies
-        return payload
-
-    tokens = [s[:MAX_TEXT_CHARS] for s in text.split(' ')]
-    splits = []
-    cutoff = 0
-    curr_length = 0
-    if quick_replies:
-        assert len(quick_replies) <= MAX_QUICK_REPLIES, (
-            'Number of quick replies {} greater than the max of {}'.format(
-                len(quick_replies), MAX_QUICK_REPLIES
-            )
-        )
-    for i in range(len(tokens)):
-        if (curr_length + len(tokens[i]) > MAX_TEXT_CHARS):
-            splits.append(_message(' '.join(tokens[cutoff:i]), None))
-            cutoff = i + 1
-            curr_length = 0
-        curr_length += len(tokens[i]) + 1
-    if cutoff < len(tokens):
-        splits.append(_message(' '.join(tokens[cutoff:]), quick_replies))
-    return splits
-
-
-def create_attachment_message(attachment_item, quick_replies=None):
-    """Create a message list made with only an attachment.
-    quick_replies should be a list of options made with create_reply_option.
-    """
-    payload = {'attachment': attachment_item}
-    if quick_replies:
-        assert len(quick_replies) <= MAX_QUICK_REPLIES, (
-            'Number of quick replies {} greater than the max of {}'.format(
-                len(quick_replies), MAX_QUICK_REPLIES
-            )
-        )
-        payload['quick_replies'] = quick_replies
-    return [payload]
-
-
-def create_list_element(element):
-    assert 'title' in element, 'List elems must have a title'
-    ret_elem = {
-        'title': element['title'],
-        'subtitle': '',
-        'default_action': {
-            'type': 'postback',
-            'title': element['title'],
-            'payload': element['title'],
-        }
-    }
-    if 'subtitle' in element:
-        ret_elem['subtitle'] = element['subtitle']
-    return ret_elem
-
-
-def create_compact_list_message(raw_elems):
-    elements = [create_list_element(elem) for elem in raw_elems]
-    return {
-        'type': 'template',
-        'payload': {
-            'template_type': 'list',
-            'top_element_style': 'COMPACT',
-            'elements': elements,
-        }
-    }
 
 
 # Socket handler
 class MessageSocket():
-    """MessageSocket is a wrapper around websocket to simplify message sends
-    and receives into parlai from FB messenger.
+    """MessageSocket is a wrapper around websocket to forward messages from the
+    remote server to the MessengerManager.
     """
 
-    def __init__(self, server_url, port, secret_token, message_callback):
+    def __init__(self, server_url, port, message_callback):
         """
         server_url:           url at which the server is to be run
         port:                 port for the socket to operate on
@@ -150,7 +35,6 @@ class MessageSocket():
         self.ws = None
         self.last_pong = None
         self.alive = False
-        self.auth_args = {'access_token': secret_token}
 
         # initialize the state
         self.listen_thread = None
@@ -188,135 +72,6 @@ class MessageSocket():
             'type': 'world_alive',
             'content': {'id': 'WORLD_ALIVE', 'sender_id': 'world'},
         }), force=True)
-
-    def send_sender_action(self, receiver_id, action):
-        api_address = 'https://graph.facebook.com/v2.6/me/messages'
-        message = {
-            'recipient': {
-                'id': receiver_id
-            },
-            "sender_action": action,
-        }
-        requests.post(
-            api_address,
-            params=self.auth_args,
-            json=message,
-        )
-
-    def send_read(self, receiver_id):
-        self.send_sender_action(receiver_id, "mark_seen")
-
-    def typing_on(self, receiver_id):
-        self.send_sender_action(receiver_id, "typing_on")
-
-    def send_fb_payload(self, receiver_id, payload):
-        """Sends a payload to messenger, processes it if we can"""
-        api_address = 'https://graph.facebook.com/v2.6/me/messages'
-        if payload['type'] == 'list':
-            data = create_compact_list_message(payload['data'])
-        elif payload['type'] in ['image', 'video', 'file', 'audio']:
-            data = create_attachment(payload)
-        else:
-            data = payload['data']
-        message = {
-            "messaging_type": 'RESPONSE',
-            "recipient": {
-                "id": receiver_id
-            },
-            "message": {
-                "attachment": data,
-            }
-        }
-        response = requests.post(
-            api_address,
-            params=self.auth_args,
-            json=message,
-        )
-        result = response.json()
-        shared_utils.print_and_log(
-            logging.INFO,
-            '"Facebook response from message send: {}"'.format(result)
-        )
-        return result
-
-    def send_fb_message(self, receiver_id, message, is_response,
-                        quick_replies=None):
-        """Sends a message directly to messenger"""
-        api_address = 'https://graph.facebook.com/v2.6/me/messages'
-        if quick_replies is not None:
-            quick_replies = [create_reply_option(x, x) for x in quick_replies]
-        ms = create_text_message(message, quick_replies)
-        results = []
-        for m in ms:
-            if m['text'] == '':
-                continue  # Skip blank messages
-            payload = {
-                "messaging_type": 'RESPONSE' if is_response else 'UPDATE',
-                "recipient": {
-                    "id": receiver_id
-                },
-                "message": m
-            }
-            response = requests.post(
-                api_address,
-                params=self.auth_args,
-                json=payload
-            )
-            result = response.json()
-            shared_utils.print_and_log(
-                logging.INFO,
-                '"Facebook response from message send: {}"'.format(result)
-            )
-            results.append(result)
-        return results
-
-    def upload_fb_attachment(self, payload):
-        """Uploads an attachment using the Attachment Upload API and returns
-        an attachment ID.
-        """
-        api_address = 'https://graph.facebook.com/v2.6/me/message_attachments'
-        assert payload['type'] in ['image', 'video', 'file', 'audio'], \
-            'unsupported attachment type'
-        if 'url' in payload:
-            message = {
-                "message": {
-                    "attachment": {
-                        "type": payload['type'],
-                        "payload": {
-                            "is_reusable": "true",
-                            "url": payload['url']
-                        }
-                    }
-                }
-            }
-            response = requests.post(
-                api_address,
-                params=self.auth_args,
-                json=message,
-            )
-        elif 'filename' in payload:
-            message = {
-                "attachment": {
-                    "type": payload['type'],
-                    "payload": {
-                        "is_reusable": "true",
-                    }
-                }
-            }
-            filedata= {"filedata": (payload['filename'], open(payload['filename'], 'rb'), payload['type']+'/'+payload['format'])}
-            response = requests.post(
-                api_address,
-                params=self.auth_args,
-                data={"message": json.dumps(message)},
-                files=filedata
-            )
-        result = response.json()
-        shared_utils.print_and_log(
-            logging.INFO,
-            '"Facebook response from attachment upload: {}"'.format(result)
-        )
-        return result
-
 
     def _setup_socket(self):
         """Create socket handlers and registers the socket"""

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -13,6 +13,7 @@ import traceback
 
 from parlai.messenger.core.agents import MessengerAgent
 from parlai.messenger.core.message_socket import MessageSocket
+from parlai.messenger.core.message_sender import MessageSender
 import parlai.messenger.core.server_utils as server_utils
 import parlai.messenger.core.shared_utils as shared_utils
 
@@ -73,6 +74,7 @@ class MessengerManager():
         self.overworld_threads = {}
         self.active_worlds = {}
         self.message_socket = None
+        self.message_sender = None
         self.page_id = None
         self._init_logs()
         self.running = True
@@ -162,15 +164,17 @@ class MessengerManager():
         for world_type, agent_pool in self.agent_pool.items():
             if world_type in eligibility_functions and \
                     eligibility_functions[world_type] is not None:
-                valid_pools[world_type] = [w for w in agent_pool \
-                        if eligibility_functions[world_type](w)]
+                valid_pools[world_type] = [
+                    w for w in agent_pool
+                    if eligibility_functions[world_type](w)
+                ]
             else:
                 valid_pools[world_type] = self.agent_pool[world_type]
         return valid_pools
 
     def _handle_bot_read(self, agent_id):
-        self.message_socket.send_read(agent_id)
-        self.message_socket.typing_on(agent_id)
+        self.message_sender.send_read(agent_id)
+        self.message_sender.typing_on(agent_id)
 
     def _confirm_message_delivery(self, event):
         # By default we don't actually do anything when messages are marked as
@@ -196,7 +200,7 @@ class MessengerManager():
             for partner in agent.message_partners:
                 # We don't know who sent the message that was seen, but we can
                 # send a message observed event to everyone else in the chat
-                self.message_socket.send_read(partner.id)
+                self.message_sender.send_read(partner.id)
 
     def _handle_webhook_event(self, event):
         if 'message' in event:
@@ -281,7 +285,7 @@ class MessengerManager():
                     "Please wait while we pair you with another person. "
                     "If you wish to exit, type *EXIT*."
                 )
-                self.message_socket.typing_on(agent_id)
+                self.message_sender.typing_on(agent_id)
         else:
             # If an agent is in a solo world, we can put a typing indicator
             # and mark the message as read
@@ -446,11 +450,14 @@ class MessengerManager():
             expanded_file_path = os.path.expanduser(access_token_file_path)
             with open(expanded_file_path, 'w+') as access_token_file:
                 access_token_file.write(self.app_token)
+
+        self.message_sender = MessageSender(self.app_token)
+
+        # Set up recieve
         socket_use_url = self.server_url
         if (self.opt['local']):  # skip some hops for local stuff
             socket_use_url = "https://localhost"
         self.message_socket = MessageSocket(socket_use_url, self.port,
-                                            self.app_token,
                                             self._handle_webhook_event)
 
     def init_new_state(self):
@@ -475,6 +482,32 @@ class MessengerManager():
 
     def set_agents_required(self, max_agents_for):
         self.max_agents_for = max_agents_for
+
+    def check_timeout_in_pool(self, world_type, agent_pool, max_time_in_pool):
+        for agent_state in agent_pool:
+            time_in_pool = agent_state.time_in_pool.get(world_type)
+            if time_in_pool and time.time() - time_in_pool \
+                    > max_time_in_pool[world_type]:
+                # remove agent from agent_pool
+                self.remove_agent_from_pool(
+                    agent_state, world_type)
+                # put agent back in overworld
+                agent_state.set_active_agent(
+                    agent_state.get_overworld_agent())
+                # reset wait message state
+                agent_state.stored_data['seen_wait_message'] = False
+            elif time_in_pool and time.time() - time_in_pool > 30:
+                # tell agent that a match is taking longer than
+                # expected
+                if not agent_state.stored_data.get('seen_wait_message') \
+                        or not agent_state.stored_data['seen_wait_message']:
+                    self.observe_message(
+                        agent_state.messenger_id,
+                        "Pairing is taking longer than expected. "
+                        "If you wish to exit, type *EXIT*.",
+                    )
+                    self.message_sender.typing_on(agent_state.messenger_id)
+                    agent_state.stored_data['seen_wait_message'] = True
 
     def start_task(self, assign_role_functions, task_functions,
                    max_time_in_pool=None, eligibility_functions=None):
@@ -518,32 +551,8 @@ class MessengerManager():
                     # check if agent has exceeded max time in pool
                     if max_time_in_pool is not None and \
                             max_time_in_pool[world_type] is not None:
-                        for agent_state in agent_pool:
-                            time_in_pool = \
-                                agent_state.time_in_pool.get(world_type)
-                            if time_in_pool and time.time() - time_in_pool \
-                                    > max_time_in_pool[world_type]:
-                                # remove agent from agent_pool
-                                self.remove_agent_from_pool(
-                                    agent_state, world_type)
-                                # put agent back in overworld
-                                agent_state.set_active_agent(
-                                    agent_state.get_overworld_agent())
-                                # reset wait message state
-                                agent_state.stored_data['seen_wait_message'] = False
-                            elif time_in_pool and time.time() - time_in_pool \
-                                    > 30:
-                                # tell agent that a match is taking longer than
-                                # expected
-                                if not agent_state.stored_data.get('seen_wait_message') \
-                                        or not agent_state.stored_data['seen_wait_message']:
-                                    self.observe_message(
-                                        agent_state.messenger_id,
-                                        "Pairing is taking longer than expected. "
-                                        "If you wish to exit, type *EXIT*.",
-                                    )
-                                    self.message_socket.typing_on(agent_state.messenger_id)
-                                    agent_state.stored_data['seen_wait_message'] = True
+                        self.check_timeout_in_pool(world_type, agent_pool,
+                                                   max_time_in_pool)
 
                     needed_agents = self.max_agents_for[world_type]
                     if len(agent_pool) >= needed_agents:
@@ -568,8 +577,11 @@ class MessengerManager():
                         agents = [a for a in agents if a.disp_id is not None]
                         for a in agents:
                             # Remove selected workers from the agent pool
-                            self.remove_agent_from_pool(self._get_agent_state(a.id), \
-                                    world_type=world_type, mark_removed=False)
+                            self.remove_agent_from_pool(
+                                self._get_agent_state(a.id),
+                                world_type=world_type,
+                                mark_removed=False
+                            )
                         for a in agents:
                             partner_list = agents.copy()
                             partner_list.remove(a)
@@ -603,12 +615,12 @@ class MessengerManager():
 
     def observe_message(self, receiver_id, text, quick_replies=None):
         """Send a message through the message manager"""
-        return self.message_socket.send_fb_message(receiver_id, text, True,
+        return self.message_sender.send_fb_message(receiver_id, text, True,
                                                    quick_replies=quick_replies)
 
     def observe_payload(self, receiver_id, data):
         """Send a payload through the message manager"""
-        return self.message_socket.send_fb_payload(receiver_id, data)
+        return self.message_sender.send_fb_payload(receiver_id, data)
 
     def upload_attachment(self, payload):
         """Uploads an attachment and returns an attachment ID
@@ -618,4 +630,4 @@ class MessengerManager():
         For example,
         {'type': 'image', 'filename': 'test.png', 'format': 'png'}
         """
-        return self.message_socket.upload_fb_attachment(payload)
+        return self.message_sender.upload_fb_attachment(payload)

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -181,7 +181,7 @@ class MessengerManager():
         # being delivered, but we expose the ability for others to
         shared_utils.print_and_log(
             logging.DEBUG,
-            "Messages {} marked as recieved.".format(event['delivery']['mids'])
+            "Messages {} marked as received.".format(event['delivery']['mids'])
         )
 
     def _handle_message_read(self, event):
@@ -453,7 +453,7 @@ class MessengerManager():
 
         self.message_sender = MessageSender(self.app_token)
 
-        # Set up recieve
+        # Set up receive
         socket_use_url = self.server_url
         if (self.opt['local']):  # skip some hops for local stuff
             socket_use_url = "https://localhost"


### PR DESCRIPTION
Splits out the message send logic from the message receive logic, as these follow two different pipelines. Having them separate means that messages can be sent without having to set up a socket, which is useful in circumstances when you're subclassing MessageManager because you have a different route for receiving messages and don't want the socket.