### PR TITLE
Enables setting Daily Work Time Limitation by workers

### DIFF
--- a/docs/source/tutorial_mturk.rst
+++ b/docs/source/tutorial_mturk.rst
@@ -145,6 +145,9 @@ Additional flags can be used for more specific purposes.
 
 - ``--max-connections`` controls the number of HITs can be launched at the same time. If not specified, it defaults to 30; 0 is unlimited.
 
+- ``--max-time`` sets a maximum limit in seconds for how many seconds per day a specific worker can work on your task. Data is logged to ``working_time.pickle``, so all runs on the same machine will share the daily work logs.
+
+- ``--max-time-qual`` sets the specific qualification name for the max-time soft block. Using this can allow you to limit worker time between separate machines where ``working_time.pickle`` isn't shared
 
 Handling Turker Disconnects
 ---------------------------

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -183,6 +183,16 @@ class ParlaiParser(argparse.ArgumentParser):
             help='Run the server locally on this server rather than setting up'
                  ' a heroku server.'
         )
+        mturk.add_argument(
+            '--max-time', dest='max_time', default=0,
+            help='Maximum number of seconds per day that a worker is allowed '
+                 'to work on this assignment'
+        )
+        mturk.add_argument(
+            '--max-time-qual', dest='max_time_qual', default='',
+            help='Qualification to use to share the maximum time requirement '
+                 'with other runs from other machines.'
+        )
 
         mturk.set_defaults(is_sandbox=True)
         mturk.set_defaults(is_debug=False)

--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -48,6 +48,7 @@ class MTurkAgent(Agent):
         self.task_group_id = manager.task_group_id
         self.message_request_time = None
         self.recieved_packets = {}
+        self.creation_time = time.time()
 
         self.msg_queue = Queue()
 

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -37,6 +37,8 @@ MAX_DISCONNECTS = 30
 DISCONNECT_PERSIST_LENGTH = 60 * 60 * 24
 
 DISCONNECT_FILE_NAME = 'disconnects.pickle'
+TIME_LOGS_FILE_NAME = 'working_time.pickle'
+TIME_LOGS_FILE_LOCK = 'working_time.lock'
 
 AMAZON_SNS_NAME = 'AmazonMTurk'
 SNS_ASSIGN_ABANDONDED = 'AssignmentAbandoned'
@@ -76,6 +78,7 @@ class MTurkManager():
         )
         self.minimum_messages = opt.get('min_messages', 0)
         self.auto_approve_delay = opt.get('auto_approve_delay', 4*7*24*3600)
+        self.has_time_limit = opt.get('max_time', 0) != 0
         self.socket_manager = None
         self.is_test = is_test
         self.is_unique = False
@@ -98,11 +101,73 @@ class MTurkManager():
         self._load_disconnects()
         self.assignment_to_worker_id = {}
         self.qualifications = None
+        self.time_limit_checked = time.time()
+        self.time_blocked_workers = []
 
     def _init_logs(self):
         """Initialize logging settings from the opt"""
         shared_utils.set_is_debug(self.opt['is_debug'])
         shared_utils.set_log_level(self.opt['log_level'])
