### PR TITLE
Make sure RepeatTeacher doesn't leak files.

### DIFF
--- a/tests/tasks/repeat.py
+++ b/tests/tasks/repeat.py
@@ -24,3 +24,9 @@ class RepeatTeacher(DialogTeacher):
     def setup_data(self, unused_path):
         for i in range(self.data_length):
             yield ((str(i), [str(i)]), True)
+
+    def num_examples(self):
+        return self.data_length
+
+    def num_episodes(self):
+        return self.data_length


### PR DESCRIPTION
Right now, running the unittest suite results in a leaking file `unused_paths.lengths`. This behavior derives from:

https://github.com/facebookresearch/ParlAI/blob/5899c07934836d8757ebfc8d98973bdef2c56c74/tests/test_train_model.py#L46

https://github.com/facebookresearch/ParlAI/blob/5899c07934836d8757ebfc8d98973bdef2c56c74/tests/tasks/repeat.py#L16-L26

https://github.com/facebookresearch/ParlAI/blob/5899c07934836d8757ebfc8d98973bdef2c56c74/parlai/core/teachers.py#L814