### PR TITLE
Workaround for batch mturk bug.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -227,7 +227,12 @@ class TorchAgent(Agent):
             # copy initialized data from shared table
             self.opt = shared['opt']
             self.dict = shared['dict']
-            self.replies = shared['replies']
+            if self.opt['batchsize'] == 1:
+                # if we're not using batching (e.g. mturk), then replies really need
+                # to stay separated
+                self.replies = {}
+            else:
+                self.replies = shared['replies']
 
         if opt.get('numthreads', 1) > 1:
             torch.set_num_threads(1)


### PR DESCRIPTION
As discussed, our temporary work around. Flagging @abisee just for fun.

For posterity, the bug revolves around the different settings between (1) hogwild (2) batch/gpu (3) mturk.

* Hogwild: separate processes are created for each instance. The resulting self.replies is a different object for every process, and therefore cleared independently. Dialogue history is maintained correctly.
* Batch/GPU: self.replies is shared across instances. Agents are created *once* and reused for each training batch. The replies are cleared at the proper time, and so dialogue history is maintained correctly
* Mturk: Every single time a turker starts a process, any calls to reset() will wipe self.replies, causing a model to forget its most recent reply. In this work around, we explicitly use separate replies when batch size is set to 1.

This patch is not desirable, theoretically we want hogwild + batch, which this patch will break.