### PR TITLE
Fix bug that loads only one example for first batch

### DIFF
--- a/parlai/tasks/coco_caption/agents.py
+++ b/parlai/tasks/coco_caption/agents.py
@@ -219,7 +219,6 @@ class DefaultTeacher(FixedDialogTeacher):
     def reset(self):
         super().reset()  # call parent reset so other fields can be set up
         self.example = None  # set up caching fields
-        self.next_example()  # call this once to get the cache moving
 
     def num_examples(self):
         # We only have annotations for the train and val sets, so for the test
@@ -270,8 +269,11 @@ class DefaultTeacher(FixedDialogTeacher):
             # load the next image in the background
             image_id = self.example['image_id']
             self.submit_load_request(image_id)
-        # return the previously cached example
-        return ready
+        # Try to return the previously cached example
+        if ready is None:
+            return self.next_example()
+        else:
+            return ready
 
     def share(self):
         shared = super().share()

--- a/parlai/tasks/flickr30k/agents.py
+++ b/parlai/tasks/flickr30k/agents.py
@@ -160,7 +160,6 @@ class DefaultTeacher(FixedDialogTeacher):
     def reset(self):
         super().reset()  # call parent reset so other fields can be set up
         self.example = None  # set up caching fields
-        self.next_example()  # call this once to get the cache moving
 
     def num_examples(self):
         return len(self.caption)
@@ -204,8 +203,11 @@ class DefaultTeacher(FixedDialogTeacher):
             # load the next image in the background
             image_id = self.example['image_id']
             self.submit_load_request(image_id)
-        # return the previously cached example
-        return ready
+        # Try to return the previously cached example
+        if ready is None:
+            return self.next_example()
+        else:
+            return ready
 
     def share(self):
         shared = super().share()

--- a/parlai/tasks/vqa_v1/agents.py
+++ b/parlai/tasks/vqa_v1/agents.py
@@ -196,8 +196,6 @@ class OeTeacher(FixedDialogTeacher):
     def reset(self):
         super().reset()
         self.example = None
-        # call this once to get the cache moving
-        self.next_example()
 
     def num_examples(self):
         """Number of examples in VQA-v1."""

--- a/parlai/tasks/vqa_v1/agents.py
+++ b/parlai/tasks/vqa_v1/agents.py
@@ -241,7 +241,11 @@ class OeTeacher(FixedDialogTeacher):
         if self.image_mode != 'none' and 'image_id' in self.example:
             image_id = self.example['image_id']
             self.submit_load_request(image_id)
-        return ready
+        # Try to return the previously cached example
+        if ready is None:
+            return self.next_example()
+        else:
+            return ready
 
     def share(self):
         shared = super().share()

--- a/parlai/tasks/vqa_v2/agents.py
+++ b/parlai/tasks/vqa_v2/agents.py
@@ -128,8 +128,11 @@ class OeTeacher(FixedDialogTeacher):
             # load the next image in the background
             image_id = self.example['image_id']
             self.submit_load_request(image_id)
-        # return the previously cached example
-        return ready
+        # Try to return the previously cached example
+        if ready is None:
+            return self.next_example()
+        else:
+            return ready
 
     def share(self):
         shared = super().share()

--- a/parlai/tasks/vqa_v2/agents.py
+++ b/parlai/tasks/vqa_v2/agents.py
@@ -81,7 +81,6 @@ class OeTeacher(FixedDialogTeacher):
     def reset(self):
         super().reset()  # call parent reset so other fields can be set up
         self.example = None  # set up caching fields
-        self.next_example()  # call this once to get the cache moving
 
     def num_examples(self):
         return len(self.ques['questions'])


### PR DESCRIPTION
When attempting to load the first batch of training or validation (world creation), we reset the dataloader `batch_size` times. This had the unintended side effect of adding the first example to the cache `batch_size` times.