### PR TITLE
Move display script, add max length arg

### DIFF
--- a/examples/display_data.py
+++ b/examples/display_data.py
@@ -11,48 +11,14 @@ see a few of them:
 `python examples/display_data.py -t babi:task1k:1`
 """
 
-from parlai.core.params import ParlaiParser
-from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
-from parlai.core.worlds import create_task
-
+from parlai.scripts.display_data import display_data, setup_args
 import random
 
-def display_data(opt):
-    # create repeat label agent and assign it to the specified task
-    agent = RepeatLabelAgent(opt)
-    world = create_task(opt, agent)
 
-    # Show some example dialogs.
-    for _ in range(opt['num_examples']):
-        world.parley()
-
-        # NOTE: If you want to look at the data from here rather than calling
-        # world.display() you could access world.acts[0] directly
-        print(world.display() + '\n~~')
-
-        if world.epoch_done():
-            print('EPOCH DONE')
-            break
-
-    try:
-        # print dataset size if available
-        print('[ loaded {} episodes with a total of {} examples ]'.format(
-            world.num_episodes(), world.num_examples()
-        ))
-    except:
-        pass
-
-
-def main():
+if __name__ == '__main__':
     random.seed(42)
 
     # Get command line arguments
-    parser = ParlaiParser()
-    parser.add_argument('-n', '--num-examples', default=10, type=int)
-    parser.set_defaults(datatype='train:stream')
+    parser = setup_args()
     opt = parser.parse_args()
-
     display_data(opt)
-    
-if __name__ == '__main__':
-    main()

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -626,7 +626,7 @@ class OffensiveLanguageDetector(object):
         return None
 
 
-def display_messages(msgs, prettify=False, ignore_fields=''):
+def display_messages(msgs, prettify=False, ignore_fields='', max_len=1000):
     """Returns a string describing the set of messages provided
     If prettify is true, candidates are displayed using prettytable.
     ignore_fields provides a list of fields in the msgs which should not be displayed.
@@ -650,8 +650,8 @@ def display_messages(msgs, prettify=False, ignore_fields=''):
             lines.append(msg['image'])
         if msg.get('text', ''):
             text = msg['text']
-            if len(text) > 1000:
-                text = text[:1000] + '...'
+            if len(text) > max_len:
+                text = text[:max_len] + '...'
             ID = '[' + msg['id'] + ']: ' if 'id' in msg else ''
             lines.append(space + ID + text)
         if msg.get('labels') and 'labels' not in ignore_fields:

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -103,7 +103,8 @@ class World(object):
             return ''
         return display_messages(self.acts,
                                 ignore_fields=self.opt.get('display_ignore_fields', ''),
-                                prettify=self.opt.get('display_prettify', False))
+                                prettify=self.opt.get('display_prettify', False),
+                                max_len=self.opt.get('max_display_len', 1000))
 
     def episode_done(self):
         """Whether the episode is done or not."""

--- a/parlai/scripts/display_data.py
+++ b/parlai/scripts/display_data.py
@@ -17,13 +17,16 @@ from parlai.core.worlds import create_task
 
 import random
 
+
 def setup_args(parser=None):
     if parser is None:
         parser = ParlaiParser(True, True)
     # Get command line arguments
     parser.add_argument('-ne', '--num-examples', type=int, default=10)
+    parser.add_argument('-mdl', '--max-display-len', type=int, default=1000)
     parser.set_defaults(datatype='train:stream')
     return parser
+
 
 def display_data(opt):
     # create repeat label agent and assign it to the specified task
@@ -52,6 +55,8 @@ def display_data(opt):
 
 
 if __name__ == '__main__':
+    random.seed(42)
+
     # Get command line arguments
     parser = setup_args()
     opt = parser.parse_args()


### PR DESCRIPTION
Moved most logic from `examples/display_data.py` over to `scripts/display_data.py` and added argument for the maximum display length for the text field (before, you couldn't change it from 1000, which isn't sufficient to view the data for tasks like SQuAD where the text field is quite long)