### PR TITLE
Adding python3 shebang to all of the python files

### DIFF
--- a/examples/base_train.py
+++ b/examples/base_train.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/examples/build_dict.py
+++ b/examples/build_dict.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/examples/build_pytorch_data.py
+++ b/examples/build_pytorch_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/examples/display_data.py
+++ b/examples/display_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/examples/display_model.py
+++ b/examples/display_model.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/examples/eval_model.py
+++ b/examples/eval_model.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/examples/extract_image_feature.py
+++ b/examples/extract_image_feature.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/examples/interactive.py
+++ b/examples/interactive.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/examples/memnn_luatorch_cpu/full_task_train.py
+++ b/examples/memnn_luatorch_cpu/full_task_train.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/examples/profile_train.py
+++ b/examples/profile_train.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/examples/remote.py
+++ b/examples/remote.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/examples/seq2seq_train_babi.py
+++ b/examples/seq2seq_train_babi.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/__init__.py
+++ b/parlai/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/__init__.py
+++ b/parlai/agents/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/coopgame_agent/__init__.py
+++ b/parlai/agents/coopgame_agent/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/coopgame_agent/coopgame_agent.py
+++ b/parlai/agents/coopgame_agent/coopgame_agent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/coopgame_agent/modules.py
+++ b/parlai/agents/coopgame_agent/modules.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/drqa/__init__.py
+++ b/parlai/agents/drqa/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/drqa/config.py
+++ b/parlai/agents/drqa/config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/drqa/drqa.py
+++ b/parlai/agents/drqa/drqa.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/drqa/layers.py
+++ b/parlai/agents/drqa/layers.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/drqa/model.py
+++ b/parlai/agents/drqa/model.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/drqa/rnn_reader.py
+++ b/parlai/agents/drqa/rnn_reader.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/drqa/utils.py
+++ b/parlai/agents/drqa/utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/example_seq2seq/__init__.py
+++ b/parlai/agents/example_seq2seq/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/example_seq2seq/example_seq2seq.py
+++ b/parlai/agents/example_seq2seq/example_seq2seq.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/fairseq/__init__.py
+++ b/parlai/agents/fairseq/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/ibm_seq2seq/__init__.py
+++ b/parlai/agents/ibm_seq2seq/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/ibm_seq2seq/ibm_seq2seq.py
+++ b/parlai/agents/ibm_seq2seq/ibm_seq2seq.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/ir_baseline/__init__.py
+++ b/parlai/agents/ir_baseline/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/ir_baseline/ir_baseline.py
+++ b/parlai/agents/ir_baseline/ir_baseline.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/language_model/__init__.py
+++ b/parlai/agents/language_model/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/language_model/language_model.py
+++ b/parlai/agents/language_model/language_model.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/language_model/modules.py
+++ b/parlai/agents/language_model/modules.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/legacy_agents/__init__.py
+++ b/parlai/agents/legacy_agents/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/legacy_agents/memnn/__init__.py
+++ b/parlai/agents/legacy_agents/memnn/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/legacy_agents/memnn/memnn_v0.py
+++ b/parlai/agents/legacy_agents/memnn/memnn_v0.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/legacy_agents/memnn/modules_v0.py
+++ b/parlai/agents/legacy_agents/memnn/modules_v0.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/legacy_agents/seq2seq/__init__.py
+++ b/parlai/agents/legacy_agents/seq2seq/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/legacy_agents/seq2seq/dict_v0.py
+++ b/parlai/agents/legacy_agents/seq2seq/dict_v0.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/legacy_agents/seq2seq/modules_v0.py
+++ b/parlai/agents/legacy_agents/seq2seq/modules_v0.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/legacy_agents/seq2seq/seq2seq_v0.py
+++ b/parlai/agents/legacy_agents/seq2seq/seq2seq_v0.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/legacy_agents/seq2seq/utils_v0.py
+++ b/parlai/agents/legacy_agents/seq2seq/utils_v0.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/local_human/__init__.py
+++ b/parlai/agents/local_human/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+

--- a/parlai/agents/local_human/__init__.py
+++ b/parlai/agents/local_human/__init__.py
@@ -1,2 +1,7 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/agents/local_human/local_human.py
+++ b/parlai/agents/local_human/local_human.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/memnn/__init__.py
+++ b/parlai/agents/memnn/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/memnn/memnn.py
+++ b/parlai/agents/memnn/memnn.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/memnn/modules.py
+++ b/parlai/agents/memnn/modules.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/memnn_luatorch_cpu/__init__.py
+++ b/parlai/agents/memnn_luatorch_cpu/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/mlb_vqa/__init__.py
+++ b/parlai/agents/mlb_vqa/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/mlb_vqa/dropout.py
+++ b/parlai/agents/mlb_vqa/dropout.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/agents/mlb_vqa/gru.py
+++ b/parlai/agents/mlb_vqa/gru.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/agents/mlb_vqa/loadstates.py
+++ b/parlai/agents/mlb_vqa/loadstates.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/agents/mlb_vqa/mlb_modules.py
+++ b/parlai/agents/mlb_vqa/mlb_modules.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/agents/mlb_vqa/mlb_vqa.py
+++ b/parlai/agents/mlb_vqa/mlb_vqa.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/agents/random_candidate/__init__.py
+++ b/parlai/agents/random_candidate/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+

