### PR TITLE
[ParlAI Messenger] fix for image sending

### DIFF
--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -215,6 +215,10 @@ class MessengerManager():
 
     def _handle_webhook_event(self, event):
         if 'message' in event:
+            if (('image_url' in event and event['image_url'] is not None) or
+                    ('attachment_url' in event and event['attachment_url'] is
+                        not None)):
+                event['message']['image'] = True
             self._on_new_message(event)
         elif 'delivery' in event:
             self.confirm_message_delivery(event)


### PR DESCRIPTION
Let users know that they can't send images if they attempt to do so (backwards sync)