### PR TITLE
update to work with drqa wiki dump

### DIFF
--- a/parlai/agents/tfidf_retriever/tfidf_doc_ranker.py
+++ b/parlai/agents/tfidf_retriever/tfidf_doc_ranker.py
@@ -40,17 +40,17 @@ class TfidfDocRanker(object):
         self.hash_size = metadata['hash_size']
         self.tokenizer = tokenizers.get_class(metadata['tokenizer'])()
         self.doc_freqs = metadata['doc_freqs'].squeeze()
-        self.doc_dict = metadata['doc_dict']
+        self.doc_dict = metadata.get('doc_dict', None)
         self.num_docs = self.doc_mat.shape[1] - 1
         self.strict = strict
 
     def get_doc_index(self, doc_id):
         """Convert doc_id --> doc_index"""
-        return self.doc_dict[0][doc_id]
+        return self.doc_dict[0][doc_id] if self.doc_dict else doc_id
 
     def get_doc_id(self, doc_index):
         """Convert doc_index --> doc_id"""
-        return self.doc_dict[1][doc_index]
+        return self.doc_dict[1][doc_index] if self.doc_dict else doc_index
 
     def closest_docs(self, query, k=1, matrix=None):
         """Closest docs by dot product between query and documents

--- a/parlai/agents/tfidf_retriever/tfidf_doc_ranker.py
+++ b/parlai/agents/tfidf_retriever/tfidf_doc_ranker.py
@@ -40,8 +40,17 @@ class TfidfDocRanker(object):
         self.hash_size = metadata['hash_size']
         self.tokenizer = tokenizers.get_class(metadata['tokenizer'])()
         self.doc_freqs = metadata['doc_freqs'].squeeze()
+        self.doc_dict = metadata['doc_dict']
         self.num_docs = self.doc_mat.shape[1] - 1
         self.strict = strict
+
+    def get_doc_index(self, doc_id):
+        """Convert doc_id --> doc_index"""
+        return self.doc_dict[0][doc_id]
+
+    def get_doc_id(self, doc_index):
+        """Convert doc_index --> doc_id"""
+        return self.doc_dict[1][doc_index]
 
     def closest_docs(self, query, k=1, matrix=None):
         """Closest docs by dot product between query and documents

--- a/parlai/agents/tfidf_retriever/tfidf_retriever.py
+++ b/parlai/agents/tfidf_retriever/tfidf_retriever.py
@@ -58,8 +58,15 @@ class TfidfRetrieverAgent(Agent):
         parser.add_argument(
             '--retriever-num-retrieved', default=5, type=int,
             help='How many docs to retrieve.')
-        parser.add_argument('--remove-title', type='bool', default=False,
+        parser.add_argument(
+            '--remove-title', type='bool', default=False,
             help='Whether to remove the title from the retrieved passage')
+        parser.add_argument(
+            '--index-by-int-id', type='bool', default=True,
+            help='Whether to index into database by doc id as an integer. This \
+                  defaults to true for DBs built using ParlAI; for the DrQA \
+                  wiki dump, it is necessary to set this to False to \
+                  index into the DB appropriately')
 
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
@@ -116,6 +123,8 @@ class TfidfRetrieverAgent(Agent):
         self.training = False
 
     def doc2txt(self, docid):
+        if not self.opt.get('index_by_int_id', True):
+            docid = self.ranker.get_doc_id(docid)
         if self.ret_mode == 'keys':
             return self.db.get_doc_text(docid)
         elif self.ret_mode == 'values':
@@ -123,7 +132,6 @@ class TfidfRetrieverAgent(Agent):
         else:
             raise RuntimeError('Retrieve mode {} not yet supported.'.format(
                 self.ret_mode))
-
 
     def rebuild(self):
         if len(self.triples_to_add) > 0:


### PR DESCRIPTION
Updates the tfidf retriever so that we can evaluate models with the wikipedia dump used in [DrQA](https://github.com/facebookresearch/DrQA). 