### PR TITLE
maintain dialog history fixes

### DIFF
--- a/parlai/agents/ibm_seq2seq/ibm_seq2seq.py
+++ b/parlai/agents/ibm_seq2seq/ibm_seq2seq.py
@@ -327,7 +327,7 @@ class IbmSeq2seqAgent(Agent):
                 self.history, obs,
                 reply=self.answers[batch_idx],
                 historyLength=self.truncate,
-                useReplies=self.opt['include_labels'],
+                useReplies='label_else_model',
                 dict=self.dict,
                 useStartEndIndices=False)
         else:

--- a/parlai/agents/ibm_seq2seq/ibm_seq2seq.py
+++ b/parlai/agents/ibm_seq2seq/ibm_seq2seq.py
@@ -97,6 +97,11 @@ class IbmSeq2seqAgent(Agent):
                                 'Any member of torch.optim is valid and will '
                                 'be used with default params except learning '
                                 'rate (as specified by -lr).')
+        agent.add_argument('-histr', '--history-replies',
+                           default='label_else_model', type=str,
+                           choices=['none', 'model', 'label',
+                                    'label_else_model'],
+                           help='Keep replies in the history, or not.')
         IbmSeq2seqAgent.dictionary_class().add_cmdline_args(argparser)
         return agent
 
@@ -327,7 +332,7 @@ class IbmSeq2seqAgent(Agent):
                 self.history, obs,
                 reply=self.answers[batch_idx],
                 historyLength=self.truncate,
-                useReplies='label_else_model',
+                useReplies=self.opt.get('history_replies', 'label_else_model'),
                 dict=self.dict,
                 useStartEndIndices=False)
         else:

--- a/parlai/agents/ibm_seq2seq/ibm_seq2seq.py
+++ b/parlai/agents/ibm_seq2seq/ibm_seq2seq.py
@@ -332,7 +332,7 @@ class IbmSeq2seqAgent(Agent):
                 self.history, obs,
                 reply=self.answers[batch_idx],
                 historyLength=self.truncate,
-                useReplies=self.opt.get('history_replies', 'label_else_model'),
+                useReplies=self.opt.get('history_replies'),
                 dict=self.dict,
                 useStartEndIndices=False)
         else:

--- a/parlai/agents/memnn/memnn.py
+++ b/parlai/agents/memnn/memnn.py
@@ -53,8 +53,9 @@ class MemnnAgent(Agent):
             help='disable GPUs even if available')
         arg_group.add_argument('--gpu', type=int, default=-1,
             help='which GPU device to use')
-        arg_group.add_argument('-histr', '--history-replies', default='label', type=str,
-            choices=['none', 'model', 'label'],
+        arg_group.add_argument('-histr', '--history-replies',
+            default='label_else_model', type=str,
+            choices=['none', 'model', 'label', 'label_else_model'],
             help='Keep replies in the history, or not.')
         DictionaryAgent.add_cmdline_args(argparser)
         return arg_group

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -146,6 +146,11 @@ class Seq2seqAgent(Agent):
                                 'softmax (see arxiv.org/abs/1711.03953).')
         agent.add_argument('-rf', '--report-freq', type=float, default=0.001,
                            help='Report frequency of prediction during eval.')
+        agent.add_argument('-histr', '--history-replies',
+                           default='label_else_model', type=str,
+                           choices=['none', 'model', 'label',
+                                    'label_else_model'],
+                           help='Keep replies in the history, or not.')
         Seq2seqAgent.dictionary_class().add_cmdline_args(argparser)
         return agent
 
@@ -459,7 +464,7 @@ class Seq2seqAgent(Agent):
                 self.history, obs,
                 reply=self.answers[batch_idx],
                 historyLength=self.truncate,
-                useReplies="label_else_model",
+                useReplies=self.opt.get('history_replies', 'label_else_model'),
                 dict=self.dict,
                 useStartEndIndices=False)
         else:

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -464,7 +464,7 @@ class Seq2seqAgent(Agent):
                 self.history, obs,
                 reply=self.answers[batch_idx],
                 historyLength=self.truncate,
-                useReplies=self.opt.get('history_replies', 'label_else_model'),
+                useReplies=self.opt.get('history_replies'),
                 dict=self.dict,
                 useStartEndIndices=False)
         else:

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -459,7 +459,7 @@ class Seq2seqAgent(Agent):
                 self.history, obs,
                 reply=self.answers[batch_idx],
                 historyLength=self.truncate,
-                useReplies=self.opt['include_labels'],
+                useReplies="label_else_model",
                 dict=self.dict,
                 useStartEndIndices=False)
         else:

