### PR TITLE
Fix for when batch size becomes to 1 at test time.

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -281,6 +281,9 @@ def load_agent_module(opt):
     if os.path.isfile(optfile):
         with open(optfile, 'rb') as handle:
             new_opt = pickle.load(handle)
+        if 'batchindex' in new_opt:
+            # This saved variable can cause trouble if we switch to BS=1 at test time
+            del new_opt['batchindex']
         # only override opts specified in 'override' dict
         if opt.get('override'):
             for k in opt['override']:


### PR DESCRIPTION
If we train a model with batches (-bs > 1) and then load it at test time (examples/eval_model.py) with the option `-bs 1`, the leftover batchindex variable will cause some troubles, as only the BatchWorld class will actually correct it.