### PR TITLE
fix for batched executable worlds

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -651,8 +651,8 @@ class BatchWorld(World):
             batch_act = self.batch_act(agent_idx, batch_observations[agent_idx])
             # We possibly execute this action in the world.
             if hasattr(self.world, 'execute'):
-                for i, w in enumerate(self.worlds):
-                    w.execute(w.agents[i], batch_act[i])
+                for w in self.worlds:
+                    w.execute(w.agents[agent_idx], batch_act[agent_idx])
             # All agents (might) observe the results.
             for other_index in range(num_agents):
                 obs = self.batch_observe(other_index, batch_act, agent_idx)


### PR DESCRIPTION
We're using the wrong index here, fails if batch size > num agents.