### PR TITLE
Fairseq 0.6

### DIFF
--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -247,6 +247,7 @@ class FairseqAgent(TorchAgent):
         # Check subargs for generation, optimizers, criterions, archs, etc
         options.add_generation_args(argparser)
         options.add_optimization_args(argparser)
+        options.add_checkpoint_args(argparser)
 
         # restore any user set defaults that fairseq possibly overrode
         argparser.set_defaults(**old_defaults)

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -560,7 +560,7 @@ class FairseqAgent(TorchAgent):
         no_prev_token = {
             k: v for k, v in samples['net_input'].items() if k != 'prev_output_tokens'
         }
-        gens = self.generator.generate(**no_prev_token, maxlen=64)
+        gens = self.generator.generate(no_prev_token, maxlen=64)
         bsz = samples['net_input']['src_tokens'].size(0)
         responses = []
         for i in range(bsz):

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -11,10 +11,19 @@ from parlai.core.utils import argsort, padded_tensor
 
 try:
     from fairseq import models, optim, criterions
+    # this is a hack around versioning check because fairseq doesn't
+    # announce version numbers yet
+    # fairseq 0.5.0 has fp16_trainer, 0.6.0 does not
+    try:
+        from fairseq import fp16_trainer
+    except ImportError:
+        pass
+    else:
+        raise ImportError
 except ImportError:
     raise ImportError(
         "Please run \"pip install -U 'git+https://github.com/pytorch/"
-        "fairseq.git@v0.5.0#egg=fairseq'\""
+        "fairseq.git@v0.6.0#egg=fairseq'\""
     )
 from fairseq import trainer
 from fairseq.sequence_generator import SequenceGenerator

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -557,11 +557,13 @@ class FairseqAgent(TorchAgent):
         return Output(generated_output, reranked_cands)
 
     def _generate(self, samples):
-        src_tokens = samples["net_input"]["src_tokens"]
-        src_lengths = samples["net_input"]["src_lengths"]
-        gens = self.generator.generate(src_tokens, src_lengths, maxlen=64)
+        no_prev_token = {
+            k: v for k, v in samples['net_input'].items() if k != 'prev_output_tokens'
+        }
+        gens = self.generator.generate(**no_prev_token, maxlen=64)
+        bsz = samples['net_input']['src_tokens'].size(0)
         responses = []
-        for i in range(len(src_tokens)):
+        for i in range(bsz):
             beams = gens[i]
             selected = max(beams, key=lambda x: x["score"])
             tokens = selected["tokens"]

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -15,7 +15,7 @@ try:
     # announce version numbers yet
     # fairseq 0.5.0 has fp16_trainer, 0.6.0 does not
     try:
-        from fairseq import fp16_trainer
+        from fairseq import fp16_trainer  # noqa: F401
     except ImportError:
         pass
     else:


### PR DESCRIPTION
Fairseq synced some internal changes and released a new version (pytorch/fairseq#291). I've been using them myself, but now I can share externally.

As an added bonus, fp16 works reliably now, and we can do evaluation on CPU.
