### PR TITLE
wmt: display data error

### DIFF
--- a/parlai/tasks/wmt/agents.py
+++ b/parlai/tasks/wmt/agents.py
@@ -27,7 +27,7 @@ class EnDeTeacher(FbDialogTeacher):
         opt = copy.deepcopy(opt)
         task = opt.get('task', 'wmt:en_de')
         self.task_name = task.split(':')[1] if ':' in task else 'en_de'
-        opt['datafile'] = _path(self.task_name, opt, opt['datatype'])
+        opt['datafile'] = _path(self.task_name, opt)
         super().__init__(opt, shared)
 
 


### PR DESCRIPTION
There was an error when display wmt data. Because in `scripts/display_data.py`, opt['datatype'] is `train:stream`, file `en_de_train:stream.txt` not found.