### PR TITLE
Revert "Cache txt2vec items."

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -15,7 +15,6 @@ import numpy as np
 import os
 import pickle
 import re
-from functools import lru_cache
 
 try:
     from subword_nmt import learn_bpe, apply_bpe
@@ -102,7 +101,6 @@ class DictionaryAgent(Agent):
     default_tok = 're'
     default_lower = False
     default_textfields = 'text,labels'
-    default_cachesize = int(2 ** 20) # slightly faster if a power of 2
 
     @staticmethod
     def add_cmdline_args(argparser):
@@ -162,12 +160,6 @@ class DictionaryAgent(Agent):
             help='Observation fields which dictionary learns vocabulary from. '
                  'Tasks with additional fields may add to this list to handle '
                  'any extra vocabulary.')
-        dictionary.add_argument(
-            '--dict-cachesize', default=DictionaryAgent.default_cachesize, type=int,
-            help='Cache size for converting strings to tensors. Using this may '
-                 'massively improve throughput if buffer is large, but you may need '
-                 'lots of ram. Works best if a power of 2.')
-
         return dictionary
 
     def __init__(self, opt, shared=None):
@@ -223,10 +215,6 @@ class DictionaryAgent(Agent):
                                                      opt['dict_initpath'])
                 self.load(opt['dict_initpath'])
 
-        if opt.get('dict_cachesize', 0):
-            # Equivalent to using the @lru_cache decorator at runtime
-            self.txt2vec = lru_cache(opt['dict_cachesize'], typed=True)(self.txt2vec)
-
         # initialize tokenizers
         if self.tokenizer == 'nltk':
             try:
@@ -281,15 +269,6 @@ class DictionaryAgent(Agent):
             index = len(self.tok2ind)
             self.tok2ind[word] = index
             self.ind2tok[index] = word
-            # since we have a new token, txt2vec could theoretically change
-            self._clear_cache()
-
-    def _clear_cache(self):
-        """Clear the vectorizer cache if there is one.
-
-        Call this if you ever touch the list of tokens."""
-        if hasattr(self.txt2vec, 'cache_clear'):
-            self.txt2vec.cache_clear()
 
     def __contains__(self, key):
         """If key is an int, returns whether the key is in the indices.
@@ -426,12 +405,6 @@ class DictionaryAgent(Agent):
             self.add_token(token)
             self.freq[token] += 1
 
-    def remove_token(self, token):
-        del self.freq[token]
-        idx = self.tok2ind.pop(token)
-        del self.ind2tok[idx]
-        self._clear_cache()
-
     def remove_tail(self, min_freq):
         """Remove elements below the frequency cutoff from the dictionary."""
         to_remove = []
@@ -441,7 +414,9 @@ class DictionaryAgent(Agent):
                 to_remove.append(token)
 
         for token in to_remove:
-            self.remove_token(token)
+            del self.freq[token]
+            idx = self.tok2ind.pop(token)
+            del self.ind2tok[idx]
 
     def _remove_non_bpe(self):
         """Set the dictionary vocab to the bpe vocab, merging counts."""
@@ -454,7 +429,9 @@ class DictionaryAgent(Agent):
                     to_add.append((t, freq))
                 to_remove.append(token)
         for token in to_remove:
-            self.remove_token(token)
+            del self.freq[token]
+            idx = self.tok2ind.pop(token)
+            del self.ind2tok[idx]
         for token, freq in to_add:
             self.add_token(token)
             self.freq[token] += freq
@@ -463,7 +440,10 @@ class DictionaryAgent(Agent):
         """Trims the dictionary to the maximum number of tokens."""
         if maxtokens >= 0 and len(self.tok2ind) > maxtokens:
             for k in range(maxtokens, len(self.ind2tok)):
-                self.remove_token(self.ind2tok[k])
+                v = self.ind2tok[k]
+                del self.ind2tok[k]
+                del self.tok2ind[v]
+                del self.freq[v]
 
     def load(self, filename):
         """Load pre-existing dictionary in 'token[<TAB>count]' format.


### PR DESCRIPTION
Reverts facebookresearch/ParlAI#1064

I'm not sure this is behaving correctly in the cases of small data sets where start and end tokens are being added. Reverting until I confirm things aren't broken.