### PR TITLE
add cache for data length, huge impact on hogwild

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -179,6 +179,8 @@ class Seq2seqAgent(Agent):
         self.use_person_tokens = opt.get('person_tokens', False)
         self.batch_idx = shared and shared.get('batchindex') or 0
         self.rank = opt['rank_candidates']
+        self.beam_size = opt.get('beam_size', 1)
+        self.topk = opt.get('topk', 1)
         states = {}
 
         # check for cuda
@@ -234,10 +236,6 @@ class Seq2seqAgent(Agent):
             self.END_IDX = self.dict[self.dict.end_token]
             # get index of null token from dictionary (probably 0)
             self.NULL_IDX = self.dict[self.dict.null_token]
-
-            # search
-            self.beam_size = opt.get('beam_size', 1)
-            self.topk = opt.get('topk', 1)
 
             if not hasattr(self, 'model_class'):
                 # this allows child classes to override this but inherit init

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -34,6 +34,8 @@ from .agents import Teacher, create_task_agent_from_taskname
 from .image_featurizers import ImageLoader
 from .utils import AttrDict, flatten, sort_data, make_batches, no_lock, str_to_msg
 
+from functools import lru_cache
+
 import concurrent.futures
 import multiprocessing
 from multiprocessing import Value, Lock
@@ -332,6 +334,7 @@ class FixedDialogTeacher(Teacher):
             return len(self.sorted_data)
         raise RuntimeError('"num_episodes" must be overriden by children.')
 
+    @lru_cache(maxsize=1)
     def num_examples(self):
         """Get the total number of examples in this dataset."""
         if self.use_batch_act:
@@ -470,6 +473,7 @@ class DialogTeacher(FixedDialogTeacher):
         except AttributeError:
             return super().num_episodes()
 
+    @lru_cache(maxsize=1)
     def num_examples(self):
         try:
             return self.data.num_examples()
@@ -625,9 +629,11 @@ class DialogData(object):
         """Return number of episodes in the dataset."""
         return len(self.data)
 
+    @lru_cache(maxsize=1)
     def num_examples(self):
-        """Returns total number of entries available. Each episode has at least
-        one entry, but might have many more.
+        """Returns total number of entries available.
+
+        Each episode has at least one entry, but might have many more.
         """
         return sum(len(episode) for episode in self.data)
 

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -43,9 +43,10 @@ All worlds are initialized with the following parameters:
 
 import copy
 import importlib
-import math
 import random
 import time
+
+from functools import lru_cache
 
 try:
     from torch.multiprocessing import Process, Value, Condition, Semaphore
@@ -846,6 +847,7 @@ class HogwildWorld(World):
     def getID(self):
         return self.inner_world.getID()
 
+    @lru_cache(maxsize=1)
     def num_examples(self):
         return self.inner_world.num_examples()
 

--- a/projects/personachat/kvmemnn/kvmemnn.py
+++ b/projects/personachat/kvmemnn/kvmemnn.py
@@ -240,6 +240,7 @@ class KvmemnnAgent(Agent):
             print("[ creating KvmemnnAgent ]")
             # this is not a shared instance of this class, so do full init
             self.threadindex = -1
+            torch.set_num_threads(1)
 
             if ((opt['dict_file'] is None and opt.get('model_file')) or
                 os.path.isfile(opt['model_file'] + '.dict')):


### PR DESCRIPTION
models were not scaling well with increased num threads, recalculating number of examples in dataset every time was dramatically slowing down the queueing of examples
```
python examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -m starspace -dt train:ordered -eps 10 -bs 1 -nt NT

STARSPACE
nt | time | new
08 |  06s | -- 
08 |  55s | 43
16 |  56s |  --
32 |  65s | 9
40 |  79s | 9
```