### PR TITLE
Personality Captions Human Eval Task

### DIFF
--- a/parlai/mturk/tasks/personality_captions/stack_rank_evals/__init__.py
+++ b/parlai/mturk/tasks/personality_captions/stack_rank_evals/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/parlai/mturk/tasks/personality_captions/stack_rank_evals/html/Chooser_index.html
+++ b/parlai/mturk/tasks/personality_captions/stack_rank_evals/html/Chooser_index.html
@@ -1,0 +1,282 @@
+{% extends "core.html" %}
+
+{% block left_pane %}
+  <div id="left-pane" class="col-xs-3" style="height: {{frame_height}}px; background-color: #dff0d8;">
+    <h1>Choose More Engaging Comment on an Image</h1>
+    <div id="left-top-pane" style="height: 80%; overflow:auto;">
+      <hr style="border-top: 1px solid #555" />
+        <span id="task-description" style="font-size: 14px">
+        </span>
+    </div>
+  </div>
+  <div id="image-pane" class="col-xs-5" style="height: {{frame_height}}px; background-color: #dff0d8;">
+    <h1>Image</h1>
+    <div id="image-main-pane" style="height: 80%;">
+      <hr style="border-top: 1px solid #555" />
+      <img src="" id="comment-image" style="max-width: 100%; max-height: 65%;">
+      <br>
+      <span id="task-personality" style="font-size: 16px"></span>
+      <br>
+      <hr style="border-top: 1px solid #555" />
+      <form id="comment-selection-form" style="display: none;">
+        <div class="radio">
+          <input type="radio" name="optradio" value="0"><label id="first_option_label"></label>
+        </div>
+        <div class="radio">
+          <input type="radio" name="optradio" value="1"><label id="second_option_label"></label>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}
+{% block right_pane %}
+<div id="right-pane" style="min-height: 100%; display: flex; flex-direction: column; justify-content: space-between;">
+    <div id="right-top-pane" style="width: 100%; height: 570px; padding-top: 60px; padding-left: 20px; padding-right: 20px; padding-bottom: 20px; overflow:scroll; ">
+        <div id="message_thread" style="width: 100%">
+        </div>
+        <div id="waiting-for-message" class="row" style="margin-left: 0; margin-right: 0; display: none">
+            <div class="alert alert-warning" role="alert" style="float: left; display:table; background-color: #fff">
+                <div id="hourglass" style="margin-top: -1px; margin-right: 5px; display: inline; float: left;">
+                    <?xml version="1.0" encoding="utf-8"?><svg width='25px' height='25px' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" class="uil-hourglass"><rect x="0" y="0" width="100" height="100" fill="none" class="bk"></rect><g><path fill="none" stroke="#007282" stroke-width="5" stroke-miterlimit="10" d="M58.4,51.7c-0.9-0.9-1.4-2-1.4-2.3s0.5-0.4,1.4-1.4 C70.8,43.8,79.8,30.5,80,15.5H70H30H20c0.2,15,9.2,28.1,21.6,32.3c0.9,0.9,1.4,1.2,1.4,1.5s-0.5,1.6-1.4,2.5 C29.2,56.1,20.2,69.5,20,85.5h10h40h10C79.8,69.5,70.8,55.9,58.4,51.7z" class="glass"></path><clipPath id="uil-hourglass-clip1"><rect x="15" y="20" width="70" height="25" class="clip"><animate attributeName="height" from="25" to="0" dur="1.5s" repeatCount="indefinite" values="25;0;0" keyTimes="0;0.5;1"></animate><animate attributeName="y" from="20" to="45" dur="1.5s" repeatCount="indefinite" values="20;45;45" keyTimes="0;0.5;1"></animate></rect></clipPath><clipPath id="uil-hourglass-clip2"><rect x="15" y="55" width="70" height="25" class="clip"><animate attributeName="height" from="0" to="25" dur="1.5s" repeatCount="indefinite" values="0;25;25" keyTimes="0;0.5;1"></animate><animate attributeName="y" from="80" to="55" dur="1.5s" repeatCount="indefinite" values="80;55;55" keyTimes="0;0.5;1"></animate></rect></clipPath><path d="M29,23c3.1,11.4,11.3,19.5,21,19.5S67.9,34.4,71,23H29z" clip-path="url(#uil-hourglass-clip1)" fill="#ffab00" class="sand"></path><path d="M71.6,78c-3-11.6-11.5-20-21.5-20s-18.5,8.4-21.5,20H71.6z" clip-path="url(#uil-hourglass-clip2)" fill="#ffab00" class="sand"></path><animateTransform attributeName="transform" type="rotate" from="0 50 50" to="180 50 50" repeatCount="indefinite" dur="1.5s" values="0 50 50;0 50 50;180 50 50" keyTimes="0;0.7;1"></animateTransform></g></svg>
+                </div>
+                <span style="font-size: 16px">Loading...</span>
+            </div>
+        </div>
+    </div>
+
+    <div id="right-bottom-pane" style="width: 100%; background-color: #eee">
+        <div id="response-type-idle" class="response-type-module" style="display:none">
+        </div>
+        <div id="response-type-text-input" class="response-type-module" style="padding-left: 35px; padding-top: 30px; padding-bottom: 30px; padding-right: 35px; float: left; display:none">
+            <div style="height: 50px; width: 100%; display: block; float: left; ">
+                <input id="id_text_input" type="text" style="width: 60%; height: 100%; float: left; font-size: 16px" class="form-control" value="" placeholder="Please enter here...">
+                <button class="btn btn-success" style="width: 88px; height: 100%; font-size: 16px; float: left; margin-left: 15px; padding: 0px; disabled: true; display:none" id="id_done_button">Done</button>
+                <button class="btn btn-primary" style="width: 88px; height: 100%; font-size: 16px; float: right; margin-left: 15px; padding: 0px; disabled: false;" id="id_send_msg_button">Send</button>
+            </div>
+        </div>
+        <div id="response-type-done" class="response-type-module" style="padding-left: 35px; padding-top: 30px; padding-bottom: 30px; padding-right: 35px; float: left; display:none">
+            <span id="inactive" style="font-size: 14pt;margin-right: 15px"></span>
+            <button id="done-button" type="button" class="btn btn-primary btn-lg">
+                <span class="glyphicon glyphicon-ok-circle" aria-hidden="true"></span> Done with this HIT
+            </button>
+        </div>
+    </div>
+</div>
+{% endblock %}
+{% block additional_scripts %}
+<script type="text/javascript">
+
+    var exceed_min_turns = false;
+    var eval = false;
+
+    function handle_new_message(new_message_id, message) {
+      if(message.text === undefined) {
+        return;
+      }
+      var agent_id = message.id;
+      var message_text = message.text.replace(/(?:\r\n|\r|\n)/g, '<br />');
+      if (displayed_messages.indexOf(new_message_id) !== -1) {
+        // This message has already been seen and put up into the chat
+        log(new_message_id + ' was a repeat message', 1);
+        return;
+      }
+      log('New message, ' + new_message_id + ' from agent ' + agent_id, 1);
+      displayed_messages.push(new_message_id);
+      if (message_text !== '') {
+        if (agent_id !== cur_agent_id) {
+          add_message_to_conversation(agent_id, message_text, false);
+        }
+        else {
+          add_message_to_conversation(agent_id, message_text, true);
+        }
+      }
+      if ("description" in message) {
+        $("span#task-description").html(message.description);
+      }
+      if ("image" in message) {
+        var image = message.image;
+        image = `data:image/jpeg;base64,${image}`;
+
+        $("#comment-image").attr('src', image);
+      }
+      if ("exceed_min_turns" in message && message.exceed_min_turns == true) {
+        exceed_min_turns = true
+        $("button#id_done_button").css("disabled", false);
+        $("button#id_done_button").css("display", "");
+        $("input#id_text_input").css("width", "40%");
+        $(window).resize(window_resize);
+      }
+      if("new_eval" in message) {
+        $("#comment-selection-form").show();
+        if("personality" in message) {
+          $("#task-personality").html(`<br><b>Personality of Commenter:</b> ${message.personality}`);
+        }
+        if(message.new_eval == true) {
+          var comments = message.comments;
+          $("label#first_option_label").text(comments[0]);
+          $("label#first_option_label").css("color", "black");
+          $("label#second_option_label").text(comments[1]);
+          $("label#second_option_label").css("color", "black");
+          $("input[type='radio']").each(function (index) {
+            $(this).prop('checked', false);
+            $(this).show();
+          });
+        }
+        else {
+          $("input[type='radio'][name='optradio']:checked").hide();
+          var val = $("input[type='radio'][name='optradio']:checked").val()
+          if (val == "0") {
+            $("label#first_option_label").css("color", "gray");
+          }
+          else if (val == "1") {
+            $("label#second_option_label").css("color", "gray");
+          }
+          else {
+            $("label#third_option_label").css("color", "gray");
+          }
+        }
+      }
+    }
+
+    $("button#id_done_button").on('click', function () {
+        var text = "I am done with the chat and clicked the 'Done' button, thank you!";
+        if (!(text == '')) {
+            $("button#id_done_button").css("disabled", true);
+            new_message_id = uuidv4();
+
+            send_packet(
+                TYPE_MESSAGE,
+                {text: text,
+                 id: cur_agent_id,
+                 message_id: new_message_id,
+                 episode_done: true},
+                true,
+                true,
+                function(msg) {
+                    $("button#id_done_button").css("disabled", false);
+                    $("input#id_text_input").val("");
+                    $("div#response-type-text-input").css("display", "none");
+                    handle_new_message(new_message_id, msg.data);
+                }
+            );
+        }
+    });
+
+    $("input[type='radio']").change(function () {
+      if($(this).is(":checked")) {
+        $("button#submit-task-eval").css("disabled", false);
+      }
+    });
+
+    $("button#id_submit_comment_eval").on('click', function () {
+        var has_evaled = false;
+        $("input[type='radio']").each(function (index) {
+          if($(this).is(":checked")) {
+            has_evaled = true;
+          }
+        });
+        if (!has_evaled) {
+          new_message_id =  uuidv4();
+          var msg = {id: "SYSTEM", text: `Please select one of the options, and then click submit.`};
+          handle_new_message(new_message_id, msg);
+          $("div#waiting-for-message").css("display", "none");
+          return;
+        }
+        var eval_value = $("input[type='radio'][name='optradio']:checked").val();
+
+        $("button#id_done_button").css("disabled", true);
+        new_message_id = uuidv4();
+        send_packet(
+            TYPE_MESSAGE,
+            {text: eval_value,
+             id: cur_agent_id,
+             message_id: new_message_id,
+             episode_done: false},
+            true,
+            true,
+            function(msg) {
+                $("button#id_done_button").css("disabled", false);
+                $("input#id_text_input").val("");
+                $("div#response-type-text-input").css("display", "none");
+                handle_new_message(new_message_id, msg.data);
+                after_send_packet();
+            }
+        );
+
+    });
+
+    $("button#id_send_msg_button").off('click');
+    // Handle submitting a message
+    $("button#id_send_msg_button").on('click', function () {
+      var has_evaled = false;
+      $("input[type='radio']").each(function (index) {
+        if($(this).is(":checked")) {
+          has_evaled = true;
+        }
+      });
+      if (!has_evaled) {
+        new_message_id =  uuidv4();
+        var msg = {id: "SYSTEM", text: `Please select one of the options, and then click submit.`};
+        handle_new_message(new_message_id, msg);
+        $("div#waiting-for-message").css("display", "none");
+        return;
+      }
+
+      var text = $("input#id_text_input").val();
+      var eval_value = $("input[type='radio'][name='optradio']:checked").val();
+
+      if (!(text == '')) {
+        // Disable the send button
+        new_message_id = uuidv4();
+        if(text.split(" ").length <= 2){
+          var msg = {id: "SYSTEM", text: "Please enter a minimum of 3 words, thanks!"};
+          handle_new_message(new_message_id, msg);
+          $("div#waiting-for-message").css("display", "none");
+          return;
+        }
+        $("button#id_send_msg_button").prop("disabled", true);
+
+        // Send a packet
+        send_packet(
+          TYPE_MESSAGE,
+          {
+            text: text,
+            chosen: eval_value,
+            id: cur_agent_id,
+            message_id: new_message_id,
+            episode_done: false
+          },
+          true,
+          true,
+          function(msg) {
+            // On callback enable the button and clear the text field
+            $("button#id_send_msg_button").prop("disabled", false);
+            $("input#id_text_input").val("");
+            $("div#response-type-text-input").css("display", "none");
+            // push the message into the conversation
+            handle_new_message(new_message_id, msg.data);
+            after_send_packet();
+          }
+        );
+      }
+    });
+
+
+    // On window resize, ensure that the UI is properly displayed
+    function window_resize() {
+      log("The window was resized", 4);
+      // Set the text input width to match the bottom width minus space
+      // for the done button
+      $("input#id_text_input").width($("div#right-bottom-pane").width() - 210);
+      if(exceed_min_turns == true) {
+        $("input#id_text_input").width($("input#id_text_input").width() - 100);
+      }
+
+      // Set the chat window height to be the remainder after removing the
+      // height of the text pane
+      var left_height = $("div#left-pane").height();
+      var text_height = $("div#right-bottom-pane").outerHeight();
+      $("div#right-top-pane").height((left_height - text_height) - 20);
+    }
+</script>
+{% endblock %}

