### PR TITLE
[MTurk] Universal task saving 'format'

### DIFF
--- a/parlai/mturk/core/.gitignore
+++ b/parlai/mturk/core/.gitignore
@@ -1,0 +1,1 @@
+run_data/

--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -190,7 +190,7 @@ class MTurkAgent(Agent):
         if self.db_logger is not None:
             if status == AssignState.STATUS_ONBOARDING:
                 self.db_logger.log_start_onboard(
-                    self.worker_id, self.assignment_id)
+                    self.worker_id, self.assignment_id, self.conversation_id)
             elif status == AssignState.STATUS_WAITING:
                 self.db_logger.log_finish_onboard(
                     self.worker_id, self.assignment_id)
@@ -324,7 +324,6 @@ class MTurkAgent(Agent):
         """Cleans up resources related to maintaining complete state"""
         self.flush_msg_queue()
         self.msg_queue = None
-        self.state.clear_messages()
         self.recieved_packets = None
 
     def get_new_act_message(self):

--- a/parlai/mturk/core/mturk_data_handler.py
+++ b/parlai/mturk/core/mturk_data_handler.py
@@ -114,7 +114,7 @@ class MTurkDataHandler():
 
     @staticmethod
     def save_world_data(prepped_save_data, task_group_id,
-                        conversation_id, sandbox=False, onboarding=False):
+                        conversation_id, sandbox=False):
         target = 'sandbox' if sandbox else 'live'
         target_dir = os.path.join(
             data_dir, target, task_group_id, conversation_id)

