### PR TITLE
PMT Frontend webapp

### DIFF
--- a/parlai/mturk/core/mturk_data_handler.py
+++ b/parlai/mturk/core/mturk_data_handler.py
@@ -105,9 +105,9 @@ class MTurkDataHandler():
         self.create_default_tables()
 
     def _get_connection(self):
-        '''Returns a singular database connection to be shared amongst all
+        """Returns a singular database connection to be shared amongst all
         calls
-        '''
+        """
         curr_thread = threading.get_ident()
         if curr_thread not in self.conn or self.conn[curr_thread] is None:
             try:
@@ -123,13 +123,14 @@ class MTurkDataHandler():
         return self.conn[curr_thread]
 
     def _force_task_group_id(self, task_group_id):
-        '''Throw an error if a task group id is neither provided nor stored'''
+        """Throw an error if a task group id is neither provided nor stored"""
         if task_group_id is None:
             task_group_id = self.task_group_id
         assert task_group_id is not None, 'Default task_group_id not set'
         return task_group_id
 
     def create_default_tables(self):
+        """Prepares the default tables in the database if they don't exist"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -141,6 +142,7 @@ class MTurkDataHandler():
             conn.commit()
 
     def log_new_run(self, target_hits, task_group_id=None):
+        """Add a new run to the runs table"""
         with self.table_access_condition:
             task_group_id = self._force_task_group_id(task_group_id)
             conn = self._get_connection()
@@ -150,7 +152,7 @@ class MTurkDataHandler():
             conn.commit()
 
     def log_hit_status(self, mturk_hit_creation_response, task_group_id=None):
-        '''Create or update an entry in the hit status table'''
+        """Create or update an entry in the hit status table"""
         task_group_id = self._force_task_group_id(task_group_id)
 
         hit_details = mturk_hit_creation_response['HIT']
@@ -166,8 +168,8 @@ class MTurkDataHandler():
             c.execute('SELECT COUNT(*) FROM hits WHERE hit_id = ?;', (id, ))
             is_new_hit = c.fetchone()[0] == 0
             if is_new_hit:
