### PR TITLE
Don't save a TorchAgent model on shutdown.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -583,13 +583,6 @@ class TorchAgent(Agent):
             self.optimizer.load_state_dict(states['optimizer'])
         return states
 
-    def shutdown(self):
-        """Save the state of the model when shutdown."""
-        path = self.opt.get('model_file', None)
-        if path is not None:
-            self.save(path + '.shutdown_state')
-        super().shutdown()
-
     def reset(self):
         """Clear internal states."""
         self.observation = None


### PR DESCRIPTION
Dumping the model on shutdown just wastes time and disk space,
especially on a Ctrl-C or an eval-only. Hard crashes won't actually
reach this, so it's unlikely to be helpful for recovery.

Extracted from #1078.