### PR TITLE
switch to torch for saving extracted images

### DIFF
--- a/parlai/agents/mlb_vqa/mlb_vqa.py
+++ b/parlai/agents/mlb_vqa/mlb_vqa.py
@@ -345,8 +345,8 @@ class MlbVqaAgent(Agent):
                            help='which GPU device to use')
         agent.add_argument('--no-data-parallel', action='store_true',
                            help='disable pytorch parallel data processing')
-        agent.add_argument('--no-hdf5', action='store_true',
-                           help='specify to not use a single hdf5 file to load \
+        agent.add_argument('--use-hdf5', type='bool', default=False,
+                           help='specify whether to use a single hdf5 file to load \
                            images')
         agent.add_argument('--no-metrics', action='store_true',
                            help='specify to not compute f1 or accuracy during \
@@ -655,4 +655,3 @@ class MlbVqaAgent(Agent):
         if path is not None:
             self.save(path + '.shutdown_state')
         super().shutdown()
-

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -380,11 +380,11 @@ class PytorchDataTeacher(FixedDialogTeacher):
         """
         dataset_name = opt.get('dataset')
         sp = dataset_name.strip().split(':')
-        agent_class = get_agent_module(opt.get('model'))
-        if hasattr(agent_class, 'collate'):
-            collate = agent_class.collate
-        else:
-            collate = default_collate
+        collate = default_collate
+        if opt.get('model', False):
+            agent_class = get_agent_module(opt.get('model'))
+            if hasattr(agent_class, 'collate'):
+                collate = agent_class.collate
         if sp[0] == 'StreamDataset':
             return StreamDataset, collate
         module_name = sp[0]

--- a/parlai/scripts/build_pytorch_data.py
+++ b/parlai/scripts/build_pytorch_data.py
@@ -53,6 +53,8 @@ def make_serializable(obj):
 
 
 def build_data(opt):
+    if not opt.get('model', False):
+        opt['model'] = 'repeat_label'
     agent = create_agent(opt)
     #If build teacher not specified, we are simply looking for the file
     if not opt.get('pytorch_buildteacher', None):

--- a/parlai/scripts/extract_image_feature.py
+++ b/parlai/scripts/extract_image_feature.py
@@ -28,9 +28,15 @@ def setup_args(parser=None):
         parser = ParlaiParser(True, False)
     arg_group = parser.add_argument_group('Image Extraction')
     arg_group.add_argument('--dataset', type=str, default=None,
-                           help='Pytorch Dataset')
+                           help='Pytorch Dataset; if specified, will save \
+                           the images in one hdf5 file according to how \
+                           they are returned by the specified dataset')
     arg_group.add_argument('-at', '--attention', action='store_true',
-                           help='Whether to extract image features with attention')
+                           help='Whether to extract image features with attention \
+                           (Note - this is specifically for the mlb_vqa model)')
+    arg_group.add_argument('--use-hdf5-extraction', type='bool', default=False,
+                           help='Whether to extract images into an hdf5 dataset')
+
     return parser
 
 
@@ -67,6 +73,7 @@ def extract_feats(opt):
     opt['gpu'] = 0
     opt['num_epochs'] = 1
     opt['no_hdf5'] = True
+    opt['num_load_threads'] = 20
     logger = ProgressLogger(should_humanize=False, throttle=0.1)
     print("[ Loading Images ]")
     # create repeat label agent and assign it to the specified task
@@ -80,7 +87,7 @@ def extract_feats(opt):
             world.parley()
             exs_seen += bsz
             logger.log(exs_seen, total_exs)
-    else:
+    elif opt.get('use_hdf5_extraction', False):
         '''One can specify a Pytorch Dataset for custom image loading'''
         nw = opt.get('numworkers', 1)
         im = opt.get('image_mode', 'raw')

--- a/parlai/scripts/extract_image_feature.py
+++ b/parlai/scripts/extract_image_feature.py
@@ -72,7 +72,7 @@ def extract_feats(opt):
     opt['no_cuda'] = False
     opt['gpu'] = 0
     opt['num_epochs'] = 1
-    opt['no_hdf5'] = True
+    opt['use_hdf5'] = False
     opt['num_load_threads'] = 20
     logger = ProgressLogger(should_humanize=False, throttle=0.1)
     print("[ Loading Images ]")

--- a/parlai/tasks/vqa_v1/agents.py
+++ b/parlai/tasks/vqa_v1/agents.py
@@ -56,6 +56,7 @@ class VQADataset(Dataset):
         self.opt = opt
         self.use_att = opt.get('attention', False)
         self.use_hdf5 = not opt.get('no_hdf5', False)
+        self.opt['use_hdf5_extraction'] = self.use_hdf5
         self.datatype = self.opt.get('datatype')
         self.training = self.datatype.startswith('train')
         self.num_epochs = self.opt.get('num_epochs', 0)

--- a/parlai/tasks/vqa_v1/agents.py
+++ b/parlai/tasks/vqa_v1/agents.py
@@ -55,7 +55,7 @@ class VQADataset(Dataset):
     def __init__(self, opt):
         self.opt = opt
         self.use_att = opt.get('attention', False)
-        self.use_hdf5 = not opt.get('no_hdf5', False)
+        self.use_hdf5 = opt.get('use_hdf5', False)
         self.opt['use_hdf5_extraction'] = self.use_hdf5
         self.datatype = self.opt.get('datatype')
         self.training = self.datatype.startswith('train')

--- a/tests/test_mlb_vqa.py
+++ b/tests/test_mlb_vqa.py
@@ -35,7 +35,7 @@ class TestTrainModel(unittest.TestCase):
                 batchsize=1,
                 num_epochs=1,
                 no_cuda=True,
-                no_hdf5=True,
+                use_hdf5=False,
                 pytorch_preprocess=False,
                 batch_sort_cache='none',
                 numworkers=1,


### PR DESCRIPTION
1. switches to torch.save rather than hdf5 storage of individual images (note - still supports large saved hdf5 datasets if one wants to)
2. can now use `pytorch_teacher` in display_data

note: waiting on #773 and #775 as I need to change a few arg names in those modified files