### PR TITLE
Use valid_world's batchsize in run_eval()

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -134,7 +134,7 @@ def run_eval(agent, opt, datatype, max_exs=-1, write_log=False, valid_world=None
         if cnt == 0 and opt['display_examples']:
             print(valid_world.display() + '\n~~')
             print(valid_world.report())
-        cnt += opt['batchsize']
+        cnt += valid_world.opt['batchsize']
         if max_exs > 0 and cnt > max_exs + opt.get('numthreads', 1):
             # note this max_exs is approximate--some batches won't always be
             # full depending on the structure of the data


### PR DESCRIPTION
On the first call to train_model(), it uses the copy of the opt dictionary that is assigned to valid_world. On future calls, this block of code is skipped, and it uses the opt that is passed in. Consequently, if eval_batchsize != batchsize, after the first iteration, eval_batchsize is ignored. This fixes that by pulling batchsize from valid_world.opt explicitly. 