### PR TITLE
update ranking error message

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -545,7 +545,7 @@ class TorchAgent(Agent):
                 vecs = obs['label_candidates_vecs']
                 for i, c in enumerate(vecs):
                     vecs[i] = self._check_truncate(c, truncate)
-        elif self.rank_candidates and 'label_candidates' in obs:
+        elif self.rank_candidates and obs.get('label_candidates'):
             obs['label_candidates'] = list(obs['label_candidates'])
             obs['label_candidates_vecs'] = [
                 self._vectorize_text(c, add_start, add_end, truncate, False)

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -220,7 +220,8 @@ class TorchRankerAgent(TorchAgent):
                 raise ValueError(
                     "If using candidate source 'inline', then batch.candidate_vecs "
                     "cannot be None. If your task does not have inline candidates, "
-                    "consider using one of --candidates={'batch','fixed','vocab'}.")
+                    "consider using one of --{m}={{'batch','fixed','vocab'}}."
+                    "".format(m='candidates' if mode == 'train' else 'eval-candidates'))
 
             cands = batch.candidates
             cand_vecs = padded_3d(batch.candidate_vecs, use_cuda=self.use_cuda)


### PR DESCRIPTION
the error message that printed before didn't work because changing -cands doesn't change ecands for a loaded model, even if ecands wasn't manually set originally. now it's more obvious to use ecands to change candidate set.