### PR TITLE
another fix to cache

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -719,17 +719,22 @@ class PerplexityEvaluatorAgent(Seq2seqAgent):
         obs = self.observation
         obs['eval_labels'] = [' '.join(partial_out)]
         batch = self.vectorize([obs])
-        if len(partial_out) == 0:
+
+        xs, ys = batch[0], batch[1]
+        if self.prev_enc is not None and (
+                xs.shape[1] != self.last_xs.shape[1] or
+                (xs == self.last_xs).sum().item() != xs.shape[1]):
             # reset prev_enc, this is a new input
             self.prev_enc = None
+        self.last_xs = xs
 
         self.model.eval()
         # no need to predict farther ahead
         # if you pass in any ys, this will be ignored
         self.model.longest_label = 1
         out = self.model(
-            batch[0],  # xs
-            ys=(batch[1] if len(partial_out) > 0 else None),
+            xs,
+            ys=(ys if len(partial_out) > 0 else None),
             prev_enc=self.prev_enc)
         scores, self.prev_enc = out[1], out[4]
         # scores is bsz x seqlen x num_words, so select probs of current index

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -701,6 +701,7 @@ class PerplexityEvaluatorAgent(Seq2seqAgent):
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
         self.prev_enc = None
+        self.last_xs = None
 
     def next_word_probability(self, partial_out):
         """Return probability distribution over next words given an input and
@@ -721,7 +722,7 @@ class PerplexityEvaluatorAgent(Seq2seqAgent):
         batch = self.vectorize([obs])
 
         xs, ys = batch[0], batch[1]
-        if self.prev_enc is not None and (
+        if self.prev_enc is not None and self.last_xs is not None and (
                 xs.shape[1] != self.last_xs.shape[1] or
                 (xs == self.last_xs).sum().item() != xs.shape[1]):
             # reset prev_enc, this is a new input

--- a/projects/convai2/baselines/seq2seq/train.py
+++ b/projects/convai2/baselines/seq2seq/train.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
         model='seq2seq',
         model_file='/tmp/convai2_self_seq2seq_model',
         dict_lower=True,
-        dict_include_valid=True,
+        dict_include_valid=False,
         dict_maxexs=-1,
         datatype='train',
         batchsize=64,


### PR DESCRIPTION
- realized cache was being reset properly on test set for seq2seq with change this morning (hotfix was already merged so isn't showing bad behavior right now)
- realized original model was trained with dict_include_valid=False, although performance is similar it seems but should reflect original training