### PR TITLE
[wip] Cache dict tensorizor.

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -15,6 +15,7 @@ import numpy as np
 import os
 import pickle
 import re
+from functools import lru_cache
 
 try:
     from subword_nmt import learn_bpe, apply_bpe
@@ -532,6 +533,7 @@ class DictionaryAgent(Agent):
         else:
             return self.vec2txt(txt_or_vec)
 
+    @lru_cache(int(2 ** 20), typed=True)
     def txt2vec(self, text, vec_type=list):
         """Converts a string to a vector (list of ints).
 

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -533,7 +533,6 @@ class DictionaryAgent(Agent):
         else:
             return self.vec2txt(txt_or_vec)
 
-    @lru_cache(int(2 ** 20), typed=True)
     def txt2vec(self, text, vec_type=list):
         """Converts a string to a vector (list of ints).
 

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -102,6 +102,7 @@ class DictionaryAgent(Agent):
     default_tok = 're'
     default_lower = False
     default_textfields = 'text,labels'
+    default_cachesize = int(2 ** 20) # slightly faster if a power of 2
 
     @staticmethod
     def add_cmdline_args(argparser):
@@ -161,6 +162,12 @@ class DictionaryAgent(Agent):
             help='Observation fields which dictionary learns vocabulary from. '
                  'Tasks with additional fields may add to this list to handle '
                  'any extra vocabulary.')
+        dictionary.add_argument(
+            '--dict-cachesize', default=DictionaryAgent.default_cachesize, type=int,
+            help='Cache size for converting strings to tensors. Using this may '
+                 'massively improve throughput if buffer is large, but you may need '
+                 'lots of ram. Works best if a power of 2.')
+
         return dictionary
 
     def __init__(self, opt, shared=None):
@@ -216,6 +223,10 @@ class DictionaryAgent(Agent):
                                                      opt['dict_initpath'])
                 self.load(opt['dict_initpath'])
 
+        if opt.get('dict_cachesize', 0):
+            # Equivalent to using the @lru_cache decorator at runtime
+            self.txt2vec = lru_cache(opt['dict_cachesize'], typed=True)(self.txt2vec)
+
         # initialize tokenizers
         if self.tokenizer == 'nltk':
             try:
@@ -270,6 +281,15 @@ class DictionaryAgent(Agent):
             index = len(self.tok2ind)
             self.tok2ind[word] = index
             self.ind2tok[index] = word
+            # since we have a new token, txt2vec could theoretically change
+            self._clear_cache()
+
+    def _clear_cache(self):
+        """Clear the vectorizer cache if there is one.
+
+        Call this if you ever touch the list of tokens."""
+        if hasattr(self.txt2vec, 'cache_clear'):
+            self.txt2vec.cache_clear()
 
     def __contains__(self, key):
         """If key is an int, returns whether the key is in the indices.
@@ -406,6 +426,12 @@ class DictionaryAgent(Agent):
             self.add_token(token)
             self.freq[token] += 1
 
+    def remove_token(self, token):
+        del self.freq[token]
+        idx = self.tok2ind.pop(token)
+        del self.ind2tok[idx]
+        self._clear_cache()
+
     def remove_tail(self, min_freq):
         """Remove elements below the frequency cutoff from the dictionary."""
         to_remove = []
@@ -415,9 +441,7 @@ class DictionaryAgent(Agent):
                 to_remove.append(token)
 
         for token in to_remove:
-            del self.freq[token]
-            idx = self.tok2ind.pop(token)
-            del self.ind2tok[idx]
+            self.remove_token(token)
 
     def _remove_non_bpe(self):
         """Set the dictionary vocab to the bpe vocab, merging counts."""
@@ -430,9 +454,7 @@ class DictionaryAgent(Agent):
                     to_add.append((t, freq))
                 to_remove.append(token)
         for token in to_remove:
-            del self.freq[token]
-            idx = self.tok2ind.pop(token)
-            del self.ind2tok[idx]
+            self.remove_token(token)
         for token, freq in to_add:
             self.add_token(token)
             self.freq[token] += freq
@@ -441,10 +463,7 @@ class DictionaryAgent(Agent):
         """Trims the dictionary to the maximum number of tokens."""
         if maxtokens >= 0 and len(self.tok2ind) > maxtokens:
             for k in range(maxtokens, len(self.ind2tok)):
-                v = self.ind2tok[k]
-                del self.ind2tok[k]
-                del self.tok2ind[v]
-                del self.freq[v]
+                self.remove_token(self.ind2tok[k])
 
     def load(self, filename):
         """Load pre-existing dictionary in 'token[<TAB>count]' format.

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -639,8 +639,11 @@ def _list_cache_safety(fn):
 
     # define the wrapper
     def wrapped(*args, **kwargs):
