### PR TITLE
Using more lenient timeouts until disconnects improved

### DIFF
--- a/parlai/mturk/core/server/html/core.html
+++ b/parlai/mturk/core/server/html/core.html
@@ -108,8 +108,8 @@
   var STATUS_INIT = 'init';
   var STATUS_SENT = 'sent';
   var SERVER_HEARTBEAT_TIMEOUT = 60000 // 60 Sec before we think manager died
-  var SOCKET_MAYBE_DEAD_TIMEOUT = 8000
-  var LOCAL_HEARTBEAT_TIMEOUT = 16000 // 16 Seconds before we assume we died
+  var SOCKET_MAYBE_DEAD_TIMEOUT = 16000
+  var LOCAL_HEARTBEAT_TIMEOUT = 30000 // 30 Seconds before we assume we died
 
   /* ================= State variables ================= */
 

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -160,7 +160,7 @@ class SocketManager():
                 Packet.TYPE_MESSAGE: 2}
 
     # Default time before socket deemed dead
-    DEF_SOCKET_TIMEOUT = 12
+    DEF_SOCKET_TIMEOUT = 30
 
     def __init__(self, server_url, port, alive_callback, message_callback,
                  socket_dead_callback, task_group_id,


### PR DESCRIPTION
After receiving some reports that workers are disconnecting much more frequently than we'd expect, I've been testing some new more lenient values for the disconnect timeouts. 

These are to be used in the meantime until I get a chance to implement the new disconnect system (Counting the number of heartbeats received from the routing server without receiving a heartbeat from the client rather than measuring pure time which is flakey on a two-hop system).