### PR TITLE
Fix broken flake8 due to upstream upgrade.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 exclude = .git,__pycache__,parlai_internal,legacy_agents,task_config.py
-ignore =
+extend-ignore =
     C
     E741
 

--- a/tests/lint_changed.sh
+++ b/tests/lint_changed.sh
@@ -13,8 +13,7 @@ set -e
 flake8 --version | grep '^3\.6\.' >/dev/null || \
     ( echo "Please install flake8 >=3.6.0." && false )
 
-FORK_POINT="$(git merge-base --fork-point origin/master)"
-CHANGED_FILES="$(git diff --name-only $FORK_POINT | grep '\.py$' | tr '\n' ' ')"
+CHANGED_FILES="$(git diff --name-only master... | grep '\.py$' | tr '\n' ' ')"
 if [ "$CHANGED_FILES" != "" ]
 then
     exec flake8 $CHANGED_FILES

--- a/tests/lint_changed.sh
+++ b/tests/lint_changed.sh
@@ -9,7 +9,12 @@
 # This shell script lints only the things that changed in the most recent change.
 # It's much more strict than our check for lint across the entire code base.
 
-CHANGED_FILES="$(git diff --name-only master... | grep '\.py$' | tr '\n' ' ')"
+set -e
+flake8 --version | grep '^3\.6\.' >/dev/null || \
+    ( echo "Please install flake8 >=3.6.0." && false )
+
+FORK_POINT="$(git merge-base --fork-point origin/master)"
+CHANGED_FILES="$(git diff --name-only $FORK_POINT | grep '\.py$' | tr '\n' ' ')"
 if [ "$CHANGED_FILES" != "" ]
 then
     exec flake8 $CHANGED_FILES


### PR DESCRIPTION
For about a week now, we've noticed weird lint issues in travis that we can't recreate.

Turns out, there was a new version of flake8 released, so travis's `pip install` grabs that. The semantics of ignore changed, breaking a lot people's builds.

One annoyance: it requires us to upgrade flake8 locally.

Here's the relevant flake8 issue:
https://gitlab.com/pycqa/flake8/issues/466

~~Note @emilydinan that this also does the same fork point fix we did for unit tests. Please say no if I've gone too far.~~ nevermind, too much work