### PR TITLE
eval_wordstat script to get word freq and average length statistics

### DIFF
--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -106,7 +106,6 @@ class Seq2seq(nn.Module):
                     cand_preds, cand_scores = self.ranker.forward(cands, valid_cands, decode_params=decode_params)
             else:
                 cand_preds, cand_scores = self.ranker.forward(cands, valid_cands, decode_params=decode_params)
-
         if ys is not None:
             y_in = ys.narrow(1, 0, ys.size(1) - 1)
             xs = torch.cat([starts, y_in], 1)

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -81,3 +81,6 @@ class TensorboardLogger(Shared):
         :return:
         """
         self.writer.add_histogram(name, vector, step)
+
+    def add_text(self, name, text, step=None):
+        self.writer.add_text(name, text, step)

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -25,28 +25,56 @@ class TensorboardLogger(Shared):
     @staticmethod
     def add_cmdline_args(argparser):
         logger = argparser.add_argument_group('Tensorboard Arguments')
-        logger.add_argument('-tblog', '--tensorboard-log', type=bool, default=False,
-                           help="Tensorboard logging of metrics")
-        logger.add_argument('-tbtag', '--tensorboard-tag', type=str, default=None,
-                           help='Specify all opt keys which you want to be presented in in TB name')
-        logger.add_argument('-tbmetrics', '--tensorboard-metrics', type=str, default=None,
-                           help="Specify metrics which you want to track, it will be extracrted from report dict.")
+        logger.add_argument(
+            '-tblog',
+            '--tensorboard-log',
+            type=bool,
+            default=False,
+            help="Tensorboard logging of metrics")
+        logger.add_argument(
+            '-tbtag',
+            '--tensorboard-tag',
+            type=str,
+            default=None,
+            help=
+            'Specify all opt keys which you want to be presented in in TB name'
+        )
+        logger.add_argument(
+            '-tbmetrics',
+            '--tensorboard-metrics',
+            type=str,
+            default=None,
+            help=
+            "Specify metrics which you want to track, it will be extracrted from report dict."
+        )
+        logger.add_argument(
+            '-tgcomment',
+            '--tensorboard-comment',
+            type=str,
+            default='',
+            help='Add any line here to distinguish your TB event file, optional'
+        )
+
     def __init__(self, opt):
         Shared.__init__(self)
         try:
             from tensorboardX import SummaryWriter
         except ModuleNotFoundError:
-            raise ModuleNotFoundError('Please `pip install tensorboardX` for logs with TB.')
+            raise ModuleNotFoundError(
+                'Please `pip install tensorboardX` for logs with TB.')
         if opt['tensorboard_tag'] == None:
             tensorboard_tag = opt['starttime']
         else:
-            tensorboard_tag = opt['starttime'] + '_'.join(
-                [i + '-' + str(opt[i]) for i in opt['tensorboard_tag'].split(',')])
+            tensorboard_tag = opt['starttime'] + '_'.join([
+                i + '-' + str(opt[i])
+                for i in opt['tensorboard_tag'].split(',')
+            ]) + '_' + opt['tensorboard_comment']
 
         tbpath = os.path.join(opt['datapath'], 'tensorboard')
         if not os.path.exists(tbpath):
             os.makedirs(tbpath)
-        self.writer = SummaryWriter(log_dir='{}/{}'.format(tbpath, tensorboard_tag))
+        self.writer = SummaryWriter(
+            log_dir='{}/{}'.format(tbpath, tensorboard_tag))
         if opt['tensorboard_metrics'] == None:
             self.tbmetrics = ['ppl', 'loss']
         else:
@@ -62,8 +90,10 @@ class TensorboardLogger(Shared):
         """
         for met in self.tbmetrics:
             if met in report.keys():
