### PR TITLE
Fixes small bug in acting after a disconnect (disconnect comes first)

### DIFF
--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -273,6 +273,8 @@ class MTurkAgent(Agent):
 
     def flush_msg_queue(self):
         """Clear all messages in the message queue"""
+        if self.msg_queue is None:
+            return
         while not self.msg_queue.empty():
             self.msg_queue.get()
 
@@ -285,12 +287,6 @@ class MTurkAgent(Agent):
 
     def get_new_act_message(self):
         """Get a new act message if one exists, return None otherwise"""
-        # Check if Turker sends a message
-        while not self.msg_queue.empty():
-            msg = self.msg_queue.get()
-            if msg['id'] == self.id:
-                return msg
-
         # See if any agent has disconnected
         if self.disconnected or self.some_agent_disconnected:
             msg = {
@@ -308,6 +304,13 @@ class MTurkAgent(Agent):
                 'episode_done': True
             }
             return msg
+
+        if self.msg_queue is not None:
+            # Check if Turker sends a message
+            while not self.msg_queue.empty():
+                msg = self.msg_queue.get()
+                if msg['id'] == self.id:
+                    return msg
 
         # There are no messages to be sent
         return None

--- a/parlai/mturk/core/test/test_socket_manager.py
+++ b/parlai/mturk/core/test/test_socket_manager.py
@@ -1001,11 +1001,11 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
 
         # Assert alive is registered
         alive_id = self.agent1.send_alive()
-        self.assertEqualBy(lambda: acked_packet is None, False, 2)
+        self.assertEqualBy(lambda: acked_packet is None, False, 4)
         self.assertIsNone(incoming_hb)
         self.assertIsNone(message_packet)
         self.assertIsNone(self.message_packet)
-        self.assertEqualBy(lambda: self.alive_packet is None, False, 2)
+        self.assertEqualBy(lambda: self.alive_packet is None, False, 4)
         self.assertEqual(self.alive_packet.id, alive_id)
         self.assertEqual(acked_packet.id, alive_id, 'Alive was not acked')
         acked_packet = None
@@ -1013,15 +1013,15 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         # assert sending heartbeats actually works, and that heartbeats don't
         # get acked
         self.agent1.send_heartbeat()
-        self.assertEqualBy(lambda: incoming_hb is None, False, 2)
+        self.assertEqualBy(lambda: incoming_hb is None, False, 4)
         self.assertIsNone(acked_packet)
         self.assertGreater(hb_count, 0)
 
         # Test message send from agent
         test_message_text_1 = 'test_message_text_1'
         msg_id = self.agent1.send_message(test_message_text_1)
-        self.assertEqualBy(lambda: self.message_packet is None, False, 2)
-        self.assertEqualBy(lambda: acked_packet is None, False, 2)
+        self.assertEqualBy(lambda: self.message_packet is None, False, 4)
+        self.assertEqualBy(lambda: acked_packet is None, False, 4)
         self.assertEqual(self.message_packet.id, acked_packet.id)
         self.assertEqual(self.message_packet.id, msg_id)
         self.assertEqual(self.message_packet.data['text'], test_message_text_1)
@@ -1034,19 +1034,19 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
             self.socket_manager.get_my_sender_id(), TEST_WORKER_ID_1,
             TEST_ASSIGNMENT_ID_1, test_message_text_2, 't2')
         self.socket_manager.queue_packet(message_send_packet)
-        self.assertEqualBy(lambda: message_packet is None, False, 2)
+        self.assertEqualBy(lambda: message_packet is None, False, 4)
         self.assertEqual(message_packet.id, manager_message_id)
         self.assertEqual(message_packet.data, test_message_text_2)
         self.assertIn(manager_message_id, self.socket_manager.packet_map)
         self.assertEqualBy(
             lambda: self.socket_manager.packet_map[manager_message_id].status,
             Packet.STATUS_ACK,
-            3,
+            6,
         )
 
         # Test agent disconnect
         self.agent1.always_beat = False
-        self.assertEqualBy(lambda: self.dead_worker_id, TEST_WORKER_ID_1, 2)
+        self.assertEqualBy(lambda: self.dead_worker_id, TEST_WORKER_ID_1, 4)
         self.assertEqual(self.dead_assignment_id, TEST_ASSIGNMENT_ID_1)
         self.assertGreater(hb_count, 1)
 
@@ -1077,11 +1077,11 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
 
         # Assert alive is registered
         alive_id = self.agent1.send_alive()
-        self.assertEqualBy(lambda: acked_packet is None, False, 2)
+        self.assertEqualBy(lambda: acked_packet is None, False, 4)
         self.assertIsNone(incoming_hb)
         self.assertIsNone(message_packet)
         self.assertIsNone(self.message_packet)
