### PR TITLE
[MTurk] Optionally banning mobile

### DIFF
--- a/parlai/mturk/core/server/html/core.html
+++ b/parlai/mturk/core/server/html/core.html
@@ -142,6 +142,11 @@
   var cur_agent_id = "{{cur_agent_id}}" || null;
   var task_description = null;
 
+  var is_mobile = false;
+  var block_mobile = true;
+  if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+    is_mobile = true;
+  }
 
   /* ============== Priority Queue Data Structure ============== */
 
@@ -439,7 +444,16 @@
   function init_cover_page() {
     $("div#ui-placeholder").css("display", "none");
     $("div#ui-content").css("display", "");
-    $("span#task-description").html(task_description);
+    if (is_mobile && block_mobile) {
+      full_task_desc = (
+        "<h1>Sorry, this task cannot be completed on mobile devices. " +
+        "Please use a computer.</h1><br>Task Description follows:<br>" +
+        task_description
+      );
+      $("span#task-description").html(full_task_desc);
+    } else {
+      $("span#task-description").html(task_description);
+    }
   }
 
   // Renders the chat panel
@@ -880,7 +894,15 @@
         if (is_cover_page) {
           init_cover_page();
         } else {
-          init_chat_page();
+          if (block_mobile && is_mobile) {
+            $("div#ui-placeholder").html(
+              "As noted in the task description, this task doesn't work " +
+              "on mobile yet. Please return it and only work on it from a " +
+              "full-screen device."
+            );
+          } else {
+            init_chat_page();
+          }
         }
       });
     } else {


### PR DESCRIPTION
It's now possible to ban mobile devices from working on a task. The default is no mobile, and the outcome is being unable to work on a task. Tasks can individually enable mobile usage by overriding the javascript and then setting `block_mobile = false;`

Mobile Allowed (and how things used to be, pretty bad):
![35238263_226991131365217_8936559008500678656_n](https://user-images.githubusercontent.com/1276867/41434622-61e67a80-6fea-11e8-87a2-27e413a07e05.jpg)
![35325188_226991114698552_4272104639622545408_n](https://user-images.githubusercontent.com/1276867/41434623-61f81510-6fea-11e8-9f3c-89877c9fee4a.jpg)
![35236671_226991161365214_4920653411512221696_n](https://user-images.githubusercontent.com/1276867/41434624-6209b0c2-6fea-11e8-8dac-7559c5eff44c.jpg)

Mobile blocked:
![35268949_226991208031876_6464080274748604416_n](https://user-images.githubusercontent.com/1276867/41434632-6dd816be-6fea-11e8-885f-dd325dd1613f.jpg)
![35333137_226991234698540_8929348381180952576_n](https://user-images.githubusercontent.com/1276867/41434633-6de86190-6fea-11e8-927b-7d6202a119fb.jpg)

Desktop still works when mobile is blocked:
![screen shot 2018-06-14 at 3 23 06 pm](https://user-images.githubusercontent.com/1276867/41434644-73a56f06-6fea-11e8-8ef0-624d1c5a9d51.png)