+
+    def _reset_time_logs(self, force=False):
+        # Uses a weak lock file to try to prevent clobbering between threads
+        file_path = os.path.join(parent_dir, TIME_LOGS_FILE_NAME)
+        file_lock = os.path.join(parent_dir, TIME_LOGS_FILE_LOCK)
+        while os.path.exists(file_lock):
+            time.sleep(shared_utils.THREAD_SHORT_SLEEP)
+        try:
+            open(file_lock, 'a').close()
+            if os.path.exists(file_path):
+                with open(file_path, 'rb+') as time_log_file:
+                    existing_times = pickle.load(time_log_file)
+                    if time.time() - existing_times['last_reset'] < 360:
+                        # no need to reset, another thread did recently
+                        os.remove(file_lock)
+                        return
+
+                # Reset the time logs
+                os.remove(file_path)
+
+            # new time logs
+            with open(file_path, 'wb+') as time_log_file:
+                time_logs = {'last_reset': time.time()}
+                pickle.dump(time_logs, time_log_file, pickle.HIGHEST_PROTOCOL)
+
+            os.remove(file_lock)
+        except Exception as e:
+            if os.path.exists(file_lock):
+                os.remove(file_lock)
+            raise e
+
+    def _log_working_time(self, mturk_worker):
+        additional_time = time.time() - mturk_worker.creation_time
+        worker_id = mturk_worker.worker_id
+        file_path = os.path.join(parent_dir, TIME_LOGS_FILE_NAME)
+        file_lock = os.path.join(parent_dir, TIME_LOGS_FILE_LOCK)
+        if not os.path.exists(file_path):
+            self._reset_time_logs()
+        while os.path.exists(file_lock):
+            time.sleep(shared_utils.THREAD_SHORT_SLEEP)
+        try:
+            open(file_lock, 'a').close()
+            with open(file_path, 'rb+') as time_log_file:
+                existing_times = pickle.load(time_log_file)
+                total_work_time = existing_times.get(worker_id, 0)
+                total_work_time += additional_time
+                existing_times[worker_id] = total_work_time
+            os.remove(file_path)
+            with open(file_path, 'wb+') as time_log_file:
+                pickle.dump(existing_times, time_log_file,
+                            pickle.HIGHEST_PROTOCOL)
+            os.remove(file_lock)
+        except Exception as e:
+            if os.path.exists(file_lock):
+                os.remove(file_lock)
+            raise e
+
+        if total_work_time > int(self.opt.get('max_time')):
+            self.give_worker_qualification(worker_id,
+                                           self.max_time_qual, 0)
 
     def _load_disconnects(self):
         """Load disconnects from file, populate the disconnects field for any
@@ -641,6 +706,21 @@ class MTurkManager():
             )
         )
 
+    def _free_time_blocked_workers(self):
+        for worker_id in self.time_blocked_workers:
+            self.remove_worker_qualification(
+                worker_id, self.max_time_qual, 'Daily time limit reset.')
+
+    def _check_time_limit(self):
+        if time.time() - self.time_limit_checked < 360:  # less than an hour
+            return
+        if int(time.time()) % (60*60*24) > 180:
+            # sync the time resets to ONCE DAILY in a 3 minute window
+            return
+        self.time_limit_checked = time.time()
+        self._reset_time_logs()
+        self._free_time_blocked_workers()
+
     # Manager Lifecycle Functions #
 
     def setup_server(self, task_directory_path=None):
@@ -904,6 +984,8 @@ class MTurkManager():
                             self.create_additional_hits(1)
 
         while True:
+            if self.has_time_limit:
+                self._check_time_limit()
             # Loop forever starting task worlds until desired convos are had
             with self.worker_pool_change_condition:
                 valid_workers = self._get_unique_pool(eligibility_function)
@@ -975,6 +1057,7 @@ class MTurkManager():
             if self.opt['unique_worker']:
                 mturk_utils.delete_qualification(self.unique_qual_id,
                                                  self.is_sandbox)
+            self._free_time_blocked_workers()
             self._save_disconnects()
 
     # MTurk Agent Interaction Functions #
@@ -1092,6 +1175,8 @@ class MTurkManager():
                 )
             if not worker.state.is_final():
                 worker.state.status = AssignState.STATUS_DONE
+            if self.has_time_limit:
+                self._log_working_time(worker)
 
     def free_workers(self, workers):
         """End completed worker threads"""
@@ -1137,6 +1222,28 @@ class MTurkManager():
             assert block_qual_id is not None, (
                 'Hits could not be created as block qualification could not be'
                 ' acquired. Shutting down server.'
+            )
+            qualifications.append({
+                'QualificationTypeId': block_qual_id,
+                'Comparator': 'DoesNotExist',
+                'RequiredToPreview': True
+            })
+
+        if self.has_time_limit:
+            block_qual_name = '{}-max-daily-time'.format(self.task_group_id)
+            if self.opt.get('max_time_qual') != '':
+                block_qual_name = self.opt.get('max_time_qual')
+            self.max_time_qual = block_qual_name
+            block_qual_id = mturk_utils.find_or_create_qualification(
+                block_qual_name,
+                'A soft ban from working on this HIT or HITs by this '
+                'requester based on a maximum amount of daily work time set '
+                'by the requester.',
+                self.is_sandbox,
+            )
+            assert block_qual_id is not None, (
+                'Hits could not be created as a time block qualification could'
+                ' not be acquired. Shutting down server.'
             )
             qualifications.append({
                 'QualificationTypeId': block_qual_id,

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -118,12 +118,13 @@ class MTurkManager():
         try:
             open(file_lock, 'a').close()
             if os.path.exists(file_path):
-                with open(file_path, 'rb+') as time_log_file:
-                    existing_times = pickle.load(time_log_file)
-                    if time.time() - existing_times['last_reset'] < 360:
-                        # no need to reset, another thread did recently
-                        os.remove(file_lock)
-                        return
+                if not force:
+                    with open(file_path, 'rb+') as time_log_file:
+                        existing_times = pickle.load(time_log_file)
+                        if time.time() - existing_times['last_reset'] < 360:
+                            # no need to reset, another thread did recently
+                            os.remove(file_lock)
+                            return
 
                 # Reset the time logs
                 os.remove(file_path)


### PR DESCRIPTION
Adds two new flags, `--max-time` which is the maximum daily time in seconds (0 is no limit) per worker, and `--max-time-qual` which is the qualification that will be used for logging whether a worker has gotten above the limit (defaults to `<task-group-id>-max-daily-time`). 

With `max_time` set to anything > 0 there's some extra logic that gets activated in `MTurkManager`. 

Worker time starts clocking at the beginning of onboarding and finishes when the worker is shown the "mark hit as complete" button. All of this is logged to a pickle file that is shared between threads. (Writing to that file is lightly blocked using a `.lock` file.)

On shutdown of a task, the workers that have been blocked by a specific task will be freed, however if they work on another task that day they'll be blocked by that thread for going over the limit upon completion.

Log files are reset *once daily* by whichever process gets to do it first. This is handled in the `_reset_time_logs` function.