### PR TITLE
Add tblogger parser, now --tensorboard-log False works when you start…

### DIFF
--- a/parlai/scripts/eval_wordstat.py
+++ b/parlai/scripts/eval_wordstat.py
@@ -31,6 +31,7 @@ from parlai.core.agents import create_agent
 from parlai.core.worlds import create_task
 from parlai.core.utils import TimeLogger
 from parlai.core.metrics import normalize_answer
+from parlai.core.logs import TensorboardLogger
 from collections import Counter
 
 import copy
@@ -54,6 +55,7 @@ def setup_args(parser=None):
     parser.add_argument('-cun', '--compute-unique', type=bool, default=True,
                         help='Compute % of unique responses from the model')
     parser.set_defaults(datatype='valid', model='repeat_label')
+    TensorboardLogger.add_cmdline_args(parser)
     return parser
 
 


### PR DESCRIPTION
… the script

We need this part in order to be able to rewrite tensorboard-log to False during eval (that is what we usually want)