### PR TITLE
Autogenerated docs for model zoo (incomplete)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/source/task_list.inc
+docs/source/zoo_list.inc
 
 # PyBuilder
 target/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -28,4 +28,5 @@ clean:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	cd "${SOURCEDIR}"; python generate_task_list.py
+	cd "${SOURCEDIR}"; python generate_zoo_list.py
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/generate_zoo_list.py
+++ b/docs/source/generate_zoo_list.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+from parlai.zoo.model_list import model_list
+
+fout = open('zoo_list.inc', 'w')
+
+for model in model_list:
+    name = model['id'].replace('_', ' ').title()
+    fout.write(name)
+    fout.write('\n')
+    fout.write('^' * len(name))
+    fout.write('\n\n')
+
+    fout.write(model['description'])
+    fout.write('\n\n')
+
+    fout.write('Example invocation:\n')
+    fout.write(
+        '``python -m parlai.scripts.eval_model -a {} -t {} -mf {}``\n'
+        .format(
+            model['agent'],
+            model['task'],
+            model['path'],
+        )
+    )
+    fout.write('\n')
+
+fout.close()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,6 +37,12 @@ ParlAI is a one-stop-shop for dialog research.
 
 .. toctree::
    :maxdepth: 1
+   :caption: Model Zoo
+
+   zoo
+
+.. toctree::
+   :maxdepth: 1
    :caption: Core Library
 
    observations

--- a/docs/source/zoo.rst
+++ b/docs/source/zoo.rst
@@ -1,3 +1,10 @@
+..
+  Copyright (c) 2017-present, Facebook, Inc.
+  All rights reserved.
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree. An additional grant
+  of patent rights can be found in the PATENTS file in the same directory.
+
 Model Zoo
 =========
 

--- a/docs/source/zoo.rst
+++ b/docs/source/zoo.rst
@@ -1,0 +1,24 @@
+Model Zoo
+=========
+
+This is a list of pretrained ParlAI models. Some are meant to be used as components in
+larger systems, while others may be used by themselves.
+
+.. include:: zoo_list.inc
+
+
+Pretrained Embeddings
+---------------------
+
+Some models support using Pretrained Embeddings, via `torchtext
+<https://github.com/pytorch/text>`_. As of writing, this includes:
+
+* ``fasttext``: Fasttext vectors based on mixed corpora (`Mikolov et al., 2018 <https://fasttext.cc/docs/en/english-vectors.html>`_)
+* ``fasttext_cc``: Fasttext vectors based on Common Crawl (`Mikolov et al., 2018 <https://fasttext.cc/docs/en/english-vectors.html>`_)
+* ``glove``: Pretrained GLoVe vectors based on 840B Common Crawl (`Pennington et al., 2014 <https://nlp.stanford.edu/projects/glove/>`_)
+* ``glove-twitter``: GLoVe vectors pretrained on 2B tweets (`Pennington et al., 2014 <https://nlp.stanford.edu/projects/glove/>`_)
+
+Example invocation:
+
+``python -m parlai.scripts.train_model -t convai2 -m seq2seq -emb-type models:fasttext_cc``
+


### PR DESCRIPTION
As discussed, generates a list based on `parlai.zoo.model_list`.

However, model_list could use some improvements at this time.