### PR TITLE
BPE support.

### DIFF
--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -373,17 +373,20 @@ class FairseqAgent(TorchAgent):
         for i in range(len(src_tokens)):
             beams = gens[i]
             selected = max(beams, key=lambda x: x["score"])
-            response = []
-            for t in selected["tokens"]:
+            tokens = selected["tokens"]
+            start = 0
+            end = -1
+            for i, t in enumerate(tokens):
                 t = t.item()
                 if t == self.dict.bos_index:
                     # don't include <s> token
+                    start = i + 1
                     continue
                 if t == self.dict.eos_index:
                     # stop (and don't include) </s> token
+                    end = i
                     break
-                response.append(self.dict[t])
-            responses.append(" ".join(response))
+            responses.append(self.dict.vec2txt(tokens[start:end]))
         return responses
 
     def report(self):

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -15,6 +15,13 @@ import numpy as np
 import os
 import re
 
+try:
+    from subword_nmt import learn_bpe, apply_bpe
+    # Don't explicitly throw the runtime error unless the user needs it
+    BPE_INSTALLED = True
+except ImportError:
+    BPE_INSTALLED = False
+
 RETOK = re.compile(r'\w+|[^\w\s]|\n', re.UNICODE)
 
 def escape(s):
@@ -129,6 +136,12 @@ class DictionaryAgent(Agent):
             dictionary.add_argument(
                 '--dict-lower', default=DictionaryAgent.default_lower, type='bool',
                 help='Whether or not to lowercase all text seen.')
+            dictionary.add_argument(
+                '--bpe-num-symbols', default=30000, type=int,
+                help='Number of BPE symbols. Recommended between 30000 and 40000')
+            dictionary.add_argument(
+                '--bpe-codecs-file',
+                help='Filename for the BPE codecs. Defaults to dictfile.codecs.')
         except argparse.ArgumentError:
             # already added
             pass
@@ -216,6 +229,15 @@ class DictionaryAgent(Agent):
                                   'or find alternative installation options '
                                   'at spacy.io')
             self.NLP = spacy.load('en')
+        elif self.tokenizer == 'bpe':
+            if not opt.get('bpe_codecs_file'):
+                if not opt.get('dict_file'):
+                    raise RuntimeError('--bpe-codecs-file or --dict-file is mandatory.')
+                opt['bpe_codecs_file'] = opt.get('dict_file') + '.codecs'
+            self.bpehelper = _BPEHelper(
+                    num_symbols=opt.get('bpe_num_symbols'),
+                    codecs_filename=opt.get('bpe_codecs_file'),
+                )
 
         if not shared:
 
@@ -365,6 +387,28 @@ class DictionaryAgent(Agent):
                                       self.max_ngram_size)
         return word_tokens
 
+    def bpe_tokenize(self, text):
+        """Returns a sequence of BPE-tokens from the text."""
+        if self.lower:
+            text = text.lower()
+        return self.bpehelper.tokenize(text)
+
+    def finalize(self):
+        """
+        Finalize and freeze the dictionary.
+
+        If using BPE tokenization, performs the codec learning.
+        """
+
+        if self.tokenizer != 'bpe':
+            # only BPE needs the second pass
+            return
+
+        # Now that we have a second pass,
+        if self.bpehelper.finalize():
+            for line in self.bpehelper.training_data:
+                self.add_to_dict(self.bpehelper.tokenize(line))
+
     def add_to_dict(self, tokens):
         """ Builds dictionary from the list of provided tokens."""
         for token in tokens:
@@ -485,7 +529,14 @@ class DictionaryAgent(Agent):
         """Converts a vector (iterable of ints) into a string, with each token
         separated by the delimiter (default ``' '``).
         """
-        return delimiter.join(self[int(idx)] for idx in vector)
+        text = delimiter.join(self[int(idx)] for idx in vector)
+        # if we used a BPE tokenizer we need to rejoin the encodings
+        if self.tokenizer == 'bpe':
+            text = text.replace('@@ ', '')
+            # It's also possible that we get a BPE encoding on the end of the word
+            if text.endswith('@@'):
+                text = text[:-2]
+        return text
 
     def act(self):
         """Add any words passed in the 'text' field of the observation to this
@@ -515,3 +566,71 @@ class DictionaryAgent(Agent):
 
     def __str__(self):
         return str(self.freq)
+
+
+class _BPEHelper(object):
+    """
+    Performs BPE subword tokenization. For technical details, please refer to
+    https://arxiv.org/abs/1508.07909.
+    """
+
+    def __init__(self, num_symbols=30000, minfreq=2, codecs_filename=None):
+        if not BPE_INSTALLED:
+            raise RuntimeError(
+                "Please run \"pip install 'git+https://github.com/rsennrich"
+                "/subword-nmt.git#egg=subword-nmt'\""
+            )
+
+        self.codecs = codecs_filename
+        if os.path.exists(self.codecs):
+            self.built = True
+            self._load_from_codecs()
+        else:
+            self.num_symbols = num_symbols
+            self.minfreq = minfreq
+            self.training_data = []
+            self.built = False
+
+    def _load_from_codecs(self):
+        with open(self.codecs, 'r') as codecs_file:
+            self.bpe = apply_bpe.BPE(codecs_file)
+
+    def _add_to_train(self, tokens):
+        """
+        Queues up all the data to learn the BPE tokenizer.
+        """
+        if self.built:
+            raise RuntimeError("BPE dictionary has been finalized.")
+        self.training_data.append(" ".join(tokens) + "\n")
+        return []
+
+    def tokenize(self, text):
+        tokens = DictionaryAgent.re_tokenize(text)
+        if self.built:
+            return self.apply(tokens)
+        else:
+            return self._add_to_train(tokens)
+
+    def apply(self, tokens):
+        return self.bpe.segment_tokens(tokens)
+
+    def finalize(self):
+        """Build the codecs"""
+        if self.built:
+            return False
+
+        self.built = True
+
+        with open(self.codecs, 'w') as outstream:
+            # There's a potentially cleaner way to do this, with the is_dict
+            # method able to handle <word> \t <count> format.
+            learn_bpe.learn_bpe(
+                self.training_data,
+                outstream,
+                num_symbols=self.num_symbols,
+                min_frequency=self.minfreq,
+                is_dict=False,
+            )
+
+        self._load_from_codecs()
+        return True

--- a/parlai/scripts/build_dict.py
+++ b/parlai/scripts/build_dict.py
@@ -98,6 +98,7 @@ def build_dict(opt, skip_if_built=False):
                 sys.stdout.write(text)
                 sys.stdout.flush()
 
+    dictionary.finalize()
     dictionary.save(opt['dict_file'], sort=True)
     print('[ dictionary built with {} tokens ]'.format(len(dictionary)))
     return dictionary


### PR DESCRIPTION
This could be more memory efficient by passing a specialized format (pseudofile of word <tab> count) into the learn_bpe. The API calls would be more complex. For now, submitting functional version that works fine.

If we need to run this on something with an extremely large training data set, we could run into problems.

We could make it *much* more memory efficient and cleaner API by reimplementing or forking the subword-nmt repo, but I think we probably want to stick to the official version.