### PR TITLE
Add separate squad2.0 task for #969

### DIFF
--- a/parlai/tasks/squad2/__init__.py
+++ b/parlai/tasks/squad2/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/tasks/squad2/agents.py
+++ b/parlai/tasks/squad2/agents.py
@@ -1,0 +1,391 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+from parlai.core.teachers import FixedDialogTeacher, DialogTeacher
+from .build import build
+
+import json
+import os
+
+
+class IndexTeacher(FixedDialogTeacher):
+    """Hand-written SQuAD teacher, which loads the json squad data and
+    implements its own `act()` method for interacting with student agent,
+    rather than inheriting from the core Dialog Teacher. This code is here as
+    an example of rolling your own without inheritance.
+
+    This teacher also provides access to the "answer_start" indices that
+    specify the location of the answer in the context.
+    """
+
+    def __init__(self, opt, shared=None):
+        build(opt)
+        super().__init__(opt, shared)
+
+        if self.datatype.startswith('train'):
+            suffix = 'train'
+        else:
+            suffix = 'dev'
+        datapath = os.path.join(
+            opt['datapath'],
+            'SQuAD2',
+            suffix + '-v2.0.json'
+        )
+        self.data = self._setup_data(datapath)
+
+        self.id = 'squad2'
+        self.reset()
+
+    def num_examples(self):
+        return len(self.examples)
+
+    def num_episodes(self):
+        return self.num_examples()
+
+    def get(self, episode_idx, entry_idx=None):
+        article_idx, paragraph_idx, qa_idx = self.examples[episode_idx]
+        article = self.squad[article_idx]
+        paragraph = article['paragraphs'][paragraph_idx]
+        qa = paragraph['qas'][qa_idx]
+        question = qa['question']
+        answers = []
+        answer_starts = []
+        if not qa['is_impossible']:
+            for a in qa['answers']:
+                answers.append(a['text'])
+                answer_starts.append(a['answer_start'])
+        context = paragraph['context']
+        plausible = qa.get("plausible_answers", [])
+
+        action = {
+            'id': 'squad',
+            'text': context + '\n' + question,
+            'labels': answers,
+            'plausible_answers': plausible,
+            'episode_done': True,
+            'answer_starts': answer_starts
+        }
+        return action
+
+    def _setup_data(self, path):
+        with open(path) as data_file:
+            self.squad = json.load(data_file)['data']
+        self.examples = []
+
+        for article_idx in range(len(self.squad)):
+            article = self.squad[article_idx]
+            for paragraph_idx in range(len(article['paragraphs'])):
+                paragraph = article['paragraphs'][paragraph_idx]
+                num_questions = len(paragraph['qas'])
+                for qa_idx in range(num_questions):
+                    self.examples.append((article_idx, paragraph_idx, qa_idx))
+
+
+class DefaultTeacher(DialogTeacher):
+    """This version of SQuAD inherits from the core Dialog Teacher, which just
+    requires it to define an iterator over its data `setup_data` in order to
+    inherit basic metrics, a default `act` function.
+    For SQuAD, this does not efficiently store the paragraphs in memory.
+    """
+
+    def __init__(self, opt, shared=None):
+        self.datatype = opt['datatype']
+        build(opt)
+        if opt['datatype'].startswith('train'):
+            suffix = 'train'
+        else:
+            suffix = 'dev'
+        opt['datafile'] = os.path.join(opt['datapath'], 'SQuAD2',
+                                       suffix + '-v2.0.json')
+        self.id = 'squad2'
+        super().__init__(opt, shared)
+
+    def setup_data(self, path):
+        print('loading: ' + path)
+        with open(path) as data_file:
+            self.squad = json.load(data_file)['data']
+        for article in self.squad:
+            # each paragraph is a context for the attached questions
+            for paragraph in article['paragraphs']:
+                # each question is an example
+                for qa in paragraph['qas']:
+                    question = qa['question']
+                    ans_list = [{"text": ""}]
+                    if not qa['is_impossible']:
+                        ans_list = qa['answers']
+                    answers = (a['text'] for a in ans_list)
+                    context = paragraph['context']
+                    yield (context + '\n' + question, answers), True
+
+
+class OpenSquadTeacher(DialogTeacher):
+    """This version of SQuAD inherits from the core Dialog Teacher, which just
+    requires it to define an iterator over its data `setup_data` in order to
+    inherit basic metrics, a default `act` function.
+    Note: This teacher omits the context paragraph
+    """
+
+    def __init__(self, opt, shared=None):
+        self.datatype = opt['datatype']
+        build(opt)
+        if opt['datatype'].startswith('train'):
+            suffix = 'train'
+        else:
+            suffix = 'dev'
+        opt['datafile'] = os.path.join(opt['datapath'], 'SQuAD2',
+                                       suffix + '-v2.0.json')
+        self.id = 'squad2'
+        super().__init__(opt, shared)
+
+    def setup_data(self, path):
+        print('loading: ' + path)
+        with open(path) as data_file:
+            self.squad = json.load(data_file)['data']
+        for article in self.squad:
+            # each paragraph is a context for the attached questions
+            for paragraph in article['paragraphs']:
+                # each question is an example
+                for qa in paragraph['qas']:
+                    question = qa['question']
+                    ans_iter = [{"text": ''}]
+                    if not qa['is_impossible']:
+                        ans_iter = qa['answers']
+                    answers = (a['text'] for a in ans_iter)
+                    yield (question, answers), True
+
+
+class TitleTeacher(DefaultTeacher):
+    """This version of SquAD inherits from the Default Teacher. The only
+    difference is that the 'text' field of an observation will contain
+    the title of the article separated by a newline from the paragraph and the
+    query.
+    Note: The title will contain underscores, as it is the part of the link for
+    the Wikipedia page; i.e., the article is at the site:
+    https://en.wikipedia.org/wiki/{TITLE}
+    Depending on your task, you may wish to remove underscores.
+    """
+
+    def __init__(self, opt, shared=None):
+        self.id = 'squad_title'
+        build(opt)
+        super().__init__(opt, shared)
+
+    def setup_data(self, path):
+        print('loading: ' + path)
+        with open(path) as data_file:
+            self.squad = json.load(data_file)['data']
+        for article in self.squad:
+            title = article['title']
+            # each paragraph is a context for the attached questions
+            for paragraph in article['paragraphs']:
+                # each question is an example
+                for qa in paragraph['qas']:
+                    question = qa['question']
+                    ans_iter = [{"text": ""}]
+                    if not qa['is_impossible']:
+                        ans_iter = qa['answers']
+                    answers = (a['text'] for a in ans_iter)
+                    context = paragraph['context']
+                    yield (
+                        '\n'.join([title, context, question]),
+                        answers
+                    ), True
+
+
+class SentenceIndexTeacher(IndexTeacher):
+    """Index teacher where the labels are the sentences the contain the true
+    answer.
+    """
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
+
+        try:
+            import nltk
+        except ImportError:
+            raise ImportError('Please install nltk (e.g. pip install nltk).')
+        # nltk-specific setup
+        st_path = 'tokenizers/punkt/{0}.pickle'.format('english')
+        try:
+            self.sent_tok = nltk.data.load(st_path)
+        except LookupError:
+            nltk.download('punkt')
+            self.sent_tok = nltk.data.load(st_path)
+
+    def get(self, episode_idx, entry_idx=None):
+        article_idx, paragraph_idx, qa_idx = self.examples[episode_idx]
+        article = self.squad[article_idx]
+        paragraph = article['paragraphs'][paragraph_idx]
+        qa = paragraph['qas'][qa_idx]
+        context = paragraph['context']
+        question = qa['question']
+
+        answers = ['']
+        if not qa['is_impossible']:
+            answers = [a['text'] for a in qa['answers']]
+
+        # temporarily remove '.', '?', '!' from answers for proper sentence
+        # tokenization
+        edited_answers = []
+        for answer in answers:
+            new_answer = answer.replace(
+                '.', '').replace('?', '').replace('!', '')
+            context = context.replace(answer, new_answer)
+            edited_answers.append(new_answer)
+
+        edited_sentences = self.sent_tok.tokenize(context)
+        sentences = []
+
+        for sentence in edited_sentences:
+            for i in range(len(edited_answers)):
+                sentence = sentence.replace(edited_answers[i], answers[i])
+                sentences.append(sentence)
+
+        for i in range(len(edited_answers)):
+            context = context.replace(edited_answers[i], answers[i])
+
+        labels = []
+        label_starts = []
+        for sentence in sentences:
+            for answer in answers:
+                if answer in sentence and sentence not in labels:
+                    labels.append(sentence)
+                    label_starts.append(context.index(sentence))
+                    break
+
+        plausible = []
+        if qa['is_impossible']:
+            plausible = qa['plausible_answers']
+        action = {
+            'id': 'squad',
+            'text': context + '\n' + question,
+            'labels': labels,
+            'plausible_answers': plausible,
+            'episode_done': True,
+            'answer_starts': label_starts
+        }
+        return action
+
+
+class SentenceIndexEditTeacher(SentenceIndexTeacher):
+    """Index teacher where the labels are the sentences the contain the true
+    answer.
+
+    Some punctuation may be removed from the context and the answer for
+    tokenization purposes.
+    """
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
+
+    def get(self, episode_idx, entry_idx=None):
+        article_idx, paragraph_idx, qa_idx = self.examples[episode_idx]
+        article = self.squad[article_idx]
+        paragraph = article['paragraphs'][paragraph_idx]
+        qa = paragraph['qas'][qa_idx]
+        context = paragraph['context']
+        question = qa['question']
+
+        answers = [""]
+        if not qa['is_impossible']:
+            answers = [a['text'] for a in qa['answers']]
+
+        # remove '.', '?', '!' from answers for proper sentence
+        # tokenization
+        edited_answers = []
+        for answer in answers:
+            new_answer = answer.replace(
+                '.', '').replace('?', '').replace('!', '')
+            context = context.replace(answer, new_answer)
+            edited_answers.append(new_answer)
+
+        edited_sentences = self.sent_tok.tokenize(context)
+
+        labels = []
+        label_starts = []
+        for sentence in edited_sentences:
+            for answer in edited_answers:
+                if answer in sentence and sentence not in labels:
+                    labels.append(sentence)
+                    label_starts.append(context.index(sentence))
+                    break
+
+        plausible = []
+        if qa['is_impossible']:
+            plausible = qa['plausible_answers']
+        action = {
+            'id': 'squad',
+            'text': context + '\n' + question,
+            'labels': labels,
+            'plausible_answers': plausible,
+            'episode_done': True,
+            'answer_starts': label_starts
+        }
+        return action
+
+
+class SentenceLabelsTeacher(IndexTeacher):
+    """Teacher which contains the question as the text, the sentences as the
+    label candidates, and the label as the sentence containing the answer.
+
+    Some punctuation may be removed for tokenization purposes.
+    """
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
+
+        try:
+            import nltk
+        except ImportError:
+            raise ImportError('Please install nltk (e.g. pip install nltk).')
+        # nltk-specific setup
+        st_path = 'tokenizers/punkt/{0}.pickle'.format('english')
+        try:
+            self.sent_tok = nltk.data.load(st_path)
+        except LookupError:
+            nltk.download('punkt')
+            self.sent_tok = nltk.data.load(st_path)
+
+    def get(self, episode_idx, entry_idx=None):
+        article_idx, paragraph_idx, qa_idx = self.examples[episode_idx]
+        article = self.squad[article_idx]
+        paragraph = article['paragraphs'][paragraph_idx]
+        qa = paragraph['qas'][qa_idx]
+        context = paragraph['context']
+        question = qa['question']
+
+        answers = ['']
+        if not qa['is_impossible']:
+            answers = [a['text'] for a in qa['answers']]
+
+        # remove '.', '?', '!' from answers for proper sentence
+        # tokenization
+        edited_answers = []
+        for answer in answers:
+            new_answer = answer.replace(
+                '.', '').replace('?', '').replace('!', '')
+            context = context.replace(answer, new_answer)
+            edited_answers.append(new_answer)
+
+        edited_sentences = self.sent_tok.tokenize(context)
+
+        labels = []
+        for sentence in edited_sentences:
+            for answer in edited_answers:
+                if answer in sentence and sentence not in labels:
+                    labels.append(sentence)
+                    break
+
+        plausible = []
+        if qa['is_impossible']:
+            plausible = qa['plausible_answers']
+        action = {
+            'id': 'SquadSentenceLabels',
+            'text': question,
+            'labels': labels,
+            'plausible_answers': plausible,
+            'label_candidates': edited_sentences,
+            'episode_done': True,
+        }
+
+        return action

