### PR TITLE
Tensorboard log with tensorboardx package in train_model.py script

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,13 +14,18 @@ SPHINXPROJ    = ParlAI
 SOURCEDIR     = source
 BUILDDIR      = build
 
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile
 
+clean:
+	rm -rfv "${BUILDDIR}"
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
+	cd "${SOURCEDIR}"; python generate_task_list.py
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ ParlAI is a one-stop-shop for dialog research.
    tutorial_seq2seq
    tutorial_mturk
    tutorial_messenger
+   tutorial_tensorboard
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/tutorial_tensorboard.rst
+++ b/docs/source/tutorial_tensorboard.rst
@@ -1,0 +1,52 @@
+..
+  Copyright (c) 2017-present, Facebook, Inc.
+  All rights reserved.
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree. An additional grant
+  of patent rights can be found in the PATENTS file in the same directory.
+
+Using tensorboard for metric tracking
+=====================================
+
+ParlAI uses tensorboardX package which provides tensorflow-free api to write tensorboard event files.
+One can install it using pip:
+``pip install tensorboardX``
+
+Default usage inside training loop
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``TrainingLoop`` class from ``train_model.py`` script supports saving any metric available in ``train_report`` or ``valid_report``.
+
+Provide the following arguments to track Perplexity, Loss and Accuracy (this is presented as arguments for parser.set_default() function):
+
+.. code-block:: python
+
+    tensorboard_log=True,
+    tensorboard_tag='task,batchsize,hiddensize,embeddingsize,attention,numlayers,rnn_class,learningrate,dropout,gradient_clip',
+    tensorboard_metrics='ppl,loss,accuracy',
+
+``tensorboard_tag`` provides sequence of arguments which will be used together with corresponding values for the tensorboard event folder name.
+In the example above, the folder name will look like this:
+``May31_10-15_task-convai2:self_batchsize-64_hiddensize-1024_embeddingsize-300_attention-``
+``general_numlayers-2_rnn_class-lstm_learningrate-3_dropout-0.1_gradient_clip-0.1``
+
+All folders are stored in ``${PARLAI_DATA}/tensorboard``
+
+In order to launch tensorboard with ParlAI logs, run:
+``tensorboard —logdir ${PARLAI_DATA}/tensorboard --port 8866``. TB will be avaialable on port 8866.
+
+Usage in other part your code
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+One can track any other values during the runtime with ``TensorboardLogger`` class:
+
+.. code-block:: python
+
+    from parlai.core.logs import TensorboardLogger
+
+    # you need access to global parlai opt to create an instance
+    if opt['tensorboard_log'] is True:
+        self.writer = TensorboardLogger(opt)
+
+    # then you can track any metric:
+    self.writer.add_scalar('test', 100)

--- a/docs/source/tutorial_worlds.rst
+++ b/docs/source/tutorial_worlds.rst
@@ -263,18 +263,18 @@ Multiprocessed Pytorch Dataloader
 For large datasets, where it is best to stream from disk during training
 rather than load initially into memory, we provide a teacher that utilizes pytorch data loading.
 