--- a/parlai/agents/random_candidate/__init__.py
+++ b/parlai/agents/random_candidate/__init__.py
@@ -1,2 +1,7 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/agents/random_candidate/random_candidate.py
+++ b/parlai/agents/random_candidate/random_candidate.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/remote_agent/__init__.py
+++ b/parlai/agents/remote_agent/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/remote_agent/remote_agent.py
+++ b/parlai/agents/remote_agent/remote_agent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/repeat_label/__init__.py
+++ b/parlai/agents/repeat_label/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/repeat_label/repeat_label.py
+++ b/parlai/agents/repeat_label/repeat_label.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/repeat_query/__init__.py
+++ b/parlai/agents/repeat_query/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/repeat_query/repeat_query.py
+++ b/parlai/agents/repeat_query/repeat_query.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/retriever_reader/__init__.py
+++ b/parlai/agents/retriever_reader/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/retriever_reader/retriever_reader.py
+++ b/parlai/agents/retriever_reader/retriever_reader.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/seq2seq/__init__.py
+++ b/parlai/agents/seq2seq/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/starspace/__init__.py
+++ b/parlai/agents/starspace/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+

--- a/parlai/agents/starspace/__init__.py
+++ b/parlai/agents/starspace/__init__.py
@@ -1,2 +1,7 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/agents/starspace/modules.py
+++ b/parlai/agents/starspace/modules.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/starspace/starspace.py
+++ b/parlai/agents/starspace/starspace.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/__init__.py
+++ b/parlai/agents/tfidf_retriever/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/build_db.py
+++ b/parlai/agents/tfidf_retriever/build_db.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/build_tfidf.py
+++ b/parlai/agents/tfidf_retriever/build_tfidf.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/doc_db.py
+++ b/parlai/agents/tfidf_retriever/doc_db.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/tfidf_doc_ranker.py
+++ b/parlai/agents/tfidf_retriever/tfidf_doc_ranker.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/tfidf_retriever.py
+++ b/parlai/agents/tfidf_retriever/tfidf_retriever.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/tokenizers/__init__.py
+++ b/parlai/agents/tfidf_retriever/tokenizers/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+
+#!/usr/bin/env python3
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/tokenizers/corenlp_tokenizer.py
+++ b/parlai/agents/tfidf_retriever/tokenizers/corenlp_tokenizer.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+
+#!/usr/bin/env python3
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/tokenizers/regexp_tokenizer.py
+++ b/parlai/agents/tfidf_retriever/tokenizers/regexp_tokenizer.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+
+#!/usr/bin/env python3
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/tokenizers/simple_tokenizer.py
+++ b/parlai/agents/tfidf_retriever/tokenizers/simple_tokenizer.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+
+#!/usr/bin/env python3
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/tokenizers/spacy_tokenizer.py
+++ b/parlai/agents/tfidf_retriever/tokenizers/spacy_tokenizer.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+
+#!/usr/bin/env python3
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/tokenizers/tokenizer.py
+++ b/parlai/agents/tfidf_retriever/tokenizers/tokenizer.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+
+#!/usr/bin/env python3
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/tfidf_retriever/utils.py
+++ b/parlai/agents/tfidf_retriever/utils.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+
+#!/usr/bin/env python3
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/vsepp_caption/__init__.py
+++ b/parlai/agents/vsepp_caption/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/agents/vsepp_caption/modules.py
+++ b/parlai/agents/vsepp_caption/modules.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This file is covered under the Apache 2.0 License listed here
 # <https://github.com/fartashf/vsepp/blob/master/LICENSE> as it is a
 # Derivative Work of the repo.