-                c.execute('''UPDATE runs SET created = created + 1
-                             WHERE run_id = ?;''',
+                c.execute("""UPDATE runs SET created = created + 1
+                             WHERE run_id = ?;""",
                           (task_group_id, ))
 
             c.execute('REPLACE INTO hits VALUES (?,?,?,?,?,?,?);',
@@ -178,6 +180,9 @@ class MTurkDataHandler():
 
     def log_worker_accept_assignment(self, worker_id, assignment_id, hit_id,
                                      task_group_id=None):
+        """Log a worker accept, update assignment state and pairings to match
+        the acceptance
+        """
         task_group_id = self._force_task_group_id(task_group_id)
         with self.table_access_condition:
             conn = self._get_connection()
@@ -193,8 +198,8 @@ class MTurkDataHandler():
                           (worker_id, 1, 0, 0, 0, 0, 0))
             else:
                 # Increment number of assignments the worker has accepted
-                c.execute('''UPDATE workers SET accepted = accepted + 1
-                             WHERE worker_id = ?;''',
+                c.execute("""UPDATE workers SET accepted = accepted + 1
+                             WHERE worker_id = ?;""",
                           (worker_id, ))
 
             # Ensure the assignment exists, mark the current worker
@@ -203,8 +208,8 @@ class MTurkDataHandler():
 
             # Create tracking for this specific pairing, as the assignment
             # may be reassigned
-            c.execute('''INSERT INTO pairings
-                         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)''',
+            c.execute("""INSERT INTO pairings
+                         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                       (AssignState.STATUS_NONE, None, None, None, None, None,
                        0, '', False, '', worker_id, assignment_id,
                        task_group_id))
@@ -212,53 +217,53 @@ class MTurkDataHandler():
 
     def log_complete_assignment(self, worker_id, assignment_id, approve_time,
                                 complete_type, task_group_id=None):
-        '''Note that an assignment was completed'''
+        """Note that an assignment was completed"""
         task_group_id = self._force_task_group_id(task_group_id)
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
             # Update assign data to completed
-            c.execute('''UPDATE assignments SET status = ?, approve_time = ?
-                         WHERE assignment_id = ?;''',
+            c.execute("""UPDATE assignments SET status = ?, approve_time = ?
+                         WHERE assignment_id = ?;""",
                       ('Completed', approve_time, assignment_id))
 
             # Increment worker completed
-            c.execute('''UPDATE workers SET completed = completed + 1
-                         WHERE worker_id = ?;''',
+            c.execute("""UPDATE workers SET completed = completed + 1
+                         WHERE worker_id = ?;""",
                       (worker_id, ))
 
             # update the payment data status
-            c.execute('''UPDATE pairings SET status = ?, task_end = ?
-                         WHERE worker_id = ? AND assignment_id = ?;''',
+            c.execute("""UPDATE pairings SET status = ?, task_end = ?
+                         WHERE worker_id = ? AND assignment_id = ?;""",
                       (complete_type, time.time(), worker_id, assignment_id))
 
             # Update run data to have another completed
-            c.execute('''UPDATE runs SET completed = completed + 1
-                         WHERE run_id = ?;''',
+            c.execute("""UPDATE runs SET completed = completed + 1
+                         WHERE run_id = ?;""",
                       (task_group_id, ))
             conn.commit()
 
     def log_disconnect_assignment(self, worker_id, assignment_id, approve_time,
                                   disconnect_type, task_group_id=None):
-        '''Note that an assignment was disconnected from'''
+        """Note that an assignment was disconnected from"""
         task_group_id = self._force_task_group_id(task_group_id)
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
 
             # Update assign data to completed for this task (we can't track)
-            c.execute('''UPDATE assignments SET status = ?, approve_time = ?
-                         WHERE assignment_id = ?;''',
+            c.execute("""UPDATE assignments SET status = ?, approve_time = ?
+                         WHERE assignment_id = ?;""",
                       ('Completed', approve_time, assignment_id))
 
             # Increment worker disconnected
-            c.execute('''UPDATE workers SET disconnected = disconnected + 1
-                         WHERE worker_id = ?;''',
+            c.execute("""UPDATE workers SET disconnected = disconnected + 1
+                         WHERE worker_id = ?;""",
                       (worker_id, ))
 
             # update the pairing status
-            c.execute('''UPDATE pairings SET status = ?, task_end = ?
-                         WHERE worker_id = ? AND assignment_id = ?;''',
+            c.execute("""UPDATE pairings SET status = ?, task_end = ?
+                         WHERE worker_id = ? AND assignment_id = ?;""",
                       (disconnect_type, time.time(), worker_id, assignment_id))
 
             # Update run data to have another completed
@@ -268,25 +273,25 @@ class MTurkDataHandler():
 
     def log_expire_assignment(self, worker_id, assignment_id,
                               task_group_id=None):
-        '''Note that an assignment was expired by us'''
+        """Note that an assignment was expired by us"""
         task_group_id = self._force_task_group_id(task_group_id)
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
 
             # Update assign data to expired
-            c.execute('''UPDATE assignments SET status = ?
-                         WHERE assignment_id = ?;''',
+            c.execute("""UPDATE assignments SET status = ?
+                         WHERE assignment_id = ?;""",
                       ('Expired', assignment_id))
 
             # Increment worker completed
-            c.execute('''UPDATE workers SET expired = expired + 1
-                         WHERE worker_id = ?;''',
+            c.execute("""UPDATE workers SET expired = expired + 1
+                         WHERE worker_id = ?;""",
                       (worker_id, ))
 
             # update the pairing status
-            c.execute('''UPDATE pairings SET status = ?, task_end = ?
-                         WHERE worker_id = ? AND assignment_id = ?;''',
+            c.execute("""UPDATE pairings SET status = ?, task_end = ?
+                         WHERE worker_id = ? AND assignment_id = ?;""",
                       (AssignState.STATUS_EXPIRED, time.time(), worker_id,
                        assignment_id))
 
@@ -296,86 +301,99 @@ class MTurkDataHandler():
             conn.commit()
 
     def log_submit_assignment(self, worker_id, assignment_id):
-        '''To be called whenever a worker hits the "submit hit" button'''
+        """To be called whenever a worker hits the "submit hit" button"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
             # update the assignment status to reviewable
-            c.execute('''UPDATE assignments SET status = ?
-                         WHERE assignment_id = ?;''',
+            c.execute("""UPDATE assignments SET status = ?
+                         WHERE assignment_id = ?;""",
                       ('Reviewable', assignment_id))
             conn.commit()
 
     def log_abandon_assignment(self, worker_id, assignment_id):
-        '''To be called whenever a worker returns a hit'''
+        """To be called whenever a worker returns a hit"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
             # update the assignment status to reviewable
-            c.execute('''UPDATE assignments SET status = ?
-                         WHERE assignment_id = ?;''',
+            c.execute("""UPDATE assignments SET status = ?
+                         WHERE assignment_id = ?;""",
                       ('Abandoned', assignment_id))
             # Increment worker completed
-            c.execute('''UPDATE workers SET disconnected = disconnected + 1
-                         WHERE worker_id = ?;''',
+            c.execute("""UPDATE workers SET disconnected = disconnected + 1
+                         WHERE worker_id = ?;""",
                       (worker_id, ))
             conn.commit()
 
     def log_start_onboard(self, worker_id, assignment_id):
+        """Update a pairing state to reflect onboarding status"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
-            c.execute('''UPDATE pairings SET status = ?, onboarding_start = ?
-                         WHERE worker_id = ? AND assignment_id = ?;''',
+            c.execute("""UPDATE pairings SET status = ?, onboarding_start = ?
+                         WHERE worker_id = ? AND assignment_id = ?;""",
                       (AssignState.STATUS_ONBOARDING, time.time(), worker_id,
                        assignment_id))
             conn.commit()
 
     def log_finish_onboard(self, worker_id, assignment_id):
+        """Update a pairing state to reflect waiting status"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
-            c.execute('''UPDATE pairings SET status = ?, onboarding_end = ?
-                         WHERE worker_id = ? AND assignment_id = ?;''',
+            c.execute("""UPDATE pairings SET status = ?, onboarding_end = ?
+                         WHERE worker_id = ? AND assignment_id = ?;""",
                       (AssignState.STATUS_WAITING, time.time(), worker_id,
                        assignment_id))
             conn.commit()
 
     def log_start_task(self, worker_id, assignment_id, conversation_id):
+        """Update a pairing state to reflect in_task status"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
-            c.execute('''UPDATE pairings SET status = ?, task_start = ?,
+            c.execute("""UPDATE pairings SET status = ?, task_start = ?,
                          conversation_id = ? WHERE worker_id = ?
-                         AND assignment_id = ?;''',
+                         AND assignment_id = ?;""",
                       (AssignState.STATUS_IN_TASK, time.time(),
                        conversation_id, worker_id, assignment_id))
             conn.commit()
 
     def log_award_amount(self, worker_id, assignment_id, amount, reason):
+        """Update a pairing state to add a bonus to be paid, appends reason"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
-            c.execute('''UPDATE pairings SET bonus_amount = ?, bonus_text = ?
-                         WHERE worker_id = ? AND assignment_id = ?;''',
+            reason = "${} for {}\n".format(amount, reason)
+            c.execute("""UPDATE pairings SET bonus_amount = bonus_amount + ?,
+                        bonus_text = bonus_text || ?
+                         WHERE worker_id = ? AND assignment_id = ?;""",
                       (amount, reason, worker_id, assignment_id))
             conn.commit()
 
     def log_bonus_paid(self, worker_id, assignment_id):
+        """Update to show that the intended bonus amount awarded for work
+        in the task has been paid
+        """
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
-            c.execute('''UPDATE pairings SET bonus_paid = ?
-                         WHERE worker_id = ? AND assignment_id = ?;''',
+            c.execute("""UPDATE pairings SET bonus_paid = ?
+                         WHERE worker_id = ? AND assignment_id = ?;""",
                       (True, worker_id, assignment_id))
             conn.commit()
 
     def log_approve_assignment(self, assignment_id):
+        """Update assignment state to reflect approval, update worker state to
+        increment number of accepted assignments
+        """
+        # TODO approve rejected assignments, make idempotent
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
-            c.execute('''UPDATE assignments SET status = ?
-                         WHERE assignment_id = ?;''',
+            c.execute("""UPDATE assignments SET status = ?
+                         WHERE assignment_id = ?;""",
                       ('Approved', assignment_id))
             c.execute('SELECT * FROM assignments WHERE assignment_id = ?;',
                       (assignment_id, ))
@@ -383,17 +401,20 @@ class MTurkDataHandler():
             if assignment is None:
                 return
             worker_id = assignment['worker_id']
-            c.execute('''UPDATE workers SET approved = approved + 1
-                         WHERE worker_id = ?;''',
+            c.execute("""UPDATE workers SET approved = approved + 1
+                         WHERE worker_id = ?;""",
                       (worker_id, ))
             conn.commit()
 
     def log_reject_assignment(self, assignment_id):
+        """Update assignment state to reflect rejection, update worker state to
+        increment number of rejected assignments
+        """
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
-            c.execute('''UPDATE assignments SET status = ?
-                         WHERE assignment_id = ?;''',
+            c.execute("""UPDATE assignments SET status = ?
+                         WHERE assignment_id = ?;""",
                       ('Rejected', assignment_id))
             c.execute('SELECT * FROM assignments WHERE assignment_id = ?;',
                       (assignment_id, ))
@@ -401,26 +422,29 @@ class MTurkDataHandler():
             if assignment is None:
                 return
             worker_id = assignment['worker_id']
-            c.execute('''UPDATE workers SET rejected = rejected + 1
-                         WHERE worker_id = ?;''',
+            c.execute("""UPDATE workers SET rejected = rejected + 1
+                         WHERE worker_id = ?;""",
                       (worker_id, ))
             conn.commit()
 
     def log_worker_note(self, worker_id, assignment_id, note):
+        """Append a note to the worker notes for a particular worker-assignment
+        pairing. Adds newline to the note.
+        """
         note += '\n'
         with self.table_access_condition:
             try:
                 conn = self._get_connection()
                 c = conn.cursor()
-                c.execute('''UPDATE pairings SET notes = notes || ?
-                             WHERE worker_id = ? AND assignment_id = ?;''',
+                c.execute("""UPDATE pairings SET notes = notes || ?
+                             WHERE worker_id = ? AND assignment_id = ?;""",
                           (note, worker_id, assignment_id))
                 conn.commit()
             except Exception as e:
                 print(repr(e))
 
     def get_all_worker_data(self, start=0, count=30):
-        '''get all the worker data for all worker_ids.'''
+        """get all the worker data for all worker_ids."""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -430,6 +454,7 @@ class MTurkDataHandler():
             return results
 
     def get_worker_data(self, worker_id):
+        """get all worker data for a particular worker_id."""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -439,19 +464,21 @@ class MTurkDataHandler():
             return results
 
     def get_assignments_for_run(self, task_group_id):
+        """get all assignments for a particular run by task_group_id"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
-            c.execute('''SELECT assignments.* FROM assignments
+            c.execute("""SELECT assignments.* FROM assignments
                          WHERE assignments.hit_id IN (
                            SELECT hits.hit_id FROM hits
                            WHERE hits.run_id = ?
-                         );''',
+                         );""",
                       (task_group_id, ))
             results = c.fetchall()
             return results
 
     def get_assignment_data(self, assignment_id):
+        """get assignment data for a particular assignment by assignment_id"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -461,6 +488,7 @@ class MTurkDataHandler():
             return results
 
     def get_worker_assignment_pairing(self, worker_id, assignment_id):
+        """get a pairing data structure between a worker and an assignment"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -471,7 +499,7 @@ class MTurkDataHandler():
             return results
 
     def get_all_run_data(self, start=0, count=30):
-        '''get all the run data for all task_group_ids.'''
+        """get all the run data for all task_group_ids."""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -481,9 +509,9 @@ class MTurkDataHandler():
             return results
 
     def get_run_data(self, task_group_id):
-        '''get the run data for the given task_group_id, return None if not
+        """get the run data for the given task_group_id, return None if not
         found.
-        '''
+        """
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -493,7 +521,7 @@ class MTurkDataHandler():
             return results
 
     def get_hits_for_run(self, run_id):
-        '''Get the full list of HITs for the given run_id'''
+        """Get the full list of HITs for the given run_id"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -502,7 +530,7 @@ class MTurkDataHandler():
             return results
 
     def get_hit_data(self, hit_id):
-        '''get the hit data for the given hit_id, return None if not'''
+        """get the hit data for the given hit_id, return None if not"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -511,6 +539,7 @@ class MTurkDataHandler():
             return results
 
     def get_pairings_for_assignment(self, assignment_id):
+        """get all pairings attached to a particular assignment_id"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -520,6 +549,7 @@ class MTurkDataHandler():
             return results
 
     def get_pairings_for_run(self, task_group_id):
+        """get all pairings from a particular run by task_group_id"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -530,6 +560,9 @@ class MTurkDataHandler():
 
     def get_pairings_for_conversation(self, conversation_id,
                                       task_group_id=None):
+        """get all pairings for a singular conversation in a run by
+        conversation_id and task_group_id
+        """
         task_group_id = self._force_task_group_id(task_group_id)
         with self.table_access_condition:
             conn = self._get_connection()
@@ -540,6 +573,7 @@ class MTurkDataHandler():
             return results
 
     def get_all_assignments_for_worker(self, worker_id):
+        """get all assignments associated with a particular worker_id"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -549,6 +583,7 @@ class MTurkDataHandler():
             return results
 
     def get_all_pairings_for_worker(self, worker_id):
+        """get all pairings associated with a particular worker_id"""
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
@@ -559,6 +594,9 @@ class MTurkDataHandler():
 
     def get_all_task_assignments_for_worker(self, worker_id,
                                             task_group_id=None):
+        """get all assignments for a particular worker within a
+        particular run by worker_id and task_group_id
+        """
         task_group_id = self._force_task_group_id(task_group_id)
         with self.table_access_condition:
             conn = self._get_connection()
@@ -575,12 +613,15 @@ class MTurkDataHandler():
             return results
 
     def get_all_task_pairings_for_worker(self, worker_id, task_group_id=None):
+        """get all pairings for a particular worker within a
+        particular run by worker_id and task_group_id
+        """
         task_group_id = self._force_task_group_id(task_group_id)
         with self.table_access_condition:
             conn = self._get_connection()
             c = conn.cursor()
-            c.execute('''SELECT * FROM pairings WHERE worker_id = ?
-                         AND run_id = ?;''',
+            c.execute("""SELECT * FROM pairings WHERE worker_id = ?
+                         AND run_id = ?;""",
                       (worker_id, task_group_id))
             results = c.fetchall()
             return results

--- a/parlai/mturk/core/mturk_data_handler.py
+++ b/parlai/mturk/core/mturk_data_handler.py
@@ -519,6 +519,15 @@ class MTurkDataHandler():
             results = c.fetchall()
             return results
 
+    def get_pairings_for_run(self, task_group_id):
+        with self.table_access_condition:
+            conn = self._get_connection()
+            c = conn.cursor()
+            c.execute("""SELECT * FROM pairings
+                         WHERE run_id = ?;""", (task_group_id, ))
+            results = c.fetchall()
+            return results
+
     def get_pairings_for_conversation(self, conversation_id,
                                       task_group_id=None):
         task_group_id = self._force_task_group_id(task_group_id)

--- a/parlai/mturk/webapp/.babelrc
+++ b/parlai/mturk/webapp/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/env", "@babel/preset-react"]
+}

--- a/parlai/mturk/webapp/.gitignore
+++ b/parlai/mturk/webapp/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -1,0 +1,376 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Button, Panel, Table} from 'react-bootstrap';
+import 'fetch';
+
+var AppURLStates = Object.freeze({
+  init:0, tasks:1, unsupported:2, runs:3,
+});
+
+function convert_time(timestamp){
+  var a = new Date(timestamp * 1000);
+  var time = (a.toLocaleDateString("en-US") + ' ' +
+              a.toLocaleTimeString("en-US"));
+  return time;
+}
+
+function resolveState(state_string) {
+  if (state_string == '') {
+    return {url_state: AppURLStates.init, args: null};
+  }
+  var args = state_string.split('/');
+  var state = {
+    url_state: AppURLStates.unsupported,
+    args: null,
+  };
+  if (AppURLStates.hasOwnProperty(args[0])) {
+    state.url_state = AppURLStates[args[0]];
+  }
+  if (args.length > 1) {
+    state.args = args.slice(1);
+  }
+  return state;
+}
+
+class NavLink extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    if (this.props.type == 'run') {
+      return (
+        <a href={'/app/runs/' + this.props.target}>
+          {this.props.children}
+        </a>
+      )
+    } else {
+      return (
+        <span>{this.props.children}</span>
+      )
+    }
+  }
+
+}
+
+class TaskTable extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  makeRow(item) {
+    return (
+      <tr key={item.run_id + '_table_row'}>
+        <td>
+          <NavLink type='run' target={item.run_id}>
+            {item.run_id}
+          </NavLink>
+        </td>
+        <td>complete</td>
+        <td>{item.created}</td>
+        <td>{item.maximum}</td>
+        <td>{item.completed}</td>
+        <td>{item.failed}</td>
+      </tr>
+    )
+  }
+
+  render() {
+    return (
+      <Table striped bordered condensed hover>
+        <thead>
+          <tr>
+            <th>Run ID</th>
+            <th>Status</th>
+            <th>Created</th>
+            <th>Maximum</th>
+            <th>Completed</th>
+            <th>Failed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {this.props.items.map(this.makeRow)}
+        </tbody>
+      </Table>
+    )
+  }
+}
+
+class HitTable extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  makeRow(item) {
+    return (
+      <tr key={item.hit_id + '_table_row'}>
+        <td>
+          <NavLink type='hit' target={item.hit_id}>
+            {item.hit_id}
+          </NavLink>
+        </td>
+        <td>{convert_time(item.expiration)}</td>
+        <td>{item.hit_status}</td>
+        <td>{item.assignments_pending}</td>
+        <td>{item.assignments_available}</td>
+        <td>{item.assignments_complete}</td>
+      </tr>
+    )
+  }
+
+  render() {
+    return (
+      <Table striped bordered condensed hover>
+        <thead>
+          <tr>
+            <th>HIT ID</th>
+            <th>Expiration</th>
+            <th>HIT Status</th>
+            <th>Pending</th>
+            <th>Available</th>
+            <th>Complete</th>
+          </tr>
+        </thead>
+        <tbody>
+          {this.props.items.map(this.makeRow)}
+        </tbody>
+      </Table>
+    )
+  }
+}
+
+class AssignmentTable extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  makeRow(item) {
+    return (
+      <tr key={item.assignment_id + '_table_row'}>
+        <td>
+          <NavLink type='assignment' target={item.assignment_id}>
+            {item.assignment_id}
+          </NavLink>
+        </td>
+        <td>{item.status}</td>
+        <td>{convert_time(item.approve_time)}</td>
+        <td>
+          <NavLink type='worker' target={item.worker_id}>
+            {item.worker_id}
+          </NavLink>
+        </td>
+        <td>
+          <NavLink type='hit' target={item.hit_id}>
+            {item.hit_id}
+          </NavLink>
+        </td>
+      </tr>
+    )
+  }
+
+  render() {
+    return (
+      <Table striped bordered condensed hover>
+        <thead>
+          <tr>
+            <th>Assignment ID</th>
+            <th>Status</th>
+            <th>Approval Time</th>
+            <th>Worker ID</th>
+            <th>HIT ID</th>
+          </tr>
+        </thead>
+        <tbody>
+          {this.props.items.map(this.makeRow)}
+        </tbody>
+      </Table>
+    )
+  }
+}
+
+class RunPanel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {runLoading: true, items: null, error: false};
+  }
+
+  fetchRunData() {
+    fetch('/runs/' + this.props.run_id)
+      .then(res => res.json())
+      .then(
+        (result) => {
+          this.setState({
+            runLoading: false,
+            data: result
+          });
+        },
+        (error) => {
+          this.setState({
+            runLoading: false,
+            error: true
+          });
+        }
+      )
+  }
+
+  componentDidMount() {
+    this.setState({runLoading: true});
+    this.fetchRunData();
+  }
+
+  renderRunInfo() {
+    return (
+      <div>
+        <TaskTable items={[this.state.data.run_details]} />
+        <AssignmentTable items={this.state.data.assignments} />
+        <HitTable items={this.state.data.hits} />
+      </div>
+    )
+  }
+
+  render() {
+    var content;
+    if (this.state.runLoading) {
+      content = <span>Run details are currently loading...</span>;
+    } else if (this.state.error !== false) {
+      content = <span>Run loading failed, perhaps run doesn't exist?</span>;
+    } else {
+      content = this.renderRunInfo();
+    }
+
+    return (
+      <Panel>
+        <Panel.Heading>
+          <Panel.Title componentClass="h3">
+            Task Details - Run: {this.props.run_id}
+          </Panel.Title>
+        </Panel.Heading>
+        <Panel.Body>
+          {content}
+        </Panel.Body>
+      </Panel>
+    )
+  }
+}
+
+class TaskPanel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {tasksLoading: true, items: null, error: false};
+  }
+
+  fetchTaskData() {
+    fetch('/tasks')
+      .then(res => res.json())
+      .then(
+        (result) => {
+          this.setState({
+            tasksLoading: false,
+            items: result
+          });
+        },
+        (error) => {
+          this.setState({
+            tasksLoading: false,
+            error: error
+          });
+        }
+      )
+  }
+
+  componentDidMount() {
+    this.setState({tasksLoading: true});
+    this.fetchTaskData();
+  }
+
+  render() {
+    var content;
+    if (this.state.tasksLoading) {
+      content = <span>Tasks are currently loading...</span>;
+    } else if (this.state.error !== false) {
+      console.log(this.state.error)
+      content = <span>Tasks loading failed...</span>;
+    } else {
+      content = <TaskTable items={this.state.items}/>;
+    }
+
+    return (
+      <Panel>
+        <Panel.Heading>
+          <Panel.Title componentClass="h3">
+            Running Tasks List
+          </Panel.Title>
+        </Panel.Heading>
+        <Panel.Body>
+          {content}
+        </Panel.Body>
+      </Panel>
+    )
+  }
+}
+
+class MainApp extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = resolveState(URL_DESTINATION);
+  }
+
+  renderInitPage() {
+    return (
+      <div>
+        <span>Welcome to the ParlAI-Dashboard. Use the button to begin</span>
+        <Button
+          bsStyle="info"
+          href="/app/tasks">
+            Click me
+        </Button>
+      </div>
+    );
+  }
+
+  renderUnsupportedPage() {
+    return (
+      <div>
+        <span>Oops something happened! use this button to return </span>
+        <Button
+          bsStyle="info"
+          href="/app/tasks">
+            Click me
+        </Button>
+      </div>
+    );
+  }
+
+  renderTaskPage() {
+    return (
+      <div style={{width: '600px'}}>
+        <TaskPanel/>
+      </div>
+    );
+  }
+
+  renderRunPage() {
+    return (
+      <div style={{width: '800px'}}>
+        <RunPanel run_id={this.state.args[0]}/>
+      </div>
+    );
+  }
+
+  render() {
+    if (this.state.url_state == AppURLStates.init) {
+      return this.renderInitPage();
+    } else if (this.state.url_state == AppURLStates.tasks) {
+      return this.renderTaskPage();
+    } else if (this.state.url_state == AppURLStates.runs) {
+      return this.renderRunPage();
+    } else {
+      return this.renderUnsupportedPage();
+    }
+  }
+}
+
+
+var main_app = <MainApp/>;
+
+ReactDOM.render(main_app, document.getElementById('app'));

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -148,7 +148,7 @@ class TaskTable extends React.Component {
   getColumnValue(header_name, item) {
     switch(header_name) {
       case 'run_id': return item.run_id;
-      case 'run_status': return 'complete';
+      case 'run_status': return item.run_status;
       case 'created': return item.created;
       case 'maximum': return item.maximum;
       case 'completed': return item.completed;

--- a/parlai/mturk/webapp/dev/main.js
+++ b/parlai/mturk/webapp/dev/main.js
@@ -1,0 +1,3 @@
+import App from './app.jsx';
+import Bootstrap from 'bootstrap/dist/css/bootstrap.css';
+import './css/style.css';

--- a/parlai/mturk/webapp/package.json
+++ b/parlai/mturk/webapp/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "webapp",
+  "version": "1.0.0",
+  "description": "",
+  "main": "webpack.config.js",
+  "scripts": {
+    "dev": "webpack --mode development"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "bootstrap": "^4.1.3",
+    "fetch": "^1.1.0",
+    "jquery": "^1.9.1",
+    "popper.js": "^1.14.4",
+    "react": "^16.5.2",
+    "react-bootstrap": "^0.32.4",
+    "react-dom": "^16.5.2"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.1.0",
+    "@babel/core": "^7.1.0",
+    "@babel/preset-env": "^7.1.0",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.2",
+    "css-loader": "^1.0.0",
+    "style-loader": "^0.23.0",
+    "webpack": "^4.19.1",
+    "webpack-cli": "^3.1.1"
+  }
+}

--- a/parlai/mturk/webapp/package.json
+++ b/parlai/mturk/webapp/package.json
@@ -16,7 +16,8 @@
     "popper.js": "^1.14.4",
     "react": "^16.5.2",
     "react-bootstrap": "^0.32.4",
-    "react-dom": "^16.5.2"
+    "react-dom": "^16.5.2",
+    "react-table": "^6.8.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",

--- a/parlai/mturk/webapp/server.py
+++ b/parlai/mturk/webapp/server.py
@@ -1,0 +1,367 @@
+# Copyright 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""ParlAI Server file"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import inspect
+import json
+import logging
+import os
+import time
+import traceback
+
+import tornado.ioloop
+import tornado.web
+import tornado.websocket
+import tornado.escape
+
+
+from parlai.mturk.core.mturk_data_handler import MTurkDataHandler
+
+DEFAULT_PORT = 8095
+DEFAULT_HOSTNAME = "localhost"
+DEFAULT_DB_FILE = 'pmt_data.db'
+IS_DEBUG = True
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+def row_to_dict(row):
+    return (dict(zip(row.keys(), row)))
+
+
+def get_rand_id():
+    return str(hex(int(time.time() * 10000000))[2:])
+
+
+def ensure_dir_exists(path):
+    """Make sure the parent dir exists for path so we can write a file."""
+    try:
+        os.makedirs(os.path.dirname(path))
+    except OSError as e1:
+        assert e1.errno == 17  # errno.EEXIST
+        pass
+
+
+def get_path(filename):
+    """Get the path to an asset."""
+    cwd = os.path.dirname(
+        os.path.abspath(inspect.getfile(inspect.currentframe())))
+    return os.path.join(cwd, filename)
+
+
+tornado_settings = {
+    "autoescape": None,
+    "debug": IS_DEBUG,
+    "static_path": get_path('static'),
+    "template_path": get_path('static'),
+    "compiled_template_cache": False
+}
+
+
+class Application(tornado.web.Application):
+    def __init__(self, port=DEFAULT_PORT, db_file=DEFAULT_DB_FILE):
+        self.state = {}
+        self.subs = {}
+        self.sources = {}
+        self.port = port
+        self.data_handler = MTurkDataHandler(file_name=db_file)
+
+        # TODO load some state from DB
+
+        handlers = [
+            (r"/app/(.*)", AppHandler, {'app': self}),
+            (r"/tasks", TaskListHandler, {'app': self}),
+            (r"/workers", WorkerListHandler, {'app': self}),
+            (r"/runs/(.*)", RunHandler, {'app': self}),
+            (r"/workers/(.*)", WorkerHandler, {'app': self}),
+            (r"/error/(.*)", ErrorHandler, {'app': self}),
+            (r"/socket", SocketHandler, {'app': self}),
+            (r"/", RedirectHandler),
+        ]
+        super(Application, self).__init__(handlers, **tornado_settings)
+
+
+def broadcast_msg(handler, msg, target_subs=None):
+    if target_subs is None:
+        target_subs = handler.subs.values()
+    for sub in target_subs:
+        sub.write_message(json.dumps(msg))
+
+
+def send_to_sources(handler, msg):
+    target_sources = handler.sources.values()
+    for source in target_sources:
+        source.write_message(json.dumps(msg))
+
+
+class SocketHandler(tornado.websocket.WebSocketHandler):
+    def initialize(self, app):
+        self.port = app.port
+        self.state = app.state
+        self.subs = app.subs
+        self.sources = app.sources
+
+    def check_origin(self, origin):
+        return True
+
+    def broadcast_default(self, target_subs=None):
+        # TODO create any default content that needs to go in msg
+        # if target_subs is None:
+        #     target_subs = self.subs.values()
+        # broadcast_msg(self, msg, target_subs)
+        pass
+
+    def open(self):
+        self.sid = get_rand_id()
+        if self not in list(self.subs.values()):
+            self.subs[self.sid] = self
+        logging.info(
+            'Opened new socket from ip: {}'.format(self.request.remote_ip))
+
+        self.write_message(
+            json.dumps({'command': 'register', 'data': self.sid}))
+        self.broadcast_default([self])
+
+    def on_message(self, message):
+        logging.info('from web client: {}'.format(message))
+        msg = tornado.escape.json_decode(tornado.escape.to_basestring(message))
+
+        cmd = msg.get('cmd')
+
+        # TODO flesh out with stubs as they develop
+        if cmd == 'todo':
+            # Do something
+            pass
+
+    def on_close(self):
+        if self in list(self.subs.values()):
+            self.subs.pop(self.sid, None)
+
+
+class BaseHandler(tornado.web.RequestHandler):
+    def __init__(self, *request, **kwargs):
+        self.include_host = False
+        super(BaseHandler, self).__init__(*request, **kwargs)
+
+    def write_error(self, status_code, **kwargs):
+        logging.error("ERROR: %s: %s" % (status_code, kwargs))
+        if self.settings.get("debug") and "exc_info" in kwargs:
+            logging.error("rendering error page")
+            exc_info = kwargs["exc_info"]
+            # exc_info is a tuple consisting of:
+            # 1. The class of the Exception
+            # 2. The actual Exception that was thrown
+            # 3. The traceback opbject
+            try:
+                params = {
+                    'error': exc_info[1],
+                    'trace_info': traceback.format_exception(*exc_info),
+                    'request': self.request.__dict__
+                }
+
+                self.render("error.html", **params)
+                logging.error("rendering complete")
+            except Exception as e:
+                logging.error(e)
+
+
+class AppHandler(tornado.web.RequestHandler):
+    def initialize(self, app):
+        self.state = app.state
+        self.subs = app.subs
+        self.sources = app.sources
+        self.port = app.port
+        self.data_handler = app.data_handler
+
+    def get(self, args):
+        self.render('index.html', initial_location=args)
+        return
+
+
+class RedirectHandler(tornado.web.RequestHandler):
+    def post(self):
+        self.set_status(404)
+
+    def get(self):
+        print('redirecting')
+        self.redirect('/app/tasks')
+
+
+class TaskListHandler(BaseHandler):
+    def initialize(self, app):
+        self.state = app.state
+        self.subs = app.subs
+        self.sources = app.sources
+        self.port = app.port
+        self.data_handler = app.data_handler
+
+    def post(self):
+        req = tornado.escape.json_decode(
+            tornado.escape.to_basestring(self.request.body)
+        )
+        self.write(json.dumps({'t': 'testing!', 'req': req}))
+
+    def get(self):
+        try:
+            req = tornado.escape.json_decode(
+                tornado.escape.to_basestring(self.request.body)
+            )
+        except Exception:
+            req = {}
+
+        # self.render(
+        #     'index.html',
+        #     user=getpass.getuser(),
+        #     items=items,
+        #     active_item=active
+        # )
+        results = self.data_handler.get_all_run_data()
+        processed_results = []
+        for res in results:
+            processed_results.append(dict(zip(res.keys(), res)))
+
+        self.write(json.dumps(processed_results))
+
+
+class RunHandler(BaseHandler):
+    def initialize(self, app):
+        self.state = app.state
+        self.subs = app.subs
+        self.sources = app.sources
+        self.port = app.port
+        self.data_handler = app.data_handler
+
+    def get(self, task_target):
+        hits = self.data_handler.get_hits_for_run(task_target)
+        processed_hits = []
+        for res in hits:
+            processed_hits.append(row_to_dict(res))
+        assignments = self.data_handler.get_assignments_for_run(task_target)
+        processed_assignments = []
+        for res in assignments:
+            processed_assignments.append(row_to_dict(res))
+        run_details = row_to_dict(self.data_handler.get_run_data(task_target))
+        data = {
+            'run_details': run_details,
+            'assignments': processed_assignments,
+            'hits': processed_hits,
+        }
+
+        self.write(json.dumps(data))
+
+
+class WorkerListHandler(BaseHandler):
+    def initialize(self, app):
+        self.state = app.state
+        self.subs = app.subs
+        self.sources = app.sources
+        self.port = app.port
+        self.data_handler = app.data_handler
+
+    def get(self):
+
+        # self.render(
+        #     'index.html',
+        #     user=getpass.getuser(),
+        #     items=items,
+        #     active_item=active
+        # )
+        results = self.data_handler.get_all_worker_data()
+        processed_results = []
+        print(results)
+        for res in results:
+            processed_results.append(dict(zip(res.keys(), res)))
+
+        self.write(json.dumps(processed_results))
+
+
+class WorkerHandler(BaseHandler):
+    def initialize(self, app):
+        self.state = app.state
+        self.subs = app.subs
+        self.sources = app.sources
+        self.port = app.port
+        self.data_handler = app.data_handler
+
+    def get(self, worker_target):
+
+        # self.render(
+        #     'index.html',
+        #     user=getpass.getuser(),
+        #     items=items,
+        #     active_item=active
+        # )
+        print(worker_target)
+        results = self.data_handler.get_all_pairings_for_worker(worker_target)
+        processed_results = []
+        for res in results:
+            processed_results.append(dict(zip(res.keys(), res)))
+
+        self.write(json.dumps(processed_results))
+
+
+class ErrorHandler(BaseHandler):
+    def get(self, text):
+        error_text = text or "test error"
+        raise Exception(error_text)
+
+
+def start_server(port=DEFAULT_PORT, hostname=DEFAULT_HOSTNAME,
+                 db_file=DEFAULT_DB_FILE):
+    print("It's Alive!")
+    app = Application(port=port, db_file=db_file)
+    app.listen(port, max_buffer_size=1024 ** 3)
+    logging.info("Application Started")
+
+    if "HOSTNAME" in os.environ and hostname == DEFAULT_HOSTNAME:
+        hostname = os.environ["HOSTNAME"]
+    else:
+        hostname = hostname
+    print("You can navigate to http://%s:%s" % (hostname, port))
+    tornado.ioloop.IOLoop.current().start()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Start the ParlAI-MTurk task managing server.')
+    parser.add_argument('-port', metavar='port', type=int, default=DEFAULT_PORT,
+                        help='port to run the server on.')
+    parser.add_argument('-hostname', metavar='hostname', type=str,
+                        default=DEFAULT_HOSTNAME,
+                        help='host to run the server on.')
+    parser.add_argument('-db_file', metavar='db_file', type=str,
+                        default=DEFAULT_DB_FILE,
+                        help='name of database to use (in core/run_data)')
+    parser.add_argument('-logging_level', metavar='logger_level', default='INFO',
+                        help='logging level (default = INFO). Can take logging '
+                             'level name or int (example: 20)')
+    FLAGS = parser.parse_args()
+
+    try:
+        logging_level = int(FLAGS.logging_level)
+    except (ValueError,):
+        try:
+            logging_level = logging._checkLevel(FLAGS.logging_level)
+        except ValueError:
+            raise KeyError(
+                "Invalid logging level : {0}".format(FLAGS.logging_level)
+            )
+
+    logging.getLogger().setLevel(logging_level)
+
+    start_server(port=FLAGS.port, hostname=FLAGS.hostname,
+                 db_file=FLAGS.db_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/parlai/mturk/webapp/static/index.html
+++ b/parlai/mturk/webapp/static/index.html
@@ -1,0 +1,31 @@
+<!--
+
+Copyright 2017-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the license found in the
+LICENSE file in the root directory of this source tree.
+
+-->
+
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>ParlAI-MTurk dashboard</title>
+    <!-- <link rel="icon" href="http://example.com/favicon.png"> -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <script>
+    // Set the initial URL to be able to provide the actual location in
+    // the app people want to go to
+    var URL_DESTINATION = '{{escape(initial_location)}}'
+    </script>
+  </head>
+
+  <body>
+    <noscript>JS is required</noscript>
+    <div id="app"></div>
+    <script src={{ static_url("bundle.js") }}></script>
+  </body>
+</html>

--- a/parlai/mturk/webapp/webpack.config.js
+++ b/parlai/mturk/webapp/webpack.config.js
@@ -1,0 +1,36 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  entry: './dev/main.js',
+  output: {
+    path: __dirname,
+    filename: 'static/bundle.js',
+  },
+  node: {
+    net: 'empty',
+    dns: 'empty'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        options: { presets: ["@babel/env"] }
+      },
+      {
+        test: /\.css$/,
+        loader: "style-loader!css-loader"
+      },
+      {
+        test: /\.png$/,
+        loader: "url-loader?limit=100000"
+      },
+      {
+        test: /\.jpg$/,
+        loader: "file-loader"
+      },
+    ]
+  },
+};


### PR DESCRIPTION
This PR lays the groundwork for the frontend webapp that will eventually be used to test UIs, launch tasks, manage qualifications, review work, manage workers, and more.

Right now it hooks up to the DB that is created when using the optional `use_db` flag. It can be used by running `npm install; npm run dev; python server.py` from inside the `webapp` directory.

Current features:
Provides views into runs and workers (currently it acts as a passive way to view metadata about runs).

Next up I'll be adding the reviewer interface, which will follow a change to how PMT stores data.