### PR TITLE
add new tokenizer to dict agent

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -307,7 +307,7 @@ class DictionaryAgent(Agent):
     @staticmethod
     def re_tokenize(text):
         """Find boundaries between word characters, newlines, and non-word
-        non-whitespace tokens (r'[\w\n]+ | [^\w\s]').
+        non-whitespace tokens (r'[\w\n]+ | [^\w\s] | \n').
 
         This splits along whitespace and punctuation and keeps the newline as
         a token in the returned list.
@@ -318,8 +318,7 @@ class DictionaryAgent(Agent):
     def split_tokenize(text):
         """Splits tokens based on whitespace after adding whitespace around
         punctuation.
-        This is old deprecated version which covers less punctuation but should
-        run faster.
+        Use re_tokenize if you want more robust handling of punctuation.
         """
         return (text.replace('.', ' . ')
                 .replace(',', ' , ').replace(';', ' ; ').replace(':', ' : ')

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -13,7 +13,7 @@ import numpy as np
 import os
 import re
 
-RETOK = re.compile(r'[\w\n]+|[^\w\s]', re.UNICODE)
+RETOK = re.compile(r'\w+|[^\w\s]|\n', re.UNICODE)
 
 def escape(s):
     """Replace potential special characters with escaped version.

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -42,7 +42,7 @@ def maintain_dialog_history(history, observation, reply='',
     if useReplies != 'none':
         if useReplies == 'model' or (useReplies == 'label_else_model' and
                                      len(history['labels']) == 0):
-            if reply != '':
+            if reply:
                 history['dialog'].extend(parse(reply, splitSentences))
         elif len(history['labels']) > 0:
             r = history['labels'][0]
@@ -196,7 +196,7 @@ class TimeLogger():
             if log["%done"] > 0:
                 log['time_left'] = str(int(self.tot_time / log['%done'] - self.tot_time)) + 's'
             z = '%.2f' % ( 100*log['%done'])
-            log['%done'] = str(z) + '%'  
+            log['%done'] = str(z) + '%'
         for k, v in report.items():
             if k not in log:
                 log[k] = v
@@ -737,13 +737,13 @@ def str_to_msg(txt, ignore_fields=[]):
         txt = txt.replace('\\n', '\n')
         txt = txt.replace('\PIPE', '|')
         return txt
-    
+
     def tolist(txt):
         vals = txt.split('|')
         for v in vals:
             v = tostr(v)
         return vals
-            
+
     def convert(key, value):
         if key == 'text' or key == 'id':
             return tostr(value)
@@ -773,7 +773,7 @@ def msg_to_str(msg, ignore_fields=[]):
         txt = txt.replace('\n', '\\n')
         txt = txt.replace('|', '\PIPE')
         return txt
-    
+
     def add_field(name, data):
         if name == 'reward' and data == 0:
             return ''

--- a/projects/convai2/build_dict.py
+++ b/projects/convai2/build_dict.py
@@ -28,6 +28,7 @@ def build_dict():
         dict_lower=True,
         dict_file=DICT_FINAL,
         dict_include_valid=True,
+        dict_tokenizer='split',
     )
     opt = parser.parse_args(args="")
     return main_build_dict(opt)

--- a/projects/convai2/eval_f1.py
+++ b/projects/convai2/eval_f1.py
@@ -16,6 +16,7 @@ def setup_args(parser=None):
         task='convai2:self:no_cands',
         datatype='valid',
         hide_labels=False,
+        dict_tokenizer='split',
     )
     return parser
 

--- a/projects/convai2/eval_hits.py
+++ b/projects/convai2/eval_hits.py
@@ -16,6 +16,7 @@ def setup_args(parser=None):
         task='convai2:self',
         datatype='valid',
         hide_labels=False,
+        dict_tokenizer='split',
     )
     return parser
 

--- a/projects/convai2/eval_ppl.py
+++ b/projects/convai2/eval_ppl.py
@@ -51,6 +51,7 @@ def setup_args(parser=None):
     parser.set_defaults(
         task='convai2:self:no_cands',
         datatype='valid',
+        dict_tokenizer='split',
     )
     return parser
 


### PR DESCRIPTION
This new tokenizer should be a better default for us. It is just a little bit slower, but does a significantly better job of tokenizing: splitting not just on whitespace and a few select punctuation items, but on all non-white-space and non-word-characters. It also includes newlines as a valid token.

In the below results:
- split is the current default, and shows behavior "\n\n" => []
- re recognizes newlines and shows "\n\n" => ["\n", "\n"]

## Speed comparisons

Building dictionary on twitter:
```
time python examples/build_dict.py -t twitter --dict-lower true -tok [split|re]

split: 1m43s, 1m37s  # 615715 tokens
re:    2m08s, 2m08s  # 366116 tokens; 
```

Building dictionary on convai2:self:
```
time py examples/build_dict.py -t convai2 -tok [split|re]

split:  8.5s, 8.7s,  7.6s # 18803 tokens
re:    10.1s, 8.9s, 10.1s # 18760 tokens
```

Building dictionary on squad:
```
time py examples/build_dict.py -t squad -tok [split|re]

split:  9.6s, 10.5s, 10.2s  # 139747 tokens
re:    12.2s, 13.3s, 13.0s  # 95875 tokens
```

Building dictionary on ubuntu:
```
time py examples/build_dict.py -t ubuntu -tok [split|re]

split: 1m37s, 1m20s, 1m26s # 1036179 tokens
re:    1m48s, 1m46s, 1m45s # 564105 tokens
```

Basically, the more varied punctuation the dataset has the more re reduces the total number of different tokens found (good!). Also, it adds newlines.

@stephenroller 