### PR TITLE
[MTurk] Separating block qualifications for disconnects and soft blocks

### DIFF
--- a/docs/source/tutorial_mturk.rst
+++ b/docs/source/tutorial_mturk.rst
@@ -153,7 +153,7 @@ Handling Turker Disconnects
 ---------------------------
 Sometimes you may find that a task you have created is leading to a lot of workers disconnecting in the middle of a conversation, or that a few people are disconnecting repeatedly. ParlAI MTurk offers two kinds of blocks to stop these workers from doing your hits.
 
-- soft blocks can be created by using the ``--block-qualification <name>`` flag with a name that you want to associate to your ParlAI tasks. Any user that hits the disconnect cap for a HIT with this flag active will not be able to participate in any HITs using this flag.
+- soft blocks can be created by using the ``--disconnect-qualification <name>`` flag with a name that you want to associate to your ParlAI tasks. Any user that hits the disconnect cap for a HIT with this flag active will not be able to participate in any HITs using this flag.
 
 - hard blocks can be used by setting the ``--hard-block`` flag. Soft blocks in general are preferred, as Turkers can be block-averse (as it may affect their reputation) and sometimes the disconnects are out of their control. This will prevent any Turkers that hit the disconnect cap with this flag active from participating in any of your future HITs of any type.
 
@@ -173,7 +173,7 @@ Approving Work
 ^^^^^^^^^^^^^^
 
 - Unless you explicitly set the flag `—auto-approve-delay` or approve the agents work by calling `mturk_agent.approve_work()`, work will be auto approved after 30 days; workers generally like getting paid sooner than this so set the `auto_approve_delay` to be shorter when possible.
-- Occasionally Turkers will take advantage of getting paid immediately without review if you auto approve their work by calling `mturk_agent.approve_work()` at the close of the task. If you aren't using any kind of validation before you `approve_work` or if you don't intend to review the work manually, consider setting the `—auto-approve-delay` flag rather than approving immediately.
+- Occasionally Turkers will take advantage of getting paid immediately without review if you auto approve their work by calling `mturk_agent.approve_work()` at the close of the task. If you aren't using any kind of validation before you `approve_work` or if you don't intend to review the work manually, consider setting the `—-auto-approve-delay` flag rather than approving immediately.
 
 Rejecting Work
 ^^^^^^^^^^^^^^
@@ -185,12 +185,12 @@ Soft-blocking vs. Hard-blocking
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Hard block sparingly; it's possible workers that aren't doing well on a particular task are perfectly good at others. Hard blocking reduces your possible worker pool.
-- Soft blocking workers that are clearly trying on a task but not **quite** getting it allows those workers to work on other tasks for you in the future. You can soft block workers by calling `mturk_manager.soft_block_worker(<worker id>)` after setting `—block-qualification`. That worker will not be able to work on any tasks that use the same `—block-qualification`.
+- Soft blocking workers that are clearly trying on a task but not **quite** getting it allows those workers to work on other tasks for you in the future. You can soft block workers by calling `mturk_manager.soft_block_worker(<worker id>)` after setting `—-block-qualification`. That worker will not be able to work on any tasks that use the same `—-block-qualification`.
 
 Preventing and Handling Crashes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Set the `-—max-connections` flag sufficiently low for your task; this controls the number of people who can work on your task at any given time. Leaving this too high might leave your heroku server running into issues depending on how many messages per second it's trying to process, and on how much data is being sent in those messages (such as picture or video data).
+- Set the `--max-connections` flag sufficiently low for your task; this controls the number of people who can work on your task at any given time. Leaving this too high might leave your heroku server running into issues depending on how many messages per second it's trying to process, and on how much data is being sent in those messages (such as picture or video data).
 - If you're using a model on your local machine, try to share the model parameters whenever possible. Needing new parameters for each of your conversations might run your machine out of memory, causing the data collection to crash in an manner that ParlAI can't handle
 - If your task crashes, you'll need to run the `delete_hits` script and find the task that had crashed to remove the orphan tasks.
 - If workers email you about task crashes with sufficient evidence that they were working on the task, offer to compensate by sending them a bonus for the failed task on one of their other completed tasks, then bonus that `HITId` with the `bonus_workers` script.

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -149,11 +149,19 @@ class ParlaiParser(argparse.ArgumentParser):
             help='importance level for what to put into the logs. the lower '
                  'the level the more that gets logged. values are 0-50')
         mturk.add_argument(
-            '--block-qualification', dest='block_qualification', default='',
-            help='Qualification to use for soft blocking users. By default '
+            '--disconnect-qualification', dest='disconnect_qualification',
+            default='',
+            help='Qualification to use for soft blocking users for '
+                 'disconnects. By default '
                  'turkers are never blocked, though setting this will allow '
                  'you to filter out turkers that have disconnected too many '
                  'times on previous HITs where this qualification was set.')