-        self.assertEqualBy(lambda: self.alive_packet is None, False, 2)
+        self.assertEqualBy(lambda: self.alive_packet is None, False, 4)
         self.assertEqual(self.alive_packet.id, alive_id)
         self.assertEqual(acked_packet.id, alive_id, 'Alive was not acked')
         acked_packet = None
@@ -1089,7 +1089,7 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         # assert sending heartbeats actually works, and that heartbeats don't
         # get acked
         self.agent1.send_heartbeat()
-        self.assertEqualBy(lambda: incoming_hb is None, False, 2)
+        self.assertEqualBy(lambda: incoming_hb is None, False, 4)
         self.assertIsNone(acked_packet)
         self.assertGreater(hb_count, 0)
 
@@ -1102,7 +1102,7 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
             self.socket_manager.get_my_sender_id(), TEST_WORKER_ID_1,
             TEST_ASSIGNMENT_ID_1, test_message_text_2, 't2')
         self.socket_manager.queue_packet(message_send_packet)
-        self.assertEqualBy(lambda: message_packet is None, False, 2)
+        self.assertEqualBy(lambda: message_packet is None, False, 4)
         self.assertEqual(message_packet.id, manager_message_id)
         self.assertEqual(message_packet.data, test_message_text_2)
         self.assertIn(manager_message_id, self.socket_manager.packet_map)
@@ -1112,14 +1112,14 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         )
         message_packet = None
         self.agent1.send_acks = True
-        self.assertEqualBy(lambda: message_packet is None, False, 2)
+        self.assertEqualBy(lambda: message_packet is None, False, 4)
         self.assertEqual(message_packet.id, manager_message_id)
         self.assertEqual(message_packet.data, test_message_text_2)
         self.assertIn(manager_message_id, self.socket_manager.packet_map)
         self.assertEqualBy(
             lambda: self.socket_manager.packet_map[manager_message_id].status,
             Packet.STATUS_ACK,
-            3,
+            6,
         )
 
     def test_one_agent_disconnect_other_alive(self):
@@ -1151,7 +1151,7 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         # Assert alive is registered
         self.agent1.send_alive()
         self.agent2.send_alive()
-        self.assertEqualBy(lambda: acked_packet is None, False, 2)
+        self.assertEqualBy(lambda: acked_packet is None, False, 4)
         self.assertIsNone(incoming_hb)
         self.assertIsNone(message_packet)
 
@@ -1161,7 +1161,7 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
 
         # Kill second agent
         self.agent2.always_beat = False
-        self.assertEqualBy(lambda: self.dead_worker_id, TEST_WORKER_ID_2, 2)
+        self.assertEqualBy(lambda: self.dead_worker_id, TEST_WORKER_ID_2, 4)
         self.assertEqual(self.dead_assignment_id, TEST_ASSIGNMENT_ID_2)
 
         # Run rest of tests
@@ -1169,8 +1169,8 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         # Test message send from agent
         test_message_text_1 = 'test_message_text_1'
         msg_id = self.agent1.send_message(test_message_text_1)
-        self.assertEqualBy(lambda: self.message_packet is None, False, 2)
-        self.assertEqualBy(lambda: acked_packet is None, False, 2)
+        self.assertEqualBy(lambda: self.message_packet is None, False, 4)
+        self.assertEqualBy(lambda: acked_packet is None, False, 4)
         self.assertEqual(self.message_packet.id, acked_packet.id)
         self.assertEqual(self.message_packet.id, msg_id)
         self.assertEqual(self.message_packet.data['text'], test_message_text_1)
@@ -1183,19 +1183,19 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
             self.socket_manager.get_my_sender_id(), TEST_WORKER_ID_1,
             TEST_ASSIGNMENT_ID_1, test_message_text_2, 't2')
         self.socket_manager.queue_packet(message_send_packet)
-        self.assertEqualBy(lambda: message_packet is None, False, 2)
+        self.assertEqualBy(lambda: message_packet is None, False, 4)
         self.assertEqual(message_packet.id, manager_message_id)
         self.assertEqual(message_packet.data, test_message_text_2)
         self.assertIn(manager_message_id, self.socket_manager.packet_map)
         self.assertEqualBy(
             lambda: self.socket_manager.packet_map[manager_message_id].status,
             Packet.STATUS_ACK,
-            2,
+            6,
         )
 
         # Test agent disconnect
         self.agent1.always_beat = False
-        self.assertEqualBy(lambda: self.dead_worker_id, TEST_WORKER_ID_1, 2)
+        self.assertEqualBy(lambda: self.dead_worker_id, TEST_WORKER_ID_1, 4)
         self.assertEqual(self.dead_assignment_id, TEST_ASSIGNMENT_ID_1)
 
 


### PR DESCRIPTION
If an agent disconnects while a world is still pulling info, the disconnect may cause the message queue to be removed before act will return that the agent has disconnected, causing a crash. This fixes that bug.