### PR TITLE
Move MemNN to TorchAgent

### DIFF
--- a/parlai/agents/memnn/memnn.py
+++ b/parlai/agents/memnn/memnn.py
@@ -177,11 +177,14 @@ class MemnnAgent(TorchAgent):
         kwargs['add_start'] = False
         kwargs['add_end'] = False
         kwargs['split_lines'] = True
+        obs = args[0]
+        if 'labels' in obs and 'label_candidates' in obs:
+            # we aren't going to rank them, don't waste time
+            del obs['label_candidates']
         return super().vectorize(*args, **kwargs)
 
     def get_dialog_history(self, *args, **kwargs):
         kwargs['add_p1_after_newln'] = True
-        kwargs['reply'] = None
         return super().get_dialog_history(*args, **kwargs)
 
     def _build_mems(self, mems):
@@ -193,6 +196,9 @@ class MemnnAgent(TorchAgent):
         for i, mem in enumerate(mems):
             for j, m in enumerate(mem):
                 padded[i, j, :len(m)] = m
+
+        # if self.use_cuda:
+        #     padded = padded.cuda()
 
         return padded
 

--- a/parlai/agents/memnn/modules.py
+++ b/parlai/agents/memnn/modules.py
@@ -13,7 +13,7 @@ from functools import lru_cache
 def opt_to_kwargs(opt):
     """Get kwargs for seq2seq from opt."""
     kwargs = {}
