### PR TITLE
Cap training episodes in tests.

### DIFF
--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -50,6 +50,7 @@ class TestTrainModel(unittest.TestCase):
                 embedding_size=8,
                 no_cuda=True,
                 validation_share_agent=True,
+                num_episodes=10,
             )
             opt = parser.parse_args()
             TrainLoop(opt).train()


### PR DESCRIPTION
This test runs can technically run for ever, and sometimes it has transient failures (takes >10min) or it just takes a long time locally.