### PR TITLE
fix memnn squeezing

### DIFF
--- a/parlai/agents/memnn/memnn.py
+++ b/parlai/agents/memnn/memnn.py
@@ -220,7 +220,7 @@ class MemnnAgent(Agent):
                 if self.opt['cuda']:
                     candidate_embeddings = candidate_embeddings.cuda()
                 last_cand = cand_list
-            scores[i, :len(cand_list)] = self.model.score.one_to_many(output_embeddings[i].unsqueeze(0), candidate_embeddings).squeeze()
+            scores[i, :len(cand_list)] = self.model.score.one_to_many(output_embeddings[i].unsqueeze(0), candidate_embeddings).squeeze(0)
         return scores
 
     def ranked_predictions(self, cands, scores):

--- a/parlai/agents/memnn/modules.py
+++ b/parlai/agents/memnn/modules.py
@@ -93,7 +93,7 @@ class Embed(nn.Embedding):
     def forward(self, lengths, indices):
         lengths_mat = lengths.data
         if lengths.dim() == 1 or lengths.size(1) == 1:
-            lengths_mat = lengths_mat.squeeze().unsqueeze(0)
+            lengths_mat = lengths_mat.unsqueeze(0)
 
         if lengths_mat.dim() == 1:
             raise RuntimeError(lengths.shape)

--- a/parlai/mturk/tasks/convai2_model_eval/__init__.py
+++ b/parlai/mturk/tasks/convai2_model_eval/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,6 +46,7 @@ class TestUtils(unittest.TestCase):
 
     def test_timer(self):
         t = Timer()
+        time.sleep(1e-6)
         elapsed = t.stop().time()
         assert elapsed > 0
 
@@ -53,14 +54,16 @@ class TestUtils(unittest.TestCase):
         assert elapsed == same
 
         t.resume()
-        time.sleep(0.1)
+        time.sleep(1e-6)
         more = t.time()
         assert more > elapsed
 
-        other = Timer()
-        less = other.reset().time()
-        assert less > 0
-        assert less < t.time()
+        rabbit = Timer()
+        time.sleep(1e-6)
+        turtle = Timer()
+        time.sleep(1e-6)
+        assert turtle.time() > 0
+        assert turtle.time() < rabbit.time()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@jaseweston @emilydinan @klshuster fyi `squeeze()` may create unexpected 0-dim tensors, especially with bsz=1

+ small fix to unit tests