--- a/parlai/agents/starspace/starspace.py
+++ b/parlai/agents/starspace/starspace.py
@@ -121,8 +121,9 @@ class StarspaceAgent(Agent):
         agent.add_argument('-hist', '--history-length', default=10000, type=int,
                            help='Number of past tokens to remember. ')
         agent.add_argument('-histr', '--history-replies',
-                           default='label', type=str,
-                           choices=['none', 'model', 'label'],
+                           default='label_else_model', type=str,
+                           choices=['none', 'model', 'label',
+                                    'label_else_model'],
                            help='Keep replies in the history, or not.')
         agent.add_argument('-fixedCands', '--fixed-candidates-file',
                            default=None, type=str,
@@ -175,7 +176,7 @@ class StarspaceAgent(Agent):
                 fcs.append(Variable(torch.LongTensor(self.parse(c)).unsqueeze(0)))
             self.fixedCands = fcs
             print("[loaded candidates]")
-            
+
     def reset(self):
         """Reset observation and episode_done."""
         self.observation = None

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -211,7 +211,7 @@ def make_batches(data, bsz):
 
 
 def maintain_dialog_history(history, observation, reply='',
-                            historyLength=1, useReplies="labels",
+                            historyLength=1, useReplies='label_else_model',
                             dict=None, useStartEndIndices=True,
                             splitSentences=False):
     """Keeps track of dialog history, up to a truncation length.
@@ -245,7 +245,8 @@ def maintain_dialog_history(history, observation, reply='',
         history['episode_done'] = False
 
     if useReplies != 'none':
-        if useReplies == 'model':
+        if useReplies == 'model' or (useReplies == 'label_else_model' and
+                                     'labels' not in observation):
             if reply != '':
                 history['dialog'].extend(parse(reply))
         elif len(history['labels']) > 0:

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -222,7 +222,7 @@ def maintain_dialog_history(history, observation, reply='',
             if splitSentences:
                 vec = [dict.txt2vec(t) for t in txt.split('\n')]
             else:
-                vec =  dict.txt2vec(txt)
+                vec = dict.txt2vec(txt)
             if useStartEndIndices:
                 parsed_x = deque([dict[dict.start_token]])
                 parsed_x.extend(vec)
@@ -246,7 +246,8 @@ def maintain_dialog_history(history, observation, reply='',
 
     if useReplies != 'none':
         if useReplies == 'model' or (useReplies == 'label_else_model' and
-                                     'labels' not in observation):
+                                     'labels' not in observation and
+                                     'eval_labels' not in observation):
             if reply != '':
                 history['dialog'].extend(parse(reply))
         elif len(history['labels']) > 0:

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -246,8 +246,7 @@ def maintain_dialog_history(history, observation, reply='',
 
     if useReplies != 'none':
         if useReplies == 'model' or (useReplies == 'label_else_model' and
-                                     'labels' not in observation and
-                                     'eval_labels' not in observation):
+                                     len(history['labels']) == 0):
             if reply != '':
                 history['dialog'].extend(parse(reply))
         elif len(history['labels']) > 0:

--- a/projects/personachat/kvmemnn/kvmemnn.py
+++ b/projects/personachat/kvmemnn/kvmemnn.py
@@ -191,9 +191,8 @@ class KvmemnnAgent(Agent):
         agent.add_argument('-hist', '--history-length', default=100, type=int,
                            help='Number of past tokens to remember. ')
         agent.add_argument('-histr', '--history-replies',
-                           default='label_else_model', type=str,
-                           choices=['none', 'model', 'label',
-                                    'label_else_model'],
+                           default='label', type=str,
+                           choices=['none', 'model', 'label'],
                            help='Keep replies in the history, or not.')
         agent.add_argument('--interactive-mode',
                            default=False, type='bool',

--- a/projects/personachat/kvmemnn/kvmemnn.py
+++ b/projects/personachat/kvmemnn/kvmemnn.py
@@ -191,8 +191,9 @@ class KvmemnnAgent(Agent):
         agent.add_argument('-hist', '--history-length', default=100, type=int,
                            help='Number of past tokens to remember. ')
         agent.add_argument('-histr', '--history-replies',
-                           default='label', type=str,
-                           choices=['none', 'model', 'label'],
+                           default='label_else_model', type=str,
+                           choices=['none', 'model', 'label',
+                                    'label_else_model'],
                            help='Keep replies in the history, or not.')
         agent.add_argument('--interactive-mode',
                            default=False, type='bool',


### PR DESCRIPTION
Fixes to `maintain_dialog_history`. The default option is 'label_else_model' which defaults to 'label' if 'labels' is in the observation and 'model' otherwise. Changed agents in ParlAI to have this as the default option.