--- a/parlai/agents/vsepp_caption/vsepp_caption.py
+++ b/parlai/agents/vsepp_caption/vsepp_caption.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/__init__.py
+++ b/parlai/core/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/thread_utils.py
+++ b/parlai/core/thread_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/__init__.py
+++ b/parlai/messenger/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/core/__init__.py
+++ b/parlai/messenger/core/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/core/message_sender.py
+++ b/parlai/messenger/core/message_sender.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/core/message_socket.py
+++ b/parlai/messenger/core/message_socket.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/core/server/__init__.py
+++ b/parlai/messenger/core/server/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/core/server_utils.py
+++ b/parlai/messenger/core/server_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/core/shared_utils.py
+++ b/parlai/messenger/core/shared_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/core/worlds.py
+++ b/parlai/messenger/core/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/tasks/__init__.py
+++ b/parlai/messenger/tasks/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/tasks/chatbot/__init__.py
+++ b/parlai/messenger/tasks/chatbot/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/tasks/chatbot/run.py
+++ b/parlai/messenger/tasks/chatbot/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/tasks/chatbot/worlds.py
+++ b/parlai/messenger/tasks/chatbot/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/tasks/overworld_demo/__init__.py
+++ b/parlai/messenger/tasks/overworld_demo/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/tasks/overworld_demo/run.py
+++ b/parlai/messenger/tasks/overworld_demo/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/tasks/overworld_demo/worlds.py
+++ b/parlai/messenger/tasks/overworld_demo/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/tasks/qa_data_collection/__init__.py
+++ b/parlai/messenger/tasks/qa_data_collection/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/tasks/qa_data_collection/run.py
+++ b/parlai/messenger/tasks/qa_data_collection/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/messenger/tasks/qa_data_collection/worlds.py
+++ b/parlai/messenger/tasks/qa_data_collection/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/__init__.py
+++ b/parlai/mturk/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/__init__.py
+++ b/parlai/mturk/core/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/data_model.py
+++ b/parlai/mturk/core/data_model.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/mturk_data_handler.py
+++ b/parlai/mturk/core/mturk_data_handler.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/scripts/__init__.py
+++ b/parlai/mturk/core/scripts/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/scripts/bonus_workers.py
+++ b/parlai/mturk/core/scripts/bonus_workers.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/scripts/delete_hits.py
+++ b/parlai/mturk/core/scripts/delete_hits.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/server/__init__.py
+++ b/parlai/mturk/core/server/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/server_utils.py
+++ b/parlai/mturk/core/server_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/shared_utils.py
+++ b/parlai/mturk/core/shared_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/test/__init__.py
+++ b/parlai/mturk/core/test/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/test/auto_complete_hit.py
+++ b/parlai/mturk/core/test/auto_complete_hit.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/test/test_db_interactions.py
+++ b/parlai/mturk/core/test/test_db_interactions.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/test/test_full_system.py
+++ b/parlai/mturk/core/test/test_full_system.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/test/test_mturk_agent.py
+++ b/parlai/mturk/core/test/test_mturk_agent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/test/test_mturk_manager.py
+++ b/parlai/mturk/core/test/test_mturk_manager.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/test/test_socket_manager.py
+++ b/parlai/mturk/core/test/test_socket_manager.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/test/test_worker_manager.py
+++ b/parlai/mturk/core/test/test_worker_manager.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/worker_manager.py
+++ b/parlai/mturk/core/worker_manager.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/core/worlds.py
+++ b/parlai/mturk/core/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/__init__.py
+++ b/parlai/mturk/tasks/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/convai2_model_eval/__init__.py
+++ b/parlai/mturk/tasks/convai2_model_eval/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/convai2_model_eval/run.py
+++ b/parlai/mturk/tasks/convai2_model_eval/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/convai2_model_eval/task_config.py
+++ b/parlai/mturk/tasks/convai2_model_eval/task_config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/convai2_model_eval/worlds.py
+++ b/parlai/mturk/tasks/convai2_model_eval/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/data_evaluator/__init__.py
+++ b/parlai/mturk/tasks/data_evaluator/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/dealnodeal/__init__.py
+++ b/parlai/mturk/tasks/dealnodeal/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/dealnodeal/run.py
+++ b/parlai/mturk/tasks/dealnodeal/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/dealnodeal/task_config.py
+++ b/parlai/mturk/tasks/dealnodeal/task_config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/dealnodeal/worlds.py
+++ b/parlai/mturk/tasks/dealnodeal/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/model_evaluator/__init__.py
+++ b/parlai/mturk/tasks/model_evaluator/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/model_evaluator/run.py
+++ b/parlai/mturk/tasks/model_evaluator/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/model_evaluator/task_config.py
+++ b/parlai/mturk/tasks/model_evaluator/task_config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/model_evaluator/worlds.py
+++ b/parlai/mturk/tasks/model_evaluator/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/multi_agent_dialog/__init__.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/multi_agent_dialog/run.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/multi_agent_dialog/task_config.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/task_config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/multi_agent_dialog/worlds.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/__init__.py
+++ b/parlai/mturk/tasks/personachat/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_chat/__init__.py
+++ b/parlai/mturk/tasks/personachat/personachat_chat/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_chat/extract_and_save_personas.py
+++ b/parlai/mturk/tasks/personachat/personachat_chat/extract_and_save_personas.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_chat/run.py
+++ b/parlai/mturk/tasks/personachat/personachat_chat/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_chat/task_config.py
+++ b/parlai/mturk/tasks/personachat/personachat_chat/task_config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_chat/worlds.py
+++ b/parlai/mturk/tasks/personachat/personachat_chat/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_collect_personas/__init__.py
+++ b/parlai/mturk/tasks/personachat/personachat_collect_personas/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_collect_personas/run.py
+++ b/parlai/mturk/tasks/personachat/personachat_collect_personas/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_collect_personas/task_config.py
+++ b/parlai/mturk/tasks/personachat/personachat_collect_personas/task_config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_collect_personas/worlds.py
+++ b/parlai/mturk/tasks/personachat/personachat_collect_personas/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_rephrase/__init__.py
+++ b/parlai/mturk/tasks/personachat/personachat_rephrase/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_rephrase/run.py
+++ b/parlai/mturk/tasks/personachat/personachat_rephrase/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_rephrase/task_config.py
+++ b/parlai/mturk/tasks/personachat/personachat_rephrase/task_config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/personachat/personachat_rephrase/worlds.py
+++ b/parlai/mturk/tasks/personachat/personachat_rephrase/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/qa_data_collection/__init__.py
+++ b/parlai/mturk/tasks/qa_data_collection/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/qa_data_collection/run.py
+++ b/parlai/mturk/tasks/qa_data_collection/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/qa_data_collection/task_config.py
+++ b/parlai/mturk/tasks/qa_data_collection/task_config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/qa_data_collection/worlds.py
+++ b/parlai/mturk/tasks/qa_data_collection/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/qualification_flow_example/__init__.py
+++ b/parlai/mturk/tasks/qualification_flow_example/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/qualification_flow_example/run.py
+++ b/parlai/mturk/tasks/qualification_flow_example/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/qualification_flow_example/task_config.py
+++ b/parlai/mturk/tasks/qualification_flow_example/task_config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/qualification_flow_example/worlds.py
+++ b/parlai/mturk/tasks/qualification_flow_example/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/talkthewalk/__init__.py
+++ b/parlai/mturk/tasks/talkthewalk/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/talkthewalk/download.py
+++ b/parlai/mturk/tasks/talkthewalk/download.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/talkthewalk/run.py
+++ b/parlai/mturk/tasks/talkthewalk/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/talkthewalk/task_config.py
+++ b/parlai/mturk/tasks/talkthewalk/task_config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/mturk/tasks/talkthewalk/worlds.py
+++ b/parlai/mturk/tasks/talkthewalk/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/__init__.py
+++ b/parlai/scripts/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/build_dict.py
+++ b/parlai/scripts/build_dict.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/build_pytorch_data.py
+++ b/parlai/scripts/build_pytorch_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/convert_data_to_parlai_format.py
+++ b/parlai/scripts/convert_data_to_parlai_format.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/detect_offensive_language.py
+++ b/parlai/scripts/detect_offensive_language.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/display_data.py
+++ b/parlai/scripts/display_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/eval_ppl.py
+++ b/parlai/scripts/eval_ppl.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/eval_wordstat.py
+++ b/parlai/scripts/eval_wordstat.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 #!/usr/bin/env python
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/parlai/scripts/extract_image_feature.py
+++ b/parlai/scripts/extract_image_feature.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/interactive.py
+++ b/parlai/scripts/interactive.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/profile_train.py
+++ b/parlai/scripts/profile_train.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/scripts/verify_data.py
+++ b/parlai/scripts/verify_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/__init__.py
+++ b/parlai/tasks/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/aqua/__init__.py
+++ b/parlai/tasks/aqua/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/aqua/agents.py
+++ b/parlai/tasks/aqua/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/aqua/build.py
+++ b/parlai/tasks/aqua/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/parlai/tasks/babi/__init__.py
+++ b/parlai/tasks/babi/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/babi/agents.py
+++ b/parlai/tasks/babi/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/babi/build.py
+++ b/parlai/tasks/babi/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/booktest/__init__.py
+++ b/parlai/tasks/booktest/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/booktest/agents.py
+++ b/parlai/tasks/booktest/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/booktest/build.py
+++ b/parlai/tasks/booktest/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/cbt/__init__.py
+++ b/parlai/tasks/cbt/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/cbt/agents.py
+++ b/parlai/tasks/cbt/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/cbt/build.py
+++ b/parlai/tasks/cbt/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/clevr/__init__.py
+++ b/parlai/tasks/clevr/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/clevr/agents.py
+++ b/parlai/tasks/clevr/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/clevr/build.py
+++ b/parlai/tasks/clevr/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/coco_caption/__init__.py
+++ b/parlai/tasks/coco_caption/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/coco_caption/agents.py
+++ b/parlai/tasks/coco_caption/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/coco_caption/build_2014.py
+++ b/parlai/tasks/coco_caption/build_2014.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/coco_caption/build_2015.py
+++ b/parlai/tasks/coco_caption/build_2015.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/coco_caption/build_2017.py
+++ b/parlai/tasks/coco_caption/build_2017.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/convai2/__init__.py
+++ b/parlai/tasks/convai2/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/convai2/agents.py
+++ b/parlai/tasks/convai2/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/convai2/build.py
+++ b/parlai/tasks/convai2/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/convai_chitchat/__init__.py
+++ b/parlai/tasks/convai_chitchat/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Moscow Institute of Physics and Technology.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/convai_chitchat/agents.py
+++ b/parlai/tasks/convai_chitchat/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Moscow Institute of Physics and Technology.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/convai_chitchat/build.py
+++ b/parlai/tasks/convai_chitchat/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Moscow Institute of Physics and Technology.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/copa/__init__.py
+++ b/parlai/tasks/copa/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/copa/agents.py
+++ b/parlai/tasks/copa/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/copa/build.py
+++ b/parlai/tasks/copa/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/cornell_movie/__init__.py
+++ b/parlai/tasks/cornell_movie/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/cornell_movie/agents.py
+++ b/parlai/tasks/cornell_movie/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/cornell_movie/build.py
+++ b/parlai/tasks/cornell_movie/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dbll_babi/__init__.py
+++ b/parlai/tasks/dbll_babi/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dbll_babi/agents.py
+++ b/parlai/tasks/dbll_babi/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dbll_babi/build.py
+++ b/parlai/tasks/dbll_babi/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dbll_movie/__init__.py
+++ b/parlai/tasks/dbll_movie/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dbll_movie/agents.py
+++ b/parlai/tasks/dbll_movie/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dbll_movie/build.py
+++ b/parlai/tasks/dbll_movie/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dealnodeal/__init__.py
+++ b/parlai/tasks/dealnodeal/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dealnodeal/agents.py
+++ b/parlai/tasks/dealnodeal/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dealnodeal/build.py
+++ b/parlai/tasks/dealnodeal/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dialog_babi/__init__.py
+++ b/parlai/tasks/dialog_babi/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dialog_babi/agents.py
+++ b/parlai/tasks/dialog_babi/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dialog_babi/build.py
+++ b/parlai/tasks/dialog_babi/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dialog_babi_plus/__init__.py
+++ b/parlai/tasks/dialog_babi_plus/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dialog_babi_plus/agents.py
+++ b/parlai/tasks/dialog_babi_plus/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dialog_babi_plus/build.py
+++ b/parlai/tasks/dialog_babi_plus/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dialogue_qe/__init__.py
+++ b/parlai/tasks/dialogue_qe/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Moscow Institute of Physics and Technology.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dialogue_qe/agents.py
+++ b/parlai/tasks/dialogue_qe/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Moscow Institute of Physics and Technology.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/dialogue_qe/build.py
+++ b/parlai/tasks/dialogue_qe/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Moscow Institute of Physics and Technology.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/flickr30k/__init__.py
+++ b/parlai/tasks/flickr30k/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/flickr30k/agents.py
+++ b/parlai/tasks/flickr30k/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/flickr30k/build.py
+++ b/parlai/tasks/flickr30k/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/fromfile/__init__.py
+++ b/parlai/tasks/fromfile/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/fromfile/agents.py
+++ b/parlai/tasks/fromfile/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/fvqa/__init__.py
+++ b/parlai/tasks/fvqa/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/fvqa/agents.py
+++ b/parlai/tasks/fvqa/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/fvqa/build.py
+++ b/parlai/tasks/fvqa/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/insuranceqa/__init__.py
+++ b/parlai/tasks/insuranceqa/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/insuranceqa/agents.py
+++ b/parlai/tasks/insuranceqa/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/insuranceqa/build.py
+++ b/parlai/tasks/insuranceqa/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/integration_tests/__init__.py
+++ b/parlai/tasks/integration_tests/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 #!/usr/bin/env
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/parlai/tasks/iwslt14/__init__.py
+++ b/parlai/tasks/iwslt14/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+