--- a/parlai/mturk/tasks/personality_captions/stack_rank_evals/html/cover_page.html
+++ b/parlai/mturk/tasks/personality_captions/stack_rank_evals/html/cover_page.html
@@ -1,0 +1,10 @@
+{% extends "core.html" %}
+
+{% block main_pane %}
+<div id="main-pane" class="col-xs-12" style="height: {{frame_height}}px; background-color: #dff0d8; padding: 30px; overflow:scroll;">
+    <h1>Choose More Engaging Comment on an Image</h1>
+    <hr style="border-top: 1px solid #555" />
+    <span id="task-description" style="font-size: 16px">
+    </span>
+</div>
+{% endblock %}

--- a/parlai/mturk/tasks/personality_captions/stack_rank_evals/html/onboarding_index.html
+++ b/parlai/mturk/tasks/personality_captions/stack_rank_evals/html/onboarding_index.html
@@ -1,0 +1,59 @@
+{% extends "core.html" %}
+{% block main_pane %}
+<div id="main-pane" style="width: 100%; height: {{frame_height}}px; background-color: #dff0d8; padding: 30px; overflow:scroll;  ">
+<span id="task-description" style="font-size: 16px"></span>
+<hr style="border-top: 1px solid #555" />
+<span id="task-personality" style="font-size: 16px"></span>
+</div>
+<div id="bottom-pane" style="width: 100%; background-color: #eee;">
+    <div id="response-type-idle" class="response-type-module" style="display:none">
+    </div>
+    <div id="response-type-text-input" class="response-type-module" style="padding-left: 35px; padding-top: 30px; padding-bottom: 30px; padding-right: 35px; float: left; display: none;">
+        <div style="height: 50px; width: 100%; display: block; float: left; ">
+            <button class="btn btn-primary" style="width: 230px; height: 100%; font-size: 16px; float: left; margin-left: 10px; padding: 0px;" id="id_send_msg_button">I am ready, continue</button>
+        </div>
+    </div>
+    <div id="response-type-waiting" class="response-type-module" style="height: 50px; width: 100%; display: block; float: left; ">
+        <span id="waiting" style="font-size: 16pt; padding-top: 30px; padding-left: 30px; margin-right: 15px">Task Loading...</span>
+    </div>
+    <div id="response-type-done" class="response-type-module" style="padding-left: 35px; padding-top: 30px; padding-bottom: 30px; padding-right: 35px; float: left; display:none">
+        <span id="disconnect" style="font-size: 14pt;margin-right: 15px"></span>
+        <button id="done-button" type="button" class="btn btn-primary btn-lg">
+            <span class="glyphicon glyphicon-ok-circle" aria-hidden="true"></span> Done with this HIT
+        </button>
+    </div>
+    <div id="response-type-inactive" class="response-type-module" style="padding-left: 35px; padding-top: 30px; padding-bottom: 30px; padding-right: 35px; float: left">
+        <span id="inactive" style="font-size: 16px"></span>
+    </div>
+</div>
+{% endblock %}
+
+{% block additional_scripts %}
+<script type="text/javascript">
+
+  var old_msg_function = handle_new_message
+
+  handle_new_message = function(new_message_id, message) {
+    if(message.text === undefined) {
+      $("div#response-type-waiting").css("display", "");
+      return
+    }
+    old_msg_function.apply(old_msg_function, [new_message_id, message])
+    console.log(message)
+    var message_text = message.text.replace(/(?:\r\n|\r|\n)/g, '<br />');
+
+    if ("show_personality" in message) {
+        $("span#task-personality").html(message_text);
+      }
+    if ("task_description" in message) {
+        $("span#task-description").html(message.role_task_description);
+    }
+  }
+
+  function window_resize() {
+  }
+  $(window).resize(window_resize);
+  window.setTimeout(function(){$('#id_send_msg_button').focus()}, 1000);
+  function scroll_conversation_to_bottom() {}
+</script>
+{% endblock %}

