### PR TITLE
Fix args injection inside add_extra_args

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -335,7 +335,7 @@ class ParlaiParser(argparse.ArgumentParser):
 
     def add_extra_args(self, args=None):
         """Add more args depending on how known args are set."""
-        parsed = vars(self.parse_known_args(nohelp=True)[0])
+        parsed = vars(self.parse_known_args(args, nohelp=True)[0])
 
         # find which image mode specified if any, and add additional arguments
         image_mode = parsed.get('image_mode', None)


### PR DESCRIPTION
A recent change broke callers that were using the Predictor class from inside another application (and thus with different command line parameters). Calling parse_known_args without injecting the args forces it to resolve sys.argv, which in that case do not correspond at all to ParlAI parameters.