### PR TITLE
Fix a bug when overriding a CLI option to an intentional blank.

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -489,7 +489,7 @@ class ParlaiParser(argparse.ArgumentParser):
                 elif self.cli_args[i] in store_false:
                     self.overridable[option_strings_dict[self.cli_args[i]]] = \
                         False
-                elif i < len(self.cli_args) - 1 and self.cli_args[i+1][0] != '-':
+                elif i < len(self.cli_args) - 1 and self.cli_args[i+1][:1] != '-':
                     key = option_strings_dict[self.cli_args[i]]
                     self.overridable[key] = self.opt[key]
         self.opt['override'] = self.overridable


### PR DESCRIPTION
As an example, consider training with:

`python examples/train.py -mf $MODEL_FILE -t $TASK --model fairseq -a lstm --encoder-embed-path "models:glove_vectors/glove.840B.300d.txt''`

Which initializes embeddings to glove vectors, a slow process because FairSeq isn't as clever about it as ParlAI. At test time, the call to fairseq's internal `build_model` will 

`python examples/interactive.py -mf $MODEL_FILE -t $TASK --model fairseq -a lstm --encoder-embed-path "''`

the override of encoder-embed-path is useful because otherwise fairseq will try to again, load the gigantic glove vectors file, only to override the actual values in `load`. So overriding these CLI params can speed up spin up time.