### PR TITLE
Moving to new metric for determining disconnects

### DIFF
--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -19,6 +19,8 @@ MTURK_DISCONNECT_MESSAGE = '[DISCONNECT]'  # Turker disconnected from conv
 TIMEOUT_MESSAGE = '[TIMEOUT]'  # the Turker did not respond but didn't return
 RETURN_MESSAGE = '[RETURNED]'  # the Turker returned the HIT
 
+# TODO move time management into another class, this way we can handle it
+# relative to heartbeats. This will come with more thorough testing.
 
 class MTurkAgent(Agent):
     """Base class for an MTurkAgent that can act in a ParlAI world"""

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -25,7 +25,6 @@ import parlai.mturk.core.shared_utils as shared_utils
 
 # Timeout before cancelling a world start
 WORLD_START_TIMEOUT = 11
-HEARTBEAT_DELAY_TIME = WORLD_START_TIMEOUT - SocketManager.DEF_SOCKET_TIMEOUT
 
 # Multiplier to apply when creating hits to ensure worker availibility
 HIT_MULT = 1.5
@@ -689,10 +688,6 @@ class MTurkManager():
         if agent.state.status != AssignState.STATUS_IN_TASK:
             # Avoid on a second ack if alive already came through
             agent.state.status = AssignState.STATUS_ASSIGNED
-            self.socket_manager.delay_heartbeat_until(
-                agent.get_connection_id(),
-                time.time() + HEARTBEAT_DELAY_TIME
-            )
 
         agent.conversation_id = conv_id
         if conv_id not in self.conv_to_agent:

--- a/parlai/mturk/core/server/html/core.html
+++ b/parlai/mturk/core/server/html/core.html
@@ -98,6 +98,7 @@
   var TYPE_ACK = 'ack';
   var TYPE_MESSAGE = 'message';
   var TYPE_HEARTBEAT = 'heartbeat';
+  var TYPE_PONG = 'pong';  // For messages back from the router on heartbeat
   var TYPE_ALIVE = 'alive';
 
   /* ================= Local Constants ================= */
@@ -107,13 +108,13 @@
   var STATUS_ACK = 'ack';
   var STATUS_INIT = 'init';
   var STATUS_SENT = 'sent';
-  var SERVER_HEARTBEAT_TIMEOUT = 60000 // 60 Sec before we think manager died
-  var SOCKET_MAYBE_DEAD_TIMEOUT = 16000
-  var LOCAL_HEARTBEAT_TIMEOUT = 30000 // 30 Seconds before we assume we died
+  var CONNECTION_DEAD_MISSING_PONGS = 15;
+  var REFRESH_SOCKET_MISSING_PONGS = 5;
+  var HEARTBEAT_TIME = 2000;  // One heartbeat every 2 seconds
 
   /* ================= State variables ================= */
 
-  var verbosity = 2;
+  var verbosity = 4;
 
   var q = new PriorityQueue();
   var mturk_submit_url = null;
@@ -127,10 +128,10 @@
   var blocking_id = null;
   var blocking_sent_time = null;
   var blocking_intend_send_time = null;
-  var last_server_heartbeat = null;
   var last_local_heartbeat = null;
   var displayed_messages = [];
   var setting_socket = false;
+  var pongs_without_heartbeat = 0;
 
   var is_cover_page = ("{{is_cover_page}}" === 'true') ? true : false;
   var is_init_page = ("{{is_init_page}}" === 'true') ? true : false;
@@ -145,7 +146,7 @@
 
   var is_mobile = false;
   var block_mobile = true;
-  if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+  if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
     is_mobile = true;
   }
 
@@ -521,7 +522,11 @@
     if (msg.type === TYPE_HEARTBEAT) {
       // Heartbeats ensure we're not disconnected from the server
       log('received heartbeat: ' + msg.id, 4);
-      last_server_heartbeat = Date.now();
+      pongs_without_heartbeat = 0;
+    } else if (msg.type === TYPE_PONG) {
+      // Messages incoming from the router, ensuring that we're at least
+      // connected to it.
+      pongs_without_heartbeat += 1;
     } else if (msg.type === TYPE_ACK) {
       // Acks update messages so that we don't resend them
       log('received ack: ' + msg.id, 3);
@@ -573,6 +578,9 @@
     } else {
       socket = new WebSocket('wss://' + url.hostname + ':' + url.port);
     }
+    // TODO if socket setup fails here, see if 404 or timeout, then check
+    // other reasonable domain. If that succeeds, assume the heroku server
+    // died.
 
     socket.onmessage = parse_socket_message;
 
@@ -581,7 +589,7 @@
       setting_socket = false
       window.setTimeout(send_alive, 100);
       if (heartbeat_id == null) {
-        heartbeat_id = window.setInterval(_heartbeat_thread, 2000);
+        heartbeat_id = window.setInterval(_heartbeat_thread, HEARTBEAT_TIME);
       }
     }
 
