### PR TITLE
Optional logging, fetch notices

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -13,7 +13,6 @@ import time
 import uuid
 import errno
 import requests
-import json
 
 from parlai.mturk.core.agents import AssignState
 from parlai.mturk.core.socket_manager import Packet, SocketManager

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -12,6 +12,8 @@ import threading
 import time
 import uuid
 import errno
+import requests
+import json
 
 from parlai.mturk.core.agents import AssignState
 from parlai.mturk.core.socket_manager import Packet, SocketManager
@@ -40,6 +42,11 @@ SNS_ASSIGN_ABANDONDED = 'AssignmentAbandoned'
 SNS_ASSIGN_SUBMITTED = 'AssignmentSubmitted'
 SNS_ASSIGN_RETURNED = 'AssignmentReturned'
 
+PARLAI_MTURK_NOTICE_URL = 'http://www.parl.ai/mturk/mturk_notice/'
+PARLAI_MTURK_UPLOAD_URL = 'http://www.parl.ai/mturk/mturk_stats/'
+PARLAI_MTURK_LOG_PERMISSION_FILE = \
+    os.path.expanduser('~/.parlai/mturk_log_permission.pickle')
+TWO_WEEKS = 60 * 60 * 24 * 7 * 2
 
 parent_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -121,6 +128,7 @@ class MTurkManager():
         self.is_shutdown = False
         self.use_db = use_db  # TODO enable always DB integration is complete
         self.db_logger = None
+        self.logging_permitted = False
         self.task_state = self.STATE_CREATED
 
     # Helpers and internal manager methods #
@@ -152,6 +160,51 @@ class MTurkManager():
         """Initialize logging settings from the opt"""
         shared_utils.set_is_debug(self.opt['is_debug'])
         shared_utils.set_log_level(self.opt['log_level'])
+
+    def _logging_permission_check(self):
+        if self.is_test:
+            return False
+        if os.path.exists(PARLAI_MTURK_LOG_PERMISSION_FILE):
+            with open(PARLAI_MTURK_LOG_PERMISSION_FILE, 'rb') as perm_file:
+                permissions = pickle.load(perm_file)
+                if permissions['allowed'] is True:
+                    return True
+                elif time.time() - permissions['asked_time'] < TWO_WEEKS:
+                    return False
+            # Snooze expired
+            os.remove(PARLAI_MTURK_LOG_PERMISSION_FILE)
+        print(
+            'Would you like to help improve ParlAI-MTurk by providing some '
+            'metrics? We would like to record acceptance, completion, and '
+            'disconnect rates by worker. These metrics let us track the '
+            'health of the platform. If you accept we\'ll collect this data '
+            'on all of your future runs. We\'d ask before collecting anything '
+            'else, but currently we have no plans to. You can decline to '
+            'snooze this request for 2 weeks.')
+        selected = ''
+        while selected not in ['y', 'Y', 'n', 'N']:
+            selected = input('Share worker rates? (y/n): ')
+            if selected not in ['y', 'Y', 'n', 'N']:
+                print('Must type one of (Y/y/N/n)')
+        if selected in ['y', 'Y']:
+            print('Thanks for helping us make the platform better!')
+        permissions = {
+            'allowed': selected in ['y', 'Y'],
+            'asked_time': time.time()
+        }
+
+        with open(PARLAI_MTURK_LOG_PERMISSION_FILE, 'wb+') as perm_file:
+            pickle.dump(permissions, perm_file)
+            return permissions['allowed']
+
+    def _upload_worker_data(self):
+        '''Uploads worker data acceptance and completion rates to the parlai
+        server
+        '''
+        worker_data = self.worker_manager.get_worker_data_package()
+        data = {'worker_data': worker_data}
+        headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+        requests.post(PARLAI_MTURK_UPLOAD_URL, json=data, headers=headers)
 
     def _maintain_hit_status(self):
         def update_status():
@@ -767,6 +820,23 @@ class MTurkManager():
             if (check != confirm_string and ('$' + check) != confirm_string):
                 raise SystemExit('Cancelling')
 
+        # Check to see if there are any additional notices on the parlai site
+        if not self.is_test:
+            shared_utils.print_and_log(
+                logging.INFO,
+                'Querying the parlai website for possible notices...',
+                should_print=True)
+            endpoint = 'sandbox' if self.is_sandbox else 'live'
+            resp = requests.post(PARLAI_MTURK_NOTICE_URL + endpoint)
+            warnings = resp.json()
+            for warn in warnings:
+                print('Notice: ' + warn)
+                accept = input('Continue? (Y/n): ')
+                if accept == 'n':
+                    raise SystemExit('Additional notice was rejected.')
+
+        self.logging_permitted = self._logging_permission_check()
+
         shared_utils.print_and_log(logging.INFO, 'Setting up MTurk server...',
                                    should_print=True)
         self.is_unique = self.opt['unique_worker'] or \
