### PR TITLE
[Messenger] Fixing message sender splits

### DIFF
--- a/parlai/messenger/core/message_sender.py
+++ b/parlai/messenger/core/message_sender.py
@@ -75,12 +75,12 @@ def create_text_message(text, quick_replies=None):
     for i in range(len(tokens)):
         if tokens[i] == '[*SPLIT*]':
             if ' '.join(tokens[cutoff:i-1]).strip() != '':
-                splits.append(_message(' '.join(tokens[cutoff:i-1]), None))
+                splits.append(_message(' '.join(tokens[cutoff:i]), None))
                 cutoff = i + 1
                 curr_length = 0
         if (curr_length + len(tokens[i]) > MAX_TEXT_CHARS):
             splits.append(_message(' '.join(tokens[cutoff:i]), None))
-            cutoff = i + 1
+            cutoff = i
             curr_length = 0
         curr_length += len(tokens[i]) + 1
     if cutoff < len(tokens):


### PR DESCRIPTION
Turns out message splitting was suffering from an off-by-one error that I had carried over into the `[*SPLIT*]` feature, so now that error has been repaired in both locations.