### PR TITLE
command to print unit test coverage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 Pillow
 pyzmq
 h5py
+gitpython

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+# Uses coverage.py
+
+pip install coverage
+if [[ ! -f setup.py ]]; then
+    cd ..
+fi
+coverage run --include "parlai*" setup.py test
+
+COVERED=""  # all tests with some unit tests
+
+for line in $(coverage report); do
+    if [[ $line =~ ".py" ]]; then
+        COVERED="$COVERED;$line"
+    fi
+done
+
+NOT_COV=""
+
+for file in $(find parlai -name "*.py"); do
+    if [[ ! $file =~ "__init__.py" ]]; then
+        if [[ ! $COVERED =~ $file ]]; then
+            file="0% coverage (not tested at all): $file"
+            NOT_COV="$NOT_COV;$file"
+        fi
+    fi
+done
+
+echo $NOT_COV | tr ';' '\n'
+echo
+coverage report


### PR DESCRIPTION
run this new file to print a simple report on unit test coverage

```
...
Ran 40 tests in 31.982s

OK

0% coverage (not tested at all): parlai/agents/drqa/layers.py
0% coverage (not tested at all): parlai/agents/drqa/rnn_reader.py
0% coverage (not tested at all): parlai/agents/drqa/utils.py
0% coverage (not tested at all): parlai/agents/drqa/config.py
0% coverage (not tested at all): parlai/agents/drqa/drqa.py
0% coverage (not tested at all): parlai/agents/drqa/model.py
0% coverage (not tested at all): parlai/agents/ir_baseline/ir_baseline.py
0% coverage (not tested at all): parlai/agents/local_human/local_human.py
0% coverage (not tested at all): parlai/agents/remote_agent/remote_agent.py
0% coverage (not tested at all): parlai/agents/seq2seq/modules.py
0% coverage (not tested at all): parlai/agents/seq2seq/seq2seq.py
0% coverage (not tested at all): parlai/agents/fairseq/fairseq.py
0% coverage (not tested at all): parlai/agents/coopgame_agent/modules.py
0% coverage (not tested at all): parlai/agents/coopgame_agent/coopgame_agent.py
0% coverage (not tested at all): parlai/agents/tfidf_retriever/build_db.py
0% coverage (not tested at all): parlai/agents/language_model/language_model.py
0% coverage (not tested at all): parlai/agents/language_model/modules.py
0% coverage (not tested at all): parlai/agents/ibm_seq2seq/ibm_seq2seq.py
0% coverage (not tested at all): parlai/agents/mlb_vqa/dropout.py
0% coverage (not tested at all): parlai/agents/mlb_vqa/gru.py
0% coverage (not tested at all): parlai/agents/mlb_vqa/loadstates.py
0% coverage (not tested at all): parlai/agents/mlb_vqa/mlb_modules.py
0% coverage (not tested at all): parlai/agents/mlb_vqa/mlb_vqa.py
0% coverage (not tested at all): parlai/agents/repeat_query/repeat_query.py
0% coverage (not tested at all): parlai/agents/starspace/modules.py
0% coverage (not tested at all): parlai/agents/starspace/starspace.py
0% coverage (not tested at all): parlai/agents/example_seq2seq/example_seq2seq.py
0% coverage (not tested at all): parlai/agents/legacy_agents/seq2seq/dict_v0.py
0% coverage (not tested at all): parlai/agents/legacy_agents/seq2seq/modules_v0.py
0% coverage (not tested at all): parlai/agents/legacy_agents/seq2seq/seq2seq_v0.py
0% coverage (not tested at all): parlai/agents/legacy_agents/seq2seq/utils_v0.py
0% coverage (not tested at all): parlai/agents/legacy_agents/memnn/memnn_v0.py
0% coverage (not tested at all): parlai/agents/legacy_agents/memnn/modules_v0.py
0% coverage (not tested at all): parlai/agents/random_candidate/random_candidate.py
0% coverage (not tested at all): parlai/agents/retriever_reader/retriever_reader.py
0% coverage (not tested at all): parlai/agents/vsepp_caption/modules.py
0% coverage (not tested at all): parlai/agents/vsepp_caption/vsepp_caption.py
0% coverage (not tested at all): parlai/mturk/core/test/auto_complete_hit.py
0% coverage (not tested at all): parlai/mturk/core/test/test_db_interactions.py
0% coverage (not tested at all): parlai/mturk/core/test/test_full_system.py
0% coverage (not tested at all): parlai/mturk/core/test/test_mturk_agent.py
0% coverage (not tested at all): parlai/mturk/core/test/test_mturk_manager.py
0% coverage (not tested at all): parlai/mturk/core/test/test_socket_manager.py
0% coverage (not tested at all): parlai/mturk/core/test/test_worker_manager.py
0% coverage (not tested at all): parlai/mturk/core/scripts/bonus_workers.py
0% coverage (not tested at all): parlai/mturk/core/scripts/delete_hits.py
0% coverage (not tested at all): parlai/mturk/core/agents.py
0% coverage (not tested at all): parlai/mturk/core/data_model.py
0% coverage (not tested at all): parlai/mturk/core/mturk_data_handler.py
0% coverage (not tested at all): parlai/mturk/core/mturk_utils.py
0% coverage (not tested at all): parlai/mturk/core/shared_utils.py
0% coverage (not tested at all): parlai/mturk/core/socket_manager.py
0% coverage (not tested at all): parlai/mturk/core/worker_manager.py
0% coverage (not tested at all): parlai/mturk/core/worlds.py
0% coverage (not tested at all): parlai/mturk/core/mturk_manager.py
0% coverage (not tested at all): parlai/mturk/core/server_utils.py
0% coverage (not tested at all): parlai/mturk/tasks/model_evaluator/run.py
0% coverage (not tested at all): parlai/mturk/tasks/model_evaluator/task_config.py
0% coverage (not tested at all): parlai/mturk/tasks/model_evaluator/worlds.py
0% coverage (not tested at all): parlai/mturk/tasks/multi_agent_dialog/task_config.py
0% coverage (not tested at all): parlai/mturk/tasks/multi_agent_dialog/worlds.py
0% coverage (not tested at all): parlai/mturk/tasks/multi_agent_dialog/run.py
0% coverage (not tested at all): parlai/mturk/tasks/qa_data_collection/run.py
0% coverage (not tested at all): parlai/mturk/tasks/qa_data_collection/task_config.py
0% coverage (not tested at all): parlai/mturk/tasks/qa_data_collection/worlds.py
0% coverage (not tested at all): parlai/mturk/tasks/dealnodeal/run.py
0% coverage (not tested at all): parlai/mturk/tasks/dealnodeal/task_config.py
0% coverage (not tested at all): parlai/mturk/tasks/dealnodeal/worlds.py
0% coverage (not tested at all): parlai/mturk/tasks/qualification_flow_example/run.py
0% coverage (not tested at all): parlai/mturk/tasks/qualification_flow_example/task_config.py
0% coverage (not tested at all): parlai/mturk/tasks/qualification_flow_example/worlds.py
0% coverage (not tested at all): parlai/mturk/tasks/personachat/personachat_chat/extract_and_save_personas.py
0% coverage (not tested at all): parlai/mturk/tasks/personachat/personachat_chat/task_config.py
0% coverage (not tested at all): parlai/mturk/tasks/personachat/personachat_chat/worlds.py
0% coverage (not tested at all): parlai/mturk/tasks/personachat/personachat_chat/run.py
0% coverage (not tested at all): parlai/mturk/tasks/personachat/personachat_collect_personas/task_config.py
0% coverage (not tested at all): parlai/mturk/tasks/personachat/personachat_collect_personas/worlds.py
0% coverage (not tested at all): parlai/mturk/tasks/personachat/personachat_collect_personas/run.py
0% coverage (not tested at all): parlai/mturk/tasks/personachat/personachat_rephrase/run.py
0% coverage (not tested at all): parlai/mturk/tasks/personachat/personachat_rephrase/task_config.py
0% coverage (not tested at all): parlai/mturk/tasks/personachat/personachat_rephrase/worlds.py
0% coverage (not tested at all): parlai/mturk/tasks/convai2_model_eval/task_config.py
0% coverage (not tested at all): parlai/mturk/tasks/convai2_model_eval/run.py
0% coverage (not tested at all): parlai/mturk/tasks/convai2_model_eval/worlds.py
0% coverage (not tested at all): parlai/mturk/tasks/talkthewalk/run.py
0% coverage (not tested at all): parlai/mturk/tasks/talkthewalk/task_config.py
0% coverage (not tested at all): parlai/mturk/tasks/talkthewalk/download.py
0% coverage (not tested at all): parlai/mturk/tasks/talkthewalk/worlds.py
0% coverage (not tested at all): parlai/tasks/booktest/build.py
0% coverage (not tested at all): parlai/tasks/booktest/agents.py
0% coverage (not tested at all): parlai/tasks/cbt/agents.py
0% coverage (not tested at all): parlai/tasks/cbt/build.py
0% coverage (not tested at all): parlai/tasks/clevr/build.py
0% coverage (not tested at all): parlai/tasks/clevr/agents.py
0% coverage (not tested at all): parlai/tasks/cornell_movie/agents.py
0% coverage (not tested at all): parlai/tasks/cornell_movie/build.py
0% coverage (not tested at all): parlai/tasks/dbll_babi/agents.py
0% coverage (not tested at all): parlai/tasks/dbll_babi/build.py
0% coverage (not tested at all): parlai/tasks/dbll_movie/agents.py
0% coverage (not tested at all): parlai/tasks/dbll_movie/build.py
0% coverage (not tested at all): parlai/tasks/dealnodeal/build.py
0% coverage (not tested at all): parlai/tasks/dealnodeal/agents.py
0% coverage (not tested at all): parlai/tasks/dialog_babi/build.py
0% coverage (not tested at all): parlai/tasks/dialog_babi/agents.py
0% coverage (not tested at all): parlai/tasks/fromfile/agents.py
0% coverage (not tested at all): parlai/tasks/fvqa/agents.py
0% coverage (not tested at all): parlai/tasks/fvqa/build.py
0% coverage (not tested at all): parlai/tasks/insuranceqa/agents.py
0% coverage (not tested at all): parlai/tasks/insuranceqa/build.py
0% coverage (not tested at all): parlai/tasks/iwslt14/agents.py
0% coverage (not tested at all): parlai/tasks/iwslt14/build.py
0% coverage (not tested at all): parlai/tasks/mctest/agents.py
0% coverage (not tested at all): parlai/tasks/mctest/build.py
0% coverage (not tested at all): parlai/tasks/mnist_qa/agents.py
0% coverage (not tested at all): parlai/tasks/mnist_qa/build.py
0% coverage (not tested at all): parlai/tasks/moviedialog/agents.py
0% coverage (not tested at all): parlai/tasks/moviedialog/build.py
0% coverage (not tested at all): parlai/tasks/ms_marco/agents.py
0% coverage (not tested at all): parlai/tasks/ms_marco/build.py
0% coverage (not tested at all): parlai/tasks/mturkwikimovies/agents.py
0% coverage (not tested at all): parlai/tasks/mturkwikimovies/build.py
0% coverage (not tested at all): parlai/tasks/opensubtitles/build_2009.py
0% coverage (not tested at all): parlai/tasks/opensubtitles/agents.py
0% coverage (not tested at all): parlai/tasks/opensubtitles/build_2018.py
0% coverage (not tested at all): parlai/tasks/personalized_dialog/build.py
0% coverage (not tested at all): parlai/tasks/personalized_dialog/agents.py
0% coverage (not tested at all): parlai/tasks/qacnn/agents.py
0% coverage (not tested at all): parlai/tasks/qacnn/build.py
0% coverage (not tested at all): parlai/tasks/qadailymail/agents.py
0% coverage (not tested at all): parlai/tasks/qadailymail/build.py
0% coverage (not tested at all): parlai/tasks/simplequestions/agents.py
0% coverage (not tested at all): parlai/tasks/simplequestions/build.py
0% coverage (not tested at all): parlai/tasks/squad/agents.py
0% coverage (not tested at all): parlai/tasks/squad/build.py
0% coverage (not tested at all): parlai/tasks/triviaqa/build.py
0% coverage (not tested at all): parlai/tasks/triviaqa/agents.py
0% coverage (not tested at all): parlai/tasks/ubuntu/agents.py
0% coverage (not tested at all): parlai/tasks/ubuntu/build.py
0% coverage (not tested at all): parlai/tasks/visdial/build.py
0% coverage (not tested at all): parlai/tasks/visdial/agents.py
0% coverage (not tested at all): parlai/tasks/vqa_v1/build.py
0% coverage (not tested at all): parlai/tasks/vqa_v1/agents.py
0% coverage (not tested at all): parlai/tasks/vqa_v2/build.py
0% coverage (not tested at all): parlai/tasks/vqa_v2/agents.py
0% coverage (not tested at all): parlai/tasks/webquestions/agents.py
0% coverage (not tested at all): parlai/tasks/webquestions/build.py
0% coverage (not tested at all): parlai/tasks/wikimovies/agents.py
0% coverage (not tested at all): parlai/tasks/wikimovies/build.py
0% coverage (not tested at all): parlai/tasks/wikiqa/agents.py
0% coverage (not tested at all): parlai/tasks/wikiqa/build.py
0% coverage (not tested at all): parlai/tasks/convai_chitchat/agents.py
0% coverage (not tested at all): parlai/tasks/convai_chitchat/build.py
0% coverage (not tested at all): parlai/tasks/dialog_babi_plus/agents.py
0% coverage (not tested at all): parlai/tasks/dialog_babi_plus/build.py
0% coverage (not tested at all): parlai/tasks/dialogue_qe/agents.py
0% coverage (not tested at all): parlai/tasks/dialogue_qe/build.py
0% coverage (not tested at all): parlai/tasks/mutualfriends/agents.py
0% coverage (not tested at all): parlai/tasks/mutualfriends/build.py
0% coverage (not tested at all): parlai/tasks/nlvr/build.py
0% coverage (not tested at all): parlai/tasks/nlvr/agents.py
0% coverage (not tested at all): parlai/tasks/scan/agents.py
0% coverage (not tested at all): parlai/tasks/scan/build.py
0% coverage (not tested at all): parlai/tasks/taskntalk/agents.py
0% coverage (not tested at all): parlai/tasks/taskntalk/build.py
0% coverage (not tested at all): parlai/tasks/wmt/agents.py
0% coverage (not tested at all): parlai/tasks/wmt/build.py
0% coverage (not tested at all): parlai/tasks/copa/agents.py
0% coverage (not tested at all): parlai/tasks/copa/build.py
0% coverage (not tested at all): parlai/tasks/multinli/agents.py
0% coverage (not tested at all): parlai/tasks/multinli/build.py
0% coverage (not tested at all): parlai/tasks/snli/agents.py
0% coverage (not tested at all): parlai/tasks/snli/build.py
0% coverage (not tested at all): parlai/tasks/personachat/agents.py
0% coverage (not tested at all): parlai/tasks/personachat/build.py
0% coverage (not tested at all): parlai/tasks/convai2/build.py
0% coverage (not tested at all): parlai/tasks/convai2/agents.py
0% coverage (not tested at all): parlai/tasks/aqua/agents.py
0% coverage (not tested at all): parlai/tasks/aqua/build.py
0% coverage (not tested at all): parlai/tasks/narrative_qa/agents.py
0% coverage (not tested at all): parlai/tasks/narrative_qa/build.py
0% coverage (not tested at all): parlai/tasks/twitter/agents.py
0% coverage (not tested at all): parlai/tasks/twitter/build.py
0% coverage (not tested at all): parlai/tasks/wikipedia/build.py
0% coverage (not tested at all): parlai/tasks/wikipedia/agents.py
0% coverage (not tested at all): parlai/tasks/coco_caption/build_2014.py
0% coverage (not tested at all): parlai/tasks/coco_caption/build_2015.py
0% coverage (not tested at all): parlai/tasks/coco_caption/build_2017.py
0% coverage (not tested at all): parlai/tasks/coco_caption/agents.py
0% coverage (not tested at all): parlai/tasks/qangaroo/agents.py
0% coverage (not tested at all): parlai/tasks/qangaroo/build.py
0% coverage (not tested at all): parlai/tasks/flickr30k/build.py
0% coverage (not tested at all): parlai/tasks/flickr30k/agents.py
0% coverage (not tested at all): parlai/tasks/integration_tests/agents.py
0% coverage (not tested at all): parlai/tasks/squad2/agents.py
0% coverage (not tested at all): parlai/tasks/squad2/build.py
0% coverage (not tested at all): parlai/scripts/convert_data_to_parlai_format.py
0% coverage (not tested at all): parlai/scripts/detect_offensive_language.py
0% coverage (not tested at all): parlai/scripts/eval_ppl.py
0% coverage (not tested at all): parlai/scripts/extract_image_feature.py
0% coverage (not tested at all): parlai/scripts/interactive.py
0% coverage (not tested at all): parlai/scripts/profile_train.py
0% coverage (not tested at all): parlai/scripts/verify_data.py
0% coverage (not tested at all): parlai/scripts/eval_wordstat.py
0% coverage (not tested at all): parlai/messenger/core/message_sender.py
0% coverage (not tested at all): parlai/messenger/core/message_socket.py
0% coverage (not tested at all): parlai/messenger/core/server_utils.py
0% coverage (not tested at all): parlai/messenger/core/shared_utils.py
0% coverage (not tested at all): parlai/messenger/core/worlds.py
0% coverage (not tested at all): parlai/messenger/core/agents.py
0% coverage (not tested at all): parlai/messenger/core/messenger_manager.py
0% coverage (not tested at all): parlai/messenger/tasks/chatbot/run.py
0% coverage (not tested at all): parlai/messenger/tasks/chatbot/worlds.py
0% coverage (not tested at all): parlai/messenger/tasks/overworld_demo/run.py
0% coverage (not tested at all): parlai/messenger/tasks/overworld_demo/worlds.py
0% coverage (not tested at all): parlai/messenger/tasks/qa_data_collection/run.py
0% coverage (not tested at all): parlai/messenger/tasks/qa_data_collection/worlds.py
0% coverage (not tested at all): parlai/zoo/glove_vectors/build.py
0% coverage (not tested at all): parlai/zoo/twitter/dict.py
0% coverage (not tested at all): parlai/zoo/twitter/seq2seq.py
0% coverage (not tested at all): parlai/zoo/drqa/squad.py
0% coverage (not tested at all): parlai/zoo/fasttext_cc_vectors/build.py
0% coverage (not tested at all): parlai/zoo/fasttext_vectors/build.py
0% coverage (not tested at all): parlai/zoo/wikipedia_2016-12-21/tfidf_retriever.py
0% coverage (not tested at all): parlai/zoo/wikipedia_full/tfidf_retriever.py
0% coverage (not tested at all): parlai/zoo/model_list.py

Name                                                            Stmts   Miss  Cover
-----------------------------------------------------------------------------------
parlai/__init__.py                                                  3      1    67%
parlai/agents/__init__.py                                           0      0   100%
parlai/agents/memnn/__init__.py                                     0      0   100%
parlai/agents/memnn/memnn.py                                      208     67    68%
parlai/agents/memnn/modules.py                                     92     32    65%
parlai/agents/repeat_label/__init__.py                              0      0   100%
parlai/agents/repeat_label/repeat_label.py                         30      4    87%
parlai/agents/tfidf_retriever/__init__.py                           0      0   100%
parlai/agents/tfidf_retriever/build_tfidf.py                      190    101    47%
parlai/agents/tfidf_retriever/doc_db.py                            38      6    84%
parlai/agents/tfidf_retriever/tfidf_doc_ranker.py                  60     10    83%
parlai/agents/tfidf_retriever/tfidf_retriever.py                  144     29    80%
parlai/agents/tfidf_retriever/tokenizers/__init__.py               32     16    50%
parlai/agents/tfidf_retriever/tokenizers/corenlp_tokenizer.py      67     56    16%
parlai/agents/tfidf_retriever/tokenizers/regexp_tokenizer.py       54     30    44%
parlai/agents/tfidf_retriever/tokenizers/simple_tokenizer.py       25      1    96%
parlai/agents/tfidf_retriever/tokenizers/spacy_tokenizer.py        29     22    24%
parlai/agents/tfidf_retriever/tokenizers/tokenizer.py              72     33    54%
parlai/agents/tfidf_retriever/utils.py                             47     12    74%
parlai/core/__init__.py                                             0      0   100%
parlai/core/agents.py                                             316    150    53%
parlai/core/build_data.py                                         156    127    19%
parlai/core/dict.py                                               361    159    56%
parlai/core/image_featurizers.py                                  127    102    20%
parlai/core/logs.py                                                40     23    42%
parlai/core/metrics.py                                            216     54    75%
parlai/core/params.py                                             280     88    69%
parlai/core/pytorch_data_teacher.py                               413    338    18%
parlai/core/teachers.py                                           573    228    60%
parlai/core/thread_utils.py                                        84     13    85%
parlai/core/torch_agent.py                                        496    229    54%
parlai/core/utils.py                                              549    362    34%
parlai/core/worlds.py                                             580    302    48%
parlai/scripts/__init__.py                                          0      0   100%
parlai/scripts/build_dict.py                                       76     48    37%
parlai/scripts/build_pytorch_data.py                              109     94    14%
parlai/scripts/display_data.py                                     31     15    52%
parlai/scripts/eval_model.py                                       60      8    87%
parlai/scripts/train_model.py                                     208     47    77%
parlai/tasks/__init__.py                                            0      0   100%
parlai/tasks/babi/__init__.py                                       0      0   100%
parlai/tasks/babi/agents.py                                        55     17    69%
parlai/tasks/babi/build.py                                         15      9    40%
parlai/tasks/task_list.py                                           2      0   100%
parlai/tasks/tasks.py                                              33      9    73%
-----------------------------------------------------------------------------------
TOTAL
```