### PR TITLE
Implement fairseq candidate ranking using generator.

### DIFF
--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -5,6 +5,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 from parlai.core.dict import DictionaryAgent
+from parlai.core.utils import argsort, padded_tensor
 
 try:
     from fairseq import models, optim, criterions
@@ -489,13 +490,13 @@ class FairseqAgent(TorchAgent):
                 # some models crash if there's leading padding on every example
                 xs = xs[:, :batch.text_lengths[i]]
                 # and appropriately pack the outputs
-                ys, _ = self._padded_tensor(cands)
+                ys, _ = padded_tensor(cands, self.NULL_IDX, self.use_cuda)
                 s = self._make_sample(xs, ys)
                 # perform the actual grading, extract the scores
                 scored = list(self.scorer.score_batched_itr([s], cuda=self.use_cuda))
                 scores = [s[3][0]['score'].item() for s in scored]
                 # intentional hanging comma here; argsort returns a list
-                ranked, = self._argsort(scores, batch.candidates[i], descending=True)
+                ranked, = argsort(scores, batch.candidates[i], descending=True)
                 reranked_cands.append(ranked)
 
         # Next generate freely to create our response

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -487,7 +487,7 @@ class FairseqAgent(TorchAgent):
                 # repeat the input many times
                 xs = batch.text_vec[i].unsqueeze(0).expand(ncand, -1)
                 # some models crash if there's leading padding on every example
-                xs = xs[:,:batch.text_lengths[i]]
+                xs = xs[:, :batch.text_lengths[i]]
                 # and appropriately pack the outputs
                 ys, _ = self._padded_tensor(cands)
                 s = self._make_sample(xs, ys)
@@ -501,7 +501,7 @@ class FairseqAgent(TorchAgent):
         # Next generate freely to create our response
         if not self.args.skip_generation:
             generated_output = self._generate(samples)
-        elif reranked_candidates:
+        elif reranked_cands:
             # we're skiping generation, but we're also grading candidates
             # so output the highest ranked candidate
             # In the case of zero candidates, we don't have something to rank,
@@ -514,7 +514,6 @@ class FairseqAgent(TorchAgent):
             pass
 
         return Output(generated_output, reranked_cands)
-
 
     def _generate(self, samples):
         src_tokens = samples["net_input"]["src_tokens"]

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -484,6 +484,8 @@ class FairseqAgent(TorchAgent):
                 ncand = len(cands)
                 # repeat the input many times
                 xs = batch.text_vec[i].unsqueeze(0).expand(ncand, -1)
+                # some models crash if there's leading padding on every example
+                xs = xs[:,:batch.text_lengths[i]]
                 # and appropriately pack the outputs
                 ys, _ = self._padded_tensor(cands)
                 s = self._make_sample(xs, ys)

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -311,6 +311,45 @@ class TorchAgent(Agent):
 
         return obs
 
