### PR TITLE
Padding utils fix

### DIFF
--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -43,6 +43,8 @@ def maintain_dialog_history(history, observation, reply='',
         if useReplies == 'model' or (useReplies == 'label_else_model' and
                                      len(history['labels']) == 0):
             if reply:
+                if useStartEndIndices:
+                    reply = dict.start_token + ' ' + reply
                 history['dialog'].extend(parse(reply, splitSentences))
         elif len(history['labels']) > 0:
             r = history['labels'][0]

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -43,8 +43,6 @@ def maintain_dialog_history(history, observation, reply='',
         if useReplies == 'model' or (useReplies == 'label_else_model' and
                                      len(history['labels']) == 0):
             if reply:
-                if useStartEndIndices:
-                    reply = dict.start_token + ' ' + reply
                 history['dialog'].extend(parse(reply, splitSentences))
         elif len(history['labels']) > 0:
             r = history['labels'][0]
@@ -471,8 +469,8 @@ class PaddingUtils(object):
             # parse each label and append END
             if dq:
                 parsed_y = [deque(maxlen=truncate) for _ in labels]
-                for dq, y in zip(parsed_y, labels):
-                    dq.extendleft(reversed(dictionary.txt2vec(y)))
+                for deq, y in zip(parsed_y, labels):
+                    deq.extendleft(reversed(dictionary.txt2vec(y)))
             else:
                 parsed_y = [dictionary.txt2vec(label) for label in labels]
             if end_idx is not None:


### PR DESCRIPTION
`dq` is already a variable name; using this name as an alias in this loop messes it up for later use if the last label is empty (`if dq` then returns `False`)