--- a/parlai/tasks/iwslt14/__init__.py
+++ b/parlai/tasks/iwslt14/__init__.py
@@ -1,2 +1,7 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/tasks/iwslt14/agents.py
+++ b/parlai/tasks/iwslt14/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/iwslt14/build.py
+++ b/parlai/tasks/iwslt14/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/mctest/__init__.py
+++ b/parlai/tasks/mctest/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/mctest/agents.py
+++ b/parlai/tasks/mctest/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/mctest/build.py
+++ b/parlai/tasks/mctest/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/mnist_qa/__init__.py
+++ b/parlai/tasks/mnist_qa/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/mnist_qa/agents.py
+++ b/parlai/tasks/mnist_qa/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/mnist_qa/build.py
+++ b/parlai/tasks/mnist_qa/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/moviedialog/__init__.py
+++ b/parlai/tasks/moviedialog/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/moviedialog/agents.py
+++ b/parlai/tasks/moviedialog/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/moviedialog/build.py
+++ b/parlai/tasks/moviedialog/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/ms_marco/__init__.py
+++ b/parlai/tasks/ms_marco/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/ms_marco/agents.py
+++ b/parlai/tasks/ms_marco/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/ms_marco/build.py
+++ b/parlai/tasks/ms_marco/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/mturkwikimovies/__init__.py
+++ b/parlai/tasks/mturkwikimovies/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/mturkwikimovies/agents.py
+++ b/parlai/tasks/mturkwikimovies/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/mturkwikimovies/build.py
+++ b/parlai/tasks/mturkwikimovies/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/multinli/__init__.py
+++ b/parlai/tasks/multinli/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/multinli/agents.py
+++ b/parlai/tasks/multinli/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/multinli/build.py
+++ b/parlai/tasks/multinli/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/parlai/tasks/mutualfriends/__init__.py
+++ b/parlai/tasks/mutualfriends/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/mutualfriends/agents.py
+++ b/parlai/tasks/mutualfriends/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/mutualfriends/build.py
+++ b/parlai/tasks/mutualfriends/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/narrative_qa/__init__.py
+++ b/parlai/tasks/narrative_qa/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/narrative_qa/agents.py
+++ b/parlai/tasks/narrative_qa/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/narrative_qa/build.py
+++ b/parlai/tasks/narrative_qa/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/parlai/tasks/nlvr/__init__.py
+++ b/parlai/tasks/nlvr/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/nlvr/agents.py
+++ b/parlai/tasks/nlvr/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/nlvr/build.py
+++ b/parlai/tasks/nlvr/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/opensubtitles/__init__.py
+++ b/parlai/tasks/opensubtitles/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/opensubtitles/agents.py
+++ b/parlai/tasks/opensubtitles/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/opensubtitles/build_2009.py
+++ b/parlai/tasks/opensubtitles/build_2009.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/opensubtitles/build_2018.py
+++ b/parlai/tasks/opensubtitles/build_2018.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/personachat/__init__.py
+++ b/parlai/tasks/personachat/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/personachat/agents.py
+++ b/parlai/tasks/personachat/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/personachat/build.py
+++ b/parlai/tasks/personachat/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/personalized_dialog/__init__.py
+++ b/parlai/tasks/personalized_dialog/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/personalized_dialog/agents.py
+++ b/parlai/tasks/personalized_dialog/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/personalized_dialog/build.py
+++ b/parlai/tasks/personalized_dialog/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/qacnn/__init__.py
+++ b/parlai/tasks/qacnn/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/qacnn/agents.py
+++ b/parlai/tasks/qacnn/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/qacnn/build.py
+++ b/parlai/tasks/qacnn/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/qadailymail/__init__.py
+++ b/parlai/tasks/qadailymail/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/qadailymail/agents.py
+++ b/parlai/tasks/qadailymail/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/qadailymail/build.py
+++ b/parlai/tasks/qadailymail/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/qangaroo/__init__.py
+++ b/parlai/tasks/qangaroo/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+