--- a/parlai/mturk/core/mturk_data_handler.py
+++ b/parlai/mturk/core/mturk_data_handler.py
@@ -86,7 +86,6 @@ CREATE_PAIRING_DATA_SQL_TABLE = (
         task_start int,
         task_end int,
         conversation_id string,
-        onboarding_id string,
         bonus_amount int,
         bonus_text string,
         bonus_paid boolean,
@@ -94,6 +93,7 @@ CREATE_PAIRING_DATA_SQL_TABLE = (
         worker_id string,
         assignment_id string,
         run_id string,
+        onboarding_id string,
         FOREIGN KEY (worker_id) REFERENCES workers (worker_id),
         FOREIGN KEY (assignment_id) REFERENCES assignments (assignment_id),
         FOREIGN KEY (run_id) REFERENCES runs (run_id)
@@ -253,9 +253,9 @@ class MTurkDataHandler():
             # may be reassigned
             c.execute("""INSERT INTO pairings
                          VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-                      (AssignState.STATUS_NONE, None, None, None, None, None,
+                      (AssignState.STATUS_NONE, None, None, None, None,
                        None, 0, '', False, '', worker_id, assignment_id,
-                       task_group_id))
+                       task_group_id, None))
             conn.commit()
 
     def log_complete_assignment(self, worker_id, assignment_id, approve_time,

--- a/parlai/mturk/core/mturk_data_handler.py
+++ b/parlai/mturk/core/mturk_data_handler.py
@@ -9,6 +9,7 @@
 import json
 import logging
 import os
+import pickle
 import sqlite3
 import time
 import threading
@@ -118,12 +119,18 @@ class MTurkDataHandler():
         target_dir = os.path.join(
             data_dir, target, task_group_id, conversation_id)
         force_dir(target_dir)
-        if prepped_save_data['custom_data'] is not None:
+        custom_data = prepped_save_data['custom_data']
+        if custom_data is not None:
             target_dir_custom = os.path.join(target_dir, 'custom')
             force_dir(target_dir_custom)
+            if custom_data.get('needs-pickle') is not None:
+                pickle_file = os.path.join(target_dir_custom, 'data.pickle')
+                with open(pickle_file, 'w') as outfile:
+                    json.dump(custom_data['needs-pickle'], outfile)
+                del custom_data['needs-pickle']
             custom_file = os.path.join(target_dir_custom, 'data.json')
             with open(custom_file, 'w') as outfile:
-                json.dump(prepped_save_data['custom_data'], outfile)
+                json.dump(custom_data, outfile)
         worker_data = prepped_save_data['worker_data']
         target_dir_workers = os.path.join(target_dir, 'workers')
         force_dir(target_dir_workers)

--- a/parlai/mturk/core/mturk_data_handler.py
+++ b/parlai/mturk/core/mturk_data_handler.py
@@ -24,7 +24,7 @@ def force_dir(path):
 
 
 data_dir = os.path.dirname(os.path.abspath(__file__)) + '/run_data'
-force_dir(data_dir)
+os.makedirs(data_dir, exist_ok=True)
 
 # Run data table:
 CREATE_RUN_DATA_SQL_TABLE = (
@@ -118,25 +118,25 @@ class MTurkDataHandler():
         target = 'sandbox' if sandbox else 'live'
         target_dir = os.path.join(
             data_dir, target, task_group_id, conversation_id)
-        force_dir(target_dir)
         custom_data = prepped_save_data['custom_data']
         if custom_data is not None:
             target_dir_custom = os.path.join(target_dir, 'custom')
-            force_dir(target_dir_custom)
             if custom_data.get('needs-pickle') is not None:
                 pickle_file = os.path.join(target_dir_custom, 'data.pickle')
-                with open(pickle_file, 'w') as outfile:
-                    json.dump(custom_data['needs-pickle'], outfile)
+                force_dir(pickle_file)
+                with open(pickle_file, 'wb') as outfile:
+                    pickle.dump(custom_data['needs-pickle'], outfile)
                 del custom_data['needs-pickle']
             custom_file = os.path.join(target_dir_custom, 'data.json')
+            force_dir(custom_file)
             with open(custom_file, 'w') as outfile:
                 json.dump(custom_data, outfile)
         worker_data = prepped_save_data['worker_data']
         target_dir_workers = os.path.join(target_dir, 'workers')
-        force_dir(target_dir_workers)
         for worker_id, w_data in worker_data.items():
             worker_file = os.path.join(
                 target_dir_workers, '{}.json'.format(worker_id))
+            force_dir(worker_file)
             with open(worker_file, 'w') as outfile:
                 json.dump(w_data, outfile)
 

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -691,8 +691,7 @@ class MTurkManager():
                 if save_data is not None:
                     MTurkDataHandler.save_world_data(
                         save_data, self.task_group_id,
-                        conversation_id, onboarding=True,
-                        sandbox=self.is_sandbox)
+                        conversation_id, sandbox=self.is_sandbox)
 
             # once onboarding is done, move into a waiting world
             self._move_agents_to_waiting([mturk_agent])

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -685,7 +685,12 @@ class MTurkManager():
                 if not did_arrive:
                     return
                 # call onboarding function
-                self.onboard_function(mturk_agent)
+                save_data = self.onboard_function(mturk_agent)
+                if save_data is not None:
+                    MTurkDataHandler.save_world_data(
+                        save_data, self.task_group_id,
+                        conversation_id, onboarding=True,
+                        sandbox=self.is_sandbox)
 
             # once onboarding is done, move into a waiting world
             self._move_agents_to_waiting([mturk_agent])
@@ -1034,7 +1039,14 @@ class MTurkManager():
                 )
             )
             self.started_conversations += 1
-            task_function(mturk_manager=self, opt=opt, workers=agents)
+            save_data = \
+                task_function(mturk_manager=self, opt=opt, workers=agents)
+
+            if save_data is not None:
+                MTurkDataHandler.save_world_data(
+                    save_data, self.task_group_id, conversation_id,
+                    sandbox=self.is_sandbox)
+
             # Delete extra state data that is now unneeded
             for agent in agents:
                 agent.clear_messages()
@@ -1048,7 +1060,6 @@ class MTurkManager():
                         if agent.submitted_hit():
                             self.create_additional_hits(1)
 
-        last_thread_count = 0
         if self.db_logger is not None:
             self._maintain_hit_status()
         while not self.is_shutdown:

--- a/parlai/mturk/core/worlds.py
+++ b/parlai/mturk/core/worlds.py
@@ -8,6 +8,7 @@
 
 from parlai.core.worlds import World
 
+
 class MTurkDataWorld(World):
     def prep_save_data(self, workers):
         '''This prepares data to be saved for later review, including

--- a/parlai/mturk/core/worlds.py
+++ b/parlai/mturk/core/worlds.py
@@ -11,8 +11,8 @@ from parlai.core.worlds import World
 
 class MTurkDataWorld(World):
     def prep_save_data(self, workers):
-        '''This prepares data to be saved for later review, including
-        chats from individual worker perspectives.'''
+        """This prepares data to be saved for later review, including
+        chats from individual worker perspectives."""
         custom_data = self.get_custom_task_data()
         save_data = {
             'custom_data': custom_data,
@@ -29,9 +29,15 @@ class MTurkDataWorld(World):
         return save_data
 
     def get_custom_task_data(self):
-        '''This function should take the contents of whatever was collected
+        """This function should take the contents of whatever was collected
         during this task that should be saved and return it in some format,
-        preferrably a dict containing acts'''
+        preferrably a dict containing acts. If data needs pickling, put it
+        in a field named 'needs-pickle'"""
+        # return {
+        #     'acts': [self.important_turn1, self.important_turn2]
+        #     'context': self.some_context_data_of_importance
+        #     'needs-pickle': self.json_incompatible_object
+        # }
         pass
 
 
@@ -39,37 +45,37 @@ class MTurkOnboardWorld(MTurkDataWorld):
     """Generic world for onboarding a Turker and collecting
     information from them."""
     def __init__(self, opt, mturk_agent):
-        '''Init should set up resources for running the onboarding world'''
+        """Init should set up resources for running the onboarding world"""
         self.mturk_agent = mturk_agent
         self.episodeDone = False
 
     def parley(self):
-        '''A parley should represent one turn of your onboarding task'''
+        """A parley should represent one turn of your onboarding task"""
         self.episodeDone = True
 
     def episode_done(self):
         return self.episodeDone
 
     def shutdown(self):
-        '''Clear up resources needed for this world'''
+        """Clear up resources needed for this world"""
         pass
 
 
 class MTurkTaskWorld(MTurkDataWorld):
     """Generic world for MTurk tasks."""
     def __init__(self, opt, mturk_agent):
-        '''Init should set up resources for running the task world'''
+        """Init should set up resources for running the task world"""
         self.mturk_agent = mturk_agent
         self.episodeDone = False
 
     def parley(self):
-        '''A parley should represent one turn of your task'''
+        """A parley should represent one turn of your task"""
         self.episodeDone = True
 
     def episode_done(self):
-        '''A ParlAI-MTurk task ends and allows workers to be marked complete
+        """A ParlAI-MTurk task ends and allows workers to be marked complete
         when the world is finished.
-        '''
+        """
         return self.episodeDone
 
     def shutdown(self):

--- a/parlai/mturk/core/worlds.py
+++ b/parlai/mturk/core/worlds.py
@@ -22,6 +22,7 @@ class MTurkDataWorld(World):
         for agent in workers:
             save_data['worker_data'][agent.worker_id] = {
                 'worker_id': agent.worker_id,
+                'agent_id': agent.id,
                 'assignment_id': agent.assignment_id,
                 'messages': agent.get_messages(),
             }

--- a/parlai/mturk/core/worlds.py
+++ b/parlai/mturk/core/worlds.py
@@ -8,8 +8,33 @@
 
 from parlai.core.worlds import World
 
+class MTurkDataWorld(World):
+    def prep_save_data(self, workers):
+        '''This prepares data to be saved for later review, including
+        chats from individual worker perspectives.'''
+        custom_data = self.get_custom_task_data()
+        save_data = {
+            'custom_data': custom_data,
+            'worker_data': {}
+        }
 
-class MTurkOnboardWorld(World):
+        for agent in workers:
+            save_data['worker_data'][agent.worker_id] = {
+                'worker_id': agent.worker_id,
+                'assignment_id': agent.assignment_id,
+                'messages': agent.get_messages(),
+            }
+
+        return save_data
+
+    def get_custom_task_data(self):
+        '''This function should take the contents of whatever was collected
+        during this task that should be saved and return it in some format,
+        preferrably a dict containing acts'''
+        pass
+
+
+class MTurkOnboardWorld(MTurkDataWorld):
     """Generic world for onboarding a Turker and collecting
     information from them."""
     def __init__(self, opt, mturk_agent):
@@ -29,7 +54,7 @@ class MTurkOnboardWorld(World):
         pass
 
 
-class MTurkTaskWorld(World):
+class MTurkTaskWorld(MTurkDataWorld):
     """Generic world for MTurk tasks."""
     def __init__(self, opt, mturk_agent):
         '''Init should set up resources for running the task world'''
@@ -83,10 +108,4 @@ class MTurkTaskWorld(World):
         # self.mturk_agent.reject_work()
         # self.mturk_agent.pay_bonus(1000) # Pay $1000 as bonus
         # self.mturk_agent.block_worker() # Block this worker from future HITs
-        pass
-
-    def save_data(self):
-        '''This function should take the contents of whatever was collected
-        during this task that needs to be stored for review and write it
-        to disk'''
         pass

--- a/parlai/mturk/tasks/qa_data_collection/run.py
+++ b/parlai/mturk/tasks/qa_data_collection/run.py
@@ -46,7 +46,8 @@ def main():
     # of agents per world of 1 (based on the length of mturk_agent_ids)
     mturk_manager = MTurkManager(
         opt=opt,
-        mturk_agent_ids=[mturk_agent_id]
+        mturk_agent_ids=[mturk_agent_id],
+        use_db=True,
     )
     mturk_manager.setup_server()
 
@@ -58,6 +59,7 @@ def main():
         while not world.episode_done():
             world.parley()
         world.shutdown()
+        return world.prep_save_data([worker])
 
     # If we want to use the above onboard function, we can replace the below
     # with set_onboard_function(onboard_function=run_onboard)
@@ -111,7 +113,9 @@ def main():
             # shutdown and review the work
             world.shutdown()
             world.review_work()
-            world.save_data()
+
+            # Return the contents for saving
+            return world.prep_save_data(workers)
 
         # Begin the task, allowing mturk_manager to start running the task
         # world on any workers who connect

--- a/parlai/mturk/tasks/qa_data_collection/worlds.py
+++ b/parlai/mturk/tasks/qa_data_collection/worlds.py
@@ -90,7 +90,8 @@ class QADataCollectionWorld(MTurkTaskWorld):
 
     def get_custom_task_data(self):
         # brings important data together for the task, to later be used for
-        # creating the dataset.
+        # creating the dataset. If data requires pickling, put it in a field
+        # called 'needs-pickle'.
         return {
             'context': self.context,
             'acts': [self.question, self.answer],

--- a/parlai/mturk/tasks/qa_data_collection/worlds.py
+++ b/parlai/mturk/tasks/qa_data_collection/worlds.py
@@ -36,6 +36,9 @@ class QADataCollectionWorld(MTurkTaskWorld):
         self.mturk_agent = mturk_agent
         self.episodeDone = False
         self.turn_index = -1
+        self.context = None
+        self.question = None
+        self.answer = None
 
     def parley(self):
         # Each turn starts from the QA Collector agent
@@ -49,10 +52,10 @@ class QADataCollectionWorld(MTurkTaskWorld):
 
             # Get context from SQuAD teacher agent
             qa = self.task.act()
-            context = '\n'.join(qa['text'].split('\n')[:-1])
+            self.context = '\n'.join(qa['text'].split('\n')[:-1])
 
             # Wrap the context with a prompt telling the turker what to do next
-            ad['text'] = (context +
+            ad['text'] = (self.context +
                           '\n\nPlease provide a question given this context.')
 
             self.mturk_agent.observe(validate(ad))
@@ -85,6 +88,10 @@ class QADataCollectionWorld(MTurkTaskWorld):
         # Can review the work here to accept or reject it
         pass
 
-    def save_data(self):
-        # should save self.question and self.answer to a file
-        pass
+    def get_custom_task_data(self):
+        # brings important data together for the task, to later be used for
+        # creating the dataset.
+        return {
+            'context': self.context,
+            'acts': [self.question, self.answer],
+        }


### PR DESCRIPTION
In order to standardize the way that MTurk files are saved/loaded/etc for the reviewal frontend, the raw outputs for the data need to be put in a location that follows some protocol.

This updates the `qa_data_collection` task to follow such a protocol. The world implements a `get_custom_task_data()` method that packages the task data in a format that will be used later. The workers full chat logs are saved so that they can be loaded later for reviewing. Directories are created in the `run_data` folder to ensure data is saved to locations that can later be retrieved using what is logged in the database.

Enabling automatic data saving is as simple as writing `return world.prep_save_data(workers)` in any task_function or onboarding_function. Data returned by a task or onboarding function is assumed to be of the format returned by `prep_save_data` and is then logged to disk.