### PR TITLE
Ability to pull parlai config details from a parlai_internal file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 install:
     - pip install flake8
     - python setup.py develop
+    - pip install regex scipy sklearn  # tfidf-retriever dependencies
+    # pip install torch?
 before_script:
     # stop the build if there are Python syntax errors or undefined names
     - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/docs/source/tutorial_mturk.rst
+++ b/docs/source/tutorial_mturk.rst
@@ -163,7 +163,7 @@ Reviewing Turker's Work
 
 You can programmatically review work using the commands available in the `MTurkManager` class. See, for example, the  `review_work function <https://github.com/facebookresearch/ParlAI/blob/master/parlai/mturk/tasks/personachat/personachat_collect_personas/worlds.py/>`__ in the ``personachat_collect_personas`` task. In this task, HITs are automatically approved if they are deemed completed by the world.
 
-If you don't take any action in 4 weeks, all HITs will be auto-approved and Turkers will be paid.
+If you don't take any action in 1 week, all HITs will be auto-approved and Turkers will be paid.
 
 
 ParlAI-MTurk Tips and Tricks

--- a/parlai/agents/tfidf_retriever/tfidf_retriever.py
+++ b/parlai/agents/tfidf_retriever/tfidf_retriever.py
@@ -4,6 +4,15 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+try:
+    import regex
+    import scipy
+    import sklearn
+    import unicodedata
+except ModuleNotFoundError:
+    raise ModuleNotFoundError('Please `pip install regex scipy sklearn`'
+                              ' to use the tfidf_retriever agent.')
+
 from parlai.core.agents import Agent
 from parlai.core.utils import AttrDict
 from .doc_db import DocDB
@@ -16,8 +25,8 @@ from collections import deque
 import math
 import random
 import os
-import sqlite3
 import pickle
+import sqlite3
 
 
 class TfidfRetrieverAgent(Agent):
@@ -58,8 +67,8 @@ class TfidfRetrieverAgent(Agent):
         parser.add_argument(
             '--retriever-num-retrieved', default=5, type=int,
             help='How many docs to retrieve.')