--- a/parlai/tasks/qangaroo/__init__.py
+++ b/parlai/tasks/qangaroo/__init__.py
@@ -1,2 +1,7 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/tasks/qangaroo/agents.py
+++ b/parlai/tasks/qangaroo/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/qangaroo/build.py
+++ b/parlai/tasks/qangaroo/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/scan/__init__.py
+++ b/parlai/tasks/scan/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/scan/agents.py
+++ b/parlai/tasks/scan/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/scan/build.py
+++ b/parlai/tasks/scan/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/simplequestions/__init__.py
+++ b/parlai/tasks/simplequestions/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/simplequestions/agents.py
+++ b/parlai/tasks/simplequestions/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/simplequestions/build.py
+++ b/parlai/tasks/simplequestions/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/snli/__init__.py
+++ b/parlai/tasks/snli/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/snli/agents.py
+++ b/parlai/tasks/snli/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/snli/build.py
+++ b/parlai/tasks/snli/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/parlai/tasks/squad/__init__.py
+++ b/parlai/tasks/squad/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/squad/agents.py
+++ b/parlai/tasks/squad/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/squad/build.py
+++ b/parlai/tasks/squad/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/squad2/__init__.py
+++ b/parlai/tasks/squad2/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/squad2/agents.py
+++ b/parlai/tasks/squad2/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/squad2/build.py
+++ b/parlai/tasks/squad2/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/taskntalk/__init__.py
+++ b/parlai/tasks/taskntalk/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/taskntalk/agents.py
+++ b/parlai/tasks/taskntalk/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/taskntalk/build.py
+++ b/parlai/tasks/taskntalk/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/tasks.py
+++ b/parlai/tasks/tasks.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/triviaqa/__init__.py
+++ b/parlai/tasks/triviaqa/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/triviaqa/agents.py
+++ b/parlai/tasks/triviaqa/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/triviaqa/build.py
+++ b/parlai/tasks/triviaqa/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/twitter/__init__.py
+++ b/parlai/tasks/twitter/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/twitter/agents.py
+++ b/parlai/tasks/twitter/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/twitter/build.py
+++ b/parlai/tasks/twitter/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/ubuntu/__init__.py
+++ b/parlai/tasks/ubuntu/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/ubuntu/agents.py
+++ b/parlai/tasks/ubuntu/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/ubuntu/build.py
+++ b/parlai/tasks/ubuntu/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/visdial/__init__.py
+++ b/parlai/tasks/visdial/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/visdial/agents.py
+++ b/parlai/tasks/visdial/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/visdial/build.py
+++ b/parlai/tasks/visdial/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/vqa_v1/__init__.py
+++ b/parlai/tasks/vqa_v1/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/vqa_v1/agents.py
+++ b/parlai/tasks/vqa_v1/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/vqa_v1/build.py
+++ b/parlai/tasks/vqa_v1/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/vqa_v2/__init__.py
+++ b/parlai/tasks/vqa_v2/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/vqa_v2/agents.py
+++ b/parlai/tasks/vqa_v2/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/vqa_v2/build.py
+++ b/parlai/tasks/vqa_v2/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/webquestions/__init__.py
+++ b/parlai/tasks/webquestions/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/webquestions/agents.py
+++ b/parlai/tasks/webquestions/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/webquestions/build.py
+++ b/parlai/tasks/webquestions/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/wikimovies/__init__.py
+++ b/parlai/tasks/wikimovies/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/wikimovies/agents.py
+++ b/parlai/tasks/wikimovies/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/wikimovies/build.py
+++ b/parlai/tasks/wikimovies/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/wikipedia/__init__.py
+++ b/parlai/tasks/wikipedia/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/wikipedia/agents.py
+++ b/parlai/tasks/wikipedia/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/wikipedia/build.py
+++ b/parlai/tasks/wikipedia/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/wikiqa/__init__.py
+++ b/parlai/tasks/wikiqa/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/wikiqa/agents.py
+++ b/parlai/tasks/wikiqa/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/wikiqa/build.py
+++ b/parlai/tasks/wikiqa/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/wmt/__init__.py
+++ b/parlai/tasks/wmt/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/wmt/agents.py
+++ b/parlai/tasks/wmt/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/tasks/wmt/build.py
+++ b/parlai/tasks/wmt/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/__init__.py
+++ b/parlai/zoo/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/drqa/__init__.py
+++ b/parlai/zoo/drqa/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/drqa/squad.py
+++ b/parlai/zoo/drqa/squad.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/fasttext_cc_vectors/__init__.py
+++ b/parlai/zoo/fasttext_cc_vectors/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/fasttext_cc_vectors/build.py
+++ b/parlai/zoo/fasttext_cc_vectors/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/fasttext_vectors/__init__.py
+++ b/parlai/zoo/fasttext_vectors/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/fasttext_vectors/build.py
+++ b/parlai/zoo/fasttext_vectors/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/glove_vectors/__init__.py
+++ b/parlai/zoo/glove_vectors/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/glove_vectors/build.py
+++ b/parlai/zoo/glove_vectors/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/twitter/__init__.py
+++ b/parlai/zoo/twitter/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/twitter/dict.py
+++ b/parlai/zoo/twitter/dict.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/twitter/seq2seq.py
+++ b/parlai/zoo/twitter/seq2seq.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/wikipedia_2016-12-21/__init__.py
+++ b/parlai/zoo/wikipedia_2016-12-21/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/wikipedia_2016-12-21/tfidf_retriever.py
+++ b/parlai/zoo/wikipedia_2016-12-21/tfidf_retriever.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/wikipedia_full/__init__.py
+++ b/parlai/zoo/wikipedia_full/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/parlai/zoo/wikipedia_full/tfidf_retriever.py
+++ b/parlai/zoo/wikipedia_full/tfidf_retriever.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai/__init__.py
+++ b/projects/convai/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Moscow Institute of Physics and Technology.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai/convai_bot.py
+++ b/projects/convai/convai_bot.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Moscow Institute of Physics and Technology.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai/convai_world.py
+++ b/projects/convai/convai_world.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Moscow Institute of Physics and Technology.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/__init__.py
+++ b/projects/convai2/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/baselines/kvmemnn/eval_f1.py
+++ b/projects/convai2/baselines/kvmemnn/eval_f1.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/baselines/kvmemnn/eval_hits.py
+++ b/projects/convai2/baselines/kvmemnn/eval_hits.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/baselines/kvmemnn/interactive.py
+++ b/projects/convai2/baselines/kvmemnn/interactive.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/baselines/kvmemnn/train.py
+++ b/projects/convai2/baselines/kvmemnn/train.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/baselines/language_model/eval_f1.py
+++ b/projects/convai2/baselines/language_model/eval_f1.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/baselines/language_model/eval_ppl.py
+++ b/projects/convai2/baselines/language_model/eval_ppl.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/baselines/seq2seq/eval_f1.py
+++ b/projects/convai2/baselines/seq2seq/eval_f1.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/baselines/seq2seq/eval_hits.py
+++ b/projects/convai2/baselines/seq2seq/eval_hits.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/baselines/seq2seq/eval_ppl.py
+++ b/projects/convai2/baselines/seq2seq/eval_ppl.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/baselines/seq2seq/eval_wordstat.py
+++ b/projects/convai2/baselines/seq2seq/eval_wordstat.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/baselines/seq2seq/interactive.py
+++ b/projects/convai2/baselines/seq2seq/interactive.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/baselines/seq2seq/train.py
+++ b/projects/convai2/baselines/seq2seq/train.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/build_dict.py
+++ b/projects/convai2/build_dict.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/eval_f1.py
+++ b/projects/convai2/eval_f1.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/eval_hits.py
+++ b/projects/convai2/eval_hits.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/convai2/eval_ppl.py
+++ b/projects/convai2/eval_ppl.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/drqa/eval_pretrained.py
+++ b/projects/drqa/eval_pretrained.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/drqa/train.py
+++ b/projects/drqa/train.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/mastering_the_dungeon/__init__.py
+++ b/projects/mastering_the_dungeon/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/agents/__init__.py
+++ b/projects/mastering_the_dungeon/agents/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/agents/graph_world2/__init__.py
+++ b/projects/mastering_the_dungeon/agents/graph_world2/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/agents/graph_world2/agents.py
+++ b/projects/mastering_the_dungeon/agents/graph_world2/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/agents/graph_world2/models.py
+++ b/projects/mastering_the_dungeon/agents/graph_world2/models.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/mastering_the_dungeon/mturk/__init__.py
+++ b/projects/mastering_the_dungeon/mturk/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/mturk/tasks/MTD/__init__.py
+++ b/projects/mastering_the_dungeon/mturk/tasks/MTD/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/mturk/tasks/MTD/run.py
+++ b/projects/mastering_the_dungeon/mturk/tasks/MTD/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/mturk/tasks/__init__.py
+++ b/projects/mastering_the_dungeon/mturk/tasks/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/projects/graph_world2/gen_sbatch_script.py
+++ b/projects/mastering_the_dungeon/projects/graph_world2/gen_sbatch_script.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/projects/graph_world2/train.py
+++ b/projects/mastering_the_dungeon/projects/graph_world2/train.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/tasks/__init__.py
+++ b/projects/mastering_the_dungeon/tasks/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/tasks/graph_world2/__init__.py
+++ b/projects/mastering_the_dungeon/tasks/graph_world2/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/tasks/graph_world2/agents.py
+++ b/projects/mastering_the_dungeon/tasks/graph_world2/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/tasks/graph_world2/graph.py
+++ b/projects/mastering_the_dungeon/tasks/graph_world2/graph.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/mastering_the_dungeon/tasks/graph_world2/worlds.py
+++ b/projects/mastering_the_dungeon/tasks/graph_world2/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ##
 ## Copyright (c) 2017-present, Facebook, Inc.
 ## All rights reserved.