--- a/parlai/mturk/tasks/personality_captions/stack_rank_evals/run.py
+++ b/parlai/mturk/tasks/personality_captions/stack_rank_evals/run.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+from parlai.core.params import ParlaiParser
+from parlai.mturk.core.mturk_manager import MTurkManager
+from worlds import \
+    MTurkCommentBattleStackRankWorld, RoleOnboardWorld, \
+    ExampleGenerator, CHOOSER
+from parlai.tasks.personality_captions.agents import PersonalityCaptionsTeacher
+from task_config import task_config
+import os
+
+
+# fill with dict keys of an example for each thing to compare
+key_choices = ['comment']
+
+
+def main():
+    """
+        Human Evaluation of various image captions/comments.
+
+        A turker is shown an image and two possible comments/captions, and
+        optionally the personality used to create these captions. Then, the
+        turker is asked to choose which caption they think is more engaging.
+
+        In this example, we will just be comparing the original comment twice
+        (this is just to demonstrate the task for future use).
+    """
+    argparser = ParlaiParser(False, False)
+    argparser.add_parlai_data_path()
+    argparser.add_mturk_args()
+    argparser.add_argument('-mx_rsp_time', '--max_resp_time', default=1800,
+                           type=int,
+                           help='time limit for entering a dialog message')
+    argparser.add_argument('-mx_onb_time', '--max_onboard_time', type=int,
+                           default=300, help='time limit for turker'
+                           'in onboarding')
+    argparser.add_argument('-ni', '--num_images', type=int,
+                           default=10, help='number of images to show \
+                           to turker')
+    argparser.add_argument('--data-path', type=str,
+                           default='', help='where to save data')
+    argparser.add_argument('-ck1', '--compare-key-1', type=str,
+                           default='comment',
+                           choices=key_choices,
+                           help='key of first option to compare')
+    argparser.add_argument('-ck2', '--compare-key-2', type=str,
+                           default='comment',
+                           choices=key_choices,
+                           help='key of second option to compare')
+    argparser.add_argument('--show-personality', default=True, type='bool',
+                           help='whether to show the personality')
+    PersonalityCaptionsTeacher.add_cmdline_args(argparser)
+    opt = argparser.parse_args()
+    directory_path = os.path.dirname(os.path.abspath(__file__))
+    opt['task'] = os.path.basename(directory_path)
+    if 'data_path' not in opt or opt['data_path'] == '':
+        opt['data_path'] = os.getcwd() + '/data/' + opt['task']
+    opt.update(task_config)
+
+    mturk_agent_ids = [CHOOSER]
+    mturk_manager = MTurkManager(
+        opt=opt,
+        mturk_agent_ids=mturk_agent_ids
+    )
+
+    example_generator = ExampleGenerator(opt)
+    mturk_manager.setup_server(task_directory_path=directory_path)
+
+    try:
+        mturk_manager.start_new_run()
+
+        def run_onboard(worker):
+            worker.example_generator = example_generator
+            world = RoleOnboardWorld(opt, worker)
+            world.parley()
+            world.shutdown()
+
+        mturk_manager.set_onboard_function(onboard_function=run_onboard)
+        mturk_manager.ready_to_accept_workers()
+        mturk_manager.create_hits()
+
+        def check_worker_eligibility(worker):
+            return True
+
+        def assign_worker_roles(workers):
+            for w in workers:
+                w.id = mturk_agent_ids[0]
+
+        def run_conversation(mturk_manager, opt, workers):
+            agents = workers[:]
+            conv_idx = mturk_manager.conversation_index
+            world = MTurkCommentBattleStackRankWorld(
+                opt,
+                agents=agents,
+                world_tag='conversation t_{}'.format(conv_idx),
+            )
+            while not world.episode_done():
+                world.parley()
+            world.save_data()
+
+            world.shutdown()
+            world.review_work()
+
+        mturk_manager.start_task(
+            eligibility_function=check_worker_eligibility,
+            assign_role_function=assign_worker_roles,
+            task_function=run_conversation
+        )
+
+    except BaseException:
+        raise
+    finally:
+        mturk_manager.expire_all_unassigned_hits()
+        mturk_manager.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/parlai/mturk/tasks/personality_captions/stack_rank_evals/run.py
+++ b/parlai/mturk/tasks/personality_captions/stack_rank_evals/run.py
@@ -37,7 +37,22 @@ def main():
                 .
             }
         Note that compare_key_1 and compare_key_2 can be any field, as long as they
