### PR TITLE
Opt fix

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -45,6 +45,7 @@ import pickle
 import random
 import os
 
+
 class Agent(object):
     """Base class for all other agents."""
 
@@ -275,6 +276,7 @@ def name_to_agent_class(name):
     class_name += 'Agent'
     return class_name
 
+
 def load_agent_module(opt):
     model_file = opt['model_file']
     optfile = model_file + '.opt'
@@ -290,6 +292,7 @@ def load_agent_module(opt):
                           str(v) + " (previously:" +
                           str(str(new_opt.get(k, None))) + ") ]")
                 new_opt[k] = v
+        # add model arguments to new_opt if they aren't in new_opt already
         for k, v in opt.items():
             if k not in new_opt:
                 new_opt[k] = v
@@ -298,6 +301,7 @@ def load_agent_module(opt):
         return model_class(new_opt)
     else:
         return None
+
 
 def get_agent_module(dir_name):
     repo = 'parlai'

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -10,6 +10,7 @@ using the ParlAI package.
 import argparse
 import importlib
 import os
+import pickle
 import sys
 from parlai.core.agents import get_agent_module, get_task_module
 from parlai.tasks.tasks import ids_to_tasks
@@ -332,6 +333,17 @@ class ParlaiParser(argparse.ArgumentParser):
         model = parsed.get('model', None)
         if model is not None:
             self.add_model_subargs(model)
+        else:
+            # try to get model name from model opt file
+            model_file = parsed.get('model_file', None)
+            if model_file is not None:
+                optfile = model_file + '.opt'
+                if os.path.isfile(optfile):
+                    with open(optfile, 'rb') as handle:
+                        new_opt = pickle.load(handle)
+                        if 'model' in new_opt:
+                            print("Adding model subargs")
+                            self.add_model_subargs(new_opt['model'])
 
         # reset parser-level defaults over any model-level defaults
         try:


### PR DESCRIPTION
Opt loading fix: fix for case when you don't specify a model (and instead load the model name from an opt file) but new arguments were added to model since the opt file was saved. In this case, we need to be able to add the command line args for the model at parsing time.