### PR TITLE
eval_model cnt from batch_size, batch_sort default False

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -300,8 +300,6 @@ def load_agent_module(opt):
                 new_opt[k] = v
         new_opt['model_file'] = model_file
         model_class = get_agent_module(new_opt['model'])
-        if 'batch_sort' in new_opt:
-            opt['batch_sort'] = new_opt['batch_sort']
         return model_class(new_opt)
     else:
         return None


### PR DESCRIPTION
The same as reverted https://github.com/facebookresearch/ParlAI/pull/980 but without opt override