### PR TITLE
train:evalmode, where labels are hidden

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -229,6 +229,8 @@ class ParlaiParser(argparse.ArgumentParser):
             '-dt', '--datatype', default='train',
             choices=['train', 'train:stream', 'train:ordered',
                      'train:ordered:stream', 'train:stream:ordered',
+                     'train:evalmode', 'train:evalmode:stream', 'train:evalmode:ordered',
+                     'train:evalmode:ordered:stream', 'train:evalmode:stream:ordered',
                      'valid', 'valid:stream', 'test', 'test:stream'],
             help='choose from: train, train:ordered, valid, test. to stream '
                  'data add ":stream" to any option (e.g., train:stream). '

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -389,7 +389,8 @@ class FixedDialogTeacher(Teacher):
 
         # remember correct answer if available
         self.lastY = action.get('labels', None)
-        if not self.datatype.startswith('train') and 'labels' in action:
+        if ((not self.datatype.startswith('train') or 'evalmode' in self.datatype)
+            and 'labels' in action):
             # move labels to eval field so not used for training
             # but this way the model can use the labels for perplexity or loss
             labels = action.pop('labels')


### PR DESCRIPTION
You can then call  eval_model  with datatype='train:evalmode' and the model will evaluate
This is useful to measure the training error!
 (Without this change, the label will be visible in the observe message, and some models might start using that/ training on it, depending on their code.)