### PR TITLE
DrQA embedding file fix 

### DIFF
--- a/parlai/agents/drqa/config.py
+++ b/parlai/agents/drqa/config.py
@@ -120,6 +120,7 @@ def set_defaults(opt):
             print('Setting fix_embeddings to False as embeddings are random.')
             opt['fix_embeddings'] = False
 
+
 def override_args(opt, override_opt):
     # Major model args are reset to the values in override_opt.
     # Non-architecture args (like dropout) are kept.

--- a/parlai/agents/drqa/config.py
+++ b/parlai/agents/drqa/config.py
@@ -19,7 +19,6 @@ def add_cmdline_args(parser):
     # Basics
     agent.add_argument('--embedding_file', type=str, default=None,
                        help='file of space separated embeddings: w e1 ... ed')
-                       help='embeddings from model zoo')
     agent.add_argument('--init_model', type=str, default=None,
                        help='Load dict/features/weights/opts from this file')
     agent.add_argument('--log_file', type=str, default=None)

--- a/parlai/agents/drqa/config.py
+++ b/parlai/agents/drqa/config.py
@@ -18,10 +18,7 @@ def add_cmdline_args(parser):
 
     # Basics
     agent.add_argument('--embedding_file', type=str, default=None,
-                       help='[deprecated: use embedding_type] '
-                            'file of space separated embeddings: w e1 ... ed')
-    agent.add_argument('--embedding_type', type=str, default='random',
-                       choices=['fasttext', 'fasttext_cc', 'random', 'glove'],
+                       help='file of space separated embeddings: w e1 ... ed')
                        help='embeddings from model zoo')
     agent.add_argument('--init_model', type=str, default=None,
                        help='Load dict/features/weights/opts from this file')
@@ -89,49 +86,40 @@ def add_cmdline_args(parser):
 
 
 def set_defaults(opt):
-    # Embeddings options
-    if (opt.get('embedding_file') is not None and
-            opt.get('embedding_type') == 'random'):
-        # backwards compatibility for older models
-        vec_zoo = ['fasttext_cc_vectors', 'fasttext_vectors', 'glove_vectors']
-        for vec in vec_zoo:
-            if vec in opt.get('embedding_file'):
-                opt['embedding_type'] = vec
-                break
-    if opt.get('embedding_type') != 'random':
-        old = opt.get('embedding_file')
+    init_model = None
+    # check first for 'init_model' for loading model from file
+    if opt.get('init_model') and os.path.isfile(opt['init_model']):
+        init_model = opt['init_model']
+    # next check for 'model_file', this would override init_model
+    if opt.get('model_file') and os.path.isfile(opt['model_file']):
+        init_model = opt['model_file']
+
+    if init_model is None:
+        # Embeddings options
         opt['embedding_file'] = modelzoo_path(
-            opt.get('datapath'), 'models:' + opt['embedding_type'])
-        if old is not None:
-            print("[ warning: overriding opt['embedding_file'] to {} "
-                  "(previously: {})]".format(opt['embedding_file'],
-                                             old))
-    elif opt.get('embedding_file'):
-        # backwards compatibility for specifying embedding file from place
-        # other than model zoo
-        if not os.path.isfile(opt['embedding_file']):
-            raise IOError('No such file: %s' % opt['embedding_file'])
-        with open(opt['embedding_file']) as f:
-            dim = len(f.readline().strip().split(' ')) - 1
-            if dim == 1:
-                # first line was a dud
+            opt.get('datapath'), opt['embedding_file'])
+        if opt.get('embedding_file'):
+            if not os.path.isfile(opt['embedding_file']):
+                raise IOError('No such file: %s' % opt['embedding_file'])
+            with open(opt['embedding_file']) as f:
                 dim = len(f.readline().strip().split(' ')) - 1
-        opt['embedding_dim'] = dim
-    elif not opt.get('embedding_dim'):
-        raise RuntimeError(('Either embedding_file or embedding_dim '
-                            'needs to be specified.'))
+                if dim == 1:
+                    # first line was a dud
+                    dim = len(f.readline().strip().split(' ')) - 1
+            opt['embedding_dim'] = dim
+        elif not opt.get('embedding_dim'):
+            raise RuntimeError(('Either embedding_file or embedding_dim '
+                                'needs to be specified.'))
 
-    # Make sure tune_partial and fix_embeddings are consistent
-    if opt['tune_partial'] > 0 and opt['fix_embeddings']:
-        print('Setting fix_embeddings to False as tune_partial > 0.')
-        opt['fix_embeddings'] = False
-
-    # Make sure fix_embeddings and embedding_file are consistent
-    if opt['fix_embeddings']:
-        if not opt.get('embedding_file') and not opt.get('init_model'):
-            print('Setting fix_embeddings to False as embeddings are random.')
+        # Make sure tune_partial and fix_embeddings are consistent
+        if opt['tune_partial'] > 0 and opt['fix_embeddings']:
+            print('Setting fix_embeddings to False as tune_partial > 0.')
             opt['fix_embeddings'] = False
 
+        # Make sure fix_embeddings and embedding_file are consistent
+        if opt['fix_embeddings'] and not opt.get('embedding_file'):
+            print('Setting fix_embeddings to False as embeddings are random.')
+            opt['fix_embeddings'] = False
 
 def override_args(opt, override_opt):
     # Major model args are reset to the values in override_opt.

--- a/parlai/agents/drqa/config.py
+++ b/parlai/agents/drqa/config.py
@@ -99,8 +99,13 @@ def set_defaults(opt):
                 opt['embedding_type'] = vec
                 break
     if opt.get('embedding_type') != 'random':
+        old = opt.get('embedding_file')
         opt['embedding_file'] = modelzoo_path(
             opt.get('datapath'), 'models:' + opt['embedding_type'])
+        if old is not None:
+            print("[ warning: overriding opt['embedding_file'] to {} "
+                  "(previously: {})]".format(opt['embedding_file'],
+                                             old))
     elif opt.get('embedding_file'):
         # backwards compatibility for specifying embedding file from place
         # other than model zoo


### PR DESCRIPTION
If you load a saved DrQA model, it tries to load an embedding_file from opts (that is not directed at your own datapath) See issue #1173.

EDIT: only need to load embedding file if we are not initializing the model from model_file or init_model.

