### PR TITLE
Attaching quick replies to facebook attachments

### DIFF
--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -35,6 +35,7 @@ class MessengerAgent(Agent):
             resp = self.manager.observe_payload(
                 self.id,
                 act['payload'],
+                act.get('quick_replies', None),
             )
         else:
             if act['id'] != '':
@@ -43,7 +44,7 @@ class MessengerAgent(Agent):
                 msg = act['text']
             resp = self.manager.observe_message(
                 self.id, msg,
-                act.get('quick_replies', None)
+                act.get('quick_replies', None),
             )
         try:
             mid = resp[0]['message_id']

--- a/parlai/messenger/core/message_sender.py
+++ b/parlai/messenger/core/message_sender.py
@@ -165,7 +165,7 @@ class MessageSender():
     def typing_on(self, receiver_id):
         self.send_sender_action(receiver_id, "typing_on")
 
-    def send_fb_payload(self, receiver_id, payload):
+    def send_fb_payload(self, receiver_id, payload, quick_replies=None):
         """Sends a payload to messenger, processes it if we can"""
         api_address = 'https://graph.facebook.com/v2.6/me/messages'
         if payload['type'] == 'list':
@@ -174,6 +174,7 @@ class MessageSender():
             data = create_attachment(payload)
         else:
             data = payload['data']
+
         message = {
             "messaging_type": 'RESPONSE',
             "recipient": {
@@ -183,6 +184,9 @@ class MessageSender():
                 "attachment": data,
             }
         }
+        if quick_replies is not None:
+            quick_replies = [create_reply_option(x, x) for x in quick_replies]
+            message['message']['quick_replies'] = quick_replies
         response = requests.post(
             api_address,
             params=self.auth_args,

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -618,9 +618,10 @@ class MessengerManager():
         return self.message_sender.send_fb_message(receiver_id, text, True,
                                                    quick_replies=quick_replies)
 
-    def observe_payload(self, receiver_id, data):
+    def observe_payload(self, receiver_id, data, quick_replies=None):
         """Send a payload through the message manager"""
-        return self.message_sender.send_fb_payload(receiver_id, data)
+        return self.message_sender.send_fb_payload(receiver_id, data,
+                                                   quick_replies=None)
 
     def upload_attachment(self, payload):
         """Uploads an attachment and returns an attachment ID


### PR DESCRIPTION
Attachments had the ability to handle quick replies but it wasn't hooked up into `MessengerManager`. Now it is hooked up