### PR TITLE
Update BLEU evaluation to suppress annoying warning.

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -85,7 +85,8 @@ def _bleu(guess, answers):
     # works with strings, which is better suited for this module.
     return nltkbleu.sentence_bleu(
         [normalize_answer(a).split(" ") for a in answers],
-        normalize_answer(guess).split(" ")
+        normalize_answer(guess).split(" "),
+        smoothing_function=nltkbleu.SmoothingFunction(epsilon=1e-12).method1,
     )
 
 


### PR DESCRIPTION
Turns on smoothing so that NLTK doesn't complain that F1 isn't defined when precision is 0. This smoothing had the effect of slightly boosting scores in the 4th decimal place when I tested it.