### PR TITLE
Safer standards for server shutdowns, both intentional and otherwise

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -116,6 +116,7 @@ class MTurkManager():
         self.is_test = is_test
         self.is_unique = False
         self._init_logs()
+        self.is_shutdown = False
 
     # Helpers and internal manager methods #
 
@@ -156,7 +157,7 @@ class MTurkManager():
                     # otherwise only need to check an hour for safety
                     compare_time = 24 * 60 * 60 if init_load else 60 * 60
                     if time.time() - existing_times['last_reset'] < \
-                            24 * 60 * 60 and not force:
+                            compare_time and not force:
                         return  # do nothing if it's been less than a day
                     reset_workers = list(existing_times.keys())
                     reset_workers.remove('last_reset')
@@ -428,6 +429,7 @@ class MTurkManager():
             self._on_socket_dead,
             self.task_group_id,
             socket_dead_timeout=timeout_seconds,
+            server_death_callback=self.shutdown,
         )
 
     def _on_alive(self, pkt):
@@ -887,6 +889,8 @@ class MTurkManager():
                                    'Local: Setting up WebSocket...',
                                    not self.is_test)
         self._setup_socket(timeout_seconds=timeout_seconds)
+        shared_utils.print_and_log(logging.INFO, 'WebSocket set up!',
+                                   should_print=True)
 
     def start_new_run(self):
         """Clear state to prepare for a new run"""
@@ -1060,14 +1064,28 @@ class MTurkManager():
                 break
             time.sleep(shared_utils.THREAD_MEDIUM_SLEEP)
 
-    def shutdown(self):
+    def _wait_for_task_length(self):
+        '''Wait for the full task duration to ensure anyone who sees the task
+        has it expired, and ensures that all tasks are properly expired
+        '''
+        start_time = time.time()
+        min_wait = self.opt['assignment_duration_in_seconds']
+        while time.time() - start_time < min_wait:
+            self.expire_all_unassigned_hits()
+            time.sleep(60)
+
+    def shutdown(self, force=False):
         """Handle any mturk client shutdown cleanup."""
         # Ensure all threads are cleaned and state and HITs are handled
+        if self.is_shutdown and not force:
+            return
+        self.is_shutdown = True
         try:
             self.expire_all_unassigned_hits()
             self._expire_onboarding_pool()
             self._expire_worker_pool()
-            self.socket_manager.close_all_channels()
+            self._wait_for_task_length()
+            self.socket_manager.shutdown()
             for assignment_id in self.assignment_to_onboard_thread:
                 self.assignment_to_onboard_thread[assignment_id].join()
         except BaseException:
@@ -1328,6 +1346,8 @@ class MTurkManager():
 
         qualifications = self.get_qualification_list(qualifications)
 