-        map to a string comment/caption
+        map to a string comment/caption.
+
+        Example Scenario:
+            Suppose you have the original Personality-Captions dataset, and
+            you would like to compare the outputs of your model called `model`.
+
+            Your data may look like the following:
+            [{
+                'image_hash': hashforimageofcat,
+                'personality': 'Sweet',
+                'comment': 'Look at the cute cat!', # Human Comment
+                'model_comment': 'That's a weird looking dog' # Model Comment
+            }, ...]
+
+            Thus, you would specify `-ck1 comment -ck2 model_comment` to evaluate
+            the outputs of the model vs. the human comments from Personality-Captions
     """
     argparser = ParlaiParser(False, False)
     argparser.add_parlai_data_path()

--- a/parlai/mturk/tasks/personality_captions/stack_rank_evals/run.py
+++ b/parlai/mturk/tasks/personality_captions/stack_rank_evals/run.py
@@ -13,10 +13,6 @@ from task_config import task_config
 import os
 
 
-# fill with dict keys of an example for each thing to compare
-key_choices = ['comment']
-
-
 def main():
     """
         Human Evaluation of various image captions/comments.
@@ -27,6 +23,21 @@ def main():
 
         In this example, we will just be comparing the original comment twice
         (this is just to demonstrate the task for future use).