@@ -788,6 +796,10 @@
   // Thread checks the message queue and handles pushing out new messages
   // as they are added to the queue
   function _sending_thread() {
+    if (socket_closed) {
+      return
+    }
+
     // Can't act if something is currently blocking
     if (blocking_id === null) {
       // Can't act on an empty queue
@@ -824,6 +836,29 @@
       return;
     }
 
+    if (pongs_without_heartbeat == REFRESH_SOCKET_MISSING_PONGS) {
+      // Treat a connection attempt as a pong.
+      pongs_without_heartbeat += 1;
+      try {
+        socket.close();
+      } catch(e) {/* Socket already terminated */}
+      window.clearInterval(heartbeat_id);
+      heartbeat_id = null;
+      setup_socket();
+    }
+
+    // Check to see if we've disconnected from the server
+    if (pongs_without_heartbeat > CONNECTION_DEAD_MISSING_PONGS) {
+      close_socket();
+      set_inactive_text('Our server appears to have gone down during the \
+        duration of this HIT. Please send us a message if you\'ve done \
+        substantial work and we can find out if the hit is complete enough to \
+        compensate.');
+      update_UI_for_response_type('inactive');
+      window.clearInterval(heartbeat_id)
+      heartbeat_id = null;
+    }
+
     var hb = {
       'id': uuidv4(),
       'receiver_id': '[World_' + task_group_id + ']',
@@ -835,30 +870,6 @@
     };
 
     safe_packet_send({type: SOCKET_ROUTE_PACKET_STRING, content: hb});
-
-    if (last_server_heartbeat != null &&
-          Date.now() - last_server_heartbeat > SOCKET_MAYBE_DEAD_TIMEOUT) {
-      try {
-        socket.close();
-      } catch(e) {/* Socket already terminated */}
-      window.clearInterval(heartbeat_id);
-      heartbeat_id = null;
-      last_server_heartbeat = null;
-      setup_socket();
-    }
-
-    // Check to see if we've disconnected from the server
-    if (last_server_heartbeat != null &&
-        Date.now() - last_server_heartbeat > SERVER_HEARTBEAT_TIMEOUT) {
-      close_socket();
-      set_inactive_text('Our server appears to have gone down during the \
-        duration of this HIT. Please send us a message if you\'ve done \
-        substantial work and we can find out if the hit is complete enough to \
-        compensate.');
-      update_UI_for_response_type('inactive');
-      window.clearInterval(heartbeat_id)
-      heartbeat_id = null;
-    }
   }
 
   /* =================== Initialization =================== */

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -32,6 +32,7 @@ class Packet():
     TYPE_ALIVE = 'alive'
     TYPE_MESSAGE = 'message'
     TYPE_HEARTBEAT = 'heartbeat'
+    TYPE_PONG = 'pong'
 
     def __init__(self, id, type, sender_id, receiver_id, assignment_id, data,
                  conversation_id=None, requires_ack=True, blocking=True,
@@ -159,8 +160,9 @@ class SocketManager():
     ACK_TIME = {Packet.TYPE_ALIVE: 2,
                 Packet.TYPE_MESSAGE: 0.5}
 
-    # Default time before socket deemed dead
-    DEF_SOCKET_TIMEOUT = 30
+    # Default pongs without heartbeat before socket considered dead
+    DEF_MISSED_PONGS = 10
+    HEARTBEAT_RATE = 2
 
     def __init__(self, server_url, port, alive_callback, message_callback,
                  socket_dead_callback, task_group_id,
@@ -183,10 +185,10 @@ class SocketManager():
         self.alive_callback = alive_callback
         self.message_callback = message_callback
         self.socket_dead_callback = socket_dead_callback
-        if socket_dead_timeout is None:
-            self.socket_dead_timeout = self.DEF_SOCKET_TIMEOUT
+        if socket_dead_timeout is not None:
+            self.missed_pongs = socket_dead_timeout / self.HEARTBEAT_RATE
         else:
-            self.socket_dead_timeout = socket_dead_timeout
+            self.missed_pongs = self.DEF_MISSED_PONGS
         self.task_group_id = task_group_id
 
         self.ws = None
@@ -197,7 +199,9 @@ class SocketManager():
         self.queues = {}
         self.threads = {}
         self.run = {}
-        self.last_heartbeat = {}
+        self.last_sent_heartbeat = {}  # time of last heartbeat sent
+        self.last_gotten_heartbeat = {}  # actual last received heartbeat
+        self.pongs_without_heartbeat = {}
         self.packet_map = {}
         self.alive = False
 
@@ -239,12 +243,19 @@ class SocketManager():
                 {'id': 'WORLD_ALIVE', 'sender_id': self.get_my_sender_id()},
         }), force=True)
 