+    def _padded_tensor(self, items):
+        """Create a right-padded matrix from an uneven list of lists.
+
+        :param list[list[int]] items: List of items
+        :param bool sort: If True, orders by the length
+        :rtype: (Tensor[int64], list[int])
+        :return: (padded, lengths)
+        """
+        n = len(items)
+        lens = [len(item) for item in items]
+        t = max(lens)
+        output = torch.LongTensor(n, t).fill_(self.NULL_IDX)
+        for i in range(len(items)):
+            output[i, :lens[i]] = items[i]
+        if self.use_cuda:
+            output = output.cuda()
+        return output, lens
+
+    def _argsort(self, keys, *lists, descending=False):
+        """Reorder each list in lists by the (descending) sorted order of keys.
+
+        :param iter keys: sort indices
+        :param list[list] lists: lists to reordered by keys's order
+        :param bool descending: Use descending order if true
+        :return list[list]]: The reordered items
+        """
+        ind_sorted = sorted(range(len(keys)), key=lambda k: keys[k])
+        if descending:
+            ind_sorted = list(reversed(ind_sorted))
+        output = []
+        for lst in lists:
+            if isinstance(lst, set):
+                lst = list(lst)
+            if isinstance(lst, torch.Tensor):
+                output.append(lst[ind_sorted])
+            else:
+                output.append([lst[i] for i in ind_sorted])
+        return output
+
     def batchify(self, obs_batch, sort=False,
                  is_valid=lambda obs: 'text_vec' in obs or 'image' in obs):
         """Create a batch of valid observations from an unchecked batch.
@@ -352,21 +391,13 @@ class TorchAgent(Agent):
         # TEXT
         xs, x_lens = None, None
         if any('text_vec' in ex for ex in exs):
-            x_text = [ex.get('text_vec', self.EMPTY) for ex in exs]
-            x_lens = [x.shape[0] for x in x_text]
-
+            _xs = [ex.get('text_vec', self.EMPTY) for ex in exs]
+            xs, x_lens = self._padded_tensor(_xs)
             if sort:
                 sort = False  # now we won't sort on labels
-                ind_sorted = sorted(range(len(x_lens)),
-                                    key=lambda k: -x_lens[k])
-                exs = [exs[k] for k in ind_sorted]
-                valid_inds = [valid_inds[k] for k in ind_sorted]
-                x_text = [x_text[k] for k in ind_sorted]
-                x_lens = [x_lens[k] for k in ind_sorted]
-
-            xs = torch.LongTensor(len(exs), max(x_lens)).fill_(self.NULL_IDX)
-            for i, ex in enumerate(x_text):
-                xs[i, :ex.shape[0]] = ex
+                xs, x_lens, valid_inds, exs = self._argsort(
+                    x_lens, xs, x_lens, valid_inds, exs, descending=True
+                )
             if self.use_cuda:
                 xs = xs.cuda()
 
@@ -384,14 +415,11 @@ class TorchAgent(Agent):
             y_lens = [y.shape[0] for y in label_vecs]
 
             if sort and xs is None:
-                # always sort on xs if we have them, not ys
-                ind_sorted = sorted(range(len(y_lens)),
-                                    key=lambda k: -y_lens[k])
-                exs = [exs[k] for k in ind_sorted]
-                valid_inds = [valid_inds[k] for k in ind_sorted]
-                label_vecs = [label_vecs[k] for k in ind_sorted]
-                labels = [labels[k] for k in ind_sorted]
-                y_lens = [y_lens[k] for k in ind_sorted]
+                ys, y_lens = self._padded_tensor(labels)
+                exs, valid_inds, label_vecs, labels, y_lens = self._argsort(
+                    y_lens, exs, valid_inds, label_vecs, labels, y_lens,
+                    descending=True
+                )
 
             ys = torch.LongTensor(len(exs), max(y_lens)).fill_(self.NULL_IDX)
             for i, y in enumerate(label_vecs):
@@ -461,10 +489,10 @@ class TorchAgent(Agent):
     def _add_person_tokens(self, text, token, add_after_newln=False):
         if add_after_newln:
             split = text.split('\n')
-            split[-1] = token + split[-1]
+            split[-1] = token + ' ' + split[-1]
             return '\n'.join(split)
         else:
-            return token + text
+            return token + ' ' +text
 
     def get_dialog_history(self, observation, reply=None,
                            add_person_tokens=False, add_p1_after_newln=False):
@@ -490,15 +518,14 @@ class TorchAgent(Agent):
         if reply is not None:
             if add_person_tokens:
                 # add person2 token to reply
-                reply = self._add_person_tokens(reply, self.P2_TOKEN + ' ')
+                reply = self._add_person_tokens(reply, self.P2_TOKEN)
             # add reply to history
             self.history.append(reply)
 
         if 'text' in obs:
             if add_person_tokens:
                 # add person1 token to text
-                obs['text'] = self._add_person_tokens(obs['text'],
-                                                      self.P1_TOKEN + ' ',
+                obs['text'] = self._add_person_tokens(obs['text'], self.P1_TOKEN,
                                                       add_p1_after_newln)
             # add text to history
             self.history.append(obs['text'])

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -314,10 +314,12 @@ class TorchAgent(Agent):
     def _padded_tensor(self, items):
         """Create a right-padded matrix from an uneven list of lists.
 
-        :param list[list[int]] items: List of items
-        :param bool sort: If True, orders by the length
-        :rtype: (Tensor[int64], list[int])
-        :return: (padded, lengths)
+        Matrix will be cuda'd automatically if this torch agent uses cuda.
+
+        :param list[iter[int]] items: List of items
+        :param bool sort:             If True, orders by the length
+        :return:                      (padded, lengths) tuple
+        :rtype:                       (Tensor[int64], list[int])
         """
         n = len(items)
         lens = [len(item) for item in items]
@@ -332,18 +334,17 @@ class TorchAgent(Agent):
     def _argsort(self, keys, *lists, descending=False):
         """Reorder each list in lists by the (descending) sorted order of keys.
 