-    for k in ['mem_size', 'time_features', 'position_encoding', 'hops'
+    for k in ['mem_size', 'time_features', 'position_encoding', 'hops',
               'dropout']:
         if k in opt:
             kwargs[k] = opt[k]

--- a/parlai/agents/memnn/modules.py
+++ b/parlai/agents/memnn/modules.py
@@ -57,9 +57,12 @@ class MemNN(nn.Module):
 
         self.dropout = nn.Dropout(dropout)
         self.query_lt = embedding()
-        self.in_memory_lt = embedding()
+        # self.in_memory_lt = embedding()
+        # self.out_memory_lt = embedding()
+        self.in_memory_lt = self.query_lt
         self.out_memory_lt = embedding()
-        self.answer_embedder = embedding(use_extra_feats=False)
+        self.answer_embedder = self.out_memory_lt
+        # self.answer_embedder = embedding(use_extra_feats=False)
         self.memory_hop = Hop(embedding_size)
 
         if use_cuda:

--- a/parlai/agents/memnn/modules.py
+++ b/parlai/agents/memnn/modules.py
@@ -6,194 +6,208 @@
 
 import torch
 import torch.nn as nn
-from torch.nn.functional import softmax
 
 from functools import lru_cache
 
 
+def opt_to_kwargs(opt):
+    """Get kwargs for seq2seq from opt."""
+    kwargs = {}
+    for k in ['mem_size', 'time_features', 'position_encoding', 'hops'
+              'dropout']:
+        if k in opt:
+            kwargs[k] = opt[k]
+    return kwargs
+
+
 class MemNN(nn.Module):
-    def __init__(self, opt, num_features, use_cuda=False):
+    """Memory Network module."""
+
+    def __init__(
+        self, num_features, embedding_size, hops=1,
+        mem_size=32, time_features=False, position_encoding=False,
+        dropout=0, padding_idx=0, use_cuda=False,
+    ):
+        """Initialize memnn model.
+
+        See cmdline args in MemnnAgent for description of arguments.
+        """
         super().__init__()
-        self.opt = opt
 
-        # Prepare features
-        self.num_time_features = opt['mem_size']
-        self.extra_features_slots = 0
-        if opt['time_features']:
-            self.time_features = torch.LongTensor(range(num_features,
-                num_features + self.num_time_features))
-            num_features += self.num_time_features
-            self.extra_features_slots += 1
+        # prepare features
+        self.hops = hops
 
-        def embedding():
-            return Embed(num_features, opt['embedding_size'],
-                position_encoding=opt['position_encoding'], padding_idx=0)
+        # time features: we learn an embedding for each memory slot
+        self.extra_features = 0
+        if time_features:
+            self.extra_features += mem_size
+            self.time_features = torch.LongTensor(
+                range(num_features, num_features + mem_size))
 
-        self.query_embedder = embedding()
-        self.answer_embedder = embedding()
-        self.in_memory_embedder = embedding()
-        self.out_memory_embedder = embedding()
-        self.memory_hop = Hop(opt['embedding_size'])
+        def embedding(use_extra_feats=True):
+            if use_extra_feats:
+                return Embed(num_features + self.extra_features,
+                             embedding_size,
+                             position_encoding=position_encoding,
+                             padding_idx=padding_idx)
+            else:
+                return Embed(num_features, embedding_size,
+                             position_encoding=position_encoding,
+                             padding_idx=padding_idx)
 
-        self.score = DotScore()
+        self.dropout = nn.Dropout(dropout)
+        self.query_lt = embedding()
+        self.in_memory_lt = embedding()
+        self.out_memory_lt = embedding()
+        self.answer_embedder = embedding(use_extra_feats=False)
+        self.memory_hop = Hop(embedding_size)
 
         if use_cuda:
             self.score.cuda()
             self.memory_hop.cuda()
         self.use_cuda = use_cuda
 
-    def time_feature(self, t):
-        return self.time_features[min(t, self.num_time_features - 1)]
+    def _score(self, output, cands):
+        if isinstance(cands, torch.Tensor):
+            return torch.matmul(output, cands.t())
+        else:
+            return torch.cat([
+                torch.matmul(output[i], cands[i].t()).unsqueeze(0)
+                for i in range(len(cands))], dim=0)
 
-    def update_memories_with_extra_features_(self, memory_lengths, memories):
-        memory_lengths = memory_lengths.data
-        memories = memories.data
-        if self.extra_features_slots > 0:
-            num_nonempty_memories = int(memory_lengths.ne(0).long().sum())
-            updated_memories = memories.new(memories.numel() + num_nonempty_memories * self.extra_features_slots)
-            src_offset = 0
-            dst_offset = 0
-            for i in range(memory_lengths.size(0)):
-                for j in range(self.opt['mem_size']):
-                    length = memory_lengths[i, j]
-                    if length > 0:
-                        if self.opt['time_features']:
-                            updated_memories[dst_offset] = self.time_feature(j)
-                            dst_offset += 1
-                        updated_memories[dst_offset:dst_offset + length] = memories[src_offset:src_offset + length]
-                        src_offset += length
-                        dst_offset += length
-            memory_lengths += memory_lengths.ne(0).long() * self.extra_features_slots
-            memories.set_(updated_memories)
+    def forward(self, xs, mems, cands=None):
+        """One forward step.
 
-    def forward(self, memories, queries, memory_lengths, query_lengths):
-        self.update_memories_with_extra_features_(memory_lengths, memories)
+        :param xs:       (bsz x seqlen) LongTensor queries to the model
+        :param mems:     (bsz x num_mems x seqlen) LongTensor memories
+        :param cands:
 
-        in_memory_embeddings = self.in_memory_embedder(memory_lengths, memories)
-        out_memory_embeddings = self.out_memory_embedder(memory_lengths, memories)
-        query_embeddings = self.query_embedder(query_lengths, queries)
-        attention_mask = memory_lengths.data.ne(0).detach()
+        :returns: scores
+            scores contains the model's predicted scores.
+                if cand_params is None, the candidates are the vocabulary;
+                otherwise, these scores are over the candidates provided.
+                (bsz x num_cands)
+        """
+        in_memory_embs = self.in_memory_lt(mems).transpose(1, 2)
+        out_memory_embs = self.out_memory_lt(mems)
+        states = self.query_lt(xs)
 
-        if self.use_cuda:
-            in_memory_embeddings = in_memory_embeddings.cuda()
-            out_memory_embeddings = out_memory_embeddings.cuda()
-            query_embeddings = query_embeddings.cuda()
-            attention_mask = attention_mask.cuda()
+        for i in range(self.hops):
+            states = self.memory_hop(states, in_memory_embs, out_memory_embs)
 
-        for _ in range(self.opt['hops']):
-            query_embeddings = self.memory_hop(query_embeddings,
-                    in_memory_embeddings, out_memory_embeddings, attention_mask)
-        return query_embeddings
+        if cands is not None:
+            if isinstance(cands, torch.Tensor):
+                cand_embs = self.answer_embedder(cands)
+            else:
+                cand_embs = [self.answer_embedder(cs) for cs in cands]
+        else:
+            cand_embs = self.answer_embedder.weight
+
+        scores = self._score(states, cand_embs)
+        return scores
 
 
 class Embed(nn.Embedding):
-    def __init__(self, *args, position_encoding=False, **kwargs):
+    """Embed sequences for MemNN model.
+
+    Applies Position Encoding if enabled and currently applies BOW sum.
+    """
+
+    def __init__(self, *args, position_encoding=False, reduction='sum',
+                 **kwargs):
+        """Initialize custom Embedding layer.
+
+        :param position_encoding: apply positional encoding transformation
+                                  on input sequences
+        :param reduction:         reduction strategy to sequences, default 'sum'
+        """
         self.position_encoding = position_encoding
+        self.reduction = reduction
         super().__init__(*args, **kwargs)
 
-    def forward(self, lengths, indices):
-        lengths_mat = lengths.data
-        if lengths.dim() == 1 or lengths.size(1) == 1:
-            lengths_mat = lengths_mat.unsqueeze(0)
+    def _reduce(self, embs):
+        # last dimension is embedding, do operation over dim before that
+        if self.reduction == 'sum':
+            return embs.sum(-2)
+        elif self.reduction == 'mean':
+            return embs.mean(-2)
+        else:
+            raise RuntimeError(
+                'reduction method {} not supported'.format(self.reduction))
 
-        if lengths_mat.dim() == 1:
-            raise RuntimeError(lengths.shape)
+    def forward(self, input):
+        """Return BOW embedding with PE reweighting if enabled.
 
-        input = torch.LongTensor(lengths_mat.size(0), lengths_mat.size(1), torch.max(lengths_mat))
-        pad = self.padding_idx if self.padding_idx is not None else 0
-        input.fill_(pad)
-        emb_list = []
-        offset = 0
-        for i, row in enumerate(lengths_mat):
-            for j, length in enumerate(row):
-                length = length.item()
-                if length > 0:
-                    input[i, j, :length] = indices[offset:offset + length]
-                offset += length
+        :param input: (bsz x seqlen) LongTensor
 
-        for i, row in enumerate(lengths_mat):
-            emb = super().forward(input[i, :, :])
-            if self.position_encoding:
-                emb = emb * self.position_tensor(row, emb)
-            emb = torch.sum(emb, dim=1).squeeze(1)
-            for j, length in enumerate(row):
-                length = length.item()
-                if length > 0:
-                    emb[j] /= length
-            emb_list.append(emb)
-        embs = torch.stack(emb_list)
-
-        if lengths.dim() == 1:
-            embs = embs.squeeze(0)
-        elif lengths.size(1) == 1:
-            embs = embs.squeeze().unsqueeze(1)
-        return embs
+        :returns: (bsz x esz) FloatTensor
+        """
+        embs = super().forward(input)
+        if self.position_encoding:
+            if embs.dim() == 3:
+                num_mems, seqlen, embdim = embs.size()
+                pe = self.position_matrix(seqlen, embdim)
+                for i in range(num_mems):
+                    embs[i] *= pe
+            else:
+                raise RuntimeError(
+                    'Input dim {} not supported with position encoding yet'
+                    ''.format(input.dim()))
+        return self._reduce(embs)
 
     @staticmethod
-    @lru_cache(maxsize=32)
+    @lru_cache(maxsize=128)
     def position_matrix(J, d):
+        """Build matrix of position encoding coeffiencents.
+
+        See https://papers.nips.cc/paper/5846-end-to-end-memory-networks,
+        section 4.1 Model Details: Sentence Representation.
+
+        :param J: number of words in the sequence
+        :param d: dimension of the embedding
+
+        :returns: Position Encoding matrix
+        """
         m = torch.Tensor(J, d)
         for k in range(1, d + 1):
             for j in range(1, J + 1):
                 m[j - 1, k - 1] = (1 - j / J) - (k / d) * (1 - 2 * j / J)
         return m
 
-    @staticmethod
-    def position_tensor(sentence_lengths, embeddings):
-        t = torch.zeros(embeddings.size())
-        embedding_dim = embeddings.size()[-1]
-        for i, length in enumerate(sentence_lengths):
-            if length > 0:
-                t[i, :length, :] = Embed.position_matrix(length, embedding_dim)
-        return t
-
 
 class Hop(nn.Module):
-    def __init__(self, embedding_size):
-        super(Hop, self).__init__()
-        self.embedding_size = embedding_size
-        self.linear = nn.Linear(embedding_size, embedding_size, bias=False)
+    """Memory Network hop outputs attention-weighted sum of memory embeddings.
 
-    def forward(self, query_embeddings, in_memory_embeddings, out_memory_embeddings, attention_mask=None):
-        attention = torch.bmm(in_memory_embeddings, query_embeddings.unsqueeze(2)).squeeze(2)
-        if attention_mask is not None:
-            # exclude masked elements from the softmax
-            attention = attention_mask.float() * attention + (1 - attention_mask.float()) * -1e20
-        probs = softmax(attention, dim=1).unsqueeze(1)
-        memory_output = torch.bmm(probs, out_memory_embeddings).squeeze(1)
-        query_embeddings = self.linear(query_embeddings)
-        output = memory_output + query_embeddings
-        return output
+    0) rotate the query embeddings
+    1) compute the dot product between the input vector and each memory vector
+    2) compute a softmax over the memory scores
+    3) compute the weighted sum of the memory embeddings using the probabilities
+    4) add the query embedding to the memory output and return the result
+    """
 
-
-class Decoder(nn.Module):
-    def __init__(self, input_size, hidden_size, num_layers, opt, dictionary):
+    def __init__(self, embedding_size, rotate=True):
+        """Initialize linear rotation."""
         super().__init__()
-        self.dict = dictionary
-        self.h2o = nn.Linear(hidden_size, len(dictionary))
-        self.dropout = nn.Dropout(opt['dropout'])
-        self.rnn = nn.GRU(input_size, hidden_size, num_layers)
+        if rotate:
+            self.rotate = nn.Linear(embedding_size, embedding_size, bias=False)
+        else:
+            self.rotate = lambda x: x
+        self.softmax = nn.Softmax(dim=1)
 
-    def hidden_to_idx(self, hidden, dropout=False):
-        """Converts hidden state vectors into indices into the dictionary."""
-        if hidden.size(0) > 1:
-            raise RuntimeError('Bad dimensions of tensor:', hidden)
-        hidden = hidden.squeeze(0)
-        scores = self.h2o(hidden)
-        if dropout:
-            scores = self.dropout(scores)
-        _, idx = scores.max(1)
-        idx.unsqueeze_(1)
-        return idx, scores
+    def forward(self, query_embs, in_mem_embs, out_mem_embs):
+        """Compute MemNN Hop step.
 
-    def forward(self, input, state):
-        output, state = self.rnn(input, state)
-        return self.hidden_to_idx(output, dropout=self.training)
+        :param query_embs:   (bsz x esz) embedding of queries
+        :param in_mem_embs:  bsz list of (num_mems x esz) embedding of memories
+                             for activation
+        :param out_mem_embs: bsz list of (num_mems x esz) embedding of memories
+                             for outputs
 
-
-class DotScore(nn.Module):
-    def one_to_one(self, query_embeddings, answer_embeddings, reply_embeddings=None):
-        return (query_embeddings * answer_embeddings).sum(dim=1).squeeze(1)
-
-    def one_to_many(self, query_embeddings, answer_embeddings, reply_embeddings=None):
-        return query_embeddings.mm(answer_embeddings.t())
+        :returns: (bsz x esz) output state
+        """
+        # rotate query embeddings
+        query_embs = self.rotate(query_embs)
+        attn = torch.bmm(query_embs.unsqueeze(1), in_mem_embs).squeeze(1)
+        probs = self.softmax(attn)
+        memory_output = torch.bmm(probs.unsqueeze(1), out_mem_embs).squeeze(1)
+        return memory_output + query_embs

--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -85,7 +85,7 @@ class Seq2seq(nn.Module):
             bidirectional=bidirectional,
             shared_lt=shared_lt, shared_rnn=shared_rnn)
 
