### PR TITLE
Add Online Static Indicator to ParlAI-MTurk worker view

### DIFF
--- a/parlai/mturk/core/server/html/core.html
+++ b/parlai/mturk/core/server/html/core.html
@@ -29,6 +29,7 @@
     <div id="right-top-pane" style="width: 100%; height: 570px; padding-top: 60px; padding-left: 20px; padding-right: 20px; padding-bottom: 20px; overflow:scroll; ">
         <div id="message_thread" style="width: 100%">
         </div>
+        <button id="connected-button" class="btn btn-lg" style="position: absolute; top: 2px; right: 2px; opacity: 1; font-size: 11px; color: white;" disabled>connected</button>
         <div id="waiting-for-message" class="row" style="margin-left: 0; margin-right: 0; display: none">
             <div class="alert alert-warning" role="alert" style="float: left; display:table; background-color: #fff">
                 <div id="hourglass" style="margin-top: -1px; margin-right: 5px; display: inline; float: left;">
@@ -132,6 +133,7 @@
   var displayed_messages = [];
   var setting_socket = false;
   var pongs_without_heartbeat = 0;
+  var heartbeats_without_pong = 0;
 
   var is_cover_page = ("{{is_cover_page}}" === 'true') ? true : false;
   var is_init_page = ("{{is_init_page}}" === 'true') ? true : false;
@@ -523,10 +525,20 @@
       // Heartbeats ensure we're not disconnected from the server
       log('received heartbeat: ' + msg.id, 4);
       pongs_without_heartbeat = 0;
+      heartbeats_without_pong += 1;
+      if (heartbeats_without_pong >= 3) {
+        $("button#connected-button").text('reconnecting to router');
+        $("#connected-button").css('background', '#f0ad4e');
+      }
     } else if (msg.type === TYPE_PONG) {
       // Messages incoming from the router, ensuring that we're at least
       // connected to it.
       pongs_without_heartbeat += 1;
+      heartbeats_without_pong = 0;
+      if (pongs_without_heartbeat >= 3) {
+        $("button#connected-button").text('reconnecting to server');
+        $("#connected-button").css('background', '#f0ad4e');
+      }
     } else if (msg.type === TYPE_ACK) {
       // Acks update messages so that we don't resend them
       log('received ack: ' + msg.id, 3);
@@ -591,6 +603,8 @@
       if (heartbeat_id == null) {
         heartbeat_id = window.setInterval(_heartbeat_thread, HEARTBEAT_TIME);
       }
+      $("button#connected-button").text('connected');
+      $("#connected-button").css('background', '#5cb85c');
     }
 
     socket.onerror = () => {
@@ -605,6 +619,8 @@
 
     socket.onclose = () => {
       log('Server closing.', 3);
+      $("button#connected-button").text('disconnected');
+      $("#connected-button").css('background', '#d9534f');
     }
   }
 


### PR DESCRIPTION
Objective: Workers using ParlAI-MTurk often send emails when they disconnect because they don't understand why the disconnection has occurred. Being able to provide a simple display location for the current connection status would be useful.

I have done the following for it:
- Created a new measuring variable heartbeat_sends_without_pong to track the number of times the frontend client has sent a message to the router and not received a response back.
- A colored button has been added to be fixed to the top-right of this pane that will display the connection status.
- The button added in 2 displays "connected" (in green) when both measures are fairly low (< 3), "reconnecting to router" (in orange) if heartbeat sends without pong exceeds 3, "reconnecting to server" (in orange) if pongs without heartbeat exceeds 3, and "disconnected" (in red) if the socket is closed.

These are the screenshots showing different status messages.
<img width="1646" alt="screen shot 2018-10-30 at 10 31 14 am" src="https://user-images.githubusercontent.com/10346824/47728468-c9fcd400-dc34-11e8-8683-ca389d6dde45.png">
<img width="1645" alt="screen shot 2018-10-30 at 10 37 04 am" src="https://user-images.githubusercontent.com/10346824/47728469-ca956a80-dc34-11e8-9909-dbd077620196.png">
<img width="1644" alt="screen shot 2018-10-30 at 10 40 54 am" src="https://user-images.githubusercontent.com/10346824/47728470-ca956a80-dc34-11e8-85d8-afdf6ccc105e.png">

I have tested the lint and run the tests. 1 test has an error in both the current master and my code. All other tests pass.