### PR TITLE
Fix for squad name changes

### DIFF
--- a/parlai/tasks/squad/agents.py
+++ b/parlai/tasks/squad/agents.py
@@ -269,7 +269,7 @@ class SentenceTeacher(IndexTeacher):
         return action
 
 
-class SentenceeditTeacher(SentenceIndexTeacher):
+class SentenceeditTeacher(SentenceTeacher):
     """Index teacher where the labels are the sentences the contain the true
     answer.
 


### PR DESCRIPTION
Fix commit that broke checks because sentenceedit teacher did not have a parent class CC @klshuster 