@@ -1060,6 +1130,9 @@ class MTurkManager():
                                                  self.is_sandbox)
             if self.socket_manager is not None:
                 self.socket_manager.shutdown()
+            if self.logging_permitted and not self.is_sandbox and \
+                    not self.is_test:
+                self._upload_worker_data()
             if self.worker_manager is not None:
                 self.worker_manager.shutdown()
 

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -198,9 +198,9 @@ class MTurkManager():
             return permissions['allowed']
 
     def _upload_worker_data(self):
-        '''Uploads worker data acceptance and completion rates to the parlai
+        """Uploads worker data acceptance and completion rates to the parlai
         server
-        '''
+        """
         worker_data = self.worker_manager.get_worker_data_package()
         data = {'worker_data': worker_data}
         headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}

--- a/parlai/mturk/core/test/test_mturk_manager.py
+++ b/parlai/mturk/core/test/test_mturk_manager.py
@@ -132,7 +132,8 @@ class InitTestMTurkManager(unittest.TestCase):
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
         self.mturk_manager = MTurkManager(
             opt=self.opt,
-            mturk_agent_ids=self.mturk_agent_ids
+            mturk_agent_ids=self.mturk_agent_ids,
+            is_test=True,
         )
 
     def tearDown(self):
@@ -202,7 +203,8 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
         self.mturk_manager = MTurkManager(
             opt=self.opt,
-            mturk_agent_ids=self.mturk_agent_ids
+            mturk_agent_ids=self.mturk_agent_ids,
+            is_test=True,
         )
         self.mturk_manager._init_state()
         self.mturk_manager.port = 3030
@@ -781,7 +783,8 @@ class TestMTurkManagerPoolHandling(unittest.TestCase):
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
         self.mturk_manager = MTurkManager(
             opt=self.opt,
-            mturk_agent_ids=self.mturk_agent_ids
+            mturk_agent_ids=self.mturk_agent_ids,
+            is_test=True,
         )
         self.mturk_manager._init_state()
         self.agent_1 = MTurkAgent(self.opt, self.mturk_manager, TEST_HIT_ID_1,
@@ -877,7 +880,8 @@ class TestMTurkManagerTimeHandling(unittest.TestCase):
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
         self.mturk_manager = MTurkManager(
             opt=self.opt,
-            mturk_agent_ids=self.mturk_agent_ids
+            mturk_agent_ids=self.mturk_agent_ids,
+            is_test=True,
         )
         self.mturk_manager.time_limit_checked = time.time()
         self.mturk_manager.worker_manager.un_time_block_workers = \
@@ -971,7 +975,8 @@ class TestMTurkManagerLifecycleFunctions(unittest.TestCase):
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
         self.mturk_manager = MTurkManager(
             opt=self.opt,
-            mturk_agent_ids=self.mturk_agent_ids
+            mturk_agent_ids=self.mturk_agent_ids,
+            is_test=True,
         )
         MTurkManagerFile.server_utils.delete_server = mock.MagicMock()
 

--- a/parlai/mturk/core/worker_manager.py
+++ b/parlai/mturk/core/worker_manager.py
@@ -70,6 +70,15 @@ class WorkerState():
                 complete_count += 1
         return complete_count
 
+    def disconnected_assignments(self):
+        """Returns the number of assignments this worker has completed"""
+        disconnect_count = 0
+        for agent in self.agents.values():
+            if agent.get_status() in [AssignState.STATUS_DISCONNECT,
+                                      AssignState.STATUS_RETURNED]:
+                disconnect_count += 1
+        return disconnect_count
+
 
 class WorkerManager():
     """Class used to keep track of workers state, as well as processing
@@ -86,6 +95,18 @@ class WorkerManager():
         self.time_blocked_workers = []
         self.load_disconnects()
         self.is_sandbox = mturk_manager.is_sandbox
+
+    def get_worker_data_package(self):
+        workers = []
+        for mturk_worker in self.mturk_workers.values():
+            worker = {
+                'id': mturk_worker.worker_id,
+                'accepted': len(mturk_worker.agents),
+                'completed': mturk_worker.completed_assignments(),
+                'disconnected': mturk_worker.disconnected_assignments(),
+            }
+            workers.append(worker)
+        return workers
 
     def _create_agent(self, hit_id, assignment_id, worker_id):
         """Initialize an agent and return it"""


### PR DESCRIPTION
With the last wave of MTurk botting, it would've been good to put in some notices that can cause an interruption for people using the ParlAI-MTurk platform. This adds a call to our website to request potential notices for live or sandbox runs. 

As I'm expanding the platform to have more features, it'll be useful to get some new metrics as well about disconnect rates and such. This PR also introduces optionally logging worker statistics on runs. Users can opt in or snooze the warning for 2 weeks.