--- a/projects/memnn_feedback/agent/__init__.py
+++ b/projects/memnn_feedback/agent/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/memnn_feedback/agent/memnn_feedback.py
+++ b/projects/memnn_feedback/agent/memnn_feedback.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/memnn_feedback/agent/modules.py
+++ b/projects/memnn_feedback/agent/modules.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/memnn_feedback/tasks/dbll_babi/__init__.py
+++ b/projects/memnn_feedback/tasks/dbll_babi/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/memnn_feedback/tasks/dbll_babi/agents.py
+++ b/projects/memnn_feedback/tasks/dbll_babi/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/memnn_feedback/tasks/dbll_babi/build.py
+++ b/projects/memnn_feedback/tasks/dbll_babi/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/memnn_feedback/tasks/dialog_babi_feedback/agents.py
+++ b/projects/memnn_feedback/tasks/dialog_babi_feedback/agents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/memnn_feedback/tasks/dialog_babi_feedback/build.py
+++ b/projects/memnn_feedback/tasks/dialog_babi_feedback/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/kvmemnn/kvmemnn.py
+++ b/projects/personachat/kvmemnn/kvmemnn.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/kvmemnn/modules.py
+++ b/projects/personachat/kvmemnn/modules.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/mturk/personachat_eval/extract_and_save_personas.py
+++ b/projects/personachat/mturk/personachat_eval/extract_and_save_personas.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/mturk/personachat_eval/init.py
+++ b/projects/personachat/mturk/personachat_eval/init.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+

