### PR TITLE
fix seq2seq ppl caching

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -294,7 +294,7 @@ class Seq2seqAgent(Agent):
             if states:
                 # set loaded states if applicable
                 self.model.load_state_dict(states['model'])
-                    
+
             if self.use_cuda:
                 self.model.cuda()
 
@@ -384,8 +384,6 @@ class Seq2seqAgent(Agent):
 
     def v2t(self, vec):
         """Convert token indices to string of tokens."""
-        if isinstance(vec, Variable):
-            vec = vec.data
         new_vec = []
         for i in vec:
             if i == self.END_IDX:
@@ -692,7 +690,7 @@ class mydefaultdict(defaultdict):
     """
     def get(self, key, default=None):
         # override default from "get" (like "__getitem__" already is)
-        return super().get(key, self.default_factory())
+        return super().get(key, default or self.default_factory())
 
 
 class PerplexityEvaluatorAgent(Seq2seqAgent):
@@ -728,12 +726,14 @@ class PerplexityEvaluatorAgent(Seq2seqAgent):
             self.prev_enc = None  # reset prev_enc
 
         self.model.eval()
-        self.model.longest_label = 1  # no need to predict farther ahead
+        # no need to predict farther ahead
+        # if you pass in any ys, this will be ignored
+        self.model.longest_label = 1
         out = self.model(
-            batch[0], # xs
+            batch[0],  # xs
             ys=(batch[1] if len(partial_out) > 0 else None),
             prev_enc=self.prev_enc)
-        scores, self.prev_enc = out[1], out[-1]
+        scores, self.prev_enc = out[1], out[4]
         # scores is bsz x seqlen x num_words, so select probs of current index
         probs = F.softmax(scores.select(1, -1), dim=1).squeeze()
         dist = mydefaultdict(lambda: 1e-7)  # default probability for any token

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -722,7 +722,7 @@ class PerplexityEvaluatorAgent(Seq2seqAgent):
         obs = self.observation
         obs['eval_labels'] = [' '.join(partial_out)]
         batch = self.vectorize([obs])
-        if self.prev_enc is not None and batch[0].shape[1] != self.prev_enc[0].shape[1]:
+        if len(partial_out) == 0:
             self.prev_enc = None  # reset prev_enc
 
         self.model.eval()

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -723,7 +723,8 @@ class PerplexityEvaluatorAgent(Seq2seqAgent):
         obs['eval_labels'] = [' '.join(partial_out)]
         batch = self.vectorize([obs])
         if len(partial_out) == 0:
-            self.prev_enc = None  # reset prev_enc
+            # reset prev_enc, this is a new input
+            self.prev_enc = None
 
         self.model.eval()
         # no need to predict farther ahead


### PR DESCRIPTION
now that ilia added beam results to the seq2seq forward return, the cached encoder states are no longer in the -1 slot, so index it properly. practically, this was returning None every time before (caching nothing). this is ~4x speedup.

however, I also noticed that this very slightly improved valid (but not test!) performance on convai2, which is strange as recomputing the encoder states, attention mask, and encoder hidden state should not result in a different output since the inputs shouldn't have changed. it turns out the method for checking when to reset the cache was flawed, resulting in a few examples (in valid, none in test test) where it didn't realize it was onto a new example and didn't clean the cache out. this should have made it worse on the next example, but I guess it got very lucky and got examples with very similar outputs. this is fixed below as well.

note: the leaderboard numbers are accurate.