### PR TITLE
Language model options loading

### DIFF
--- a/parlai/agents/language_model/language_model.py
+++ b/parlai/agents/language_model/language_model.py
@@ -139,6 +139,13 @@ class LanguageModelAgent(Agent):
                 print('[ Setting opt from {} ]'.format(
                     init_model
                 ))
+                # since .opt file does not exist, save one for future use
+                with open(init_model + ".opt", 'wb') as handle:
+                    pickle.dump(
+                        new_opt,
+                        handle,
+                        protocol=pickle.HIGHEST_PROTOCOL
+                    )
                 opt = self.override_opt(new_opt)
 
             if (init_model is not None and

--- a/parlai/agents/language_model/language_model.py
+++ b/parlai/agents/language_model/language_model.py
@@ -130,10 +130,10 @@ class LanguageModelAgent(Agent):
             if opt.get('model_file') and os.path.isfile(opt['model_file']):
                 init_model = opt['model_file']
 
-            if init_model is not None and \
-                    not os.path.isfile(init_model + '.opt'):
-                # this will only be called for loading older models before
-                # .opt file is saved
+            # for backwards compatibility: will only be called for older models
+            # for which .opt file does not exist
+            if (init_model is not None and
+                    not os.path.isfile(init_model + '.opt')):
                 new_opt = self.load_opt(init_model)
                 # load model parameters if available
                 print('[ Setting opt from {} ]'.format(
@@ -149,9 +149,9 @@ class LanguageModelAgent(Agent):
                     )
                 opt = self.override_opt(new_opt)
 
-            if (init_model is not None and
-                    os.path.isfile(init_model + '.dict')) or \
-                    opt['dict_file'] is None:
+            if ((init_model is not None and
+                    os.path.isfile(init_model + '.dict')) or
+                    opt['dict_file'] is None):
                 opt['dict_file'] = init_model + '.dict'
 
             # load dictionary and basic tokens & vectors

--- a/parlai/agents/language_model/language_model.py
+++ b/parlai/agents/language_model/language_model.py
@@ -140,6 +140,7 @@ class LanguageModelAgent(Agent):
                     init_model
                 ))
                 # since .opt file does not exist, save one for future use
