### PR TITLE
Move torchtext vectors to model zoo

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -236,12 +236,27 @@ class Seq2seqAgent(Agent):
                     raise ex
                 if opt['embedding_type'].startswith('glove'):
                     init = 'glove'
-                    embs = vocab.GloVe(name='840B', dim=300,
-                        cache=os.path.join(opt['parlai_home'], '.vector_cache'))
+                    embs = vocab.GloVe(
+                        name='840B',
+                        dim=300,
+                        cache=os.path.join(
+                            opt['parlai_home'],
+                            'data',
+                            'models',
+                            'glove_vectors'
+                        )
+                    )
                 elif opt['embedding_type'].startswith('fasttext'):
                     init = 'fasttext'
-                    embs = vocab.FastText(language='en',
-                        cache=os.path.join(opt['parlai_home'], '.vector_cache'))
+                    embs = vocab.FastText(
+                        language='en',
+                        cache=os.path.join(
+                            opt['parlai_home'],
+                            'data',
+                            'models',
+                            'fasttext_vectors'
+                        )
+                    )
                 else:
                     raise RuntimeError('embedding type not implemented')
 

--- a/projects/personachat/persona_seq2seq.py
+++ b/projects/personachat/persona_seq2seq.py
@@ -41,7 +41,17 @@ except ModuleNotFoundError:
 from parlai.core.params import ParlaiParser
 ParlaiParser()  # instantiate to set PARLAI_HOME environment var
 
-Glove = vocab.GloVe(name='840B', dim=300, cache=os.path.join(os.environ['PARLAI_HOME'], '.vector_cache'))
+
+Glove = vocab.GloVe(
+    name='840B',
+    dim=300,
+    cache=os.path.join(
+        os.environ['PARLAI_HOME'],
+        'data',
+        'models',
+        'glove_vectors'
+    )
+)
 
 
 import operator


### PR DESCRIPTION
Moves torchtext vectors to ParlAI model zoo and changes name to `glove_vectors` or `fasttext_vectors`