-                self.writer.add_scalar("{}/{}".format(setting, met), report[met],
-                                       global_step=step)
+                self.writer.add_scalar(
+                    "{}/{}".format(setting, met),
+                    report[met],
+                    global_step=step)
 
     def add_scalar(self, name, y, step=None):
         """

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -25,35 +25,14 @@ class TensorboardLogger(Shared):
     @staticmethod
     def add_cmdline_args(argparser):
         logger = argparser.add_argument_group('Tensorboard Arguments')
-        logger.add_argument(
-            '-tblog',
-            '--tensorboard-log',
-            type=bool,
-            default=False,
-            help="Tensorboard logging of metrics")
-        logger.add_argument(
-            '-tbtag',
-            '--tensorboard-tag',
-            type=str,
-            default=None,
-            help=
-            'Specify all opt keys which you want to be presented in in TB name'
-        )
-        logger.add_argument(
-            '-tbmetrics',
-            '--tensorboard-metrics',
-            type=str,
-            default=None,
-            help=
-            "Specify metrics which you want to track, it will be extracrted from report dict."
-        )
-        logger.add_argument(
-            '-tgcomment',
-            '--tensorboard-comment',
-            type=str,
-            default='',
-            help='Add any line here to distinguish your TB event file, optional'
-        )
+        logger.add_argument('-tblog', '--tensorboard-log', type=bool, default=False,
+                            help="Tensorboard logging of metrics")
+        logger.add_argument('-tbtag', '--tensorboard-tag', type=str, default=None,
+                            help='Specify all opt keys which you want to be presented in in TB name')
+        logger.add_argument('-tbmetrics', '--tensorboard-metrics', type=str, default=None,
+                            help="Specify metrics which you want to track, it will be extracrted from report dict.")
+        logger.add_argument('-tgcomment', '--tensorboard-comment', type=str, default='',
+                            help='Add any line here to distinguish your TB event file, optional')
 
     def __init__(self, opt):
         Shared.__init__(self)

--- a/parlai/scripts/eval_wordstat.py
+++ b/parlai/scripts/eval_wordstat.py
@@ -53,9 +53,9 @@ def setup_args(parser=None):
 def get_word_stats(sequence, agent_dict, bins=[0, 100, 1000, 100000]):
     """
     Function which takes text sequence and dict, returns word freq and length statistics