+                print("Saving opt file at:", init_model + ".opt")
                 with open(init_model + ".opt", 'wb') as handle:
                     pickle.dump(
                         new_opt,

--- a/parlai/agents/language_model/language_model.py
+++ b/parlai/agents/language_model/language_model.py
@@ -597,7 +597,4 @@ class LanguageModelAgent(Agent):
             # load model parameters if available
             print('[ Loading existing model params from {} ]'.format(path))
             self.states = torch.load(path, map_location=lambda cpu, _: cpu)
-
-        if self.states:
-            # set loaded states if applicable
             self.model.load_state_dict(self.states['model'])

--- a/parlai/agents/language_model/language_model.py
+++ b/parlai/agents/language_model/language_model.py
@@ -555,7 +555,6 @@ class LanguageModelAgent(Agent):
         return self.batch_act([self.observation])[0]
 
     def save(self, path=None):
-        print("SAVING!!!!")
         """Save model parameters if model_file is set."""
         path = self.opt.get('model_file', None) if path is None else path
 

--- a/parlai/agents/language_model/language_model.py
+++ b/parlai/agents/language_model/language_model.py
@@ -122,31 +122,29 @@ class LanguageModelAgent(Agent):
                 print('[ Using CUDA ]')
                 torch.cuda.set_device(opt['gpu'])
 
+            init_model = None
             # check first for 'init_model' for loading model from file
             if opt.get('init_model') and os.path.isfile(opt['init_model']):
                 init_model = opt['init_model']
-            # next check for 'model_file'
-            elif opt.get('model_file') and os.path.isfile(opt['model_file']):
+            # next check for 'model_file', this would override init_model
+            if opt.get('model_file') and os.path.isfile(opt['model_file']):
                 init_model = opt['model_file']
-            else:
-                init_model = None
 
-            if init_model is not None:
+            if init_model is not None and \
+                    not os.path.isfile(init_model + '.opt'):
+                # this will only be called for loading older models before
+                # .opt file is saved
+                new_opt = self.load_opt(init_model)
                 # load model parameters if available
-                print('Loading existing model params from ' + init_model)
-                new_opt, self.states = self.load(init_model)
-                # override model-specific options with stored ones if not
-                # already overriden with .opt file
-                if not os.path.isfile(init_model + '.opt'):
-                    opt = self.override_opt(new_opt)
+                print('[ Setting opt from {} ]'.format(
+                    init_model
+                ))
+                opt = self.override_opt(new_opt)
 
-            if opt['dict_file'] is None:
-                if init_model is not None and os.path.isfile(init_model + '.dict'):
-                    # check first to see if a dictionary exists
-                    opt['dict_file'] = init_model + '.dict'
-                elif opt.get('model_file'):
-                    # otherwise, set default dict-file if it is not set
-                    opt['dict_file'] = opt['model_file'] + '.dict'
+            if (init_model is not None and
+                    os.path.isfile(init_model + '.dict')) or \
+                    opt['dict_file'] is None:
+                opt['dict_file'] = init_model + '.dict'
 
             # load dictionary and basic tokens & vectors
             self.dict = DictionaryAgent(opt)
@@ -164,9 +162,8 @@ class LanguageModelAgent(Agent):
             # set model
             self.model = RNNModel(opt, len(self.dict))
 
-            if self.states:
-                # set loaded states if applicable
-                self.model.load_state_dict(self.states['model'])
+            if init_model is not None:
+                self.load(init_model)
 
             if self.use_cuda:
                 self.model.cuda()
@@ -581,7 +578,18 @@ class LanguageModelAgent(Agent):
         if 'loss' in metrics_dict and self.scheduler is not None:
             self.scheduler.step(metrics_dict['loss'])
 
-    def load(self, path):
-        """Return opt and model states."""
+    def load_opt(self, path):
+        """Return opt, states."""
         states = torch.load(path, map_location=lambda cpu, _: cpu)
-        return states['opt'], states
+        return states['opt']
+
+    def load(self, path):
+        """Load model states."""
+        if os.path.isfile(path):
+            # load model parameters if available
+            print('[ Loading existing model params from {} ]'.format(path))
+            self.states = torch.load(path, map_location=lambda cpu, _: cpu)
+
+        if self.states:
+            # set loaded states if applicable
+            self.model.load_state_dict(self.states['model'])

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -85,6 +85,7 @@ class ParlaiParser(argparse.ArgumentParser):
 
         # remember which args were specified on the command line
         self.cli_args = sys.argv
+        self.overridable = {}
 
         if add_parlai_args:
             self.add_parlai_args()
@@ -405,19 +406,21 @@ class ParlaiParser(argparse.ArgumentParser):
                             store_true.append(option)
                         elif '_StoreFalseAction' in str(type(a)):
                             store_false.append(option)
-        override = {}
+
         for i in range(len(self.cli_args)):
             if self.cli_args[i] in option_strings_dict:
                 if self.cli_args[i] in store_true:
-                    override[option_strings_dict[self.cli_args[i]]] = True
+                    self.overridable[option_strings_dict[self.cli_args[i]]] = \
+                        True
                 elif self.cli_args[i] in store_false:
-                    override[option_strings_dict[self.cli_args[i]]] = False
+                    self.overridable[option_strings_dict[self.cli_args[i]]] = \
+                        False
                 else:
                     if i < (len(self.cli_args) - 1) and \
                             self.cli_args[i+1][0] != '-':
-                        override[option_strings_dict[self.cli_args[i]]] = \
+                        self.overridable[option_strings_dict[self.cli_args[i]]] = \
                             self.cli_args[i+1]
-        self.opt['override'] = override
+        self.opt['override'] = self.overridable
 
         if print_args:
             self.print_args()
@@ -444,3 +447,9 @@ class ParlaiParser(argparse.ArgumentParser):
                         print('[ ' + group.title + ': ] ')
                     count += 1
                     print('[  ' + key + ': ' + values[key] + ' ]')
+
+    def set_params(self, **kwargs):
+        """Set overridable kwargs."""
+        self.set_defaults(**kwargs)
+        for k, v in kwargs.items():
+            self.overridable[k] = v

--- a/projects/convai2/baselines/language_model/eval_f1.py
+++ b/projects/convai2/baselines/language_model/eval_f1.py
@@ -13,7 +13,7 @@ from projects.convai2.eval_f1 import setup_args, eval_f1
 
 if __name__ == '__main__':
     parser = setup_args()
-    parser.set_defaults(
+    parser.set_params(
         model='language_model',
         model_file='models:convai2/language_model/model',
         dict_file='models:convai2/language_model/model.dict',
@@ -21,7 +21,6 @@ if __name__ == '__main__':
     )
     opt = parser.parse_args()
     opt['model_type'] = 'language_model'
-    opt['override'] = ['dict_file', 'batchsize']
     fnames = ['model', 'model.dict', 'model.opt']
     download_models(opt, fnames, 'convai2', version='v2.0',
                     use_model_type=True)

--- a/projects/convai2/baselines/language_model/eval_f1.py
+++ b/projects/convai2/baselines/language_model/eval_f1.py
@@ -21,6 +21,7 @@ if __name__ == '__main__':
     )
     opt = parser.parse_args()
     opt['model_type'] = 'language_model'
+    opt['override'] = ['dict_file', 'batchsize']
     fnames = ['model', 'model.dict', 'model.opt']
     download_models(opt, fnames, 'convai2', version='v2.0',
                     use_model_type=True)

--- a/projects/convai2/baselines/language_model/eval_f1.py
+++ b/projects/convai2/baselines/language_model/eval_f1.py
@@ -21,6 +21,7 @@ if __name__ == '__main__':
     )
     opt = parser.parse_args()
     opt['model_type'] = 'language_model'