-        :param iter keys: sort indices
-        :param list[list] lists: lists to reordered by keys's order
-        :param bool descending: Use descending order if true
-        :return list[list]]: The reordered items
+        :param iter keys:        Keys to order by
+        :param list[list] lists: Lists to reordered by keys's order.
+                                 Correctly handles lists and 1-D tensors.
+        :param bool descending:  Use descending order if true
+        :return:                 The reordered items
         """
         ind_sorted = sorted(range(len(keys)), key=lambda k: keys[k])
         if descending:
             ind_sorted = list(reversed(ind_sorted))
         output = []
         for lst in lists:
-            if isinstance(lst, set):
-                lst = list(lst)
             if isinstance(lst, torch.Tensor):
                 output.append(lst[ind_sorted])
             else:

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -416,7 +416,7 @@ class TorchAgent(Agent):
             y_lens = [y.shape[0] for y in label_vecs]
 
             if sort and xs is None:
-                ys, y_lens = self._padded_tensor(labels)
+                ys, y_lens = self._padded_tensor(label_vecs)
                 exs, valid_inds, label_vecs, labels, y_lens = self._argsort(
                     y_lens, exs, valid_inds, label_vecs, labels, y_lens,
                     descending=True

--- a/tests/run_tests_short.sh
+++ b/tests/run_tests_short.sh
@@ -9,6 +9,7 @@
 set -e # stop if any tests fail
 for test in $(ls); do
     if [ ${test: -3} == ".py" ] && [ $test != "test_downloads.py" ] && [ $test != "test_mlb_vqa.py" ]; then
+        echo "Running $test"
         python3 $test;
     fi
 done

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -520,12 +520,12 @@ class TestTorchAgent(unittest.TestCase):
             "Attack ships on fire off the shoulder of Orion.\n"
             "I watched C-beams glitter in the dark near the Tannhauser gate.\n"
             "All those moments will be lost in time, like tears in rain.")
-        prefix = 'PRE '
+        prefix = 'PRE'
         out = agent._add_person_tokens(text, prefix, add_after_newln=False)
-        self.assertEqual(out, prefix + text)
+        self.assertEqual(out, prefix + ' ' + text)
         out = agent._add_person_tokens(text, prefix, add_after_newln=True)
         idx = text.rfind('\n') + 1
-        self.assertEqual(out, text[:idx] + prefix + text[idx:])
+        self.assertEqual(out, text[:idx] + prefix + ' ' + text[idx:])
 
     def test_get_dialog_history(self):
         """Test different dialog history settings."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,13 +4,18 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-from parlai.core.utils import Timer, round_sigfigs, set_namedtuple_defaults
+from parlai.core.utils import Timer
+from parlai.core.utils import round_sigfigs
+from parlai.core.utils import set_namedtuple_defaults
+from parlai.core.utils import padded_tensor
+from parlai.core.utils import argsort
 import time
 import unittest
+import torch
+import numpy as np
 
 
 class TestUtils(unittest.TestCase):
-
     def test_round_sigfigs(self):
         x = 0
         y = 0
@@ -89,3 +94,30 @@ class TestUtils(unittest.TestCase):
         assert nt.a is 1
         assert nt.b is 1
         assert nt.c is 1
+
+    def test_padded_tensor(self):
+        # list of lists
+        lol = [[1, 2], [3, 4, 5]]
+        output, lens = padded_tensor(lol)
+        assert np.all(output.numpy() == np.array([[1, 2, 0], [3, 4, 5]]))
+        assert lens == [2, 3]
+        output, _ = padded_tensor(lol, left_padded=True)
+        assert np.all(output.numpy() == np.array([[0, 1, 2], [3, 4, 5]]))
+        output, _ = padded_tensor(lol, pad_idx=99)
+        assert np.all(output.numpy() == np.array([[1, 2, 99], [3, 4, 5]]))
+
+    def test_argsort(self):
+        keys = [5, 4, 3, 2, 1]
+        items = ["five", "four", "three", "two", "one"]
+        items2 = ["e", "d", "c", "b", "a"]
+        torch_keys = torch.LongTensor(keys)
+        assert argsort(keys, items, items2) == [
+            list(reversed(items)), list(reversed(items2))
+        ]
+        assert argsort(keys, items, items2, descending=True) == [items, items2]
+
+        assert torch.all(argsort(torch_keys, torch_keys)[0] == torch.arange(1, 6))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,7 +116,7 @@ class TestUtils(unittest.TestCase):
         ]
         assert argsort(keys, items, items2, descending=True) == [items, items2]
 
-        assert torch.all(argsort(torch_keys, torch_keys)[0] == torch.arange(1, 6))
+        assert np.all(argsort(torch_keys, torch_keys)[0].numpy() == np.arange(1, 6))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Uses avg probability per token of the sequence (should be same thing `seq2seq` uses). This is not configurable; it is just a dumb call to fairseq's grader.

Supports variable number of candidates. The way this is done is with multiple calls to scorer, so the batch size isn't as exploited as it could be. We could increase throughput by streamlining, but it would come at the cost of complexity. Seems fine for now.

Holding until #1049 is merged, as there will likely need to be unit test updates and resolving conflicts.

Fixes #924.