### PR TITLE
Pipe-less fix for Twitter task, minor fix for build_dict log part, language_model agent and pytorch 0.4 fixes

### DIFF
--- a/parlai/scripts/build_dict.py
+++ b/parlai/scripts/build_dict.py
@@ -77,8 +77,8 @@ def build_dict(opt):
                 # don't wait too long...
                 break
             world_dict.parley()
-    print('[ dictionary built with {} tokens ]'.format(len(dictionary)))
     dictionary.save(opt['dict_file'], sort=True)
+    print('[ dictionary built with {} tokens ]'.format(len(dictionary)))
     return dictionary
 
 

--- a/parlai/tasks/twitter/build.py
+++ b/parlai/tasks/twitter/build.py
@@ -21,11 +21,13 @@ def create_fb_format(data, dpath):
         use = True
         x = data[i].rstrip(' ').lstrip(' ').replace('\t', ' ')
         y = data[i + 1].rstrip(' ').lstrip(' ').replace('\t', ' ')
+        x = x.replace('|', ' __PIPE__ ')
+        y = y.replace('|', ' __PIPE__ ')
         if len(x) < 1 or len(y) < 1:
             use = False
         if use:
             s = '1 ' + x + '\t' + y
-            fout.write(s + '\n')
+            fout.write('{} \n'.format(s))
     fw1.close()
     fw2.close()
     fw3.close()

--- a/parlai/tasks/twitter/build.py
+++ b/parlai/tasks/twitter/build.py
@@ -6,7 +6,18 @@
 # Download and build the data if it does not exist.
 
 import parlai.core.build_data as build_data
+from emoji.unicode_codes import UNICODE_EMOJI
+import unidecode
 import os
+
+def replace_emoji(x):
+    if x in UNICODE_EMOJI.keys():
+        return ' ' + UNICODE_EMOJI[x].replace(':', '@') + ' '
+    else:
+        return x
+
+def split_punctuation(x):
+    return x.replace('.', ' . ').replace('. . .', '...').replace(',', ' , ').replace(';', ' ; ').replace(':', ' : ').replace('!', ' ! ').replace('?', ' ? ').replace('"', ' " ').replace('(',' ( ').replace(')', ' ) ')
 
 def create_fb_format(data, dpath):
     fw1 = open(os.path.join(dpath, 'train.txt'), 'w')
@@ -23,6 +34,13 @@ def create_fb_format(data, dpath):
         y = data[i + 1].rstrip(' ').lstrip(' ').replace('\t', ' ')
         x = x.replace('|', ' __PIPE__ ')
         y = y.replace('|', ' __PIPE__ ')
+        x = ''.join(list(map(replace_emoji, x)))
+        y = ''.join(list(map(replace_emoji, y)))
+        x = split_punctuation(unidecode.unidecode(x))
+        y = split_punctuation(unidecode.unidecode(y))
+        x = ' '.join(x.split())
+        y = ' '.join(y.split())
+
         if len(x) < 1 or len(y) < 1:
             use = False
         if use:


### PR DESCRIPTION
The twitter task has similar problem as mentioned in [#721](https://github.com/facebookresearch/ParlAI/issues/721), so now "|" is replaced with "__PIPE__" in
 the text.
In general, when one uses build_dict script, then with whatever options are specified (dict-maxtokens or dict-minfreq) the log says that the dict file contains max possible num words, because the print is located before the sort function, where resizing happens. So print happens afterwards now.