### PR TITLE
Add gatekeeper options.

### DIFF
--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -36,16 +36,18 @@ class TensorboardLogger(Shared):
         )
         logger.add_argument(
             '-tbtag', '--tensorboard-tag', type=str, default=None,
+            gatekeeper='tensorboard_log',
             help='Specify all opt keys which you want to be presented in in TB name'
         )
         logger.add_argument(
             '-tbmetrics', '--tensorboard-metrics', type=str, default=None,
+            gatekeeper='tensorboard_log',
             help='Specify metrics which you want to track, it will be extracted '
                  'from report dict.'
         )
         logger.add_argument(
             '-tbcomment', '--tensorboard-comment', type=str, default='',
-            hidden=True,
+            gatekeeper='tensorboard_log',
             help='Add any line here to distinguish your TB event file, optional'
         )
 


### PR DESCRIPTION
Adds gatekeeper options.

These options are similar to hidden, in that `--show-advanced-args` causes them to display, but they may also be triggered if a "gatekeeper" flag is set to a non-null value.

This is a good way to do grouped advanced options, as an alternative to what was done in #1237 or #1246 (cc @klshuster)