### PR TITLE
switch ModuleNotFoundError to parent ImportError

### DIFF
--- a/parlai/agents/drqa/drqa.py
+++ b/parlai/agents/drqa/drqa.py
@@ -20,8 +20,8 @@ To automatically download glove, use:
 
 try:
     import torch
-except ModuleNotFoundError:
-    raise ModuleNotFoundError('Need to install pytorch: go to pytorch.org')
+except ImportError:
+    raise ImportError('Need to install pytorch: go to pytorch.org')
 
 import bisect
 import os

--- a/parlai/agents/ibm_seq2seq/ibm_seq2seq.py
+++ b/parlai/agents/ibm_seq2seq/ibm_seq2seq.py
@@ -8,8 +8,8 @@ try:
     from seq2seq.models.seq2seq import Seq2seq
     from seq2seq.models.EncoderRNN import EncoderRNN
     from seq2seq.models.DecoderRNN import DecoderRNN
-except ModuleNotFoundError:
-    raise ModuleNotFoundError('Please install IBM\'s seq2seq package at '
+except ImportError:
+    raise ImportError('Please install IBM\'s seq2seq package at '
                               'https://github.com/IBM/pytorch-seq2seq')
 
 from parlai.core.agents import Agent

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -242,7 +242,7 @@ class Seq2seqAgent(Agent):
                 # set up preinitialized embeddings
                 try:
                     import torchtext.vocab as vocab
-                except ModuleNotFoundError as ex:
+                except ImportError as ex:
                     print('Please install torch text with `pip install torchtext`')
                     raise ex
                 pretrained_dim = 300

--- a/parlai/agents/tfidf_retriever/tfidf_retriever.py
+++ b/parlai/agents/tfidf_retriever/tfidf_retriever.py
@@ -9,8 +9,8 @@ try:
     import scipy
     import sklearn
     import unicodedata
-except ModuleNotFoundError:
-    raise ModuleNotFoundError('Please `pip install regex scipy sklearn`'
+except ImportError:
+    raise ImportError('Please `pip install regex scipy sklearn`'
                               ' to use the tfidf_retriever agent.')
 
 from parlai.core.agents import Agent

--- a/parlai/agents/tfidf_retriever/utils.py
+++ b/parlai/agents/tfidf_retriever/utils.py
@@ -13,8 +13,8 @@ import scipy.sparse as sp
 from sklearn.utils import murmurhash3_32
 try:
     import torch
-except ModuleNotFoundError as e:
-    raise ModuleNotFoundError('Need to install Pytorch: go to pytorch.org')
+except ImportError as e:
+    raise ImportError('Need to install Pytorch: go to pytorch.org')
 
 
 # ------------------------------------------------------------------------------

--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -234,6 +234,6 @@ def modelzoo_path(datapath, path):
             my_module = importlib.import_module(module_name)
             download = getattr(my_module, 'download')
             download(datapath)
-        except (ModuleNotFoundError, AttributeError):
+        except (ImportError, AttributeError):
             pass
         return os.path.join(datapath, 'models', path[7:])

--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -75,8 +75,8 @@ class ImageLoader():
             self.use_cuda = (not opt.get('no_cuda', False)
                              and torch.cuda.is_available())
             self.torch = torch
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError('Need to install Pytorch: go to pytorch.org')
+        except ImportError:
+            raise ImportError('Need to install Pytorch: go to pytorch.org')
         from torch.autograd import Variable
         import torchvision
         import torchvision.transforms as transforms

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -38,8 +38,8 @@ class TensorboardLogger(Shared):
         Shared.__init__(self)
         try:
             from tensorboardX import SummaryWriter
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError(
+        except ImportError:
+            raise ImportError(
                 'Please `pip install tensorboardX` for logs with TB.')
         if opt['tensorboard_tag'] == None:
             tensorboard_tag = opt['starttime']

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -20,7 +20,7 @@ import copy
 try:
     import torch
 except Exception as e:
-    raise ModuleNotFoundError('Need to install Pytorch: go to pytorch.org')
+    raise ImportError('Need to install Pytorch: go to pytorch.org')
 from torch.utils.data import Dataset, DataLoader, sampler
 from torch.multiprocessing import Lock, Value
 import ctypes

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -9,8 +9,8 @@ from parlai.core.dict import DictionaryAgent
 
 try:
     import torch
-except ModuleNotFoundError as e:
-    raise ModuleNotFoundError('Need to install Pytorch: go to pytorch.org')
+except ImportError as e:
+    raise ImportError('Need to install Pytorch: go to pytorch.org')
 
 from collections import deque, namedtuple
 import pickle

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -682,8 +682,8 @@ def display_messages(msgs, prettify=False, ignore_fields=''):
                 cands = [c for c in msg['text_candidates'] if c is not None]
                 try:
                     import prettytable
-                except ModuleNotFoundError:
-                    raise ModuleNotFoundError('Please install prettytable to \
+                except ImportError:
+                    raise ImportError('Please install prettytable to \
                     display text candidates: `pip install prettytable`')
                 scores = None
                 if msg.get('candidate_scores') is not None:

--- a/parlai/messenger/core/__init__.py
+++ b/parlai/messenger/core/__init__.py
@@ -9,5 +9,5 @@ try:
     import joblib
     import websocket
     import sh
-except ModuleNotFoundError:
+except ImportError:
     raise SystemExit("Please install 3rd-party dependencies by running: pip install joblib websocket-client sh")

--- a/parlai/mturk/core/__init__.py
+++ b/parlai/mturk/core/__init__.py
@@ -11,5 +11,5 @@ try:
     import joblib
     import websocket
     import sh
-except ModuleNotFoundError:
+except ImportError:
     raise SystemExit("Please install 3rd-party dependencies by running: pip install boto3 joblib websocket-client sh")

--- a/parlai/mturk/core/test/auto_complete_hit.py
+++ b/parlai/mturk/core/test/auto_complete_hit.py
@@ -9,7 +9,7 @@ Script for auto-completing HITs. Please change the test flow according to your t
 try:
     from selenium import webdriver
     import chromedriver_installer
-except ModuleNotFoundError:
+except ImportError:
     raise SystemExit("Please make sure your computer has Chrome installed, and then install selenium and chromedriver by running: pip install selenium chromedriver_installer")
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC

--- a/parlai/scripts/extract_image_feature.py
+++ b/parlai/scripts/extract_image_feature.py
@@ -97,8 +97,8 @@ def extract_feats(opt):
         try:
             import torch
             from torch.utils.data import DataLoader
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError('Need to install Pytorch: go to pytorch.org')
+        except ImportError:
+            raise ImportError('Need to install Pytorch: go to pytorch.org')
 
         dataset = get_dataset_class(opt)(opt)
         pre_image_path, _ = os.path.split(dataset.image_path)

--- a/parlai/scripts/profile_train.py
+++ b/parlai/scripts/profile_train.py
@@ -20,7 +20,7 @@ import pdb
 import pstats
 try:
     import torch
-except ModuleNotFoundError:
+except ImportError:
     print('Torch not found--only cProfile allowed with this tool.')
 
 

--- a/parlai/tasks/coco_caption/agents.py
+++ b/parlai/tasks/coco_caption/agents.py
@@ -14,7 +14,7 @@ from .build_2017 import buildImage as buildImage_2017
 try:
     import torch
 except Exception as e:
-    raise ModuleNotFoundError('Need to install Pytorch: go to pytorch.org')
+    raise ImportError('Need to install Pytorch: go to pytorch.org')
 from torch.utils.data import Dataset
 from parlai.core.dict import DictionaryAgent
 
@@ -84,8 +84,8 @@ class DefaultDataset(Dataset):
             try:
                 import h5py
                 self.h5py = h5py
-            except ModuleNotFoundError:
-                raise ModuleNotFoundError('Need to install h5py - `pip install h5py`')
+            except ImportError:
+                raise ImportError('Need to install h5py - `pip install h5py`')
             self._setup_image_data()
         self.dict_agent = DictionaryAgent(opt)
 

--- a/parlai/tasks/flickr30k/agents.py
+++ b/parlai/tasks/flickr30k/agents.py
@@ -11,7 +11,7 @@ from .build import build
 try:
     import torch
 except Exception as e:
-    raise ModuleNotFoundError('Need to install Pytorch: go to pytorch.org')
+    raise ImportError('Need to install Pytorch: go to pytorch.org')
 from torch.utils.data import Dataset
 from parlai.core.dict import DictionaryAgent
 
@@ -48,8 +48,8 @@ class FlickrDataset(Dataset):
             try:
                 import h5py
                 self.h5py = h5py
-            except ModuleNotFoundError:
-                raise ModuleNotFoundError('Need to install h5py - `pip install h5py`')
+            except ImportError:
+                raise ImportError('Need to install h5py - `pip install h5py`')
             self._setup_image_data()
         self.dict_agent = DictionaryAgent(opt)
 

--- a/parlai/tasks/twitter/build.py
+++ b/parlai/tasks/twitter/build.py
@@ -8,8 +8,8 @@
 try:
     from emoji.unicode_codes import UNICODE_EMOJI
     import unidecode
-except ModuleNotFoundError:
-    raise ModuleNotFoundError('Please `pip install emoji unidecode` for the twitter task.')
+except ImportError:
+    raise ImportError('Please `pip install emoji unidecode` for the twitter task.')
 
 import parlai.core.build_data as build_data
 import os

--- a/parlai/tasks/vqa_v1/agents.py
+++ b/parlai/tasks/vqa_v1/agents.py
@@ -13,7 +13,7 @@ from parlai.tasks.coco_caption.build_2015 import buildImage as buildImage_2015
 try:
     import torch
 except Exception as e:
-    raise ModuleNotFoundError('Need to install Pytorch: go to pytorch.org')
+    raise ImportError('Need to install Pytorch: go to pytorch.org')
 from torch.utils.data import Dataset
 from parlai.agents.mlb_vqa.mlb_vqa import VqaDictionaryAgent
 
@@ -74,8 +74,8 @@ class VQADataset(Dataset):
             try:
                 import h5py
                 self.h5py = h5py
-            except ModuleNotFoundError:
-                raise ModuleNotFoundError('Need to install h5py - `pip install h5py`')
+            except ImportError:
+                raise ImportError('Need to install h5py - `pip install h5py`')
             self._setup_image_data()
         self.dict_agent = VqaDictionaryAgent(opt)
 

--- a/projects/personachat/persona_seq2seq.py
+++ b/projects/personachat/persona_seq2seq.py
@@ -33,8 +33,8 @@ import torch.nn.functional as F
 import torch
 try:
     import torchtext.vocab as vocab
-except ModuleNotFoundError:
-    raise ModuleNotFoundError('Please `pip install torchtext`')
+except ImportError:
+    raise ImportError('Please `pip install torchtext`')
 
 cos = torch.nn.CosineSimilarity(dim=0, eps=1e-6)
 
@@ -52,8 +52,8 @@ with open(os.path.join(os.environ['PARLAI_HOME'], 'projects', 'personachat', 'st
 
 try:
     from stop_words import get_stop_words
-except ModuleNotFoundError:
-    raise ModuleNotFoundError('Please `pip install stop-words`')
+except ImportError:
+    raise ImportError('Please `pip install stop-words`')
 
 STOP_WORDS = get_stop_words('en') + [',', '.', '!', '?']
 STOP_WORDS.remove('not')

--- a/tests/test_tfidf_retriever.py
+++ b/tests/test_tfidf_retriever.py
@@ -18,7 +18,7 @@ class TestTfidfRetriever(unittest.TestCase):
     def test_sparse_tfidf_retriever(self):
         try:
             from parlai.agents.tfidf_retriever.tfidf_retriever import TfidfRetrieverAgent
-        except ModuleNotFoundError as e:
+        except ImportError as e:
             if 'pip install' in e.msg or 'pytorch' in e.msg:
                 print('Skipping TestTfidfRetriever, missing optional pip packages or pytorch.')
                 return

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -34,7 +34,7 @@ class TestTorchAgent(unittest.TestCase):
     def test_vectorize(self):
         try:
             from parlai.core.torch_agent import TorchAgent
-        except ModuleNotFoundError as e:
+        except ImportError as e:
             if 'pytorch' in e.msg:
                 print('Skipping TestTorchAgent.test_vectorize, no pytorch.')
                 return
@@ -76,7 +76,7 @@ class TestTorchAgent(unittest.TestCase):
     def test_map_unmap(self):
         try:
             from parlai.core.torch_agent import TorchAgent
-        except ModuleNotFoundError as e:
+        except ImportError as e:
             if 'pytorch' in e.msg:
                 print('Skipping TestTorchAgent.test_map_unmap, no pytorch.')
                 return
@@ -146,7 +146,7 @@ class TestTorchAgent(unittest.TestCase):
     def test_maintain_dialog_history(self):
         try:
             from parlai.core.torch_agent import TorchAgent
-        except ModuleNotFoundError as e:
+        except ImportError as e:
             if 'pytorch' in e.msg:
                 print('Skipping TestTorchAgent.test_maintain_dialog_history, no pytorch.')
                 return


### PR DESCRIPTION
ModuleNotFoundError is new to python3.6, so this will be more compatible for more users.

(While I wouldn't mind switching fully to 3.6, I don't see this as a good reason to make the hard requirement yet. Plus, ImportError has a shorter name so it's less easy to hit the 80-char lint underlines...)