### PR TITLE
Adjust some TorchAgent/Fairseq API for easier extension.

### DIFF
--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -317,8 +317,9 @@ class FairseqAgent(TorchAgent):
             self.task = _ParlaiTask(self.dict)
 
             # actually construct the model and generator
-            model_class = models.ARCH_MODEL_REGISTRY[self.args.arch]
-            self.model = model_class.build_model(self.args, self.task)
+            self.model = self.build_model()
+
+            # Construct the generator
             self.generator = SequenceGenerator(
                 [self.model],
                 tgt_dict=self.dict,
@@ -376,6 +377,15 @@ class FairseqAgent(TorchAgent):
                 raise ValueError(
                     '{} cannot be overridden when --model-file is specified'.format(k)
                 )
+
+    def build_model(self):
+        """
+        Construct the actual Fairseq model. Default implementation is to use
+        Fairseq's arch builder, but this method may be overridden to build custom
+        models.
+        """
+        model_class = models.ARCH_MODEL_REGISTRY[self.args.arch]
+        return model_class.build_model(self.args, self.task)
 
     def share(self):
         shared = super().share()

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -483,7 +483,7 @@ class TorchAgent(Agent):
                                    before the actual utterance (e.g. squad,
                                    babi, personachat).
 
-        :return: vectorized observation with text replaced with full dialog
+        :return: observation with text replaced with full dialog
         """
         obs = observation
 
@@ -507,7 +507,7 @@ class TorchAgent(Agent):
         if obs.get('episode_done', True):
             # end of this episode, clear the history
             self.history.clear()
-        return self.vectorize(obs, truncate=self.truncate)
+        return obs
 
     def last_reply(self, use_label=True):
         """Retrieve the last reply from the model.
@@ -520,6 +520,7 @@ class TorchAgent(Agent):
         :param use_label: default true, use the label when available instead of
                           the model's generated response.
         """
+        # if the last observation was the end, then we shouldn't use it as history
         if not self.observation or self.observation.get('episode_done', True):
             return None
 
@@ -546,7 +547,7 @@ class TorchAgent(Agent):
         """
         reply = self.last_reply()
         self.observation = self.get_dialog_history(observation, reply=reply)
-        return self.observation
+        return self.vectorize(self.observation, truncate=self.truncate)
 
     def save(self, path=None):
         """Save model parameters to path (or default to model_file arg).

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -538,7 +538,6 @@ class TestTorchAgent(unittest.TestCase):
         out = agent.get_dialog_history(obs.copy())
         self.assertEqual(out['text'], 'I am Groot.')
         self.assertEqual(out['labels'][0], 'I am Groot?')
-        self.assertTrue('text_vec' in out, 'Text should be vectorized.')
 
         # second exchange, no reply
         out = agent.get_dialog_history(obs.copy())
@@ -687,6 +686,7 @@ class TestTorchAgent(unittest.TestCase):
         # episode was done so shouldn't remember history
         out = agent.observe(obs.copy())
         self.assertEqual(out['text'], 'I\'ll be back.')
+        self.assertTrue('text_vec' in out, 'Text should be vectorized.')
 
         # now try with episode not done
         obs['episode_done'] = False


### PR DESCRIPTION
Please note that the vectorize call has been moved from `maintain_dialog_history` to `observe`.

This is desirable because I'm working on a custom that need to do specialized vectorization of multiple bits, but still maintain a dialog history appropriately. If the In this way, `observe()` can just call `maintain_dialog_history` in order to make sure it's got all the dialog in one place, and do its vectorization however it wants.

The changes to Fairseq are just to make the model building procedure overridable.

Seeking discussion.