### PR TITLE
topk sampling from the seq2seq model, make softmax_layer_bias argument to configure bias in the last decoder layer

### DIFF
--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -351,7 +351,7 @@ class Decoder(nn.Module):
             self.o2e = lambda x: x
         # embedding to scores, use custom linear to possibly share weights
         shared_weight = self.lt.weight if share_output else None
-        self.e2s = Linear(emb_size, num_features, bias=False,
+        self.e2s = Linear(emb_size, num_features, bias=True,
                           shared_weight=shared_weight)
         self.shared = shared_weight is not None
 

--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -345,7 +345,7 @@ class Decoder(nn.Module):
         if hidden_size != emb_size and numsoftmax == 1:
             # self.o2e = RandomProjection(hidden_size, emb_size)
             # other option here is to learn these weights
-            self.o2e = nn.Linear(hidden_size, emb_size, bias=False)
+            self.o2e = nn.Linear(hidden_size, emb_size, bias=True)
         else:
             # no need for any transformation here
             self.o2e = lambda x: x

--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -153,7 +153,7 @@ class Seq2seq(nn.Module):
             else:
                 for i in range(ys.size(1)):
                     xi = xs.select(1, i)
-                    preds, score, hidden = self.decoder(xs, hidden, enc_out, attn_mask)
+                    preds, score, hidden = self.decoder(xi, hidden, enc_out, attn_mask)
                     predictions.append(preds)
                     scores.append(score)
         else:

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -161,6 +161,7 @@ class Seq2seqAgent(Agent):
         agent.add_argument('--beam-size', type=int, default=1, help='Beam size, if 1 then greedy search')
         agent.add_argument('--beam-log-freq', type=float, default=0.0,
                            help='The portion of beams to dump from minibatch into model_name.beam_dump folder')
+        agent.add_argument('--topk', type=int, default=1, help='Top k sampling from renormalized softmax, default 1 means simple greedy max output')
         Seq2seqAgent.dictionary_class().add_cmdline_args(argparser)
         return agent
 
@@ -235,6 +236,7 @@ class Seq2seqAgent(Agent):
 
             # search
             self.beam_size = opt.get('beam_size', 1)
+            self.topk = opt.get('topk', 1)
 
             if not hasattr(self, 'model_class'):
                 # this allows child classes to override this but inherit init
@@ -524,7 +526,7 @@ class Seq2seqAgent(Agent):
             self.update_params()
         else:
             self.model.eval()
-            out = self.model(xs, ys=None, cands=cands, valid_cands=valid_cands, beam_size=self.beam_size)
+            out = self.model(xs, ys=None, cands=cands, valid_cands=valid_cands, beam_size=self.beam_size, topk=self.topk)
             predictions, cand_preds = out[0], out[2]
 
             if ys is not None:

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -161,7 +161,7 @@ class Seq2seqAgent(Agent):
         agent.add_argument('--beam-size', type=int, default=1, help='Beam size, if 1 then greedy search')
         agent.add_argument('--beam-log-freq', type=float, default=0.0,
                            help='The portion of beams to dump from minibatch into model_name.beam_dump folder')
-        agent.add_argument('--topk', type=int, default=1, help='Top k sampling from renormalized softmax, default 1 means simple greedy max output')
+        agent.add_argument('--topk', type=int, default=1, help='Top k sampling from renormalized softmax in test/valid time, default 1 means simple greedy max output')
         agent.add_argument('--softmax-layer-bias', type='bool', default=False, help='Put True if you want to include the bias in decoder.e2s layer')
         Seq2seqAgent.dictionary_class().add_cmdline_args(argparser)
         return agent

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -162,6 +162,7 @@ class Seq2seqAgent(Agent):
         agent.add_argument('--beam-log-freq', type=float, default=0.0,
                            help='The portion of beams to dump from minibatch into model_name.beam_dump folder')
         agent.add_argument('--topk', type=int, default=1, help='Top k sampling from renormalized softmax, default 1 means simple greedy max output')
+        agent.add_argument('--softmax-layer-bias', type='bool', default=False, help='Put True if you want to include the bias in decoder.e2s layer')
         Seq2seqAgent.dictionary_class().add_cmdline_args(argparser)
         return agent
 
@@ -295,7 +296,7 @@ class Seq2seqAgent(Agent):
             if states:
                 # set loaded states if applicable
                 self.model.load_state_dict(states['model'])
-
+                    
             if self.use_cuda:
                 self.model.cuda()
 


### PR DESCRIPTION
So now one can do topk sampling for search (so greedy, beam and topk is supported). K is specified with --topk cmd arg. Default value is 1, which goes down to greedy search.

Another change is a bias in the last decoder layer. Now one can turn it on by using --softmax-layer-bias True argument. It is False by default.