### PR TITLE
seq2seq agent explicit casting for pytorch 0.4

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -458,9 +458,9 @@ class Seq2seqAgent(Agent):
             out = self.model(xs, ys)
             predictions, scores = out[0], out[1]
             score_view = scores.view(-1, scores.size(-1))
-            loss = self.criterion(score_view, ys.view(-1))
+            loss = self.criterion(score_view, ys.view(-1)).double()
             # save loss to metrics
-            target_tokens = ys.ne(self.NULL_IDX).long().sum().data[0]
+            target_tokens = ys.ne(self.NULL_IDX).double().sum().data[0]
             self.metrics['loss'] += loss.double().data[0]
             self.metrics['num_tokens'] += target_tokens
             loss /= target_tokens  # average loss per token

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -394,7 +394,7 @@ class Seq2seqAgent(Agent):
         """
         m = {}
         if self.metrics['num_tokens'] > 0:
-            m['loss'] = self.metrics['loss'] / self.metrics['num_tokens']
+            m['loss'] = self.metrics['loss'] / float(self.metrics['num_tokens'])
             m['ppl'] = math.exp(m['loss'])
         for k, v in m.items():
             # clean up: rounds to sigfigs and converts tensors to floats


### PR DESCRIPTION
seq2seq agent did not work with pytorch 0.4 due to type mismatches. With fixes it works. This changes tested on twitter task with both pytorch 0.4 and 0.3.1-post2.