### PR TITLE
Remove linting of full codebase from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ install:
     - pip install regex scipy sklearn pexpect  # tfidf-retriever dependencies
     # install pytorch non-cuda version
     - pip install http://download.pytorch.org/whl/cpu/torch-0.4.0-cp36-cp36m-linux_x86_64.whl
-before_script:
-    # stop the build if there are Python syntax errors or undefined names
-    - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-    - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
     - bash tests/check_copyright.sh
     - ./tests/lint_changed.sh


### PR DESCRIPTION
We're spending ~45s in each CI counting lint errors. Since strict linting is enabled on changes, this is no longer necessary.