### PR TITLE
during eval revert to vocab when no cands in ranker

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -546,7 +546,6 @@ class TorchAgent(Agent):
                 for i, c in enumerate(vecs):
                     vecs[i] = self._check_truncate(c, truncate)
         elif self.rank_candidates and obs.get('label_candidates'):
-            # import pdb; pdb.set_trace()
             obs['label_candidates'] = list(obs['label_candidates'])
             obs['label_candidates_vecs'] = [
                 self._vectorize_text(c, add_start, add_end, truncate, False)

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -545,7 +545,8 @@ class TorchAgent(Agent):
                 vecs = obs['label_candidates_vecs']
                 for i, c in enumerate(vecs):
                     vecs[i] = self._check_truncate(c, truncate)
-        elif self.rank_candidates and 'label_candidates' in obs:
+        elif self.rank_candidates and obs.get('label_candidates'):
+            # import pdb; pdb.set_trace()
             obs['label_candidates'] = list(obs['label_candidates'])
             obs['label_candidates_vecs'] = [
                 self._vectorize_text(c, add_start, add_end, truncate, False)


### PR DESCRIPTION
error flagged in #1271, during interactive mode no candidates are available so model crashes

this way model can at least send one-token replies during eval to attempt to answer the question

during training, if a batch happens to have no labels, skip it (some datasets have a final text-only example at the end of episodes with no label)