-        # call the fn and copy the list
-        return fn(*args, **kwargs).copy()
+        # call the fn and copy if it's a mutable list
+        retval = fn(*args, **kwargs)
+        if isinstance(retval, list):
+            retval = retval.copy()
+        return retval
 
     # be kind about passing along lru_cache's stuff
     setattr(wrapped, 'cache_clear', fn.cache_clear)

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -640,7 +640,7 @@ def _list_cache_safety(fn):
     # define the wrapper
     def wrapped(*args, **kwargs):
         # call the fn and copy the list
-        return list(fn(*args, **kwargs))
+        return fn(*args, **kwargs).copy()
 
     # be kind about passing along lru_cache's stuff
     setattr(wrapped, 'cache_clear', fn.cache_clear)

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -19,8 +19,6 @@ import random
 import math
 from operator import attrgetter
 
-from functools import lru_cache
-
 """
 Batch is a namedtuple containing data being sent to an agent.
 
@@ -205,14 +203,14 @@ class TorchAgent(Agent):
         if truncate is None or len(vec) + add_start + add_end < truncate:
             # simple: no truncation
             if add_start:
-                vec = [self.START_IDX] + vec
+                vec.insert(0, self.START_IDX)
             if add_end:
-                vec = vec + [self.END_IDX]
+                vec.append(self.END_IDX)
         elif truncate_left:
             # don't check add_start, we know are truncating it
             if add_end:
                 # add the end token first
-                vec = vec + [self.END_IDX]
+                vec.append(self.END_IDX)
             vec = vec[len(vec) - truncate:]
         else:
             # truncate from the right side
@@ -220,7 +218,7 @@ class TorchAgent(Agent):
             vec = vec[:truncate - add_start]
             if add_start:
                 # always keep the start token if it's there
-                vec = [self.START_IDX] + vec
+                vec.insert(0, self.START_IDX)
         tensor = torch.LongTensor(vec)
         return tensor
 

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -19,6 +19,8 @@ import random
 import math
 from operator import attrgetter
 
+from functools import lru_cache
+
 """
 Batch is a namedtuple containing data being sent to an agent.
 
@@ -203,14 +205,14 @@ class TorchAgent(Agent):
         if truncate is None or len(vec) + add_start + add_end < truncate:
             # simple: no truncation
             if add_start:
-                vec.insert(0, self.START_IDX)
+                vec = [self.START_IDX] + vec
             if add_end:
-                vec.append(self.END_IDX)
+                vec = vec + [self.END_IDX]
         elif truncate_left:
             # don't check add_start, we know are truncating it
             if add_end:
                 # add the end token first
-                vec.append(self.END_IDX)
+                vec = vec + [self.END_IDX]
             vec = vec[len(vec) - truncate:]
         else:
             # truncate from the right side
@@ -218,7 +220,7 @@ class TorchAgent(Agent):
             vec = vec[:truncate - add_start]
             if add_start:
                 # always keep the start token if it's there
-                vec.insert(0, self.START_IDX)
+                vec = [self.START_IDX] + vec
         tensor = torch.LongTensor(vec)
         return tensor
 


### PR DESCRIPTION
Seeking comments; noticed I can get some massive speedups in some cases with this, but it's probably the Wrong Way(TM) to do it.

I did a version of this (#1064) that was buggy (#1065), because the mutable lists, the start and end markers would get repeatedly added on and on and on. This version doesn't have that problem, but I don't have any guarantee that *other* calls to txt2vec don't also modify the list inplace, so it would require some careful effort.

Alternative to this would be to do it in TorchAgent, and then only that model gets to see it.

It makes a surprising amount of difference, particularly when there's candidate ranking where the candidates are sampled from the other corpus. Then you get massive improvements. This is on an internal dataset, with 2 epochs of training + val + test, so we might want further testing.
```
Candidate ranking task (using fairseq):
no cache, no batchsort: 18:49.66
no cache and batchsort: 11:11.43
dict cache, no batchsr: 10:48.79
dict cache, w/ batchsr:  9:24.12
```
In fact, what's I've realized here is that batchsort predominantly saves the time because it ends up caching `obs['text_vec']` and not having to recompute it, so after the first epoch, you can see like a 4x speed increase.

Probably doing like #1064 and having a cmd line parameter for the cache size would probably help, so that we can use large caches on large machines, but smaller caches on laptops.

This is also more or less made completely irrelevant if you use a PytorchDataTeacher, so we might want to drop it for that sole reason.