### PR TITLE
Memoize beam hypos on the way

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -28,7 +28,7 @@ from parlai.core.utils import (set_namedtuple_defaults, argsort, padded_tensor,
 try:
     import torch
 except ImportError as e:
-    raise ImportError('Need to install Pytorch: go to pytorch.org')
+    raise e('Need to install Pytorch: go to pytorch.org')
 
 
 from torch import optim

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -988,7 +988,8 @@ class Beam(object):
 
         self.outputs.append(tok_ids)
         self.bookkeep.append(hyp_ids)
-        self.partial_hyps = [self.partial_hyps[hyp_ids[i]] + [tok_ids[i].item()] for i in range(self.beam_size)]
+        self.partial_hyps = [self.partial_hyps[hyp_ids[i]] +
+                             [tok_ids[i].item()] for i in range(self.beam_size)]
 
         #  check new hypos for eos label, if we have some, add to finished
         for hypid in range(self.beam_size):

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -27,8 +27,8 @@ from parlai.core.utils import (set_namedtuple_defaults, argsort, padded_tensor,
 
 try:
     import torch
-except ImportError as e:
-    raise e('Need to install Pytorch: go to pytorch.org')
+except ImportError:
+    raise ImportError('Need to install Pytorch: go to pytorch.org')
 
 
 from torch import optim


### PR DESCRIPTION
So actually previous way of getting current hypos was terrible (I did it so yeah, terrible), with ngram block 7 speed was like this on twitter:
```bash
33s elapsed: {'exs': 32, '%done': '0.31%', 'time_left': '10717s', 'accuracy': 0, 'f1': 0.08652, 'bleu': 5.141e-06, 'token_acc': 0.3022, 'loss': 4.142, 'ppl': 62.91}                                                                                                                                                        
60s elapsed: {'exs': 64, '%done': '0.62%', 'time_left': '9728s', 'accuracy': 0, 'f1': 0.07378, 'bleu': 5.256e-06, 'token_acc': 0.3022, 'loss': 4.177, 'ppl': 65.2}                                                                                                                                                          
109s elapsed: {'exs': 96, '%done': '0.92%', 'time_left': '11792s', 'accuracy': 0, 'f1': 0.08872, 'bleu': 0.004175, 'token_acc': 0.3049, 'loss': 4.102, 'ppl': 60.47}                                                                                                                                                        
159s elapsed: {'exs': 128, '%done': '1.23%', 'time_left': '12795s', 'accuracy': 0, 'f1': 0.08498, 'bleu': 0.003132, 'token_acc': 0.3106, 'loss': 4.014, 'ppl': 55.35}
```

with new hyps cache it is like this:
```
2s elapsed: {'exs': 32, '%done': '0.31%', 'time_left': '704s', 'accuracy': 0, 'f1': 0.08652, 'bleu': 5.141e-06, 'token_acc': 0.3022, 'loss': 4.142, 'ppl': 62.91}                                                                                                                                                          
6s elapsed: {'exs': 96, '%done': '0.92%', 'time_left': '733s', 'accuracy': 0, 'f1': 0.08872, 'bleu': 0.004175, 'token_acc': 0.3049, 'loss': 4.102, 'ppl': 60.47}                                                                                                                                                           
9s elapsed: {'exs': 128, '%done': '1.23%', 'time_left': '767s', 'accuracy': 0, 'f1': 0.08498, 'bleu': 0.003132, 'token_acc': 0.3106, 'loss': 4.014, 'ppl': 55.35}                                                                                                                                                          
11s elapsed: {'exs': 160, '%done': '1.54%', 'time_left': '758s', 'accuracy': 0, 'f1': 0.07828, 'bleu': 0.002505, 'token_acc': 0.2996, 'loss': 4.15, 'ppl': 63.41}
```

my bad