### PR TITLE
opensubtitles 2009 version change

### DIFF
--- a/parlai/tasks/opensubtitles/build_2009.py
+++ b/parlai/tasks/opensubtitles/build_2009.py
@@ -73,7 +73,7 @@ def create_fb_format(inpath, outpath):
 
 def build(datapath):
     dpath = os.path.join(datapath, 'OpenSubtitles')
-    version = '1'
+    version = '2'
 
     if not build_data.built(dpath, version_string=version):
         print('[building data: ' + dpath + ']')


### PR DESCRIPTION
Bug in fbformat introduced from an old PR. Bug fixed in later PRs but version number needed to be updated.