-    def _send_response_heartbeat(self, packet):
-        """Sends a response heartbeat to an incoming heartbeat packet"""
+    def _send_needed_heartbeat(self, connection_id):
+        """Sends a heartbeat to a connection if needed"""
+        if self.last_gotten_heartbeat[connection_id] is None:
+            return
+        if (time.time() - self.last_sent_heartbeat[connection_id]
+                < self.HEARTBEAT_RATE):
+            return
+        packet = self.last_gotten_heartbeat[connection_id]
         self._safe_send(json.dumps({
             'type': data_model.SOCKET_ROUTE_PACKET_STRING,
-            'content': packet.swap_sender().set_data('').as_dict()
+            'content': packet.new_copy().swap_sender().set_data('').as_dict()
         }))
+        self.last_sent_heartbeat[connection_id] = time.time()
 
     def _send_ack(self, packet):
         """Sends an ack to a given packet"""
@@ -342,7 +353,7 @@ class SocketManager():
 
         def on_message(*args):
             """Incoming message handler for ACKs, ALIVEs, HEARTBEATs,
-            and MESSAGEs"""
+            PONGs, and MESSAGEs"""
             packet_dict = json.loads(args[1])
             if packet_dict['type'] == 'conn_success':
                 self.alive = True
@@ -372,9 +383,15 @@ class SocketManager():
                 except Exception:
                     pass  # state already reduced, perhaps by ack_func
             elif packet_type == Packet.TYPE_HEARTBEAT:
-                # Heartbeats update the last heartbeat time and respond in kind
-                self.last_heartbeat[connection_id] = time.time()
-                self._send_response_heartbeat(packet)
+                # Heartbeats update the last heartbeat, clears pongs w/o beat
+                self.last_gotten_heartbeat[connection_id] = packet
+                self.pongs_without_heartbeat[connection_id] = 0
+            elif packet_type == Packet.TYPE_PONG:
+                # Message in response from the router, ensuring we're connected
+                # to it. Redundant but useful for metering from web client.
+                pong_connection_id = packet.get_receiver_connection_id()
+                if self.last_gotten_heartbeat[pong_connection_id] is not None:
+                    self.pongs_without_heartbeat[pong_connection_id] += 1
             else:
                 # Remaining packet types need to be acknowledged
                 shared_utils.print_and_log(
@@ -384,7 +401,6 @@ class SocketManager():
                 self._send_ack(packet)
                 # Call the appropriate callback
                 if packet_type == Packet.TYPE_ALIVE:
-                    self.last_heartbeat[connection_id] = time.time()
                     self.alive_callback(packet)
                 elif packet_type == Packet.TYPE_MESSAGE:
                     self.message_callback(packet)
@@ -446,11 +462,16 @@ class SocketManager():
                 logging.DEBUG,
                 'Channel ({}) opened'.format(connection_id)
             )
+            self.last_sent_heartbeat[connection_id] = 0
+            self.pongs_without_heartbeat[connection_id] = 0
+            self.last_gotten_heartbeat[connection_id] = None
             while self.run[connection_id]:
                 try:
+                    # Send a heartbeat if needed
+                    self._send_needed_heartbeat(connection_id)
                     # Check if client is still alive
-                    if (time.time() - self.last_heartbeat[connection_id]
-                            > self.socket_dead_timeout):
+                    if (self.pongs_without_heartbeat[connection_id] >
+                            self.missed_pongs):
                         self.run[connection_id] = False
                         self.socket_dead_callback(worker_id, assignment_id)
 
@@ -506,10 +527,6 @@ class SocketManager():
             # Clean up other resources
             del self.queues[connection_id]
             del self.threads[connection_id]
-
-    def delay_heartbeat_until(self, connection_id, delayed_time):
-        """Delay a heartbeat prolong a disconnect until delayed_time"""
-        self.last_heartbeat[connection_id] = delayed_time
 
     def close_all_channels(self):
         """Closes a channel by clearing the list of channels"""


### PR DESCRIPTION
Migrates from a time-dependent timeout model (which isn't very strong in a 3 point system where the middle one acts as a router) to one that relies more strongly on heartbeats and ping/pong semantics. Changes are as follows:
- The ParlAI Python thread now keeps track of it's own heartbeat time rather than just responding to heartbeats with heartbeats.
- The router both forwards heartbeats and responds to them with a pong message (which ensures connectivity with the router).
- Both the javascript and python clients now keep track of the number of pongs they've received from the router since they've received a heartbeat from one another. This is a proxy way of telling when the router is up but the client on the other side of the router is dead.

Why do this at all?
- Increases the number of handled failure states
- Makes it easier to detect which node in the system is having issues
- Opens the door for better online indicators on the Turker's side and better feedback as to what happened in a crash.
- Opens the door for proper handling of a disconnected task once ParlAI-MTurk switches to a base-pay + bonus system.
- Potentially allows *restarting a HIT* when there's a segfault on the python client once HIT state is stored in a DB rather than in python mem.