### PR TITLE
Clean up squad sentence teachers

### DIFF
--- a/parlai/tasks/squad/agents.py
+++ b/parlai/tasks/squad/agents.py
@@ -241,6 +241,7 @@ class SentenceTeacher(IndexTeacher):
     """
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
+        self.sent_tok = get_sentence_tokenizer()
         self.include_context = opt.get('include_context', False)
 
     @staticmethod


### PR DESCRIPTION
Delete some unnecessary squad sentence teachers. Now there are two "sentence teachers: `squad:sentence` and `squad:fulldocsentence`. 

Use the flag `--include-context` to have the data formatted as `'text': <context>\n<question>` (if `True`) or `'context': <context>, 'text': <question>` (if `False`, this is the default behavior)