### PR TITLE
Updates to TorchAgent

### DIFF
--- a/parlai/agents/example_seq2seq/example_seq2seq.py
+++ b/parlai/agents/example_seq2seq/example_seq2seq.py
@@ -13,8 +13,6 @@ from torch import optim
 import torch.nn as nn
 import torch.nn.functional as F
 
-import copy
-
 
 class EncoderRNN(nn.Module):
     def __init__(self, input_size, hidden_size, numlayers):
@@ -132,11 +130,6 @@ class ExampleSeq2seqAgent(TorchAgent):
 
         self.reset()
 
-    def reset(self):
-        """Reset observation and episode_done."""
-        self.observation = None
-        self.episode_done = True
-
     def zero_grad(self):
         """Zero out optimizer."""
         for optimizer in self.optims.values():
@@ -157,17 +150,6 @@ class ExampleSeq2seqAgent(TorchAgent):
             shared['decoder'] = self.decoder
 
         return shared
-
-    def observe(self, observation):
-        observation = copy.deepcopy(observation)
-        if not self.episode_done:
-            # if the last example wasn't the end of an episode, then we need to
-            # recall what was said in that example
-            prev_dialogue = self.observation['text']
-            observation['text'] = prev_dialogue + '\n' + observation['text']
-        self.observation = observation
-        self.episode_done = observation['episode_done']
-        return observation
 
     def predict(self, xs, ys=None, is_training=False):
         """Produce a prediction from our model.
@@ -273,7 +255,3 @@ class ExampleSeq2seqAgent(TorchAgent):
                 rep['text'] = self.dict.vec2txt(output_tokens)
 
         return batch_reply
-
-    def act(self):
-        # call batch_act with this batch of one
-        return self.batch_act([self.observation])[0]

--- a/parlai/agents/example_seq2seq/example_seq2seq.py
+++ b/parlai/agents/example_seq2seq/example_seq2seq.py
@@ -5,7 +5,6 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 from parlai.core.torch_agent import TorchAgent
-from parlai.core.thread_utils import SharedTable
 
 import torch
 from torch.autograd import Variable
@@ -51,8 +50,8 @@ class DecoderRNN(nn.Module):
 class ExampleSeq2seqAgent(TorchAgent):
     """Agent which takes an input sequence and produces an output sequence.
 
-    This model is based of Sean Robertson's seq2seq tutorial
-    `here <http://pytorch.org/tutorials/intermediate/seq2seq_translation_tutorial.html>`_.
+    This model is based of Sean Robertson's `seq2seq tutorial
+    <http://pytorch.org/tutorials/intermediate/seq2seq_translation_tutorial.html>`_.
     """
 
     @staticmethod

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -234,14 +234,11 @@ class TorchAgent(Agent):
         """
 
         def parse(txt, splitSentences):
-            if dict is not None:
-                if splitSentences:
-                    vec = [self.dict.txt2vec(t) for t in txt.split('\n')]
-                else:
-                    vec = self.dict.txt2vec(txt)
-                return vec
+            if splitSentences:
+                vec = [self.dict.txt2vec(t) for t in txt.split('\n')]
             else:
-                return [txt]
+                vec = self.dict.txt2vec(txt)
+            return vec
 
         allow_reply = True
 

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -18,12 +18,23 @@ import random
 import copy
 
 Batch = namedtuple("Batch", [
-    "text_vec",  # bsz x seqlen tensor containing the parsed text data
-    "text_lengths", # bsz x 1 tensor containing the lengths of the text in same order as text_vec; necessary for pack_padded_sequence
-    "label_vec", # bsz x seqlen tensor containing the parsed label (one per batch row)
-    "labels", # list of length bsz containing the selected label for each batch row (some datasets have multiple labels per input example)
-    "valid_indices",  # list of length bsz containing the original indices of each example in the batch. we use these to map predictions back to their proper row, since e.g. we may sort examples by their length or some examples may be invalid.
+    # bsz x seqlen tensor containing the parsed text data
+    "text_vec",
+    # bsz x 1 tensor containing the lengths of the text in same order as
+    # text_vec; necessary for pack_padded_sequence
+    "text_lengths",
+    # bsz x seqlen tensor containing the parsed label (one per batch row)
+    "label_vec",
+    # list of length bsz containing the selected label for each batch row (some
+    # datasets have multiple labels per input example)
+    "labels",
+    # list of length bsz containing the original indices of each example in the
+    # batch. we use these to map predictions back to their proper row, since
+    # e.g. we may sort examples by their length or some examples may be
+    # invalid.
+    "valid_indices",
 ])