-        shared_weight = (self.decoder.lt
+        shared_weight = (self.decoder.lt.weight
                          if lookuptable in ('dec_out', 'all') else None)
         self.output = OutputLayer(
             num_features, embeddingsize, hiddensize, dropout=dropout,

--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -447,6 +447,7 @@ class OutputLayer(nn.Module):
 
         self.numsoftmax = numsoftmax
         if numsoftmax > 1:
+            self.esz = embeddingsize
             self.softmax = nn.Softmax(dim=1)
             self.prior = nn.Linear(hiddensize, numsoftmax, bias=False)
             self.latent = nn.Linear(hiddensize, numsoftmax * embeddingsize)

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -321,6 +321,7 @@ class Seq2seqAgent(TorchAgent):
                                self.truncate or 180)
         self.model.train()
         self.zero_grad()
+
         try:
             out = self.model(batch.text_vec, batch.label_vec)
 
@@ -369,6 +370,8 @@ class Seq2seqAgent(TorchAgent):
 
     def eval_step(self, batch):
         """Evaluate a single batch of examples."""
+        if batch.text_vec is None:
+            return
         self.model.eval()
         cand_params = self._build_cands(batch)
         out = self.model(batch.text_vec, ys=None, cand_params=cand_params)

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -139,10 +139,15 @@ class TorchAgent(Agent):
                  'ignored unless you append "-force" to your choice.')
         # optimizer arguments
         agent.add_argument(
-            '-opt', '--optimizer', default='sgd',
-            choices=cls.OPTIM_OPTS,
+            '-opt', '--optimizer', default='sgd', choices=cls.OPTIM_OPTS,
             help='Choose between pytorch optimizers. Any member of torch.optim'
                  ' should be valid.')
