### PR TITLE
pytorch_teacher dataset loading update

### DIFF
--- a/docs/source/tutorial_worlds.rst
+++ b/docs/source/tutorial_worlds.rst
@@ -16,7 +16,7 @@ Overview
 If you are unfamiliar with the basics of displaying data or
 calling train or evaluate on a model, please first see
 the `getting started <tutorial_basic.html>`_ section.
-If you are interested in creating a task, please see 
+If you are interested in creating a task, please see
 `that section <tutorial_task.html>`_.
 
 This section will cover the details of:
@@ -29,7 +29,7 @@ This section will cover the details of:
 
 
 For all tasks one might make,
-there's one function we need to support for both hogwild and batching: ``share()``. 
+there's one function we need to support for both hogwild and batching: ``share()``.
 This function should provide whatever is needed to set up a "copy" of the original
 instance of the agent for either each row of a batch or each thread in hogwild.
 
@@ -417,10 +417,11 @@ specified above in the ``PytorchDataTeacher``. If you would like to specify your
 own ``collate_fn``, you can implement a static method ``collate`` in the **agent**
 to which you will be providing the data. This function takes one argument, ``batch``, which
 is a list of data items returned by your custom ``Dataset``, and returns a
-collated batch.
+collated batch. Alternatively, you can also implement the method in the **dataset**.
 
-3. Finally, you would need to specify the ``Dataset`` location on the command line
-in the following fashion: ``--dataset path.to.dataset:DatasetClassName``. If you
+3. Finally, you would need to specify the ``Dataset`` on the command line
+in the following fashion: ``--dataset dataset_task:DatasetClassName``, where
+``dataset_class`` is the agents file where your ``Dataset`` is written. If you
 name your custom dataset ``DefaultDataset``, then you do not need to specify the
 ``DatasetClassName``.
 
@@ -439,7 +440,7 @@ list of examples provided by the ``VQADataset``.
 3. Finally, to use the ``PytorchDataTeacher`` with the custom ``Dataset`` and
 ``collate``, run the following command::
 
-  python examples/train_model.py -m mlb_vqa -t pytorch_teacher --dataset parlai.tasks.vqa_v1.agents
+  python examples/train_model.py -m mlb_vqa -t pytorch_teacher --dataset vqa_v1
 
 PyTorch Batch Sorting and Squashing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -240,39 +240,6 @@ class LoaderProcess(Thread):
             return None
 
 
-def get_dataset_module(datasetname):
-    # get the module of the dataset
-    sp = datasetname.strip()
-    repo = 'parlai'
-    if sp.startswith('internal:'):
-        # To switch to local repo, useful for non-public projects
-        # (make a directory called 'parlai_internal' with your private agents)
-        repo = 'parlai_internal'
-        sp = sp[9:]
-    sp = sp.split(':')
-    if '.' in sp[0]:
-        module_name = sp[0]
-    else:
-        dataset = sp[0].lower()
-        module_name = "%s.tasks.%s.agents" % (repo, dataset)
-    if len(sp) > 1:
-        sp[1] = sp[1][0].upper() + sp[1][1:]
-        dataset = sp[1]
-        if '.' not in sp[0] and 'Dataset' not in dataset:
-            # Reformat from underscore to CamelCase and append "Dataset" to
-            # class name by default if a complete path is not given.
-            words = dataset.split('_')
-            teacher_name = ''
-            for w in words:
-                teacher_name += (w[0].upper() + w[1:])
-            dataset = teacher_name + "Dataset"
-    else:
-        dataset = "DefaultDataset"
-    my_module = importlib.import_module(module_name)
-    dataset_class = getattr(my_module, dataset)
-    return dataset_class
-
-
 # Default collate function (for how to prepare a batch)
 def default_collate(batch):
     new_batch = []

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -390,7 +390,6 @@ class PytorchDataTeacher(FixedDialogTeacher):
         dataset_name = opt.get('dataset')
         if dataset_name == 'StreamDataset':
             return StreamDataset, default_collate
-
         sp = dataset_name.strip()
         repo = 'parlai'
         if sp.startswith('internal:'):
@@ -403,7 +402,7 @@ class PytorchDataTeacher(FixedDialogTeacher):
             module_name = sp[0]
         else:
             dataset = sp[0].lower()
-            module_name = "%s.tasks.%s.agents" % (repo, dataset)
+            module_name = '{}.tasks.{}.agents'.format(repo, dataset)
         if len(sp) > 1:
             sp[1] = sp[1][0].upper() + sp[1][1:]
             dataset = sp[1]
@@ -414,9 +413,9 @@ class PytorchDataTeacher(FixedDialogTeacher):
                 teacher_name = ''
                 for w in words:
                     teacher_name += (w[0].upper() + w[1:])
-                dataset = teacher_name + "Dataset"
+                dataset = teacher_name + 'Dataset'
         else:
-            dataset = "DefaultDataset"
+            dataset = 'DefaultDataset'
         my_module = importlib.import_module(module_name)
         dataset_class = getattr(my_module, dataset)
 


### PR DESCRIPTION
You can now just specify `--dataset vqa_v1` rather than `--dataset parlai.tasks.agents.vqa_v1` when specifying the dataset for the pytorch data teacher