### PR TITLE
Revert last commit, which broke pytorch 0.3 backwards compatibility

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -186,10 +186,10 @@ class Seq2seqAgent(TorchAgent):
         # set up criteria
         if opt.get('numsoftmax', 1) > 1:
             self.criterion = nn.NLLLoss(
-                ignore_index=self.NULL_IDX, reduction='sum')
+                ignore_index=self.NULL_IDX, size_average=False)
         else:
             self.criterion = nn.CrossEntropyLoss(
-                ignore_index=self.NULL_IDX, reduction='sum')
+                ignore_index=self.NULL_IDX, size_average=False)
 
         if self.use_cuda:
             self.criterion.cuda()


### PR DESCRIPTION
Whoops, mistakenly pushed to master on the last [commit](https://github.com/facebookresearch/ParlAI/commit/c42b2b0b0f4c368621f4b83216537c06e6460184), and it broke pytorch 0.3 backwards compatibility. Reverting.