+        agent.add_argument(
+            '-lr', '--learningrate', type=float, default=1,
+            help='learning rate')
+        agent.add_argument(
+            '-clip', '--gradient-clip', type=float, default=0.1,
+            help='gradient clipping using l2 norm')
         agent.add_argument(
             '-mom', '--momentum', default=0, type=float,
             help='if applicable, momentum value for optimizer.')
@@ -213,7 +218,7 @@ class TorchAgent(Agent):
 
         # now set up any fields that all instances may need
         self.id = 'TorchAgent'  # child can override
-        self.EMPTY = torch.Tensor([])
+        self.EMPTY = torch.LongTensor([])
         self.NULL_IDX = self.dict[self.dict.null_token]
         self.START_IDX = self.dict[self.dict.start_token]
         self.END_IDX = self.dict[self.dict.end_token]
@@ -276,6 +281,17 @@ class TorchAgent(Agent):
         # TODO: Move scheduler params to command line args
         self.scheduler = optim.lr_scheduler.ReduceLROnPlateau(
             self.optimizer, 'min', factor=0.5, patience=3, verbose=True)
+
+    def receive_metrics(self, metrics_dict):
+        """Use the metrics to decide when to adjust LR schedule.
+
+        This uses the loss as the validation metric if present, if not this
+        function does nothing. Note that the model must be reporting loss for
+        this to work.
+        Override this to override the behavior.
+        """
+        if 'loss' in metrics_dict:
+            self.scheduler.step(metrics_dict['loss'])
 
     def _get_embtype(self, emb_type):
         # set up preinitialized embeddings