+        mturk.add_argument(
+            '--block-qualification', dest='block_qualification', default='',
+            help='Qualification to use for soft blocking users. This '
+                 'qualification is granted whenever soft_block_worker is '
+                 'called, and can thus be used to filter workers out from a '
+                 'single task or group of tasks by noted performance.')
         mturk.add_argument(
             '--count-complete', dest='count_complete',
             default=False, action='store_true',

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -1250,9 +1250,9 @@ class MTurkManager():
         if self.opt['block_qualification'] != '':
             block_qual_id = mturk_utils.find_or_create_qualification(
                 self.opt['block_qualification'],
-                'A soft ban from using a ParlAI-created HIT due to frequent '
-                'disconnects from conversations, leading to negative '
-                'experiences for other Turkers and for the requester.',
+                'A soft ban from this ParlAI-created HIT at the requesters '
+                'discretion. Generally used to restrict how frequently a '
+                'particular worker can work on a particular task.',
                 self.is_sandbox,
             )
             assert block_qual_id is not None, (

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -245,8 +245,9 @@ class MTurkManager():
                         ),
                         True
                     )
-                elif self.opt['block_qualification'] != '':
-                    self.soft_block_worker(worker_id)
+                elif self.opt['disconnect_qualification'] != '':
+                    self.soft_block_worker(worker_id,
+                                           'disconnect_qualification')
                     shared_utils.print_and_log(
                         logging.INFO,
                         'Worker {} soft blocked - too many disconnects'.format(
@@ -1227,6 +1228,24 @@ class MTurkManager():
         if qualifications is None:
             qualifications = []
 
+        if self.opt['disconnect_qualification'] != '':
+            block_qual_id = mturk_utils.find_or_create_qualification(
+                self.opt['disconnect_qualification'],
+                'A soft ban from using a ParlAI-created HIT due to frequent '
+                'disconnects from conversations, leading to negative '
+                'experiences for other Turkers and for the requester.',
+                self.is_sandbox,
+            )
+            assert block_qual_id is not None, (
+                'Hits could not be created as disconnect qualification could '
+                'not be acquired. Shutting down server.'
+            )
+            qualifications.append({
+                'QualificationTypeId': block_qual_id,
+                'Comparator': 'DoesNotExist',
+                'RequiredToPreview': True
+            })
+
         # Add the soft block qualification if it has been specified
         if self.opt['block_qualification'] != '':
             block_qual_id = mturk_utils.find_or_create_qualification(
@@ -1430,17 +1449,19 @@ class MTurkManager():
             ''.format(worker_id, reason),
         )
 
-    def soft_block_worker(self, worker_id):
+    def soft_block_worker(self, worker_id, qual='block_qualification'):
         """Soft block a worker by giving the worker the block qualification"""
-        qual_name = self.opt['block_qualification']
-        assert qual_name != '', ('No block qualification has been specified')
+        qual_name = self.opt[qual]
+        assert qual_name != '', ('No qualification {} has been specified'
+                                 ''.format(qual))
         self.give_worker_qualification(worker_id, qual_name)
 
-    def un_soft_block_worker(self, worker_id):
+    def un_soft_block_worker(self, worker_id, qual='block_qualification'):
         """Remove a soft block from a worker by removing a block qualification
             from the worker"""
-        qual_name = self.opt['block_qualification']
-        assert qual_name != '', ('No block qualification has been specified')
+        qual_name = self.opt[qual]
+        assert qual_name != '', ('No qualification {} has been specified'
+                                 ''.format(qual))
         self.remove_worker_qualification(worker_id, qual_name)
 
     def give_worker_qualification(self, worker_id, qual_name, qual_value=None):


### PR DESCRIPTION
Generalizes `soft_block_worker` by pulling the requested qualification from `opt`. Adds a new qualification for `disconnect_qualification` which is now being used when a user has specified blocking workers due to disconnecting too frequently.