### PR TITLE
parlai dialog should return copy of its messages, not the (modifiable) original

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -1198,7 +1198,7 @@ class ParlAIDialogTeacher(FixedDialogTeacher):
         return len(self.episodes)
 
     def get(self, episode_idx, entry_idx=None):
-        return self.episodes[episode_idx][entry_idx]
+        return self.episodes[episode_idx][entry_idx].copy()
 
     def _setup_data(self, path):
         print("[loading parlAI text data:" + path + "]")


### PR DESCRIPTION
torch_agent modifies the message dict that it receives, which for parlai dialog teacher (e.g. fromfile tasks), the original message is modified, becoming corrupted over time e.g. by p1/p2 tokens piling up within the messages