### PR TITLE
Sort opts when printing.

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -524,7 +524,7 @@ class ParlaiParser(argparse.ArgumentParser):
             }
             namespace = argparse.Namespace(**group_dict)
             count = 0
-            for key in namespace.__dict__:
+            for key in sorted(namespace.__dict__):
                 if key in values:
                     if count == 0:
                         print('[ ' + group.title + ': ] ')


### PR DESCRIPTION
When printing the options to output in the training script, print them in sorted order. This makes it a big easier to find what a specific option is set to.