### PR TITLE
Throw away empty vector items from the batch.

### DIFF
--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -416,8 +416,12 @@ class FairseqAgent(TorchAgent):
         self.reset_metrics()
 
     def batchify(self, obs_batch):
-        # Fairseq depends on sorted batch inputs for a call to rnn.pad_packed_sequence.
-        # Fairseq models cannot handle zero length sentences
+        """
+        Override parent batchify to set requirements for fairseq.
+
+        Fairseq depends on sorted batch inputs for a call to rnn.pad_packed_sequence.
+        Fairseq models cannot handle zero length sentences
+        """
         return super().batchify(obs_batch, sort=True, is_valid=_is_nonempty_observation)
 
     def train_step(self, batch):

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -43,6 +43,11 @@ NON_OVERRIDABLE_ARGS = {
 }
 
 
+def _is_nonempty_observation(obs):
+    """Check if an observation has no tokens in it."""
+    return len(obs.get('text_vec', [])) > 0
+
+
 def _fairseq_opt_wrapper(opt, skip_pretrained_embedding_loading=False):
     """
     Marshalls from a dict to a argparse.Namespace object for API compatibility.
@@ -410,13 +415,10 @@ class FairseqAgent(TorchAgent):
         super().reset()
         self.reset_metrics()
 
-    def batchify(self, *args, **kwargs):
-        """Override parent batchify to set sorting to true.
-
-        Sorting inputs is needed for torch.nn.utils.rnn.pack_padded_sequence.
-        """
-        kwargs['sort'] = True
-        return super().batchify(*args, **kwargs)
+    def batchify(self, obs_batch):
+        # Fairseq depends on sorted batch inputs for a call to rnn.pad_packed_sequence.
+        # Fairseq models cannot handle zero length sentences
+        return super().batchify(obs_batch, sort=True, is_valid=_is_nonempty_observation)
 
     def train_step(self, batch):
         """Process batch of inputs and targets and train on them.


### PR DESCRIPTION
This causes problems for all of the fairseq models, and will probably cause problems for future models once they are built on top of TorchAgent.

The issue is that on the final batch (but only when using `-bsrt True`), you can get a batch with items that are only pad tokens. This has a tendency to either break attention mechanisms (Transformer) or break the calls to `pad_packed_sequence` (lstm, including seq2seq). By filtering these examples, we don't have to build model-specific work arounds.