+
+        To use your own data, please specify `--eval-data-path` to an
+        appropriate json file with a list of examples, where each example
+        has the following structure:
+            {
+                'image_hash': <hash of image>,
+                'personality': <personality, if applicable>,
+                '<compare_key_1>': <first option to compare>,
+                '<compare_key_2>': <second option to compare>,
+                .
+                .
+                .
+            }
+        Note that compare_key_1 and compare_key_2 can be any field, as long as they
+        map to a string comment/caption
     """
     argparser = ParlaiParser(False, False)
     argparser.add_parlai_data_path()
@@ -42,13 +53,14 @@ def main():
                            to turker')
     argparser.add_argument('--data-path', type=str,
                            default='', help='where to save data')
+    argparser.add_argument('--eval-data-path', type=str, default='',
+                           help='where to load data to rank from. Leave '
+                                'blank to use Personality-Captions data')
     argparser.add_argument('-ck1', '--compare-key-1', type=str,
                            default='comment',
-                           choices=key_choices,
                            help='key of first option to compare')
     argparser.add_argument('-ck2', '--compare-key-2', type=str,
                            default='comment',
-                           choices=key_choices,
                            help='key of second option to compare')
     argparser.add_argument('--show-personality', default=True, type='bool',
                            help='whether to show the personality')

--- a/parlai/mturk/tasks/personality_captions/stack_rank_evals/task_config.py
+++ b/parlai/mturk/tasks/personality_captions/stack_rank_evals/task_config.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+task_config = {}
+
+"""A short and descriptive title about the kind of task the HIT contains.
+On the Amazon Mechanical Turk web site, the HIT title appears in search results,
+and everywhere the HIT is mentioned.
+"""
+task_config['hit_title'] = 'Choose Most Engaging Comment on an Image'
+
+
+"""A description includes detailed information about the kind of task the HIT contains.
+On the Amazon Mechanical Turk web site, the HIT description appears in the expanded
+view of search results, and in the HIT and assignment screens.
+"""
+task_config['hit_description'] = 'You will choose the most engaging '
+'comment on an image.'
+
+
+"""One or more words or phrases that describe the HIT, separated by commas.
+On MTurk website, these words are used in searches to find HITs.
+"""
+task_config['hit_keywords'] = 'image'
+
+
+"""A detailed task description that will be shown on the HIT task preview page
+and on the left side of the chat page. Supports HTML formatting.
+"""
+task_config['task_description'] = \
+    '''
+<h2><b>Description</b></h2>
+In this task, you will be shown 5 images, each with two comments.
+The goal of this task is to pick which comment is the <b><span style="color:blue">
+most engaging (interesting, captivating, attention-grabbing)</span></b>.
+<br>
+<br>
+<h4><b>STEP 1</b></h4> You will be shown an image and two comments.
+Additionally, you may be shown the personality of the person who wrote the image.
+<br>
+<br>
+E.g., you may be shown an image of a tree, and the following two comments:
+<br> 1. "A tree in a park in the summer time"
+<br> 2. "What an absolutely beautiful tree! I would put this in my living room
+it's so extravagent!"
+<br>
+<br>
+And, you may be shown a personality, e.g. 'Cheerful'.
+<br>
+<br>
+<h4><b>STEP 2</b></h4> You will choose which comment is <b><span
+style="color:blue">more engaging</span></b>.
+<br>
+<br>
+E.g. in the example above, the second comment is more engaging than the first.
+<br>
+<br>
+<h4><b>STEP 3</b></h4> You will describe why you feel the comment you chose is
+<b><span style="color:blue">more engaging</span></b>.
+<br>
+<br>
+You will then write a reason indicating why you believe this comment is
+the more engaging one.
+<br>
+E.g. in the example above, you may say "The comment I chose was more lively
+and entertaining."
+<br>
+<h4><b>REWARD/BONUS</b></h4>
+To complete this task, <b><span style="color:blue">you must rank the comments
+on ALL 5 images.</span></b>
+If you complete the task, you will receive $0.46.
+<br>
+<br>
+<br>
+<h4><b>CLOSE WINDOW/TIMEOUT/RETURN HIT</b></h4>
+Once the task has started, close window/timeout or return HIT will result in
+<b><span style="color:blue">HIT EXPIRED</span></b> to you and NO reward paid.
+<br>
+<br>
+<br>
+If you are ready, please click "Accept HIT" to start this task.
+'''

--- a/parlai/mturk/tasks/personality_captions/stack_rank_evals/worlds.py
+++ b/parlai/mturk/tasks/personality_captions/stack_rank_evals/worlds.py
@@ -53,8 +53,11 @@ class ExampleGenerator(object):
             opt['compare_key_2'])
         self.examples_idx_stack_path = os.path.join(os.getcwd(), handle)
         build_pc(opt)
-        data_path = os.path.join(self.opt['datapath'],
-                                 'personality_captions/train.json')
+        if opt.get('eval_data_path') != '':
+            data_path = opt.get('eval_data_path')
+        else:
+            data_path = os.path.join(self.opt['datapath'],
+                                     'personality_captions/train.json')
         with open(data_path) as f:
             self.data = json.load(f)
 

--- a/parlai/mturk/tasks/personality_captions/stack_rank_evals/worlds.py
+++ b/parlai/mturk/tasks/personality_captions/stack_rank_evals/worlds.py
@@ -1,0 +1,286 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+from parlai.mturk.core.worlds import MTurkOnboardWorld
+from parlai.mturk.core.agents import TIMEOUT_MESSAGE
+from parlai.tasks.personality_captions.build import build as build_pc
+from parlai.core.worlds import validate, MultiAgentDialogWorld
+from joblib import Parallel, delayed
+from task_config import task_config as config
+import numpy as np
+import time
+import os
+import pickle
+import random
+import json
+import base64
+from PIL import Image
+from io import BytesIO
+
+CHOOSER = 'Chooser'
+ONBOARD_MSG = '\nWelcome! \
+        When you are ready to begin, \
+        click the "I am ready, continue" button below\n'
+PICK_BEST_MSG = '\nImage number {}! Please take a look at the image, and select \
+                 the comment you think is <b>more engaging \
+                 (interesting, captivating, attention-grabbing).</b>\
+                  Then, please explain why you chose that comment \
+                  in the chat box below.'
+PICK_WORST_MSG = 'Now, please pick the the comment you think is the <b>LEAST</b> \
+                  engaging.'
+TIMEOUT_MSG = '<b> The other person has timed out. \
+        Please click the "Done with this HIT" button below to finish this HIT.\
+        </b>'
+CHAT_ENDED_MSG = 'You are done with {} images. Thanks for your time! \nPlease \
+        click <span style="color:blue"><b>Done with this HIT</b> </span> \
+        button below to finish this HIT.'
+WAITING_MSG = 'Please wait...'
+
+
+def load_image(path):
+    return Image.open(path).convert('RGB')
+
+
+class ExampleGenerator(object):
+    """Retrieve Example from Personality-Captions Dataset"""
+    def __init__(self, opt):
+        self.opt = opt
+        handle = './examples_stack{}{}{}.pkl'.format(
+            '_sandbox' if opt['is_sandbox'] else '',
+            opt['compare_key_1'],
+            opt['compare_key_2'])
+        self.examples_idx_stack_path = os.path.join(os.getcwd(), handle)
+        build_pc(opt)
+        data_path = os.path.join(self.opt['datapath'],
+                                 'personality_captions/train.json')
+        with open(data_path) as f:
+            self.data = json.load(f)
+
+        if os.path.exists(self.examples_idx_stack_path):
+            with open(self.examples_idx_stack_path, 'rb') as handle:
+                self.idx_stack = pickle.load(handle)
+        else:
+            self.idx_stack = []
+            self.add_idx_stack()
+            self.save_idx_stack()
+
+    def add_idx_stack(self):
+        stack = list(range(len(self.data)))
+        random.seed()
+        random.shuffle(stack)
+        self.idx_stack = stack + self.idx_stack
+
+    def pop_example(self):
+        if len(self.idx_stack) == 0:
+            self.add_idx_stack()
+        idx = self.idx_stack.pop()
+        ex = self.data[idx]
+        return (idx, ex)
+
+    def push_example(self, idx):
+        self.idx_stack.append(idx)
+
+    def save_idx_stack(self):
+        with open(self.examples_idx_stack_path, 'wb') as handle:
+            pickle.dump(self.idx_stack, handle)
+
+
+class RoleOnboardWorld(MTurkOnboardWorld):
+    """A world that provides the appropriate instructions during onboarding"""
+    def __init__(self, opt, mturk_agent):
+        self.task_type = 'sandbox' if opt['is_sandbox'] else 'live'
+        self.max_onboard_time = opt['max_onboard_time']
+        super().__init__(opt, mturk_agent)
+
+    def parley(self):
+        onboard_msg = {
+            'id': 'SYSTEM',
+            'text': ONBOARD_MSG}
+
+        onboard_msg['task_description'] = config['task_description']
+        self.mturk_agent.observe(onboard_msg)
+
+        act = self.mturk_agent.act(timeout=self.max_onboard_time)
+
+        # timeout
+        if act['episode_done'] or (('text' in act and
+                                    act['text'] == TIMEOUT_MESSAGE)):
+            self.episodeDone = True
+            return
+
+        if 'text' not in act:
+            control_msg = {'id': 'SYSTEM',
+                           'text': WAITING_MSG}
+            self.mturk_agent.observe(validate(control_msg))
+            self.episodeDone = True
+
+
+class MTurkCommentBattleStackRankWorld(MultiAgentDialogWorld):
+    """World where an agent observes 5 images and 3 comments about the images,
+       and ranks the comments
+    """
+    def __init__(self, opt, agents=None, shared=None, world_tag='NONE'):
+        self.turn_idx = 0
+        self.task_type = 'sandbox' if opt['is_sandbox'] else 'live'
+        self.chat_done = False
+        self.world_tag = world_tag
+        self.max_resp_time = opt['max_resp_time']  # in secs
+        super().__init__(opt, agents, shared)
+        self.agents = agents
+        self.agent = agents[0]
+        self.data = []
+        self.num_images = opt['num_images']
+        self.ck1 = opt.get('compare_key_1')
+        self.ck2 = opt.get('compare_key_2')
+        self.show_personality = opt.get('show_personality')
+        if opt.get('yfcc_path'):
+            self.image_path = opt['yfcc_path']
+        else:
+            self.image_path = os.path.join(opt['datapath'], 'yfcc_images')
+
+    def episode_done(self):
+        return self.chat_done
+
+    def parley(self):
+        """CHOOSER is given an image and 2 comments/captions, and is asked
+           to choose more engaging comment.
+        """
+        # Initial Message Value
+        control_msg = {'episode_done': False}
+        control_msg['id'] = 'SYSTEM'
+
+        """We only have to worry about 1 agent"""
+        agent = self.agents[0]
+
+        """First, we give CHOOSER the image
+        """
+        while self.turn_idx < self.num_images:
+            print(self.world_tag + ' is at turn {}...'.format(self.turn_idx))
+            # Send image to turker
+            control_msg['description'] = config['task_description']
+            self.example_num, example = self.agent.example_generator.pop_example()
+            img = load_image(os.path.join(
+                             self.image_path,
+                             '{}.jpg'.format(example['image_hash'])))
+            buffered = BytesIO()
+            img.save(buffered, format="JPEG")
+            encoded = str(base64.b64encode(buffered.getvalue()).decode('ascii'))
+            control_msg['image'] = encoded
+            """
+                Setup comments for ranking
+            """
+            comments = [(ck, example[ck]) for ck in [self.ck1, self.ck2]]
+            random.shuffle(comments)
+            control_msg['comments'] = [c[1] for c in comments]
+            if self.show_personality:
+                control_msg['personality'] = '<b><span style="color:blue">' \
+                                               '{}\n</span></b>'.format(
+                                              example['personality'].strip())
+
+            best_pick = None
+            control_msg['text'] = PICK_BEST_MSG.format(self.turn_idx + 1)
+            control_msg['new_eval'] = True
+            agent.observe(validate(control_msg))
+            time.sleep(1)
+            act = agent.act(timeout=self.max_resp_time)
+            # First timeout check
+            self.check_timeout(act)
+            if self.chat_done:
+                break
+            try:
+                best_idx = int(act['chosen'])
+                reason = act['text']
+                best_pick = comments[best_idx]
+            except Exception:
+                # Agent disconnected
+                break
+            example['choices'] = comments
+            example['best_pick'] = best_pick
+            example['reason'] = reason
+            self.data.append(example)
+            self.turn_idx += 1
+
+        if self.turn_idx == self.num_images:
+            control_msg['text'] = CHAT_ENDED_MSG.format(self.num_images)
+            agent.observe(validate(control_msg))
+        self.chat_done = True
+        return
+
+    def check_timeout(self, act):
+        if act['text'] == '[TIMEOUT]' and act['episode_done']:
+            control_msg = {'episode_done': True}
+            control_msg['id'] = 'SYSTEM'
+            control_msg['text'] = TIMEOUT_MSG
+            for ag in self.agents:
+                if ag.id != act['id']:
+                    ag.observe(validate(control_msg))
+            self.chat_done = True
+            return True
+        elif act['text'] == '[DISCONNECT]':
+            self.chat_done = True
+            return True
+        else:
+            return False
+
+    def save_data(self):
+        convo_finished = True
+        for ag in self.agents:
+            if (ag.hit_is_abandoned or ag.hit_is_returned or
+                    ag.disconnected or ag.hit_is_expired):
+                convo_finished = False
+        if not convo_finished:
+            ag.example_generator.push_example(self.example_num)
+            print("\n**Push image {} back to stack. **\n".format(
+                    self.example_num))
+        self.agents[0].example_generator.save_idx_stack()
+        data_path = self.opt['data_path']
+        if not os.path.exists(data_path):
+            os.makedirs(data_path)
+        if convo_finished:
+            filename = os.path.join(
+                data_path,
+                '{}_{}_{}.pkl'.format(
+                    time.strftime("%Y%m%d-%H%M%S"),
+                    np.random.randint(0, 1000),
+                    self.task_type))
+        else:
+            filename = os.path.join(
+                data_path,
+                '{}_{}_{}_incomplete.pkl'.format(
+                    time.strftime("%Y%m%d-%H%M%S"),
+                    np.random.randint(0, 1000),
+                    self.task_type))
+        pickle.dump({'data': self.data,
+                     'worker': self.agents[0].worker_id,
+                     'hit_id': self.agents[0].hit_id,
+                     'assignment_id': self.agents[0].assignment_id
+                     }, open(filename, 'wb'))
+        print('{}: Data successfully saved at {}.'.format(
+            self.world_tag,
+            filename))
+
+    def review_work(self):
+        global review_agent
+
+        def review_agent(ag):
+            pass  # auto approve 5 days
+        Parallel(
+            n_jobs=len(self.agents),
+            backend='threading'
+        )(delayed(review_agent)(agent) for agent in self.agents)
+
+    def shutdown(self):
+        """Shutdown all mturk agents in parallel, otherwise if one mturk agent
+        is disconnected then it could prevent other mturk agents from
+        completing.
+        """
+        global shutdown_agent
+
+        def shutdown_agent(agent):
+            agent.shutdown()
+        Parallel(
+            n_jobs=len(self.agents),
+            backend='threading'
+        )(delayed(shutdown_agent)(agent) for agent in self.agents)


### PR DESCRIPTION
Task that shows two comments for one image (and optionally the personality) and asks the turker to 1) choose the more engaging comment and 2) explain their choice. 

The current setup just lists the collected comment from the Personality-Captions dataset twice; if one were to provide an `--eval-data-path`, the task would use this for evaluation.

While the PR claims there are over 800 additions, the _meaningful_ code snippets are relatively short.

cc @jaseweston 