-        parser.add_argument(	       
-            '--retriever-mode', choices=['keys', 'values'], default='values',	
+        parser.add_argument(
+            '--retriever-mode', choices=['keys', 'values'], default='values',
              help='Whether to retrieve the stored key or the stored value.'
         )
         parser.add_argument(

--- a/parlai/agents/tfidf_retriever/utils.py
+++ b/parlai/agents/tfidf_retriever/utils.py
@@ -11,7 +11,10 @@ import unicodedata
 import numpy as np
 import scipy.sparse as sp
 from sklearn.utils import murmurhash3_32
-import torch
+try:
+    import torch
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError('Need to install Pytorch: go to pytorch.org')
 
 
 # ------------------------------------------------------------------------------

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -167,14 +167,14 @@ class ParlaiParser(argparse.ArgumentParser):
                  'the level the more that gets logged. values are 0-50')
         mturk.add_argument(
             '--disconnect-qualification', dest='disconnect_qualification',
-            default='',
+            default=None,
             help='Qualification to use for soft blocking users for '
                  'disconnects. By default '
                  'turkers are never blocked, though setting this will allow '
                  'you to filter out turkers that have disconnected too many '
                  'times on previous HITs where this qualification was set.')
         mturk.add_argument(
-            '--block-qualification', dest='block_qualification', default='',
+            '--block-qualification', dest='block_qualification', default=None,
             help='Qualification to use for soft blocking users. This '
                  'qualification is granted whenever soft_block_worker is '
                  'called, and can thus be used to filter workers out from a '
@@ -214,7 +214,7 @@ class ParlaiParser(argparse.ArgumentParser):
                  'to work on this assignment'
         )
         mturk.add_argument(
-            '--max-time-qual', dest='max_time_qual', default='',
+            '--max-time-qual', dest='max_time_qual', default=None,
             help='Qualification to use to share the maximum time requirement '
                  'with other runs from other machines.'
         )

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -9,7 +9,7 @@ from parlai.core.dict import DictionaryAgent
 
 try:
     import torch
-except Exception as e:
+except ModuleNotFoundError as e:
     raise ModuleNotFoundError('Need to install Pytorch: go to pytorch.org')
 
 from collections import deque, namedtuple

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -626,7 +626,7 @@ class OffensiveLanguageDetector(object):
         return None
 
 
-def display_messages(msgs, prettify=False,ignore_fields=''):
+def display_messages(msgs, prettify=False, ignore_fields=''):
     """Returns a string describing the set of messages provided
     If prettify is true, candidates are displayed using prettytable.
     ignore_fields provides a list of fields in the msgs which should not be displayed.
@@ -730,12 +730,19 @@ def display_messages(msgs, prettify=False,ignore_fields=''):
     return '\n'.join(lines)
 
 
-def str_to_msg(txt, ignore_fields=[]):
+def str_to_msg(txt, ignore_fields=''):
+    """Convert formatted string to ParlAI message dict.
+
+    :param txt: formatted string to convert. String format is tab-separated
+        fields, with colon separating field name and contents.
+    :param ignore_fields: (default '') comma-separated field names to not
+        include in the msg dict even if they're in the string.
+    """
     def tostr(txt):
         txt = str(txt)
         txt = txt.replace('\\t', '\t')
         txt = txt.replace('\\n', '\n')
-        txt = txt.replace('\PIPE', '|')
+        txt = txt.replace('__PIPE__', '|')
         return txt
 
     def tolist(txt):
@@ -755,29 +762,37 @@ def str_to_msg(txt, ignore_fields=[]):
         else:
             return tostr(value)
 
-    if txt == '' or txt == None:
+    if txt == '' or txt is None:
         return None
+
     msg = {}
     for t in txt.split('\t'):
         ind = t.find(':')
         key = t[:ind]
         value = t[ind+1:]
-        if key not in ignore_fields:
+        if key not in ignore_fields.split(','):
             msg[key] = convert(key, value)
     return msg
 
-def msg_to_str(msg, ignore_fields=[]):
+
+def msg_to_str(msg, ignore_fields=''):
+    """Convert ParlAI message dict to string.
+
+    :param msg: dict to convert into a string.
+    :param ignore_fields: (default '') comma-separated field names to not
+        include in the string even if they're in the msg dict.
+    """
     def filter(txt):
         txt = str(txt)
         txt = txt.replace('\t', '\\t')
         txt = txt.replace('\n', '\\n')
-        txt = txt.replace('|', '\PIPE')
+        txt = txt.replace('|', '__PIPE__')
         return txt
 
     def add_field(name, data):
         if name == 'reward' and data == 0:
             return ''
-        if name == 'episode_done' and data == False:
+        if name == 'episode_done' and data is False:
             return ''
         txt = ''
         if type(data) == tuple or type(data) == set or type(data) == list:
@@ -790,8 +805,10 @@ def msg_to_str(msg, ignore_fields=[]):
             txt = filter(data)
         return name + ":" + txt + '\t'
 
-    default_fields = ['id', 'text', 'labels', 'label_candidates', 'episode_done', 'reward']
+    default_fields = ['id', 'text', 'labels', 'label_candidates',
+                      'episode_done', 'reward']
     txt = ""
+    ignore_fields = ignore_fields.split(',')
     for f in default_fields:
         if f in msg and f not in ignore_fields:
             txt += add_field(f, msg[f])

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -85,6 +85,13 @@ class MTurkManager():
         """Create an MTurkManager using the given setup opts and a list of
         agent_ids that will participate in each conversation
         """
+        try:
+            import parlai_internal.mturk.configs as local_configs
+            opt = local_configs.apply_default_opts(opt)
+        except Exception:
+            # not all users will be drawing configs from internal settings
+            pass
+        print(opt)
         self.opt = opt
         if self.opt['unique_worker'] or \
                 self.opt['unique_qual_name'] is not None:
@@ -246,7 +253,7 @@ class MTurkManager():
                         ),
                         True
                     )
-                elif self.opt['disconnect_qualification'] != '':
+                elif self.opt['disconnect_qualification'] is not None:
                     self.soft_block_worker(worker_id,
                                            'disconnect_qualification')
                     shared_utils.print_and_log(
@@ -1229,7 +1236,16 @@ class MTurkManager():
         if qualifications is None:
             qualifications = []
 
-        if self.opt['disconnect_qualification'] != '':
+        if not self.is_sandbox:
+            try:
+                import parlai_internal.mturk.configs as local_configs
+                qualifications = \
+                    local_configs.set_default_qualifications(qualifications)
+            except Exception:
+                # not all users will be drawing configs from internal settings
+                pass
+
+        if self.opt['disconnect_qualification'] is not None:
             block_qual_id = mturk_utils.find_or_create_qualification(
                 self.opt['disconnect_qualification'],
                 'A soft ban from using a ParlAI-created HIT due to frequent '
@@ -1248,7 +1264,7 @@ class MTurkManager():
             })
 
         # Add the soft block qualification if it has been specified
-        if self.opt['block_qualification'] != '':
+        if self.opt['block_qualification'] is not None:
             block_qual_id = mturk_utils.find_or_create_qualification(
                 self.opt['block_qualification'],
                 'A soft ban from this ParlAI-created HIT at the requesters '
@@ -1268,8 +1284,8 @@ class MTurkManager():
 
         if self.has_time_limit:
             block_qual_name = '{}-max-daily-time'.format(self.task_group_id)
-            if self.opt.get('max_time_qual') != '':
-                block_qual_name = self.opt.get('max_time_qual')
+            if self.opt['max_time_qual'] is not None:
+                block_qual_name = self.opt['max_time_qual']
             self.max_time_qual = block_qual_name
             block_qual_id = mturk_utils.find_or_create_qualification(
                 block_qual_name,
@@ -1452,17 +1468,17 @@ class MTurkManager():
 
     def soft_block_worker(self, worker_id, qual='block_qualification'):
         """Soft block a worker by giving the worker the block qualification"""
-        qual_name = self.opt[qual]
-        assert qual_name != '', ('No qualification {} has been specified'
-                                 ''.format(qual))
+        qual_name = self.opt.get(qual, None)
+        assert qual_name is not None, ('No qualification {} has been specified'
+                                       ''.format(qual))
         self.give_worker_qualification(worker_id, qual_name)
 
     def un_soft_block_worker(self, worker_id, qual='block_qualification'):
         """Remove a soft block from a worker by removing a block qualification
             from the worker"""
-        qual_name = self.opt[qual]
-        assert qual_name != '', ('No qualification {} has been specified'
-                                 ''.format(qual))
+        qual_name = self.opt.get(qual, None)
+        assert qual_name is not None, ('No qualification {} has been specified'
+                                       ''.format(qual))
         self.remove_worker_qualification(worker_id, qual_name)
 
     def give_worker_qualification(self, worker_id, qual_name, qual_value=None):

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -91,7 +91,7 @@ class MTurkManager():
         except Exception:
             # not all users will be drawing configs from internal settings
             pass
-        print(opt)
+
         self.opt = opt
         if self.opt['unique_worker'] or \
                 self.opt['unique_qual_name'] is not None:

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -276,7 +276,7 @@ def remove_worker_qualification(worker_id, qualification_id,
 def create_hit_type(hit_title, hit_description, hit_keywords, hit_reward,
                     assignment_duration_in_seconds, is_sandbox,
                     qualifications=None,
-                    auto_approve_delay=4*7*24*3600,  # default 4 weeks
+                    auto_approve_delay=7*24*3600,  # default 1 week
                     ):
     """Create a HIT type to be used to generate HITs of the requested params"""
     client = get_mturk_client(is_sandbox)

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -283,16 +283,16 @@ def create_hit_type(hit_title, hit_description, hit_keywords, hit_reward,
 
     # If the user hasn't specified a location qualification, we assume to
     # restrict the HIT to some english-speaking countries.
-    local_requirements = []
+    locale_requirements = []
     has_locale_qual = False
     if qualifications is not None:
         for q in qualifications:
             if q['QualificationTypeId'] == '00000000000000000071':
                 has_locale_qual
-        local_requirements += qualifications
+        locale_requirements += qualifications
 
     if not has_locale_qual:
-        local_requirements.append({
+        locale_requirements.append({
             'QualificationTypeId': '00000000000000000071',
             'Comparator': 'In',
             'LocaleValues': [
@@ -313,7 +313,7 @@ def create_hit_type(hit_title, hit_description, hit_keywords, hit_reward,
         Title=hit_title,
         Keywords=hit_keywords,
         Description=hit_description,
-        QualificationRequirements=local_requirements,
+        QualificationRequirements=locale_requirements,
     )
     hit_type_id = response['HITTypeId']
     return hit_type_id

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -276,26 +276,34 @@ def remove_worker_qualification(worker_id, qualification_id,
 def create_hit_type(hit_title, hit_description, hit_keywords, hit_reward,
                     assignment_duration_in_seconds, is_sandbox,
                     qualifications=None,
-                    auto_approve_delay=4*7*24*3600, # default 4 weeks
+                    auto_approve_delay=4*7*24*3600,  # default 4 weeks
                     ):
     """Create a HIT type to be used to generate HITs of the requested params"""
     client = get_mturk_client(is_sandbox)
 
-    # Create a qualification with Locale In('US', 'CA') requirement attached
-    localRequirements = [{
-        'QualificationTypeId': '00000000000000000071',
-        'Comparator': 'In',
-        'LocaleValues': [
-            {'Country': 'US'},
-            {'Country': 'CA'},
-            {'Country': 'GB'},
-            {'Country': 'AU'},
-            {'Country': 'NZ'}
-        ],
-        'RequiredToPreview': True
-    }]
+    # If the user hasn't specified a location qualification, we assume to
+    # restrict the HIT to some english-speaking countries.
+    local_requirements = []
+    has_locale_qual = False
     if qualifications is not None:
-        localRequirements += qualifications
+        for q in qualifications:
+            if q['QualificationTypeId'] == '00000000000000000071':
+                has_locale_qual
+        local_requirements += qualifications
+
+    if not has_locale_qual:
+        local_requirements.append({
+            'QualificationTypeId': '00000000000000000071',
+            'Comparator': 'In',
+            'LocaleValues': [
+                {'Country': 'US'},
+                {'Country': 'CA'},
+                {'Country': 'GB'},
+                {'Country': 'AU'},
+                {'Country': 'NZ'}
+            ],
+            'RequiredToPreview': True
+        })
 
     # Create the HIT type
     response = client.create_hit_type(
@@ -305,7 +313,7 @@ def create_hit_type(hit_title, hit_description, hit_keywords, hit_reward,
         Title=hit_title,
         Keywords=hit_keywords,
         Description=hit_description,
-        QualificationRequirements=localRequirements
+        QualificationRequirements=local_requirements,
     )
     hit_type_id = response['HITTypeId']
     return hit_type_id

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -288,7 +288,7 @@ def create_hit_type(hit_title, hit_description, hit_keywords, hit_reward,
     if qualifications is not None:
         for q in qualifications:
             if q['QualificationTypeId'] == '00000000000000000071':
-                has_locale_qual
+                has_locale_qual = True
         locale_requirements += qualifications
 
     if not has_locale_qual:

--- a/parlai/mturk/core/server/html/core.html
+++ b/parlai/mturk/core/server/html/core.html
@@ -108,8 +108,8 @@
   var STATUS_INIT = 'init';
   var STATUS_SENT = 'sent';
   var SERVER_HEARTBEAT_TIMEOUT = 60000 // 60 Sec before we think manager died
-  var SOCKET_MAYBE_DEAD_TIMEOUT = 8000
-  var LOCAL_HEARTBEAT_TIMEOUT = 16000 // 16 Seconds before we assume we died
+  var SOCKET_MAYBE_DEAD_TIMEOUT = 16000
+  var LOCAL_HEARTBEAT_TIMEOUT = 30000 // 30 Seconds before we assume we died
 
   /* ================= State variables ================= */
 

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -160,7 +160,7 @@ class SocketManager():
                 Packet.TYPE_MESSAGE: 2}
 
     # Default time before socket deemed dead
-    DEF_SOCKET_TIMEOUT = 12
+    DEF_SOCKET_TIMEOUT = 30
 
     def __init__(self, server_url, port, alive_callback, message_callback,
                  socket_dead_callback, task_group_id,

--- a/parlai/scripts/convert_data_to_parlai_format.py
+++ b/parlai/scripts/convert_data_to_parlai_format.py
@@ -15,27 +15,29 @@ from parlai.core.utils import msg_to_str
 
 import random
 
+
 def dump_data(opt):
     # create repeat label agent and assign it to the specified task
     agent = RepeatLabelAgent(opt)
     world = create_task(opt, agent)
-    ignorefields = opt['ignore_fields'].split(',')
-    
-    print("[ starting to convert.. ]")
+    ignorefields = opt.get('ignore_fields', '')
+
+    print('[ starting to convert.. ]')
     fw = open(opt['outfile'], 'w')
     for _ in range(opt['num_examples']):
         world.parley()
         world.acts[0]['labels'] = world.acts[0].get(
             'labels', world.acts[0].pop('eval_labels', None))
         txt = msg_to_str(world.acts[0], ignore_fields=ignorefields)
-        fw.write(txt + "\n")
+        fw.write(txt + '\n')
         if world.acts[0].get('episode_done', False):
-            fw.write("\n")
-        
+            fw.write('\n')
+
         if world.epoch_done():
             print('EPOCH DONE')
             break
     fw.close()
+
 
 def main():
     random.seed(42)
@@ -47,6 +49,7 @@ def main():
     parser.set_defaults(datatype='train:stream')
     opt = parser.parse_args()
     dump_data(opt)
-    
+
+
 if __name__ == '__main__':
     main()

--- a/tests/test_tfidf_retriever.py
+++ b/tests/test_tfidf_retriever.py
@@ -16,6 +16,13 @@ class TestTfidfRetriever(unittest.TestCase):
     """Basic tests on the display_data.py example."""
 
     def test_sparse_tfidf_retriever(self):
+        try:
+            from parlai.agents.tfidf_retriever.tfidf_retriever import TfidfRetrieverAgent
+        except ModuleNotFoundError as e:
+            if 'pip install' in e.msg or 'pytorch' in e.msg:
+                print('Skipping TestTfidfRetriever, missing optional pip packages or pytorch.')
+                return
+
         MODEL_FILE = '/tmp/tmp_test_babi'
         DB_PATH = '/tmp/tmp_test_babi.db'
         TFIDF_PATH = '/tmp/tmp_test_babi.tfidf'

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -4,10 +4,6 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-from parlai.core.torch_agent import TorchAgent
-
-
-import os
 import unittest
 
 
@@ -31,10 +27,18 @@ class MockDict(object):
     def txt2vec(self, txt):
         return [1, 3, 5]
 
+
 class TestTorchAgent(unittest.TestCase):
     """Basic tests on the util functions in TorchAgent."""
 
     def test_vectorize(self):
+        try:
+            from parlai.core.torch_agent import TorchAgent
+        except ModuleNotFoundError as e:
+            if 'pytorch' in e.msg:
+                print('Skipping TestTorchAgent.test_vectorize, no pytorch.')
+                return
+
         opt = {}
         opt['no_cuda'] = True
         opt['history_tokens'] = 10000
@@ -70,11 +74,20 @@ class TestTorchAgent(unittest.TestCase):
                         "Vectorized label is incorrect.")
 
     def test_map_unmap(self):
+        try:
+            from parlai.core.torch_agent import TorchAgent
+        except ModuleNotFoundError as e:
+            if 'pytorch' in e.msg:
+                print('Skipping TestTorchAgent.test_map_unmap, no pytorch.')
+                return
+
         observations = []
-        observations.append({"text": "What is a painting?", "labels": ["Paint on a canvas."]})
+        observations.append({"text": "What is a painting?",
+                             "labels": ["Paint on a canvas."]})
         observations.append({})
         observations.append({})
-        observations.append({"text": "What is a painting?", "labels": ["Paint on a canvas."]})
+        observations.append({"text": "What is a painting?",
+                             "labels": ["Paint on a canvas."]})
         observations.append({})
         observations.append({})
 
@@ -106,10 +119,12 @@ class TestTorchAgent(unittest.TestCase):
                         "Returns incorrect indices of valid observations.")
 
         observations = []
-        observations.append({"text": "What is a painting?", "eval_labels": ["Paint on a canvas."]})
+        observations.append({"text": "What is a painting?",
+                             "eval_labels": ["Paint on a canvas."]})
         observations.append({})
         observations.append({})
-        observations.append({"text": "What is a painting?", "eval_labels": ["Paint on a canvas."]})
+        observations.append({"text": "What is a painting?",
+                             "eval_labels": ["Paint on a canvas."]})
         observations.append({})
         observations.append({})
 
@@ -129,6 +144,13 @@ class TestTorchAgent(unittest.TestCase):
                         "Unmapped predictions do not match expected results.")
 
     def test_maintain_dialog_history(self):
+        try:
+            from parlai.core.torch_agent import TorchAgent
+        except ModuleNotFoundError as e:
+            if 'pytorch' in e.msg:
+                print('Skipping TestTorchAgent.test_maintain_dialog_history, no pytorch.')
+                return
+
         opt = {}
         opt['no_cuda'] = True
         opt['history_tokens'] = 5
@@ -158,7 +180,6 @@ class TestTorchAgent(unittest.TestCase):
         observation['text_vec'] = agent.maintain_dialog_history(observation)
         self.assertTrue(list(agent.history['dialog']) == [3, 5, 1, 3, 5],
                         "Failed adding vectorized text to dialog.")
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Basic flow here is that if you have a `parlai_internal.mturk.config` file, you can specify some defaults to use in your opts and in your qualifications. This doesn't break any existing flow.

Additional fixes:
- Cleans up default parameters for qualification names
- Cleans up some underscores and makes soft_block functions safer.
- Makes it so that locale qualifications are only added in the mturk utils if they haven't already been provided beforehand