### PR TITLE
Fix a bug when --dict-file has no folder name.

### DIFF
--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -124,7 +124,9 @@ def download(url, path, fname, redownload=False):
 
 def make_dir(path):
     """Makes the directory and any nonexistent parent directories."""
-    os.makedirs(path, exist_ok=True)
+    # the current working directory is a fine path
+    if path != '':
+        os.makedirs(path, exist_ok=True)
 
 
 def move(path1, path2):


### PR DESCRIPTION
to test, run `train_model.py --dict-file 'testdict'` and watch it throw an OSError.