-    fnames = ['model', 'model.dict']
-    download_models(opt, fnames, 'convai2', use_model_type=True)
+    fnames = ['model', 'model.dict', 'model.opt']
+    download_models(opt, fnames, 'convai2', version='v2.0',
+                    use_model_type=True)
     eval_f1(opt, print_parser=parser)

--- a/projects/convai2/baselines/language_model/eval_ppl.py
+++ b/projects/convai2/baselines/language_model/eval_ppl.py
@@ -106,11 +106,12 @@ if __name__ == '__main__':
         model='projects.convai2.baselines.language_model.eval_ppl:LanguageModelEntry',
         model_file='models:convai2/language_model/model',
         dict_file='models:convai2/language_model/model.dict',
-        datatype='test',
         batchsize=1,
     )
     opt = parser.parse_args()
+    opt['override'] = ['model', 'batchsize']
     opt['model_type'] = 'language_model'
-    fnames = ['model', 'model.dict']
-    download_models(opt, fnames, 'convai2', use_model_type=True)
+    fnames = ['model', 'model.dict', 'model.opt']
+    download_models(opt, fnames, 'convai2', version='v2.0',
+                    use_model_type=True)
     eval_ppl(opt)

--- a/projects/convai2/baselines/language_model/eval_ppl.py
+++ b/projects/convai2/baselines/language_model/eval_ppl.py
@@ -102,14 +102,13 @@ class LanguageModelEntry(LanguageModelAgent):
 if __name__ == '__main__':
     parser = setup_args()
     parser.add_argument('-vme', '--validation-max-exs', type=int, default=-1)
-    parser.set_defaults(
+    parser.set_params(
         model='projects.convai2.baselines.language_model.eval_ppl:LanguageModelEntry',
         model_file='models:convai2/language_model/model',
         dict_file='models:convai2/language_model/model.dict',
         batchsize=1,
     )
     opt = parser.parse_args()
-    opt['override'] = ['model', 'batchsize']
     opt['model_type'] = 'language_model'
     fnames = ['model', 'model.dict', 'model.opt']
     download_models(opt, fnames, 'convai2', version='v2.0',

--- a/projects/personachat/scripts/languagemodel_opensub2018_interactive.py
+++ b/projects/personachat/scripts/languagemodel_opensub2018_interactive.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     parser = ParlaiParser(add_model_args=True)
     parser.add_argument('-d', '--display-examples', type='bool', default=False)
     LanguageModelAgent.add_cmdline_args(parser)
-    parser.set_defaults(
+    parser.set_params(
         dict_file='models:personachat/language_model/opensubtitles2018.dict',
         sampling_mode=True,
         task='parlai.agents.local_human.local_human:LocalHumanAgent',
@@ -28,7 +28,6 @@ if __name__ == '__main__':
     opt = parser.parse_args()
     opt['model_type'] = 'language_model' # for builder
     # build all profile memory models
-    opt['override'] = ['dict_file', 'sampling_mode']
     fnames = ['languagemodel_esz512_hid1024_nl2.pt',
               'languagemodel_esz512_hid1024_nl2.pt.opt',
               'opensubtitles2018.dict']

--- a/projects/personachat/scripts/languagemodel_opensub2018_interactive.py
+++ b/projects/personachat/scripts/languagemodel_opensub2018_interactive.py
@@ -30,7 +30,8 @@ if __name__ == '__main__':
     opt['model_type'] = 'language_model' # for builder
     # build all profile memory models
     fnames = ['languagemodel_esz512_hid1024_nl2.pt',
+              'languagemodel_esz512_hid1024_nl2.pt.opt',
               'opensubtitles2018.dict']
-    download_models(opt, fnames, 'personachat')
+    download_models(opt, fnames, 'personachat', version='v2.0')
 
     interactive(opt)

--- a/projects/personachat/scripts/languagemodel_opensub2018_interactive.py
+++ b/projects/personachat/scripts/languagemodel_opensub2018_interactive.py
@@ -25,10 +25,10 @@ if __name__ == '__main__':
         model_file='models:personachat/language_model/languagemodel_esz512_hid1024_nl2.pt'
     )
 
-
     opt = parser.parse_args()
     opt['model_type'] = 'language_model' # for builder
     # build all profile memory models
+    opt['override'] = ['dict_file', 'sampling_mode']
     fnames = ['languagemodel_esz512_hid1024_nl2.pt',
               'languagemodel_esz512_hid1024_nl2.pt.opt',
               'opensubtitles2018.dict']


### PR DESCRIPTION
Save a `.opt` file which will be loaded when `load_agent_module` is called. If this file doesn't exist, the opt is loaded from the `opt` key in the dictionary in the model file (to make compatible with older models for which a `.opt` file is not saved)