### PR TITLE
speed up s2s ~2x

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -418,9 +418,11 @@ class Seq2seqAgent(Agent):
         differ from a truly independent measurement.
         """
         m = {}
-        if self.metrics['num_tokens'] > 0:
-            m['token_acc'] = self.metrics['correct_tokens'] / self.metrics['num_tokens']
-            m['loss'] = self.metrics['loss'] / self.metrics['num_tokens']
+        num_tok = self.metrics['num_tokens']
+        if num_tok > 0:
+            if self.metrics['correct_tokens'] > 0:
+                m['token_acc'] = self.metrics['correct_tokens'] / num_tok
+            m['loss'] = self.metrics['loss'] / num_tok
             try:
                 m['ppl'] = math.exp(m['loss'])
             except OverflowError:
@@ -526,10 +528,7 @@ class Seq2seqAgent(Agent):
                 score_view = scores.view(-1, scores.size(-1))
                 loss = self.criterion(score_view, ys.view(-1))
                 # save loss to metrics
-                y_ne = ys.ne(self.NULL_IDX)
-                target_tokens = y_ne.long().sum().item()
-                correct = ((ys == _preds) * y_ne).sum().item()
-                self.metrics['correct_tokens'] += correct
+                target_tokens = ys.ne(self.NULL_IDX).long().sum().item()
                 self.metrics['loss'] += loss.item()
                 self.metrics['num_tokens'] += target_tokens
 

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -525,7 +525,11 @@ class Seq2seqAgent(Agent):
                 scores = out[1]
                 score_view = scores.view(-1, scores.size(-1))
                 loss = self.criterion(score_view, ys.view(-1))
-                target_tokens = ys.ne(self.NULL_IDX).long().sum().item()
+                # save loss to metrics
+                y_ne = ys.ne(self.NULL_IDX)
+                target_tokens = y_ne.long().sum().item()
+                correct = ((ys == _preds) * y_ne).sum().item()
+                self.metrics['correct_tokens'] += correct
                 self.metrics['loss'] += loss.item()
                 self.metrics['num_tokens'] += target_tokens
 


### PR DESCRIPTION
seq2seq was returning its predictions as texts to the teacher to get accuracy and f1 metrics, this was hurting it a surprising amount.

this diff removes that, losing access to accuracy and f1 during training logs, but seq2seq now returns token-accuracy as a useful proxy metric instead.

---
babi:task10k:1 experiments

seq2seq command:
`py examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 128 -eps 20 -dt train:ordered -m seq2seq -hs 128 -esz 128 -nl 2`

fairseq command:
`py examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 128 -eps 20 -dt train:ordered -m fairseq --arch lstm --encoder_embed_dim 128 --encoder-hidden-size 128 --encoder-layers 2 --decoder-embed-dim 128 --decoder-hidden-size 128 --decoder-layers 2 --decoder-out-embed-dim 128 --decoder-attention 0
`

seq2seq before: 77s, 78s
seq2seq after: 40s, 40s
fairseq2seq: 62s, 66s

---
convai2 experiments

seq2seq command:
`py examples/train_model.py -t convai2 --dict-file /tmp/dict_convai2 -bs 128 -m seq2seq -eps 1 -dt train:ordered`

fairseq command:
`py examples/train_model.py -t convai2 --dict-file /tmp/dict_convai2 -bs 128 -eps 1 -dt train:ordered -m fairseq --arch lstm --encoder_embed_dim 128 --encoder-hidden-size 128 --encoder-layers 2 --decoder-embed-dim 128 --decoder-hidden-size 128 --decoder-layers 2 --decoder-out-embed-dim 128 --decoder-attention 0`

seq2seq before: 182s, 174s
seq2seq after: 84s, 82s
fairseq: 125s, 125s