### PR TITLE
TorchAgent and Fairseq fixes/enhancements

### DIFF
--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -19,7 +19,6 @@ from fairseq.sequence_generator import SequenceGenerator
 from fairseq.sequence_scorer import SequenceScorer
 from fairseq import options
 from fairseq.tasks.fairseq_task import FairseqTask
-from fairseq.utils import convert_padding_direction
 
 from parlai.core.torch_agent import TorchAgent, Output
 from parlai.core.build_data import modelzoo_path
@@ -597,11 +596,10 @@ class FairseqAgent(TorchAgent):
         """Generate a sample object that Fairseq expects."""
         # add extra info to samples
         # TODO: should the right/left padding thing be in torch agent?
-        repadded = convert_padding_direction(xs, self.dict.pad(), right_to_left=True)
         sample = {}
         sample["id"] = torch.arange(len(xs) - 1)
         sample["net_input"] = {
-            "src_tokens": repadded,
+            "src_tokens": xs,
             "src_lengths": self._seq_length(xs),
         }
         if ys is not None:

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -143,7 +143,7 @@ class TorchAgent(Agent):
             help='Choose between pytorch optimizers. Any member of torch.optim'
                  ' should be valid.')
         agent.add_argument(
-            '-mom', '--momentum', default=-1, type=float,
+            '-mom', '--momentum', default=0, type=float,
             help='if applicable, momentum value for optimizer.')
         # preprocessing arguments
         agent.add_argument(
@@ -533,14 +533,12 @@ class TorchAgent(Agent):
         xs, x_lens = None, None
         if any('text_vec' in ex for ex in exs):
             _xs = [ex.get('text_vec', self.EMPTY) for ex in exs]
-            xs, x_lens = padded_tensor(_xs)
+            xs, x_lens = padded_tensor(_xs, self.NULL_IDX, self.use_cuda)
             if sort:
                 sort = False  # now we won't sort on labels
                 xs, x_lens, valid_inds, exs = argsort(
                     x_lens, xs, x_lens, valid_inds, exs, descending=True
                 )
-            if self.use_cuda:
-                xs = xs.cuda()
 
         # LABELS
         labels_avail = any('labels_vec' in ex for ex in exs)
@@ -555,19 +553,12 @@ class TorchAgent(Agent):
             labels = [ex.get(field + '_choice') for ex in exs]
             y_lens = [y.shape[0] for y in label_vecs]
 
+            ys, y_lens = padded_tensor(label_vecs, self.NULL_IDX, self.use_cuda, False)
             if sort and xs is None:
-                ys, y_lens = padded_tensor(label_vecs)
-                exs, valid_inds, label_vecs, labels, y_lens = argsort(
-                    y_lens, exs, valid_inds, label_vecs, labels, y_lens,
+                ys, valid_inds, label_vecs, labels, y_lens = argsort(
+                    y_lens, ys, valid_inds, label_vecs, labels, y_lens,
                     descending=True
                 )
-
-            ys = torch.LongTensor(len(exs), max(y_lens)).fill_(self.NULL_IDX)
-            for i, y in enumerate(label_vecs):
-                if y.shape[0] != 0:
-                    ys[i, :y.shape[0]] = y
-            if self.use_cuda:
-                ys = ys.cuda()
 
         # LABEL_CANDIDATES
         cands, cand_vecs = None, None

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -125,7 +125,8 @@ class TorchAgent(Agent):
         agent.add_argument(
             '-emb', '--embedding-type', default='random',
             choices=['random', 'glove', 'glove-fixed', 'glove-twitter-fixed',
-                     'fasttext', 'fasttext-fixed'],
+                     'fasttext', 'fasttext-fixed', 'fasttext_cc',
+                     'fasttext_cc-fixed'],
             help='Choose between different strategies for initializing word '
                  'embeddings. Default is random, but can also preinitialize '
                  'from Glove or Fasttext. Preinitialized embeddings can also '
@@ -296,6 +297,12 @@ class TorchAgent(Agent):
                 name=name, dim=pretrained_dim,
                 cache=modelzoo_path(self.opt.get('datapath'),
                                     'models:glove_vectors'))
+        elif emb_type.startswith('fasttext_cc'):
+            init = 'fasttext_cc'
+            embs = vocab.FastText(
+                language='en',
+                cache=modelzoo_path(self.opt.get('datapath'),
+                                    'models:fasttext_cc_vectors'))
         elif emb_type.startswith('fasttext'):
             init = 'fasttext'
             embs = vocab.FastText(

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -326,6 +326,9 @@ class TorchAgent(Agent):
                 # random projection
                 if not hasattr(self, 'proj_rp'):
                     self.proj_rp = torch.Tensor(pre_dim, target_dim).normal_()
+                    # rescale so we're not destroying norms too much
+                    # http://scikit-learn.org/stable/modules/random_projection.html#gaussian-random-projection
+                    self.proj_rp /= target_dim
                 return torch.mm(vec.unsqueeze(0), self.proj_rp)
             else:
                 # TODO: PCA

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -543,7 +543,9 @@ class TorchAgent(Agent):
         xs, x_lens = None, None
         if any('text_vec' in ex for ex in exs):
             _xs = [ex.get('text_vec', self.EMPTY) for ex in exs]
-            xs, x_lens = padded_tensor(_xs, self.NULL_IDX, self.use_cuda)
+            xs, x_lens = padded_tensor(
+                _xs, self.NULL_IDX, self.use_cuda, left_padded=True
+            )
             if sort:
                 sort = False  # now we won't sort on labels
                 xs, x_lens, valid_inds, exs = argsort(

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -360,9 +360,9 @@ class TestTorchAgent(unittest.TestCase):
 
             # contents of certain fields:
             self.assertEqual(batch.text_vec.tolist(),
-                             [[1, 2, 3, 4, 5, 0],
+                             [[0, 1, 2, 3, 4, 5],
                               [1, 2, 3, 4, 5, 6],
-                              [1, 2, 0, 0, 0, 0]])
+                              [0, 0, 0, 0, 1, 2]])
             self.assertEqual(batch.text_lengths, [5, 6, 2])
             self.assertEqual(batch.label_vec.tolist(),
                              [[1, 0, 0, 0, 0],
@@ -376,8 +376,8 @@ class TestTorchAgent(unittest.TestCase):
             batch = agent.batchify(obs_vecs, sort=True)
             self.assertEqual(batch.text_vec.tolist(),
                              [[1, 2, 3, 4, 5, 6],
-                              [1, 2, 3, 4, 5, 0],
-                              [1, 2, 0, 0, 0, 0]])
+                              [0, 1, 2, 3, 4, 5],
+                              [0, 0, 0, 0, 1, 2]])
             self.assertEqual(batch.text_lengths, [6, 5, 2])
             self.assertEqual(batch.label_vec.tolist(),
                              [[1, 2, 3, 4, 5],


### PR DESCRIPTION
- Support FastText common crawl. These are decidedly better than normal fasttext
- Default momentum to 0; using -1 causes a bug in fairseq, and 0 works just fine for TorchAgent
- Random projection should be scaled according to the [size of the output dimension](http://scikit-learn.org/stable/modules/random_projection.html#gaussian-random-projection). Otherwise it breaks the norms! This change dramatically lowers PPL in early iterations
- Use explicit padding index when vectorizing text. Otherwise breaks fairseq. Also use enhancements of torch_padded.