### PR TITLE
better display_data

### DIFF
--- a/parlai/scripts/display_data.py
+++ b/parlai/scripts/display_data.py
@@ -22,8 +22,9 @@ def setup_args(parser=None):
     if parser is None:
         parser = ParlaiParser(True, True)
     # Get command line arguments
-    parser.add_argument('-ne', '--num-examples', type=int, default=10)
-    parser.add_argument('-mdl', '--max-display-len', type=int, default=1000)
+    parser.add_argument('-ne', '--num_examples', type=int, default=10)
+    parser.add_argument('-mdl', '--max_display_len', type=int, default=1000)
+    parser.add_argument('--display_ignore_fields', type=str, default='agent_reply')
     parser.set_defaults(datatype='train:stream')
     return parser
 


### PR DESCRIPTION
- doesn't show repeatLabelAgent (we already have the 'labels' field anyway)
- shows other hidden fields if they exist (unless you ignore them). clips the text of those too if needed

