### PR TITLE
change default value of empty observation to {} from None

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -881,7 +881,7 @@ class TorchAgent(Agent):
 
     def reset(self):
         """Clear internal states."""
-        self.observation = None
+        self.observation = {}
         self.history.clear()
         self.replies.clear()
         self.reset_metrics()


### PR DESCRIPTION
this allows the model to be the first to speak without getting an error for finding None, e.g. in #1292 