+        self.opt['assignment_duration_in_seconds'] = self.opt.get(
+            'assignment_duration_in_seconds', 30 * 60)
         hit_type_id = mturk_utils.create_hit_type(
             hit_title=self.opt['hit_title'],
             hit_description='{} (ID: {})'.format(self.opt['hit_description'],
@@ -1526,7 +1546,6 @@ class MTurkManager():
                 ''.format(worker_id, qual_name, repr(e)),
                 should_print=True
             )
-
 
     def create_qualification(self, qualification_name, description,
                              can_exist=True):

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -315,22 +315,30 @@ class SocketManager():
                 self._safe_put(connection_id, (t, packet))
 
     def _spawn_reaper_thread(self):
-        start_time = time.time()
-        wait_time = self.DEF_MISSED_PONGS * self.HEARTBEAT_RATE
-        while time.time() - start_time < wait_time:
-            if self.is_shutdown:
-                return
-            if self.alive:
-                return
-            time.sleep(0.3)
-        if self.server_death_callback is not None:
-            shared_utils.print_and_log(
-                logging.WARN,
-                'Server has disconnected and could not reconnect. Assuming the'
-                ' worst and calling the death callback. (Usually shutdown)',
-                should_print=True,
-            )
-            self.server_death_callback()
+        def _reaper_thread(*args):
+            start_time = time.time()
+            wait_time = self.DEF_MISSED_PONGS * self.HEARTBEAT_RATE
+            while time.time() - start_time < wait_time:
+                if self.is_shutdown:
+                    return
+                if self.alive:
+                    return
+                time.sleep(0.3)
+            if self.server_death_callback is not None:
+                shared_utils.print_and_log(
+                    logging.WARN,
+                    'Server has disconnected and could not reconnect. '
+                    'Assuming the worst and calling the death callback. '
+                    '(Usually shutdown)',
+                    should_print=True,
+                )
+                self.server_death_callback()
+        reaper_thread = threading.Thread(
+            target=_reaper_thread,
+            name='socket-reaper-{}'.format(self.task_group_id)
+        )
+        reaper_thread.daemon = True
+        reaper_thread.start()
 
     def _setup_socket(self):
         """Create socket handlers and registers the socket"""

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -166,7 +166,7 @@ class SocketManager():
 
     def __init__(self, server_url, port, alive_callback, message_callback,
                  socket_dead_callback, task_group_id,
-                 socket_dead_timeout=None):
+                 socket_dead_timeout=None, server_death_callback=None):
         """
         server_url:           url at which the server is to be run
         port:                 port for the socket to operate on
@@ -185,6 +185,7 @@ class SocketManager():
         self.alive_callback = alive_callback
         self.message_callback = message_callback
         self.socket_dead_callback = socket_dead_callback
+        self.server_death_callback = server_death_callback
         if socket_dead_timeout is not None:
             self.missed_pongs = socket_dead_timeout / self.HEARTBEAT_RATE
         else:
@@ -204,6 +205,7 @@ class SocketManager():
         self.pongs_without_heartbeat = {}
         self.packet_map = {}
         self.alive = False
+        self.is_shutdown = False
 
         # setup the socket
         self._setup_socket()
@@ -312,6 +314,24 @@ class SocketManager():
                 t = time.time() + self.ACK_TIME[packet.type]
                 self._safe_put(connection_id, (t, packet))
 
+    def _spawn_reaper_thread(self):
+        start_time = time.time()
+        wait_time = self.DEF_MISSED_PONGS * self.HEARTBEAT_RATE
+        while time.time() - start_time < wait_time:
+            if self.is_shutdown:
+                return
+            if self.alive:
+                return
+            time.sleep(0.3)
+        if self.server_death_callback is not None:
+            shared_utils.print_and_log(
+                logging.WARN,
+                'Server has disconnected and could not reconnect. Assuming the'
+                ' worst and calling the death callback. (Usually shutdown)',
+                should_print=True,
+            )
+            self.server_death_callback()
+
     def _setup_socket(self):
         """Create socket handlers and registers the socket"""
         def on_socket_open(*args):
@@ -343,13 +363,16 @@ class SocketManager():
 
         def on_disconnect(*args):
             """Disconnect event is a no-op for us, as the server reconnects
-            automatically on a retry"""
+            automatically on a retry. Just in case the server is actually
+            dead we set up a thread to reap the whole task.
+            """
             shared_utils.print_and_log(
                 logging.INFO,
                 'World server disconnected: {}'.format(args)
             )
             self.alive = False
             self._ensure_closed()
+            self._spawn_reaper_thread()
 
         def on_message(*args):
             """Incoming message handler for ACKs, ALIVEs, HEARTBEATs,
@@ -578,3 +601,8 @@ class SocketManager():
                     connection_id
                 )
             )
+
+    def shutdown(self):
+        '''marks the socket manager as closing, shuts down all channels'''
+        self.is_shutdown = False
+        self.close_all_channels()


### PR DESCRIPTION
- During intentional shutdown, waits for the full duration of the task trying to expire tasks every 60 seconds until the task is complete. This ensures people connecting during shutdown will see expired tasks
- Server disconnect now spawns a reaper thread. If the server doesn't reconnect within 20 seconds we kill the whole task.

![screen shot 2018-07-24 at 5 49 56 pm](https://user-images.githubusercontent.com/1276867/43168182-540e9a56-8f6a-11e8-9ca2-2a3d8b3320be.png)
