### PR TITLE
Print args after model is loaded in interactive

### DIFF
--- a/examples/interactive.py
+++ b/examples/interactive.py
@@ -21,4 +21,4 @@ if __name__ == '__main__':
     random.seed(42)
     parser = setup_args()
     opt = parser.parse_args()
-    interactive(opt)
+    interactive(opt, print_parser=parser)

--- a/parlai/scripts/interactive.py
+++ b/parlai/scripts/interactive.py
@@ -35,7 +35,12 @@ def setup_args(parser=None):
     return parser
 
 
-def interactive(opt):
+def interactive(opt, print_parser=None):
+    if print_parser is not None:
+        if print_parser is True and isinstance(opt, ParlaiParser):
+            print_parser = opt
+        elif print_parser is False:
+            print_parser = None
     if isinstance(opt, ParlaiParser):
         print('[ Deprecated Warning: interactive should be passed opt not Parser ]')
         opt = opt.parse_args()
@@ -44,6 +49,11 @@ def interactive(opt):
     # Create model and assign it to the specified task
     agent = create_agent(opt, requireModelExists=True)
     world = create_task(opt, agent)
+
+    if print_parser:
+        # Show arguments after loading model
+        print_parser.opt = agent.opt
+        print_parser.print_args()
 
     # Show some example dialogs:
     while True:
@@ -58,4 +68,5 @@ def interactive(opt):
 
 if __name__ == '__main__':
     random.seed(42)
-    interactive(setup_args().parse_args())
+    parser = setup_args()
+    interactive(parser.parse_args(print_args=False), print_parser=parser)


### PR DESCRIPTION
Model opts were printing incorrectly with the interactive script because opts were loaded from the model file after printing. Fixed this so that it functions along the same lines as in `eval_model.py`.