### PR TITLE
Add heroku team option

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -218,6 +218,10 @@ class ParlaiParser(argparse.ArgumentParser):
             help='Qualification to use to share the maximum time requirement '
                  'with other runs from other machines.'
         )
+        mturk.add_argument(
+            '--heroku-team', dest='heroku_team', default=None,
+            help='Specify Heroku team name to use for launching Dynos.'
+        )
 
         mturk.set_defaults(is_sandbox=True)
         mturk.set_defaults(is_debug=False)

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -875,9 +875,14 @@ class MTurkManager():
         task_name = '{}-{}'.format(str(uuid.uuid4())[:8], self.opt['task'])
         self.server_task_name = \
             ''.join(e for e in task_name.lower() if e.isalnum() or e == '-')
+        if 'heroku_team' in self.opt:
+            heroku_team = self.opt['heroku_team']
+        else:
+            heroku_team = None
         self.server_url = server_utils.setup_server(self.server_task_name,
                                                     self.task_files_to_copy,
-                                                    self.opt['local'])
+                                                    self.opt['local'],
+                                                    heroku_team)
         shared_utils.print_and_log(logging.INFO, self.server_url)
 
         shared_utils.print_and_log(logging.INFO, "MTurk server setup done.\n",

--- a/parlai/mturk/core/server_utils.py
+++ b/parlai/mturk/core/server_utils.py
@@ -31,7 +31,7 @@ heroku_url = \
     'https://cli-assets.heroku.com/heroku-cli/channels/stable/heroku-cli'
 
 
-def setup_heroku_server(task_name, task_files_to_copy=None):
+def setup_heroku_server(task_name, task_files_to_copy=None, heroku_team=None):
     print("Heroku: Collecting files...")
     # Install Heroku CLI
     os_name = None
@@ -144,12 +144,12 @@ def setup_heroku_server(task_name, task_files_to_copy=None):
 
     # Create or attach to the server
     try:
-        if os.getenv('HEROKU_TEAM') is not None:
+        if heroku_team is not None:
             subprocess.check_output(shlex.split(
                 '{} create {} --team {}'.format(
                     heroku_executable_path,
                     heroku_app_name,
-                    os.getenv('HEROKU_TEAM')
+                    heroku_team
                 )
             ))
         else:
@@ -295,7 +295,7 @@ def delete_local_server(task_name):
     sh.rm(shlex.split('-rf {}'.format(local_server_directory_path)))
 
 
-def setup_server(task_name, task_files_to_copy, local=False):
+def setup_server(task_name, task_files_to_copy, local=False, heroku_team=None):
     if local:
         return setup_local_server(
             task_name,
@@ -303,7 +303,8 @@ def setup_server(task_name, task_files_to_copy, local=False):
         )
     return setup_heroku_server(
         task_name,
-        task_files_to_copy=task_files_to_copy
+        task_files_to_copy=task_files_to_copy,
+        heroku_team=heroku_team
     )
 
 

--- a/parlai/mturk/core/server_utils.py
+++ b/parlai/mturk/core/server_utils.py
@@ -144,9 +144,18 @@ def setup_heroku_server(task_name, task_files_to_copy=None):
 
     # Create or attach to the server
     try:
-        subprocess.check_output(shlex.split(
-            '{} create {}'.format(heroku_executable_path, heroku_app_name)
-        ))
+        if os.getenv('HEROKU_TEAM') is not None:
+            subprocess.check_output(shlex.split(
+                '{} create {} --team {}'.format(
+                    heroku_executable_path,
+                    heroku_app_name,
+                    os.getenv('HEROKU_TEAM')
+                )
+            ))
+        else:
+            subprocess.check_output(shlex.split(
+                '{} create {}'.format(heroku_executable_path, heroku_app_name)
+            ))
     except subprocess.CalledProcessError:  # User has too many apps
         sh.rm(shlex.split('-rf {}'.format(heroku_server_directory_path)))
         raise SystemExit(


### PR DESCRIPTION
Since I'm soon going to expire my free dyno quota with Heroku, we've set up a team account on our lab's funds. The diff is meant to enable the launch of a Heroku dyno on the team account.

Note: You have to have all permissions within the team to be able to destroy the dyno you've created.

Going with environment variable was the simplest way to pass down the team info to `mturk/core` that I found. I guess we could add it as a command argument if needed. Currently using with:
```
HEROKU_TEAM=dialogeval python run.py
```
