### PR TITLE
Autogenerate docs for each of the CLI scripts we distribute.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ instance/
 docs/_build/
 docs/source/task_list.inc
 docs/source/zoo_list.inc
+docs/source/cli_usage.inc
 
 # PyBuilder
 target/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -29,4 +29,5 @@ clean:
 %: Makefile
 	cd "${SOURCEDIR}"; python generate_task_list.py
 	cd "${SOURCEDIR}"; python generate_zoo_list.py
+	cd "${SOURCEDIR}"; python generate_cli.py
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -1,0 +1,14 @@
+..
+  Copyright (c) 2017-present, Facebook, Inc.
+  All rights reserved.
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree. An additional grant
+  of patent rights can be found in the PATENTS file in the same directory.
+
+Command Line Usage
+==================
+
+This contains the command line usage for each of the standard scripts we
+release. These are each included in ``parlai/scripts``.
+
+.. include:: cli_usage.inc

--- a/docs/source/generate_cli.py
+++ b/docs/source/generate_cli.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import os
+import parlai.scripts
+import subprocess
+
+
+def indent(rawstr, indentstr='    '):
+    lines = rawstr.split('\n')
+    indented = [(indentstr + l) for l in lines]
+    return '\n'.join(indented).replace('\\', '\\\\').rstrip()
+
+
+def get_scripts():
+    pathname = os.path.dirname(parlai.scripts.__file__)
+    for fn in os.listdir(pathname):
+        if fn.endswith('.py') and not fn.startswith('__'):
+            yield os.path.join(pathname, fn)
+
+
+def main():
+    fout = open('cli_usage.inc', 'w')
+
+    for script_path in get_scripts():
+        script_name = os.path.basename(script_path).replace(".py", "")
+        captured = subprocess.run(
+            ['python3', script_path, '--help'],
+            stdout=subprocess.PIPE
+        )
+        fout.write(script_name)
+        fout.write('\n')
+        fout.write('-' * len(script_name))
+        fout.write('\n')
+        fout.write('::\n\n')
+        fout.write(indent(captured.stdout.decode('utf-8')))
+        fout.write('\n\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/source/generate_cli.py
+++ b/docs/source/generate_cli.py
@@ -25,8 +25,8 @@ def get_scripts():
             yield os.path.join(pathname, fn)
 
 
-def cleanup_docstring(docstr):
-    return docstr.replace('`', '``')
+def escape_output(str):
+    return str.replace('`', '``')
 
 
 def main():
@@ -45,16 +45,24 @@ def main():
         fout.write('\n')
         fout.write('-' * len(script_name))
         fout.write('\n')
-        # docstring for module
-        fout.write(cleanup_docstring(module.__doc__))
-        fout.write('\n\n')
-        # literal block
-        # fout.write('usage:\n')
-        # fout.write('^^^^^^\n\n\n')
-        fout.write('::\n\n')
+
+        # docs from the module
+        fout.write('Information\n')
+        fout.write('^^^^^^^^^^^\n\n\n')
+        fout.write('.. automodule:: parlai.scripts.{}\n'.format(script_name))
+        fout.write('   :members:\n')
+        fout.write('   :exclude-members: __dict__,__weakref__,setup_args\n')
+        fout.write('\n')
+        fout.write('CLI help\n')
+        fout.write('^^^^^^^^\n\n\n')
+
+        # output the --help
+        fout.write('::\n\n')  # literal block
         capture = io.StringIO()
-        module.setup_args().print_help(capture)
-        fout.write(indent(cleanup_docstring(capture.getvalue())))
+        parser = module.setup_args()
+        parser.prog = 'python -m parlai.scripts.{}'.format(script_name)
+        parser.print_help(capture)
+        fout.write(indent(escape_output(capture.getvalue())))
         fout.write('\n\n')
 
 

--- a/docs/source/generate_cli.py
+++ b/docs/source/generate_cli.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
 import os
 import parlai.scripts
 import subprocess

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,6 +31,12 @@ ParlAI is a one-stop-shop for dialog research.
 
 .. toctree::
    :maxdepth: 1
+   :caption: Scripts
+
+   cli_usage
+
+.. toctree::
+   :maxdepth: 1
    :caption: Tasks
 
    tasks

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,15 +31,15 @@ ParlAI is a one-stop-shop for dialog research.
 
 .. toctree::
    :maxdepth: 1
-   :caption: Scripts
-
-   cli_usage
-
-.. toctree::
-   :maxdepth: 1
    :caption: Tasks
 
    tasks
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Scripts
+
+   cli_usage
 
 .. toctree::
    :maxdepth: 1

--- a/parlai/scripts/eval_wordstat.py
+++ b/parlai/scripts/eval_wordstat.py
@@ -55,7 +55,7 @@ def setup_args(parser=None):
     parser.add_argument('-dup', '--dump-predictions-path', type=str, default=None,
                         help='Dump predictions into file')
     parser.add_argument('-cun', '--compute-unique', type=bool, default=True,
-                        help='Compute % of unique responses from the model')
+                        help='Compute %% of unique responses from the model')
     parser.set_defaults(datatype='valid', model='repeat_label')
     TensorboardLogger.add_cmdline_args(parser)
     return parser


### PR DESCRIPTION
This isn't much more than just calling `--help` with each one. It's not the prettiest now, so maybe we should discuss it.

Also fix a bug with the help string of one script.