### PR TITLE
Making it possible to determine the split location in long messages

### DIFF
--- a/parlai/messenger/core/message_sender.py
+++ b/parlai/messenger/core/message_sender.py
@@ -73,6 +73,11 @@ def create_text_message(text, quick_replies=None):
             )
         )
     for i in range(len(tokens)):
+        if tokens[i] == '[*SPLIT*]':
+            if ' '.join(tokens[cutoff:i-1]).strip() != '':
+                splits.append(_message(' '.join(tokens[cutoff:i-1]), None))
+                cutoff = i + 1
+                curr_length = 0
         if (curr_length + len(tokens[i]) > MAX_TEXT_CHARS):
             splits.append(_message(' '.join(tokens[cutoff:i]), None))
             cutoff = i + 1


### PR DESCRIPTION
Slight quality of life improvement for the messenger manager. Putting `[*SPLIT*]` as a token in the text ensures a message break.