--- a/projects/personachat/mturk/personachat_eval/init.py
+++ b/projects/personachat/mturk/personachat_eval/init.py
@@ -1,2 +1,7 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/projects/personachat/mturk/personachat_eval/run.py
+++ b/projects/personachat/mturk/personachat_eval/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/mturk/personachat_eval/task_config.py
+++ b/projects/personachat/mturk/personachat_eval/task_config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/mturk/personachat_eval/worlds.py
+++ b/projects/personachat/mturk/personachat_eval/worlds.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/persona_seq2seq.py
+++ b/projects/personachat/persona_seq2seq.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/scripts/kvmemnn_eval.py
+++ b/projects/personachat/scripts/kvmemnn_eval.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/scripts/kvmemnn_interactive.py
+++ b/projects/personachat/scripts/kvmemnn_interactive.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/scripts/languagemodel_opensub2018_interactive.py
+++ b/projects/personachat/scripts/languagemodel_opensub2018_interactive.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/scripts/profilememory_eval_f1.py
+++ b/projects/personachat/scripts/profilememory_eval_f1.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/scripts/profilememory_eval_hitsat1.py
+++ b/projects/personachat/scripts/profilememory_eval_hitsat1.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/scripts/profilememory_interactive.py
+++ b/projects/personachat/scripts/profilememory_interactive.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/scripts/seq2seq_withprofile_eval_hitsat1.py
+++ b/projects/personachat/scripts/seq2seq_withprofile_eval_hitsat1.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/personachat/scripts/seq2seq_withprofile_interactive.py
+++ b/projects/personachat/scripts/seq2seq_withprofile_interactive.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/twitter/__init__.py
+++ b/projects/twitter/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/twitter/constants.py
+++ b/projects/twitter/constants.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/twitter/seq2seq/eval_f1.py
+++ b/projects/twitter/seq2seq/eval_f1.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/twitter/seq2seq/eval_ppl.py
+++ b/projects/twitter/seq2seq/eval_ppl.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/twitter/seq2seq/interactive.py
+++ b/projects/twitter/seq2seq/interactive.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/projects/twitter/seq2seq/train.py
+++ b/projects/twitter/seq2seq/train.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/tasks/convai_chitchat/TeacherTest.py
+++ b/tests/tasks/convai_chitchat/TeacherTest.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/tasks/repeat.py
+++ b/tests/tasks/repeat.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_display_data.py
+++ b/tests/test_display_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_fairseq.py
+++ b/tests/test_fairseq.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_hogwild.py
+++ b/tests/test_hogwild.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_mlb_vqa.py
+++ b/tests/test_mlb_vqa.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_tasklist.py
+++ b/tests/test_tasklist.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_tfidf_retriever.py
+++ b/tests/test_tfidf_retriever.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_threadutils.py
+++ b/tests/test_threadutils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the


### PR DESCRIPTION
Adding this shebang to all of the files means that the internal sync script will have 1/3 the number of linter errors, which is a step in the direction of getting ParlAI to not be broken internally. Externally it labels all the files as being written for python3, (though we were already pretty clear on that).