### PR TITLE
[MTurk] Using more strict timeframes for refreshing time logs on init, more lenient elsewhere.

### DIFF
--- a/parlai/mturk/tasks/qa_data_collection/run.py
+++ b/parlai/mturk/tasks/qa_data_collection/run.py
@@ -25,7 +25,7 @@ def main():
     class_name = 'DefaultTeacher'
     my_module = importlib.import_module(module_name)
     task_class = getattr(my_module, class_name)
-    task_opt = {}
+    task_opt = opt.copy()
     task_opt['datatype'] = 'train'
     task_opt['datapath'] = opt['datapath']
 


### PR DESCRIPTION
This prevents the problem of not having the time logs refresh on the first day you run your code. As long as you've started more than an hour before the 8pm reset, the log reset should happen.