### PR TITLE
Add personas feature to ParlAI Messenger

### DIFF
--- a/parlai/messenger/core/message_sender.py
+++ b/parlai/messenger/core/message_sender.py
@@ -147,7 +147,7 @@ class MessageSender():
         """
         self.auth_args = {'access_token': secret_token}
 
-    def send_sender_action(self, receiver_id, action):
+    def send_sender_action(self, receiver_id, action, persona_id=None):
         api_address = 'https://graph.facebook.com/v2.6/me/messages'
         message = {
             'recipient': {
@@ -155,6 +155,8 @@ class MessageSender():
             },
             "sender_action": action,
         }
+        if persona_id is not None:
+            message['persona_id'] = persona_id
         requests.post(
             api_address,
             params=self.auth_args,
@@ -164,10 +166,11 @@ class MessageSender():
     def send_read(self, receiver_id):
         self.send_sender_action(receiver_id, "mark_seen")
 
-    def typing_on(self, receiver_id):
-        self.send_sender_action(receiver_id, "typing_on")
+    def typing_on(self, receiver_id, persona_id=None):
+        self.send_sender_action(receiver_id, "typing_on", persona_id)
 
-    def send_fb_payload(self, receiver_id, payload, quick_replies=None):
+    def send_fb_payload(self, receiver_id, payload,
+                        quick_replies=None, persona_id=None):
         """Sends a payload to messenger, processes it if we can"""
         api_address = 'https://graph.facebook.com/v2.6/me/messages'
         if payload['type'] == 'list':
@@ -189,6 +192,8 @@ class MessageSender():
         if quick_replies is not None:
             quick_replies = [create_reply_option(x, x) for x in quick_replies]
             message['message']['quick_replies'] = quick_replies
+        if persona_id is not None:
+            payload['persona_id'] = persona_id
         response = requests.post(
             api_address,
             params=self.auth_args,
@@ -211,7 +216,7 @@ class MessageSender():
         return result
 
     def send_fb_message(self, receiver_id, message, is_response,
-                        quick_replies=None):
+                        quick_replies=None, persona_id=None):
         """Sends a message directly to messenger"""
         api_address = 'https://graph.facebook.com/v2.6/me/messages'
         if quick_replies is not None:
@@ -228,6 +233,8 @@ class MessageSender():
                 },
                 "message": m
             }
+            if persona_id is not None:
+                payload['persona_id'] = persona_id
             response = requests.post(
                 api_address,
                 params=self.auth_args,
@@ -249,6 +256,33 @@ class MessageSender():
             )
             results.append(result)
         return results
+
+    def create_persona(self, name, image_url):
+        """Creates a new persona and returns persona_id"""
+        api_address = 'https://graph.facebook.com/me/personas'
+        message = {'name': name, "profile_picture_url": image_url}
+        response = requests.post(
+            api_address,
+            params=self.auth_args,
+            json=message,
+        )
+        result = response.json()
+        shared_utils.print_and_log(
+            logging.INFO,
+            '"Facebook response from create persona: {}"'.format(result)
+        )
+        return result
+
+    def delete_persona(self, persona_id):
+        """Deletes the persona"""
+        api_address = 'https://graph.facebook.com/' + persona_id
+        response = requests.delete(api_address, params=self.auth_args)
+        result = response.json()
+        shared_utils.print_and_log(
+            logging.INFO,
+            '"Facebook response from delete persona: {}"'.format(result)
+        )
+        return result
 
     def upload_fb_attachment(self, payload):
         """Uploads an attachment using the Attachment Upload API and returns


### PR DESCRIPTION
Modified message_sender.py to include create_persona, delete_persona and as well as extended functionality of send_fb_payload, send_fb_message, and typing_on to take advantage of created personas. 
![img_0188](https://user-images.githubusercontent.com/5303204/49609155-8f7f0900-f94f-11e8-891f-523ef9937359.PNG)