+
 
 class TorchAgent(Agent):
     """A provided base agent for any model that wants to use Torch. Exists to
@@ -275,7 +286,9 @@ class TorchAgent(Agent):
         labels = obs.get('labels', obs.get('eval_labels', None))
         if labels is not None:
             if useStartEndIndices:
-                self.history['labels'] = [self.dict.start_token + ' ' + l for l in labels]
+                self.history['labels'] = [
+                    self.dict.start_token + ' ' + l for l in labels
+                ]
             else:
                 self.history['labels'] = labels
 

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -41,8 +41,8 @@ class TorchAgent(Agent):
     @staticmethod
     def add_cmdline_args(argparser):
         agent = argparser.add_argument_group('TorchAgent Arguments')
-        agent.add_argument('-histk', '--history-tokens', default=-1, type=int,
-                           help='Number of past tokens to remember.')
+        agent.add_argument('-tr', '--truncate', default=-1, type=int,
+                           help='Truncate input lengths to speed up training.')
         agent.add_argument('-histd', '--history-dialog', default=-1, type=int,
                            help='Number of past dialog examples to remember.')
         agent.add_argument('-histr', '--history-replies',
@@ -77,7 +77,7 @@ class TorchAgent(Agent):
         self.START_IDX = self.dict[self.dict.start_token]
 
         self.history = {}
-        self.history_tokens = opt['history_tokens']
+        self.truncate = opt['truncate']
         self.history_dialog = opt['history_dialog']
         self.history_replies = opt['history_replies']
 
@@ -246,7 +246,9 @@ class TorchAgent(Agent):
         allow_reply = True
 
         if 'dialog' not in self.history:
-            self.history['dialog'] = deque(maxlen=self.history_tokens)
+            self.history['dialog'] = deque(
+                maxlen=self.truncate if self.truncate >= 0 else None
+            )
             self.history['episode_done'] = False
             self.history['labels'] = []
 

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -45,7 +45,7 @@ class TestTorchAgent(unittest.TestCase):
 
         opt = {}
         opt['no_cuda'] = True
-        opt['history_tokens'] = 10000
+        opt['truncate'] = 10000
         opt['history_dialog'] = 10
         opt['history_replies'] = 'label_else_model'
         mdict = MockDict()
@@ -114,7 +114,7 @@ class TestTorchAgent(unittest.TestCase):
 
         opt = {}
         opt['no_cuda'] = True
-        opt['history_tokens'] = 10000
+        opt['truncate'] = 10000
         opt['history_dialog'] = 10
         opt['history_replies'] = 'label_else_model'
         mdict = MockDict()
@@ -180,7 +180,7 @@ class TestTorchAgent(unittest.TestCase):
 
         opt = {}
         opt['no_cuda'] = True
-        opt['history_tokens'] = 5
+        opt['truncate'] = 5
         opt['history_dialog'] = 10
         opt['history_replies'] = 'label_else_model'
         mdict = MockDict()


### PR DESCRIPTION
- Move some logic from example_seq2seq to TorchAgent so it can be more readily used (by fairseq) for example
- fix a minor bug that came from copying the original maintain_dialog_history code
- Rename the TorchAgent `--history-tokens` option to `--truncate` for consistency with seq2seq and others.

Note that the `--truncate` bit does *not* truncate the output space, so there's an inconsistency with the option, so we should debate this.

Requesting both Victor and Alex review.