### PR TITLE
Setting namedtuple defaults utility.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -6,6 +6,7 @@
 
 from parlai.core.agents import Agent
 from parlai.core.dict import DictionaryAgent
+from parlai.core.utils import set_namedtuple_defaults
 
 try:
     import torch
@@ -60,7 +61,7 @@ Batch = namedtuple('Batch', ['text_vec', 'text_lengths', 'label_vec',
                              'label_lengths', 'labels', 'valid_indices',
                              'candidates', 'candidate_vecs', 'image',
                              'memory_vecs'])
-Batch.__new__.__defaults__ = (None,) * len(Batch._fields)
+set_namedtuple_defaults(Batch, default=None)
 
 
 """
@@ -76,7 +77,7 @@ though agents can choose to return None if they do not want to answer.
                         ranking of strings, of variable length.
 """
 Output = namedtuple('Output', ['text', 'text_candidates'])
-Output.__new__.__defaults__ = (None,) * len(Output._fields)
+set_namedtuple_defaults(Output, default=None)
 
 
 class TorchAgent(Agent):

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -851,3 +851,19 @@ def msg_to_str(msg, ignore_fields=''):
         if f not in default_fields and f not in ignore_fields:
             txt += add_field(f, msg[f])
     return txt.rstrip('\t')
+
+
+def set_namedtuple_defaults(namedtuple, default=None):
+    """
+    Set *all* of the fields for a given nametuple to a singular value.
+    Modifies the tuple in place, but returns it anyway.
+
+    More info:
+    https://stackoverflow.com/a/18348004
+
+    :param namedtuple: A constructed collections.namedtuple
+    :param default: The default value to set.
+    :return: the modified namedtuple
+    """
+    namedtuple.__new__.__defaults__ = (default,) * len(namedtuple._fields)
+    return namedtuple

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-from parlai.core.utils import Timer, round_sigfigs
+from parlai.core.utils import Timer, round_sigfigs, set_namedtuple_defaults
 import time
 import unittest
 
@@ -65,6 +65,27 @@ class TestUtils(unittest.TestCase):
         assert turtle.time() > 0
         assert turtle.time() < rabbit.time()
 
+    def test_setnamedtupledefaults(self):
+        from collections import namedtuple
+        NT = namedtuple("NT", ("a", "b", "c"))
 
-if __name__ == '__main__':
-    unittest.main()
+        # Shouldn't be able to construct a namedtuple without providing info
+        try:
+            NT()
+            assert False, "Shouldn't be able to construct namedtuple"
+        except TypeError:
+            pass
+
+        # Test setting default value
+        set_namedtuple_defaults(NT)
+        nt = NT()
+        assert nt.a is None
+        assert nt.b is None
+        assert nt.c is None
+
+        # Test setting it with something else
+        set_namedtuple_defaults(NT, default=1)
+        nt = NT()
+        assert nt.a is 1
+        assert nt.b is 1
+        assert nt.c is 1


### PR DESCRIPTION
Just a utility method to hide some of the magic and make it easier to reuse in submodules.