### PR TITLE
if logic for deque with truncation case

### DIFF
--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -358,8 +358,9 @@ class PaddingUtils(object):
         else:
             parsed_x = [dictionary.txt2vec(ex['text']) for ex in exs]
 
-        if dq and not isinstance(parsed_x[0], deque):
-            parsed_x = [deque(x, maxlen=truncate) for x in parsed_x]
+        if dq:
+            if not isinstance(parsed_x[0], deque):
+                parsed_x = [deque(x, maxlen=truncate) for x in parsed_x]
         elif truncate is not None and truncate > 0:
             parsed_x = [x[-truncate:] for x in parsed_x]
 


### PR DESCRIPTION
There has to be nested if for deque instance check.

Was this error before (because was not handled properly by if):
`File "/private/home/kulikov/code/ParlAI/parlai/core/utils.py", line 364, in <listcomp>
    parsed_x = [x[-truncate:] for x in parsed_x]
TypeError: sequence index must be integer, not 'slice'`