-(Note: the module `here <https://github.com/facebookresearch/ParlAI/blob/master/parlai/core/pytorch_data_teacher.py>`_
+(Note: the module `here <https://github.com/facebookresearch/ParlAI/blob/master/parlai/core/pytorch_data_teacher.py>`__
 contains all of the code discussed in this tutorial)
 
 Pytorch Dataloading Intro
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 A Pytorch ``DataLoader`` is a dataloading mechanism that provides multiprocessed
-loading of data from disk (as described `here <http://pytorch.org/tutorials/beginner/data_loading_tutorial.html>`_).
+loading of data from disk (as described `here <http://pytorch.org/tutorials/beginner/data_loading_tutorial.html>`__).
 A ``DataLoader`` can be initialized with a variety of different options; the only
 ones that concern us are ``dataset`` and ``collate_fn``.
 
 The ``dataset`` is a
-Pytorch ``Dataset`` (as described `here <http://pytorch.org/tutorials/beginner/data_loading_tutorial.html>`_),
+Pytorch ``Dataset`` (as described `here <http://pytorch.org/tutorials/beginner/data_loading_tutorial.html>`__),
 which is a class that implements two functions: ``__getitem__(self, idx)`` and ``__len__(self)``.
 As is readily apparent, the ``__getitem__`` method is given an ``idx`` and returns the
 data item at that ``idx``, while the ``__len__`` method returns the length of the underlying dataset.

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -5,6 +5,9 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 """
 This file provides interface to log any metrics in tensorboard, could be extended to any other tool like visdom
+Tensorboard:
+    If you use tensorboard logging, all event folders will be stored in PARLAI_DATA/tensorboard folder. In order to
+    open it with TB, launch tensorboard as : tensorboard --logdir <PARLAI_DATA/tensorboard> --port 8888.
 """
 import datetime
 from parlai.core.params import ParlaiParser
@@ -19,13 +22,17 @@ class Shared(object):
 
 
 class TensorboardLogger(Shared):
+    @staticmethod
+    def add_cmdline_args(argparser):
+        logger = argparser.add_argument_group('Tensorboard Arguments')
+        logger.add_argument('-tblog', '--tensorboard-log', type=bool, default=False,
+                           help="Tensorboard logging of metrics")
+        logger.add_argument('-tbtag', '--tensorboard-tag', type=str, default=None,
+                           help='Specify all opt keys which you want to be presented in in TB name')
+        logger.add_argument('-tbmetric', '--tensorboard-metric', type=str, default=None,
+                           help="Specify metrics which you want to track, it will be extracrted from report dict.")
     def __init__(self, opt):
         Shared.__init__(self)
-
-        if isinstance(opt, ParlaiParser):
-            print('[ Deprecated Warning: TrainLoop should be passed opt not Parser ]')
-            opt = opt.parse_args()
-        assert opt['tensorboard_log'] is True, 'TensorboardLogger class requires tensorboard_log to be True'
         try:
             from tensorboardX import SummaryWriter
         except ModuleNotFoundError:
@@ -47,7 +54,7 @@ class TensorboardLogger(Shared):
 
     def add_metrics(self, setting, step, report):
         """
-        setting - ['train', 'valid']
+        setting - whatever setting is used, train valid or test, it will be just the title of the graph
         step - num of parleys (x axis in graph), in train - parleys, in valid - wall time
         report - from TrainingLoop
         this method adds all metrics from tensorboard_metrics opt key

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -29,7 +29,7 @@ class TensorboardLogger(Shared):
                            help="Tensorboard logging of metrics")
         logger.add_argument('-tbtag', '--tensorboard-tag', type=str, default=None,
                            help='Specify all opt keys which you want to be presented in in TB name')
-        logger.add_argument('-tbmetric', '--tensorboard-metric', type=str, default=None,
+        logger.add_argument('-tbmetrics', '--tensorboard-metrics', type=str, default=None,
                            help="Specify metrics which you want to track, it will be extracrted from report dict.")
     def __init__(self, opt):
         Shared.__init__(self)
@@ -47,7 +47,7 @@ class TensorboardLogger(Shared):
         if not os.path.exists(tbpath):
             os.makedirs(tbpath)
         self.writer = SummaryWriter(log_dir='{}/{}'.format(tbpath, tensorboard_tag))
-        if opt['tensorboard_metrics'] is None:
+        if opt['tensorboard_metrics'] == None:
             self.tbmetrics = ['ppl', 'loss']
         else:
             self.tbmetrics = opt['tensorboard_metrics'].split(',')

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+"""
+This file provides interface to log any metrics in tensorboard, could be extended to any other tool like visdom
+"""
+import datetime
+from parlai.core.params import ParlaiParser
+import os
+
+
+class Shared(object):
+    _shared_state = {}
+
+    def __init__(self):
+        self.__dict__ = self._shared_state
+
+
+class TensorboardLogger(Shared):
+    def __init__(self, opt):
+        Shared.__init__(self)
+
+        if isinstance(opt, ParlaiParser):
+            print('[ Deprecated Warning: TrainLoop should be passed opt not Parser ]')
+            opt = opt.parse_args()
+        assert opt['tensorboard_log'] is True, 'TensorboardLogger class requires tensorboard_log to be True'
+        try:
+            from tensorboardX import SummaryWriter
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError('Please `pip install tensorboardX` for logs with TB.')
+        if opt['tensorboard_tag'] == None:
+            tensorboard_tag = opt['starttime']
+        else:
+            tensorboard_tag = opt['starttime'] + '_'.join(
+                [i + '-' + str(opt[i]) for i in opt['tensorboard_tag'].split(',')])
+
+        tbpath = os.path.join(opt['datapath'], 'tensorboard')
+        if not os.path.exists(tbpath):
+            os.makedirs(tbpath)
+        self.writer = SummaryWriter(log_dir='{}/{}'.format(tbpath, tensorboard_tag))
+        if opt['tensorboard_metrics'] is None:
+            self.tbmetrics = ['ppl', 'loss']
+        else:
+            self.tbmetrics = opt['tensorboard_metrics'].split(',')
+
+    def add_metrics(self, setting, step, report):
+        """
+        setting - ['train', 'valid']
+        step - num of parleys (x axis in graph), in train - parleys, in valid - wall time
+        report - from TrainingLoop
+        this method adds all metrics from tensorboard_metrics opt key
+        :return:
+        """
+        for met in self.tbmetrics:
+            if met in report.keys():
+                self.writer.add_scalar("{}/{}".format(setting, met), report[met],
+                                       global_step=step)
+
+    def add_scalar(self, name, y, step=None):
+        """
+        :param name: the title of the graph, use / to group like "train/loss/ce" or so
+        :param y: value
+        :param step: x axis step
+        :return:
+        """
+        self.writer.add_scalar(name, y, step)
+
+    def add_histogram(self, name, vector, step=None):
+        """
+        :param name:
+        :param vector:
+        :return:
+        """
+        self.writer.add_histogram(name, vector, step)

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -11,6 +11,7 @@ import argparse
 import importlib
 import os
 import sys
+import datetime
 from parlai.core.agents import get_agent_module, get_task_module
 from parlai.tasks.tasks import ids_to_tasks
 
@@ -421,6 +422,9 @@ class ParlaiParser(argparse.ArgumentParser):
                         self.overridable[option_strings_dict[self.cli_args[i]]] = \
                             self.cli_args[i+1]
         self.opt['override'] = self.overridable
+
+        # add start time of an experiment
+        self.opt['starttime'] = datetime.datetime.today().strftime('%b%d_%H-%M')
 
         if print_args:
             self.print_args()

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -182,8 +182,8 @@ class TrainLoop():
         if opt['tensorboard_log'] is True:
             try:
                 from tensorboardX import SummaryWriter
-            except ModuleNotFound:
-                raise ModuleNotFound('Please `pip install emoji tensorboardX` for logs with TB.')
+            except ModuleNotFoundError:
+                raise ModuleNotFoundError('Please `pip install emoji tensorboardX` for logs with TB.')
             if opt['tensorboard_tag'] == None:
                 tensorboard_tag = datetime.datetime.today().strftime('%b%d_%H-%M')
             else:

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -82,12 +82,7 @@ def setup_args(parser=None):
     train.add_argument('-lfc', '--load-from-checkpoint',
                        type='bool', default=False,
                        help='load model from checkpoint if available')
-    train.add_argument('-tblog', '--tensorboard-log', type=bool, default=False,
-                       help="Tensorboard logging of metrics")
-    train.add_argument('-tbtag', '--tensorboard-tag', type=str, default=None,
-                       help='Specify all opt keys which you want to be presented in in TB name')
-    train.add_argument('-tbmetric', '--tensorboard-metric', type=str, default=None,
-                       help="Specify metrics which you want to track, it will be extracrted from report dict.")
+    TensorboardLogger.add_cmdline_args(parser)
     parser = setup_dict_args(parser)
     return parser
 

--- a/parlai/tasks/twitter/build.py
+++ b/parlai/tasks/twitter/build.py
@@ -8,8 +8,8 @@
 try:
     from emoji.unicode_codes import UNICODE_EMOJI
     import unidecode
-except ModuleNotFound:
-    raise ModuleNotFound('Please `pip install emoji unidecode` for the twitter task.')
+except ModuleNotFoundError:
+    raise ModuleNotFoundError('Please `pip install emoji unidecode` for the twitter task.')
 
 import parlai.core.build_data as build_data
 import os


### PR DESCRIPTION
It is quite comfortable to compare curves rather than numbers. TensorboardX provides single api to log any kind of numbers in TB and can be used separate from tensorflow.

However, in order to run actual tensorboard you need to install any basic tensorflow from pip.

Right now there is an option to turn logging on (off by default), and one can also configure the metrics to track, options to keep in the event file name (useful to distinguish different setups).