### PR TITLE
Better support for socket errors on sends

### DIFF
--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -229,6 +229,9 @@ class SocketManager():
         except websocket.WebSocketConnectionClosedException:
             # The channel died mid-send, wait for it to come back up
             return False
+        except BrokenPipeError:  # noqa F821 we don't support p2
+            # The channel died mid-send, wait for it to come back up
+            return False
         return True
 
     def _ensure_closed(self):

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -232,6 +232,13 @@ class SocketManager():
         except BrokenPipeError:  # noqa F821 we don't support p2
             # The channel died mid-send, wait for it to come back up
             return False
+        except Exception as e:
+            shared_utils.print_and_log(
+                logging.WARN,
+                'Unexpected socket error occured: {}'.format(repr(e)),
+                should_print=True
+            )
+            return False
         return True
 
     def _ensure_closed(self):


### PR DESCRIPTION
Heroku started sending pipes over dead sockets, which caused monitoring threads to die. This should prevent these errors from interrupting normal operation.