### PR TITLE
Options for specifying different batch size at test time.

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -41,6 +41,8 @@ def setup_args(parser=None):
     train.add_argument('-et', '--evaltask',
                        help=('task to use for valid/test (defaults to the '
                              'one used for training if not set)'))
+    train.add_argument('--eval-batchsize', type=int,
+                       help='Eval time batch size (defaults to same as -bs)')
     train.add_argument('--display-examples', type='bool', default=False)
     train.add_argument('-eps', '--num-epochs', type=float, default=-1)
     train.add_argument('-ttim', '--max-train-time',
@@ -116,6 +118,9 @@ def run_eval(agent, opt, datatype, max_exs=-1, write_log=False, valid_world=None
         opt['datatype'] = datatype
         if opt.get('evaltask'):
             opt['task'] = opt['evaltask']
+        if opt.get('eval_batchsize'):
+            # override eval time batchsize
+            opt['batchsize'] = opt['eval_batchsize']
         if opt.get('validation_share_agent', False):
             valid_agent = create_agent_from_shared(agent.share())
         else:


### PR DESCRIPTION
Some models may make approximations during training to speed things up (for example,  negative sampling instead of full softmax), but need to do the full, memory-expensive computation at test time. This option enables us to lower the batch size during only test time.

Defaults to current behavior.