-    :param sequence:
-    :param agent_dict:
-    :param bins:
+    :param sequence: text sequence
+    :param agent_dict: can be external dict or dict from the model
+    :param bins: list with range boundaries
     :return: freqs dictionary, num words, avg word length, avg char length
     """
     pred_list = sequence.split()

--- a/parlai/scripts/eval_wordstat.py
+++ b/parlai/scripts/eval_wordstat.py
@@ -119,6 +119,7 @@ def eval_model(opt, printargs=None, print_parser=None):
     cnt = 0
     mean_length = []
     freqs_cnt = Counter()
+    word_cnt = 0
     bins = [int(i) for i in opt['freq_bins'].split(',')]
 
     while not world.epoch_done():
@@ -128,7 +129,7 @@ def eval_model(opt, printargs=None, print_parser=None):
         pred_vec = agent.dict.txt2vec(prediction)
 
         freqs, _cnt, length = get_word_stats(pred_vec, agent.dict, bins=bins)
-        cnt += _cnt
+        word_cnt += _cnt
 
         mean_length.append(length)
 
@@ -139,10 +140,10 @@ def eval_model(opt, printargs=None, print_parser=None):
             print(str(int(tot_time)) + "s elapsed: " + str(world.report()))
             log_time.reset()
             if opt['display_freq'] is True:
-                stat_str = 'w: {}, '.format(cnt) + ', '.join([
+                stat_str = 'w: {}, '.format(word_cnt) + ', '.join([
                     '<{}:{} ({:.{prec}f}%)'.format(
                         b,
-                        freqs_cnt.get(b, 0), (freqs_cnt.get(b, 0) / cnt) * 100,
+                        freqs_cnt.get(b, 0), (freqs_cnt.get(b, 0) / word_cnt) * 100,
                         prec=2) for b in bins
                 ])
                 print("Word statistics: {}, avg.length: {:.{prec}f}wrd".format(stat_str, numpy.array(mean_length).mean(), prec=2))

--- a/parlai/scripts/eval_wordstat.py
+++ b/parlai/scripts/eval_wordstat.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+"""
+This helper script can be used alone with modelfile and task: the output will contain the
+word statistics of the model outputs.
+One can also use the function defined here in other places in order to get such statistic
+for any agent given the agent object (with corr. dict) and a sequence.
+
+Example:
+    python eval_wordstat.py -mf data/model -t convai2:self
+
+One can specify bins boundaries with argument -fb | --freq-bins 10,100,1000 or so
+
+Also function get_word_stats can be used in other parts of runtime code since it depends only on
+the agent object. To use it - firstly do the import:
+
+    from parlai.scripts.eval_wordstat import get_word_stats
+
+then you can call this function like this:
+
+    reqs, cnt = get_word_stats(predictions.tolist(), self.dict)
+"""
+
+from parlai.core.params import ParlaiParser
+from parlai.core.agents import create_agent
+from parlai.core.worlds import create_task
+from parlai.core.utils import Timer
+from collections import Counter
+
+import random
+import numpy
+
+
+def setup_args(parser=None):
+    if parser is None:
+        parser = ParlaiParser(True, True)
+    # Get command line arguments
+    parser.add_argument('-ne', '--num-examples', type=int, default=-1)
+    parser.add_argument('-d', '--display-freq', type='bool', default=True)
+    parser.add_argument('-ltim', '--log-every-n-secs', type=float, default=2)
+    parser.add_argument(
+        '-fb',
+        '--freq-bins',
+        type=str,
+        default='100,1000',
+        help='Bins boundaries for rare words stat')
+    parser.set_defaults(datatype='valid')
+    return parser
+
+
+def get_word_stats(sequence, agent_dict, bins=[100,1000,100000]):
+    """
+
+    :param sequence: input sequence to analyze
+    :param agent_dict: dictionary where we take freqs from
+    :return:
+    """
+    lengths = None
+    if any(isinstance(i, list) for i in sequence):
+        lengths = [len(l) for l in sequence]
+        sequence = [item for sublist in sequence for item in sublist]
+    pred_str = agent_dict.vec2txt(sequence)
+    pred_list = pred_str.split()
+    pred_freq = [agent_dict.freq[word] for word in pred_list]
+    freqs = {i: 0 for i in bins}
+    for f in pred_freq:
+        for b in bins:
+            if f <= b:
+                freqs[b] += 1
+                break
+    if lengths:
+        length = numpy.ndarray(lengths).mean()
+    else:
+        length = len(pred_list)
+    return freqs, len(pred_freq), length
+
+
+def eval_model(opt, printargs=None, print_parser=None):
+    """Evaluates a model.
+
+    Arguments:
+    opt -- tells the evaluation function how to run
+    print_parser -- if provided, prints the options that are set within the
+        model after loading the model
+    """
+    if printargs is not None:
+        print('[ Deprecated Warning: eval_model no longer uses `printargs` ]')
+        print_parser = printargs
+    if print_parser is not None:
+        if print_parser is True and isinstance(opt, ParlaiParser):
+            print_parser = opt
+        elif print_parser is False:
+            print_parser = None
+    if isinstance(opt, ParlaiParser):
+        print(
+            '[ Deprecated Warning: eval_model should be passed opt not Parser ]'
+        )
+        opt = opt.parse_args()
+
+    random.seed(42)
+
+    # Create model and assign it to the specified task
+    agent = create_agent(opt, requireModelExists=True)
+    world = create_task(opt, agent)
+
+    if print_parser:
+        # Show arguments after loading model
+        print_parser.opt = agent.opt
+        print_parser.print_args()
+    log_every_n_secs = opt.get('log_every_n_secs', -1)
+    if log_every_n_secs <= 0:
+        log_every_n_secs = float('inf')
+    log_time = Timer()
+    tot_time = 0
+
+    cnt = 0
+    mean_length = 0
+    freqs_cnt = Counter()
+    bins = [int(i) for i in opt['freq_bins'].split(',')]
+
+    while not world.epoch_done():
+        cnt += 1
+        world.parley()
+        prediction = world.display().split('\n')[-1].split(':')[-1]
+        pred_vec = agent.dict.txt2vec(prediction)
+
+        freqs, _cnt, length = get_word_stats(pred_vec, agent.dict, bins=bins)
+        cnt += _cnt
+        if mean_length == 0:
+            mean_length = length
+        else:
+            mean_length = (mean_length + length) / 2
+        freqs_cnt += Counter(freqs)
+
+        if log_time.time() > log_every_n_secs:
+            tot_time += log_time.time()
+            print(str(int(tot_time)) + "s elapsed: " + str(world.report()))
+            log_time.reset()
+            if opt['display_freq'] is True:
+                stat_str = 'w: {}, '.format(cnt) + ', '.join([
+                    '<{}:{} ({:.{prec}f}%)'.format(
+                        b,
+                        freqs_cnt.get(b, 0), (freqs_cnt.get(b, 0) / cnt) * 100,
+                        prec=2) for b in bins
+                ])
+                print("Word statistics: {}, avg.length: {:.{prec}f}wrd".format(stat_str, mean_length, prec=2))
+        if opt['num_examples'] > 0 and cnt >= opt['num_examples']:
+            break
+    if world.epoch_done():
+        print("EPOCH DONE")
+    report = world.report()
+    print(report)
+    return report
+
+
+if __name__ == '__main__':
+    parser = setup_args()
+    eval_model(parser.parse_args(print_args=False), print_parser=parser)

--- a/parlai/scripts/eval_wordstat.py
+++ b/parlai/scripts/eval_wordstat.py
@@ -72,7 +72,7 @@ def get_word_stats(sequence, agent_dict, bins=[100,1000,100000]):
                 freqs[b] += 1
                 break
     if lengths:
-        length = numpy.ndarray(lengths).mean()
+        length = numpy.array(lengths).mean()
     else:
         length = len(pred_list)
     return freqs, len(pred_freq), length
@@ -117,7 +117,7 @@ def eval_model(opt, printargs=None, print_parser=None):
     tot_time = 0
 
     cnt = 0
-    mean_length = 0
+    mean_length = []
     freqs_cnt = Counter()
     bins = [int(i) for i in opt['freq_bins'].split(',')]
 
@@ -129,10 +129,9 @@ def eval_model(opt, printargs=None, print_parser=None):
 
         freqs, _cnt, length = get_word_stats(pred_vec, agent.dict, bins=bins)
         cnt += _cnt
-        if mean_length == 0:
-            mean_length = length
-        else:
-            mean_length = (mean_length + length) / 2
+
+        mean_length.append(length)
+
         freqs_cnt += Counter(freqs)
 
         if log_time.time() > log_every_n_secs:
@@ -146,7 +145,7 @@ def eval_model(opt, printargs=None, print_parser=None):
                         freqs_cnt.get(b, 0), (freqs_cnt.get(b, 0) / cnt) * 100,
                         prec=2) for b in bins
                 ])
-                print("Word statistics: {}, avg.length: {:.{prec}f}wrd".format(stat_str, mean_length, prec=2))
+                print("Word statistics: {}, avg.length: {:.{prec}f}wrd".format(stat_str, numpy.array(mean_length).mean(), prec=2))
         if opt['num_examples'] > 0 and cnt >= opt['num_examples']:
             break
     if world.epoch_done():


### PR DESCRIPTION
eval_wordstat script helps to get word freq and average length statistics from the model predictions.

Can be used as a stand-alone script or as a function get_word_stat() in any other place where agent dict is available.

+ some additions for tb logger