@@ -375,6 +391,17 @@ class TorchAgent(Agent):
         shared['dict'] = self.dict
         shared['replies'] = self.replies
         return shared
+
+    def _v2t(self, vec):
+        """Convert token indices to string of tokens."""
+        new_vec = []
+        if hasattr(vec, 'cpu'):
+            vec = vec.cpu()
+        for i in vec:
+            if i == self.END_IDX:
+                break
+            new_vec.append(i)
+        return self.dict.vec2txt(new_vec)
 
     def _vectorize_text(self, text, add_start=False, add_end=False,
                         truncate=None, truncate_left=True):

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -896,6 +896,33 @@ def padded_tensor(items, pad_idx=0, use_cuda=False, left_padded=False):
     return output, lens
 
 
+def padded_3d(tensors, pad_idx=0, use_cuda=0):
+    """Make 3D padded tensor for list of lists of 1D tensors or lists.
+
+    :param tensors:  list of lists of 1D tensors (or lists)
+    :param pad_idx:  padding to fill tensor with
+    :param use_cuda: whether to call cuda() before returning
+
+    :returns: 3D tensor with the maximum dimensions of the inputs
+    """
+    a = len(tensors)
+    b = max(len(row) for row in tensors)
+    c = max(len(item) for row in tensors for item in row)
+
+    output = torch.LongTensor(a, b, c).fill_(pad_idx)
+
+    for i, row in enumerate(tensors):
+        for j, item in enumerate(row):
+            if not isinstance(item, torch.Tensor):
+                item = torch.LongTensor(item)
+            output[i, j, :len(item)] = item
+
+    if use_cuda:
+        output = output.cuda()
+
+    return output
+
+
 def argsort(keys, *lists, descending=False):
     """Reorder each list in lists by the (descending) sorted order of keys.
 


### PR DESCRIPTION
- move memnn parent to torch agent, remove tons of unnecessary or overly complex code
- currently removed the generator, I'll add it back in later
- now it ranks on the batch of labels instead of label_candidates field during training
- now reports mean_rank and loss, no longer calculates hits@1 during training

speed tests with bsz 32, esz 128, time features on, 3 hops on babi:task10k:1
~24x faster using 1 thread on the GPU
~8x faster using 1 thread on the CPU
~1.7x faster using 30 threads on the CPU

(not going to land until I add model versioning code and back current code up to legacy)