--- a/parlai/tasks/squad2/agents.py
+++ b/parlai/tasks/squad2/agents.py
@@ -222,7 +222,7 @@ class SentenceIndexTeacher(IndexTeacher):
         context = paragraph['context']
         question = qa['question']
 
-        answers = ['']
+        answers = []
         if not qa['is_impossible']:
             answers = [a['text'] for a in qa['answers']]
 
@@ -254,6 +254,8 @@ class SentenceIndexTeacher(IndexTeacher):
                     labels.append(sentence)
                     label_starts.append(context.index(sentence))
                     break
+        if len(labels) == 0:
+            labels.append('')
 
         plausible = []
         if qa['is_impossible']:

--- a/parlai/tasks/squad2/build.py
+++ b/parlai/tasks/squad2/build.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+# Download and build the data if it does not exist.
+
+import parlai.core.build_data as build_data
+import os
+
+
+def build(opt):
+    dpath = os.path.join(opt['datapath'], 'SQuAD2')
+    version = None
+
+    if not build_data.built(dpath, version_string=version):
+        print('[building data: ' + dpath + ']')
+        if build_data.built(dpath):
+            # An older version exists, so remove these outdated files.
+            build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # Download the data.
+        fname1 = 'train-v2.0.json'
+        fname2 = 'dev-v2.0.json'
+        url = 'https://rajpurkar.github.io/SQuAD-explorer/dataset/'
+        build_data.download(url + fname1, dpath, fname1)
+        build_data.download(url + fname2, dpath, fname2)
+
+        # Mark the data as built.
+        build_data.mark_done(dpath, version_string=version)

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -215,6 +215,13 @@ task_list = [
         "description": "The SNLI corpus (version 1.0) is a collection of 570k human-written English sentence pairs manually labeled for balanced classification with the labels entailment, contradiction, and neutral, supporting the task of natural language inference (NLI), also known as recognizing textual entailment (RTE). See https://nlp.stanford.edu/projects/snli/"
     },
     {
+        "id": "SQuAD2",
+        "display_name": "SQuAD2",
+        "task": "squad2",
+        "tags": [ "All",  "QA" ],
+        "description": "Open-domain QA dataset answerable from a given paragraph from Wikipedia, from Rajpurkar & Jia et al. '18. Link: http://arxiv.org/abs/1806.03822"
+    },
+    {
         "id": "SQuAD",
         "display_name": "SQuAD",
         "task": "squad",


### PR DESCRIPTION
Differences from squad

- If answering the question is impossible, answer is an empty string as per the dataset.
- `plausible_answers` key is populated in the event of an impossible question.

Everything else remains the same as the squad 1.1 task