### PR TITLE
[MTurk] Demo react tasks in webapp frontend

### DIFF
--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -184,6 +184,13 @@ class MTurkAgent(Agent):
 
         self.msg_queue = Queue()
 
+    def _get_episode_done_msg(self, text):
+        return {
+            'id': self.id,
+            'text': text,
+            'episode_done': True
+        }
+
     def set_status(self, status):
         """Set the status of this agent on the task, update db"""
         self.state.set_status(status)
@@ -228,7 +235,6 @@ class MTurkAgent(Agent):
 
     def get_status(self):
         """Get the status of this agent on its task"""
-
         return self.state.get_status()
 
     def submitted_hit(self):
@@ -330,21 +336,11 @@ class MTurkAgent(Agent):
         """Get a new act message if one exists, return None otherwise"""
         # See if any agent has disconnected
         if self.disconnected or self.some_agent_disconnected:
-            msg = {
-                'id': self.id,
-                'text': MTURK_DISCONNECT_MESSAGE,
-                'episode_done': True
-            }
-            return msg
+            return self._get_episode_done_msg(MTURK_DISCONNECT_MESSAGE)
 
         # Check if the current turker already returned the HIT
         if self.hit_is_returned:
-            msg = {
-                'id': self.id,
-                'text': RETURN_MESSAGE,
-                'episode_done': True
-            }
-            return msg
+            return self._get_episode_done_msg(RETURN_MESSAGE)
 
         if self.msg_queue is not None:
             # Check if Turker sends a message
@@ -368,12 +364,7 @@ class MTurkAgent(Agent):
             self.worker_id,
             self.assignment_id
         )
-        msg = {
-            'id': self.id,
-            'text': TIMEOUT_MESSAGE,
-            'episode_done': True
-        }
-        return msg
+        return self._get_episode_done_msg(TIMEOUT_MESSAGE)
 
     def request_message(self):
         if not (self.disconnected or self.some_agent_disconnected or

--- a/parlai/mturk/core/react_server/dev/app.jsx
+++ b/parlai/mturk/core/react_server/dev/app.jsx
@@ -15,6 +15,7 @@ import CustomComponents from './components/custom.jsx';
 import SocketHandler from './components/socket_handler.jsx';
 import {MTurkSubmitForm, allDoneCallback} from './components/mturk_submit_form.jsx';
 import 'fetch';
+import $ from 'jquery';
 
 var UseCustomComponents = {}
 if (Object.keys(BuiltCustomComponents).length) {
@@ -38,7 +39,7 @@ function getHitConfig(callback_function) {
   $.ajax({
     url: '/get_hit_config',
     timeout: 3000 // in milliseconds
-  }).retry({times: 10, timeout: 3000}).then(
+  }).then(
     function(data) {
       if (callback_function) {
         callback_function(data);

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {FormControl, Button} from 'react-bootstrap';
 import Slider from 'rc-slider';
+import $ from 'jquery';
 
 import 'rc-slider/assets/index.css';
 
@@ -76,7 +77,7 @@ class MessageList extends React.Component {
         message={m.text}
         context={m.context}
         message_id={m.message_id}
-        duration={this.props.is_review ? m.duration : null}/>
+        duration={this.props.is_review ? m.duration : undefined}/>
     );
   }
 

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -243,6 +243,7 @@ class ChatPane extends React.Component {
     super(props);
     this.state = {chat_height: this.getChatHeight()}
   }
+
   componentDidUpdate(prevProps, prevState, snapshot) {
     if (this.props.message_count != prevProps.message_count) {
       $('div#right-top-pane').animate({

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -246,8 +246,8 @@ class ChatPane extends React.Component {
 
   componentDidUpdate(prevProps, prevState, snapshot) {
     if (this.props.message_count != prevProps.message_count) {
-      $('div#right-top-pane').animate({
-        scrollTop: $('div#right-top-pane').get(0).scrollHeight
+      $('div#message-pane-segment').animate({
+        scrollTop: $('div#message-pane-segment').get(0).scrollHeight
       }, 500);
     }
   }

--- a/parlai/mturk/core/react_server/dev/components/mturk_submit_form.jsx
+++ b/parlai/mturk/core/react_server/dev/components/mturk_submit_form.jsx
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import $ from 'jquery';
 
 // If we're in the amazon turk HIT page (within an iFrame) return True
 function inMTurkHITPage() {

--- a/parlai/mturk/core/react_server/server/static/index.html
+++ b/parlai/mturk/core/react_server/server/static/index.html
@@ -16,7 +16,6 @@ LICENSE file in the root directory of this source tree.
     <title>MTurk Chat</title>
     <!-- <link rel="icon" href="http://example.com/favicon.png"> -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.0.0/jquery.min.js"></script>
     <script src="https://github.com/lancedikson/bowser/releases/download/1.6.0/bowser.min.js"></script>
     <script src="https://cdn.rawgit.com/yf225/jquery-ajax-retry/master/dist/jquery.ajax-retry.min.js"></script>
     <script>

--- a/parlai/mturk/core/react_server/server/static/index.html
+++ b/parlai/mturk/core/react_server/server/static/index.html
@@ -17,7 +17,6 @@ LICENSE file in the root directory of this source tree.
     <!-- <link rel="icon" href="http://example.com/favicon.png"> -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <script src="https://github.com/lancedikson/bowser/releases/download/1.6.0/bowser.min.js"></script>
-    <script src="https://cdn.rawgit.com/yf225/jquery-ajax-retry/master/dist/jquery.ajax-retry.min.js"></script>
     <script>
     /* ================= Config variables ================= */
 

--- a/parlai/mturk/tasks/react_task_demo/react_custom_no_extra_deps/frontend/components/custom.jsx
+++ b/parlai/mturk/tasks/react_task_demo/react_custom_no_extra_deps/frontend/components/custom.jsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import {FormControl, Button} from 'react-bootstrap';
+import $ from 'jquery';
 
 // Create custom components
 class EvaluatorIdleResponse extends React.Component {

--- a/parlai/mturk/tasks/react_task_demo/react_custom_no_extra_deps/run.py
+++ b/parlai/mturk/tasks/react_task_demo/react_custom_no_extra_deps/run.py
@@ -10,7 +10,8 @@ from parlai.mturk.tasks.react_task_demo.react_custom_no_extra_deps.worlds \
     import AskerOnboardingWorld, AnswererOnboardingWorld, \
     EvaluatorOnboardingWorld, MultiRoleAgentWorld
 from parlai.mturk.core.mturk_manager import MTurkManager
-from task_config import task_config
+from parlai.mturk.tasks.react_task_demo.react_custom_no_extra_deps.task_config\
+    import task_config
 import os
 
 
@@ -30,6 +31,8 @@ def main():
     # append the contents of task_config.py to the configuration
     opt.update(task_config)
 
+    print(opt)
+
     # Select an agent_id that worker agents will be assigned in their world
     mturk_agent_roles = ['Asker', 'Answerer', 'Evaluator']
 
@@ -40,6 +43,7 @@ def main():
         mturk_agent_ids=mturk_agent_roles,
         use_db=True,
     )
+
     mturk_manager.setup_server(
         task_directory_path=os.path.dirname(os.path.abspath(__file__)))
 

--- a/parlai/mturk/tasks/react_task_demo/react_custom_no_extra_deps/run.py
+++ b/parlai/mturk/tasks/react_task_demo/react_custom_no_extra_deps/run.py
@@ -31,8 +31,6 @@ def main():
     # append the contents of task_config.py to the configuration
     opt.update(task_config)
 
-    print(opt)
-
     # Select an agent_id that worker agents will be assigned in their world
     mturk_agent_roles = ['Asker', 'Answerer', 'Evaluator']
 

--- a/parlai/mturk/tasks/react_task_demo/react_custom_with_deps/frontend/components/custom.jsx
+++ b/parlai/mturk/tasks/react_task_demo/react_custom_with_deps/frontend/components/custom.jsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import {FormControl, Button} from 'react-bootstrap';
+import $ from 'jquery';
 
 // Create custom components
 class EvaluatorIdleResponse extends React.Component {

--- a/parlai/mturk/tasks/react_task_demo/react_custom_with_deps/run.py
+++ b/parlai/mturk/tasks/react_task_demo/react_custom_with_deps/run.py
@@ -10,7 +10,8 @@ from parlai.mturk.tasks.react_task_demo.react_custom_with_deps.worlds import \
     AskerOnboardingWorld, AnswererOnboardingWorld, EvaluatorOnboardingWorld, \
     MultiRoleAgentWorld
 from parlai.mturk.core.mturk_manager import MTurkManager
-from task_config import task_config
+from parlai.mturk.tasks.react_task_demo.react_custom_with_deps.task_config \
+    import task_config
 import os
 
 

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -1577,7 +1577,6 @@ class TaskListPanel extends React.Component {
       .then(res => res.json())
       .then(
         (result) => {
-          console.log(result)
           this.setState({
             tasks_loading: false,
             items: result

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -41,7 +41,6 @@ function resolveState(state_string) {
 }
 
 function postData(url = ``, data = {}) {
-  console.log('posting', data, url);
   return fetch(url, {
       method: "POST",
       mode: "cors",
@@ -1551,7 +1550,6 @@ class DemoTaskPanel extends React.Component {
 
   _handleMessage(evt) {
     let msg = JSON.parse(evt.data);
-    console.log(msg, msg.command, msg.command == 'sync');
     if (msg.command == 'sync') {
       this.handleNewData(msg);
     }
@@ -1650,7 +1648,6 @@ class DemoTaskPanel extends React.Component {
   }
 
   sendMessage(message, data, callback, worker) {
-    console.log(worker);
     let msg = JSON.stringify(
       {'text': message, 'data': data,
        'sender': worker.worker_id, 'id': worker.agent_id});

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -1710,6 +1710,7 @@ class DemoTaskPanel extends React.Component {
       $('div#message-pane-segment').animate({
         scrollTop: $('div#message-pane-segment').get(0).scrollHeight
       }, 500);
+      $("input#id_text_input").focus();
     }
   }
 

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -1824,6 +1824,10 @@ class DemoTaskPanel extends React.Component {
       curr_worker.chat_state = chat_state;
       curr_worker.agent_id = w.agent_id;
       if (w.all_messages.length > curr_worker.messages.length) {
+        // If somehow the messages got out of sync, just grab the full message
+        // list. This isn't great to do all the time (as then messages would
+        // need to wait to be recieved by the server before we could even
+        // display them. This also solves eventual 'refresh' issues)
         curr_worker.messages = w.all_messages;
       }
     });

--- a/parlai/mturk/webapp/run_mocks/mock_turk_agent.py
+++ b/parlai/mturk/webapp/run_mocks/mock_turk_agent.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import logging
+import time
+from queue import Queue
+
+from parlai.core.agents import Agent
+from parlai.mturk.core.agents import AssignState
+import parlai.mturk.core.shared_utils as shared_utils
+
+# Special act messages for failure states
+MTURK_DISCONNECT_MESSAGE = '[DISCONNECT]'  # Turker disconnected from conv
+TIMEOUT_MESSAGE = '[TIMEOUT]'  # the Turker did not respond but didn't return
+RETURN_MESSAGE = '[RETURNED]'  # the Turker returned the HIT
+
+
+class MockTurkAgent(Agent):
+    """Mock turk agent that can act in a parlai mturk world"""
+
+    # MTurkAgent Possible Statuses
+    ASSIGNMENT_NOT_DONE = 'NotDone'
+    ASSIGNMENT_DONE = 'Submitted'
+    ASSIGNMENT_APPROVED = 'Approved'
+    ASSIGNMENT_REJECTED = 'Rejected'
+
+    MTURK_DISCONNECT_MESSAGE = MTURK_DISCONNECT_MESSAGE
+    TIMEOUT_MESSAGE = TIMEOUT_MESSAGE
+    RETURN_MESSAGE = RETURN_MESSAGE
+
+    def __init__(self, opt, mturk_manager, hit_id, assignment_id, worker_id):
+        super().__init__(opt)
+        self.conversation_id = None
+        self.mturk_manager = mturk_manager
+        self.id = None
+        self.mock_status = AssignState.STATUS_NONE
+        self.state = AssignState()
+        self.assignment_id = assignment_id
+        self.hit_id = hit_id
+        self.worker_id = worker_id
+        self.some_agent_disconnected = False
+        self.hit_is_expired = False
+        self.hit_is_abandoned = False  # state from Amazon MTurk system
+        self.hit_is_returned = False  # state from Amazon MTurk system
+        self.hit_is_complete = False  # state from Amazon MTurk system
+        self.disconnected = False
+        self.wants_message = False
+        self.task_group_id = mturk_manager.task_group_id
+        self.message_request_time = None
+        self.creation_time = time.time()
+        self.msg_queue = Queue()
+        self.unread_messages = []
+
+    def get_update_packet(self):
+        """Produce an update packet that represents the state change
+        of this agent"""
+        send_messages = []
+        while len(self.unread_messages) > 0:
+            pkt = self.unread_messages.pop(0)
+            send_messages.append(pkt.data)
+        done_text = self.state.get_inactive_command_text()[0] if \
+            self.state.is_final() else None
+        return {
+            'new_messages': send_messages,
+            'all_messages': self.state.get_messages(),
+            'wants_message': self.wants_message,
+            'disconnected': self.disconnected,
+            'agent_id': self.id,
+            'worker_id': self.worker_id,
+            'conversation_id': self.conversation_id,
+            'task_done': self.state.is_final(),
+            'done_text': done_text,
+            'status': self.state.get_status(),
+        }
+
+    def set_status(self, status):
+        """Set the status of this agent on the task"""
+        self.state.set_status(status)
+
+    def get_status(self):
+        """Get the status of this agent on its task"""
+        return self.state.get_status()
+
+    def submitted_hit(self):
+        return self.get_status() in [
+            AssignState.STATUS_DONE,
+            AssignState.STATUS_PARTNER_DISCONNECT
+        ]
+
+    def is_final(self):
+        """Determine if this agent is in a final state"""
+        return self.state.is_final()
+
+    def append_message(self, message):
+        """Add a received message to the state"""
+        self.state.append_message(message)
+
+    def set_last_command(self, command):
+        """Changes the last command recorded as sent to the agent"""
+        self.state.set_last_command(command)
+
+    def get_last_command(self):
+        """Returns the last command to be sent to this agent"""
+        return self.state.get_last_command()
+
+    def clear_messages(self):
+        """Clears the message history for this agent"""
+        self.state.clear_messages()
+
+    def get_messages(self):
+        """Returns all the messages stored in the state"""
+        return self.state.get_messages()
+
+    def get_connection_id(self):
+        """Returns an appropriate connection_id for this agent"""
+        return "{}_{}".format(self.worker_id, self.assignment_id)
+
+    def log_reconnect(self):
+        pass
+
+    def get_inactive_command_data(self):
+        """Get appropriate inactive command data to respond to a reconnect"""
+        text, command = self.state.get_inactive_command_text()
+        return {
+            'text': command,
+            'inactive_text': text,
+            'conversation_id': self.conversation_id,
+            'agent_id': self.worker_id,
+        }
+
+    def wait_for_status(self, desired_status):
+        """Suspend a thread until a particular assignment state changes
+        to the desired state
+        """
+        while True:
+            if self.get_status() == desired_status:
+                return True
+            if self.is_final():
+                return False
+            time.sleep(shared_utils.THREAD_SHORT_SLEEP)
+
+    def is_in_task(self):
+        return self.status == AssignState.STATUS_IN_TASK
+
+    def observe(self, msg):
+        """Send an agent a message through the mturk_manager"""
+        self.mturk_manager.send_message(
+            self.worker_id, self.assignment_id, msg)
+
+    def put_data(self, id, data):
+        """Put data into the message queue if it hasn't already been seen"""
+        self.msg_queue.put(data)
+        print('data was queued!')
+
+    def flush_msg_queue(self):
+        """Clear all messages in the message queue"""
+        if self.msg_queue is None:
+            return
+        while not self.msg_queue.empty():
+            self.msg_queue.get()
+
+    def reduce_state(self):
+        """Cleans up resources related to maintaining complete state"""
+        self.flush_msg_queue()
+        self.msg_queue = None
+
+    def get_new_act_message(self):
+        """Get a new act message if one exists, return None otherwise"""
+        # See if any agent has disconnected
+        if self.disconnected or self.some_agent_disconnected:
+            msg = {
+                'id': self.id,
+                'text': MTURK_DISCONNECT_MESSAGE,
+                'episode_done': True
+            }
+            return msg
+
+        # Check if the current turker already returned the HIT
+        if self.hit_is_returned:
+            msg = {
+                'id': self.id,
+                'text': RETURN_MESSAGE,
+                'episode_done': True
+            }
+            return msg
+
+        if self.msg_queue is not None:
+            # Check if Turker sends a message
+            while not self.msg_queue.empty():
+                msg = self.msg_queue.get()
+                if msg['id'] == self.id:
+                    return msg
+
+        # There are no messages to be sent
+        return None
+
+    def prepare_timeout(self):
+        """Log a timeout event, tell mturk manager it occurred, return message
+        to return for the act call
+        """
+        shared_utils.print_and_log(
+            logging.INFO,
+            '{} timed out before sending.'.format(self.id)
+        )
+        self.timed_out = True
+        msg = {
+            'id': self.id,
+            'text': TIMEOUT_MESSAGE,
+            'episode_done': True
+        }
+        return msg
+
+    def request_message(self):
+        if not (self.disconnected or self.some_agent_disconnected or
+                self.hit_is_expired):
+            self.wants_message = True
+
+    def act(self, timeout=None, blocking=True):
+        """Return a message sent by this agent. If blocking, wait for that
+        message to come in. If not, return None if no messages are ready
+        at the current moment"""
+        if not blocking:
+            # if this is the first act since last sent message start timing
+            if self.message_request_time is None:
+                self.request_message()
+                self.message_request_time = time.time()
+
+            # If checking timeouts
+            if timeout:
+                # If time is exceeded, timeout
+                if time.time() - self.message_request_time > timeout:
+                    return self.prepare_timeout()
+
+            # Get a new message, if it's not None reset the timeout
+            msg = self.get_new_act_message()
+            if msg is not None and self.message_request_time is not None:
+                self.message_request_time = None
+                self.wants_message = False
+            return msg
+        else:
+            self.request_message()
+            self.message_request_time = time.time()
+
+            # Timeout in seconds, after which the HIT is expired automatically
+            if timeout:
+                start_time = time.time()
+
+            # Wait for agent's new message
+            while True:
+                msg = self.get_new_act_message()
+                self.message_request_time = None
+                if msg is not None:
+                    self.wants_message = False
+                    return msg
+
+                # Check if the Turker waited too long to respond
+                if timeout:
+                    current_time = time.time()
+                    if (current_time - start_time) > timeout:
+                        self.message_request_time = None
+                        return self.prepare_timeout()
+                time.sleep(shared_utils.THREAD_SHORT_SLEEP)
+
+    def episode_done(self):
+        """Return whether or not this agent believes the conversation to
+        be done"""
+        if self.status == AssignState.STATUS_DONE:
+            return False
+        else:
+            return True
+
+    def approve_work(self):
+        print('[mock] Worker {} approved'.format(self.worker_id))
+
+    def reject_work(self, reason='unspecified'):
+        print('[mock] Worker {} rejected for reason {}'.format(
+            self.worker_id, reason))
+
+    def block_worker(self, reason='unspecified'):
+        print('[mock] Worker {} blocked for reason {}'.format(
+            self.worker_id, reason))
+
+    def pay_bonus(self, bonus_amount, reason='unspecified'):
+        print('[mock] Worker {} bonused {} for reason {}'.format(
+            self.worker_id, bonus_amount, reason))
+
+    def email_worker(self, subject, message_text):
+        return True
+
+    def set_hit_is_abandoned(self):
+        self.hit_is_abandoned = True
+
+    def wait_for_hit_completion(self, timeout=None):
+        pass
+
+    def shutdown(self, timeout=None, direct_submit=False):
+        pass
+
+    def update_agent_id(self, agent_id):
+        """Workaround used to force an update to an agent_id on the front-end
+        to render the correct react components for onboarding and waiting
+        worlds. Only really used in special circumstances where different
+        agents need different onboarding worlds.
+        """
+        self.id = agent_id

--- a/parlai/mturk/webapp/run_mocks/mock_turk_agent.py
+++ b/parlai/mturk/webapp/run_mocks/mock_turk_agent.py
@@ -11,13 +11,10 @@ import time
 from queue import Queue
 
 from parlai.core.agents import Agent
+from parlai.mturk.core.agents import \
+    MTURK_DISCONNECT_MESSAGE, TIMEOUT_MESSAGE, RETURN_MESSAGE
 from parlai.mturk.core.agents import AssignState
 import parlai.mturk.core.shared_utils as shared_utils
-
-# Special act messages for failure states
-MTURK_DISCONNECT_MESSAGE = '[DISCONNECT]'  # Turker disconnected from conv
-TIMEOUT_MESSAGE = '[TIMEOUT]'  # the Turker did not respond but didn't return
-RETURN_MESSAGE = '[RETURNED]'  # the Turker returned the HIT
 
 
 class MockTurkAgent(Agent):

--- a/parlai/mturk/webapp/run_mocks/mock_turk_agent.py
+++ b/parlai/mturk/webapp/run_mocks/mock_turk_agent.py
@@ -63,8 +63,10 @@ class MockTurkAgent(Agent):
         while len(self.unread_messages) > 0:
             pkt = self.unread_messages.pop(0)
             send_messages.append(pkt.data)
-        done_text = self.state.get_inactive_command_text()[0] if \
-            self.state.is_final() else None
+        done_text = None
+        if self.state.is_final() and \
+                self.get_status() != AssignState.STATUS_DONE:
+            done_text = self.state.get_inactive_command_text()[0]
         return {
             'new_messages': send_messages,
             'all_messages': self.state.get_messages(),
@@ -155,7 +157,6 @@ class MockTurkAgent(Agent):
     def put_data(self, id, data):
         """Put data into the message queue if it hasn't already been seen"""
         self.msg_queue.put(data)
-        print('data was queued!')
 
     def flush_msg_queue(self):
         """Clear all messages in the message queue"""

--- a/parlai/mturk/webapp/run_mocks/mock_turk_agent.py
+++ b/parlai/mturk/webapp/run_mocks/mock_turk_agent.py
@@ -7,51 +7,22 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 import logging
-import time
-from queue import Queue
 
-from parlai.core.agents import Agent
-from parlai.mturk.core.agents import \
-    MTURK_DISCONNECT_MESSAGE, TIMEOUT_MESSAGE, RETURN_MESSAGE
+from parlai.mturk.core.agents import MTurkAgent, TIMEOUT_MESSAGE
 from parlai.mturk.core.agents import AssignState
 import parlai.mturk.core.shared_utils as shared_utils
 
 
-class MockTurkAgent(Agent):
+class MockTurkAgent(MTurkAgent):
     """Mock turk agent that can act in a parlai mturk world"""
 
-    # MTurkAgent Possible Statuses
-    ASSIGNMENT_NOT_DONE = 'NotDone'
-    ASSIGNMENT_DONE = 'Submitted'
-    ASSIGNMENT_APPROVED = 'Approved'
-    ASSIGNMENT_REJECTED = 'Rejected'
-
-    MTURK_DISCONNECT_MESSAGE = MTURK_DISCONNECT_MESSAGE
-    TIMEOUT_MESSAGE = TIMEOUT_MESSAGE
-    RETURN_MESSAGE = RETURN_MESSAGE
-
     def __init__(self, opt, mturk_manager, hit_id, assignment_id, worker_id):
-        super().__init__(opt)
-        self.conversation_id = None
-        self.mturk_manager = mturk_manager
-        self.id = None
+        super().__init__(opt, mturk_manager, hit_id, assignment_id, worker_id)
+        self.db_logger = None
         self.mock_status = AssignState.STATUS_NONE
-        self.state = AssignState()
-        self.assignment_id = assignment_id
-        self.hit_id = hit_id
-        self.worker_id = worker_id
-        self.some_agent_disconnected = False
-        self.hit_is_expired = False
-        self.hit_is_abandoned = False  # state from Amazon MTurk system
-        self.hit_is_returned = False  # state from Amazon MTurk system
-        self.hit_is_complete = False  # state from Amazon MTurk system
-        self.disconnected = False
         self.wants_message = False
-        self.task_group_id = mturk_manager.task_group_id
-        self.message_request_time = None
-        self.creation_time = time.time()
-        self.msg_queue = Queue()
         self.unread_messages = []
+        self.timed_out = False
 
     def get_update_packet(self):
         """Produce an update packet that represents the state change
@@ -77,82 +48,15 @@ class MockTurkAgent(Agent):
             'status': self.state.get_status(),
         }
 
-    def set_status(self, status):
-        """Set the status of this agent on the task"""
-        self.state.set_status(status)
-
-    def get_status(self):
-        """Get the status of this agent on its task"""
-        return self.state.get_status()
-
-    def submitted_hit(self):
-        return self.get_status() in [
-            AssignState.STATUS_DONE,
-            AssignState.STATUS_PARTNER_DISCONNECT
-        ]
-
-    def is_final(self):
-        """Determine if this agent is in a final state"""
-        return self.state.is_final()
-
-    def append_message(self, message):
-        """Add a received message to the state"""
-        self.state.append_message(message)
-
-    def set_last_command(self, command):
-        """Changes the last command recorded as sent to the agent"""
-        self.state.set_last_command(command)
-
-    def get_last_command(self):
-        """Returns the last command to be sent to this agent"""
-        return self.state.get_last_command()
-
-    def clear_messages(self):
-        """Clears the message history for this agent"""
-        self.state.clear_messages()
-
-    def get_messages(self):
-        """Returns all the messages stored in the state"""
-        return self.state.get_messages()
-
-    def get_connection_id(self):
-        """Returns an appropriate connection_id for this agent"""
-        return "{}_{}".format(self.worker_id, self.assignment_id)
-
     def log_reconnect(self):
+        """We aren't logging behavior in the mock"""
         pass
-
-    def get_inactive_command_data(self):
-        """Get appropriate inactive command data to respond to a reconnect"""
-        text, command = self.state.get_inactive_command_text()
-        return {
-            'text': command,
-            'inactive_text': text,
-            'conversation_id': self.conversation_id,
-            'agent_id': self.worker_id,
-        }
-
-    def wait_for_status(self, desired_status):
-        """Suspend a thread until a particular assignment state changes
-        to the desired state
-        """
-        while True:
-            if self.get_status() == desired_status:
-                return True
-            if self.is_final():
-                return False
-            time.sleep(shared_utils.THREAD_SHORT_SLEEP)
 
     def is_in_task(self):
         return self.status == AssignState.STATUS_IN_TASK
 
-    def observe(self, msg):
-        """Send an agent a message through the mturk_manager"""
-        self.mturk_manager.send_message(
-            self.worker_id, self.assignment_id, msg)
-
     def put_data(self, id, data):
-        """Put data into the message queue if it hasn't already been seen"""
+        """Put data into the message queue"""
         self.msg_queue.put(data)
 
     def flush_msg_queue(self):
@@ -161,41 +65,6 @@ class MockTurkAgent(Agent):
             return
         while not self.msg_queue.empty():
             self.msg_queue.get()
-
-    def reduce_state(self):
-        """Cleans up resources related to maintaining complete state"""
-        self.flush_msg_queue()
-        self.msg_queue = None
-
-    def get_new_act_message(self):
-        """Get a new act message if one exists, return None otherwise"""
-        # See if any agent has disconnected
-        if self.disconnected or self.some_agent_disconnected:
-            msg = {
-                'id': self.id,
-                'text': MTURK_DISCONNECT_MESSAGE,
-                'episode_done': True
-            }
-            return msg
-
-        # Check if the current turker already returned the HIT
-        if self.hit_is_returned:
-            msg = {
-                'id': self.id,
-                'text': RETURN_MESSAGE,
-                'episode_done': True
-            }
-            return msg
-
-        if self.msg_queue is not None:
-            # Check if Turker sends a message
-            while not self.msg_queue.empty():
-                msg = self.msg_queue.get()
-                if msg['id'] == self.id:
-                    return msg
-
-        # There are no messages to be sent
-        return None
 
     def prepare_timeout(self):
         """Log a timeout event, tell mturk manager it occurred, return message
@@ -206,12 +75,7 @@ class MockTurkAgent(Agent):
             '{} timed out before sending.'.format(self.id)
         )
         self.timed_out = True
-        msg = {
-            'id': self.id,
-            'text': TIMEOUT_MESSAGE,
-            'episode_done': True
-        }
-        return msg
+        return self._get_episode_done_msg(TIMEOUT_MESSAGE)
 
     def request_message(self):
         if not (self.disconnected or self.some_agent_disconnected or
@@ -219,55 +83,17 @@ class MockTurkAgent(Agent):
             self.wants_message = True
 
     def act(self, timeout=None, blocking=True):
-        """Return a message sent by this agent. If blocking, wait for that
-        message to come in. If not, return None if no messages are ready
-        at the current moment"""
-        if not blocking:
-            # if this is the first act since last sent message start timing
-            if self.message_request_time is None:
-                self.request_message()
-                self.message_request_time = time.time()
-
-            # If checking timeouts
-            if timeout:
-                # If time is exceeded, timeout
-                if time.time() - self.message_request_time > timeout:
-                    return self.prepare_timeout()
-
-            # Get a new message, if it's not None reset the timeout
-            msg = self.get_new_act_message()
-            if msg is not None and self.message_request_time is not None:
-                self.message_request_time = None
-                self.wants_message = False
-            return msg
-        else:
-            self.request_message()
-            self.message_request_time = time.time()
-
-            # Timeout in seconds, after which the HIT is expired automatically
-            if timeout:
-                start_time = time.time()
-
-            # Wait for agent's new message
-            while True:
-                msg = self.get_new_act_message()
-                self.message_request_time = None
-                if msg is not None:
-                    self.wants_message = False
-                    return msg
-
-                # Check if the Turker waited too long to respond
-                if timeout:
-                    current_time = time.time()
-                    if (current_time - start_time) > timeout:
-                        self.message_request_time = None
-                        return self.prepare_timeout()
-                time.sleep(shared_utils.THREAD_SHORT_SLEEP)
+        """Retrieve an act in the normal expected way (out of the queue), but
+        clear the act request if we do end up getting an act."""
+        gotten_act = super().act(timeout, blocking)
+        if gotten_act is not None:
+            self.wants_message = False
+        return gotten_act
 
     def episode_done(self):
         """Return whether or not this agent believes the conversation to
         be done"""
-        if self.status == AssignState.STATUS_DONE:
+        if self.get_status() == AssignState.STATUS_DONE:
             return False
         else:
             return True
@@ -300,9 +126,7 @@ class MockTurkAgent(Agent):
         pass
 
     def update_agent_id(self, agent_id):
-        """Workaround used to force an update to an agent_id on the front-end
-        to render the correct react components for onboarding and waiting
-        worlds. Only really used in special circumstances where different
-        agents need different onboarding worlds.
+        """State is sent directly from the agent, so no need to send like
+        MTurkAgent does in the full version
         """
         self.id = agent_id

--- a/parlai/mturk/webapp/run_mocks/mock_turk_manager.py
+++ b/parlai/mturk/webapp/run_mocks/mock_turk_manager.py
@@ -123,6 +123,9 @@ class MockTurkManager():
             agent.conversation_id = 'in_task'
 
         task_function(mturk_manager=self, opt=self.opt, workers=agents)
+        for agent in agents:
+            agent.mock_status = AssignState.STATUS_DONE
+            agent.set_status(AssignState.STATUS_DONE)
 
     def shutdown(self, force=False):
         """No servers, nothing to clean up"""
@@ -181,12 +184,10 @@ class MockTurkManager():
             """Onboarding wrapper to set state to onboarding properly"""
             if self.onboard_function:
                 agent.id = 'Onboarding'
-                print('onboard running!')
                 self.onboard_function(agent)
 
             # once onboarding is done, move into a waiting world
             self.move_agents_to_waiting([agent])
-            print(agent, " was moved over!!")
 
         # Start the onboarding thread and run it
         onboard_thread = threading.Thread(

--- a/parlai/mturk/webapp/run_mocks/mock_turk_manager.py
+++ b/parlai/mturk/webapp/run_mocks/mock_turk_manager.py
@@ -126,10 +126,11 @@ class MockTurkManager():
         for agent in agents:
             agent.mock_status = AssignState.STATUS_DONE
             agent.set_status(AssignState.STATUS_DONE)
+            agent.task_done = True
 
     def shutdown(self, force=False):
         """No servers, nothing to clean up"""
-        pass
+        print('[mock] shutdown called')
 
     def move_agents_to_waiting(self, agents):
         """Mock moving to a waiting world"""
@@ -241,6 +242,11 @@ class MockTurkManager():
                      ack_func=None):
         """Commands aren't actually sent this way, as state updates are read"""
         return None
+
+    def timeout_all_agents(self):
+        """Set all agent statuses to disconnect to kill the world"""
+        for agent in self.agents:
+            agent.disconnected = True
 
     # BELOW ARE STUBS THAT EXIST TO HOPEFULLY MAKE RUN FILES NOT CRASH
     # NONE OF THEM DO ANYTHING (though some return success values)

--- a/parlai/mturk/webapp/run_mocks/mock_turk_manager.py
+++ b/parlai/mturk/webapp/run_mocks/mock_turk_manager.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import logging
+import os
+import threading
+import time
+import uuid
+
+from parlai.mturk.core.agents import AssignState
+from parlai.mturk.core.socket_manager import Packet
+from parlai.mturk.webapp.run_mocks.mock_turk_agent import MockTurkAgent
+import parlai.mturk.core.data_model as data_model
+import parlai.mturk.core.shared_utils as shared_utils
+
+parent_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+class MockTurkManager():
+    """Manages interactions between MTurk agents as well as direct interactions
+    between a world and the MTurk server.
+    """
+
+    current_manager = None
+
+    def __init__(self, opt, mturk_agent_ids, is_test=False, use_db=False):
+        """Fake an MTurk manager that has the functionality to run a task,
+        but not on mturk
+        """
+        self.opt = opt
+        self.mturk_agent_ids = mturk_agent_ids
+        self.has_run = False
+        self.sandbox = True
+
+    # Required lifecycle functions below
+    def setup_server(self, task_directory_path=None):
+        """Noop, we aren't connecting to a server"""
+        print('[mock] setup_server called')
+
+    def start_new_run(self):
+        """Initialize expected state to not cause crashes"""
+        self.run_id = str(int(time.time()))
+        self.task_group_id = '{}_{}'.format(self.opt['task'], self.run_id)
+        print('[mock] start_new_run called')
+
+    def ready_to_accept_workers(self, timeout_seconds=None):
+        """No threads, as there is no sustained worker pool. Instead
+        we instantiate x MockTurkAgents in onboarding"""
+        self.id_to_agent = {
+            agent_id: MockTurkAgent(
+                self.opt, self, 'hit_id_{}'.format(agent_id),
+                'assignment_id_{}'.format(agent_id), agent_id,
+            ) for agent_id in self.mturk_agent_ids
+        }
+        self.agents = list(self.id_to_agent.values())
+        MockTurkManager.current_manager = self
+        print('[mock] ready_to_accept_workers called')
+
+    def set_onboard_function(self, onboard_function):
+        self.onboard_function = onboard_function
+        print('[mock] set_onboard_function called')
+
+    def start_task(self, eligibility_function, assign_role_function,
+                   task_function):
+        """Handle running a task by checking to see when enough agents are
+        in the pool to start an instance of the task. Continue doing this
+        until the desired number of conversations is had.
+        """
+        print('[mock] start_task called')
+        if callable(eligibility_function):
+            # Convert legacy eligibility_functions to the new format
+            eligibility_function = {
+                'multiple': False,
+                'func': eligibility_function,
+            }
+        else:
+            # Ensure the eligibility function is valid
+            if 'func' not in eligibility_function:
+                shared_utils.print_and_log(
+                    logging.CRITICAL,
+                    "eligibility_function has no 'func'. Cancelling."
+                )
+                raise Exception(
+                    'eligibility_function dict must contain a `func` field '
+                    'containing the actual function.'
+                )
+            elif not callable(eligibility_function['func']):
+                shared_utils.print_and_log(
+                    logging.CRITICAL,
+                    "eligibility_function['func'] not a function. Cancelling."
+                )
+                raise Exception(
+                    "eligibility_function['func'] must contain a function. "
+                    "If eligibility_function['multiple'] is set, it should "
+                    "filter through the list of workers and only return those "
+                    "that are currently eligible to participate. If it is not "
+                    "set, it should take in a single worker and return whether"
+                    " or not they are eligible."
+                )
+            if 'multiple' not in eligibility_function:
+                eligibility_function['multiple'] = False
+
+        valid_agents = [a for a in self.agents if a.mock_status == 'waiting']
+        needed_agents = len(self.mturk_agent_ids)
+        while len(valid_agents) < needed_agents:
+            valid_agents = [a for a in self.agents
+                            if a.mock_status == 'waiting']
+
+        # Add the required number of valid agents to the conv
+        agents = [a for a in valid_agents[:needed_agents]]
+        assign_role_function(agents)
+        # Allow task creator to filter out agents and run
+        # versions of the task that require fewer agents
+        agents = [a for a in agents if a.id is not None]
+        for agent in agents:
+            agent.mock_status = AssignState.STATUS_IN_TASK
+            agent.set_status(AssignState.STATUS_IN_TASK)
+            agent.conversation_id = 'in_task'
+
+        task_function(mturk_manager=self, opt=self.opt, workers=agents)
+
+    def shutdown(self, force=False):
+        """No servers, nothing to clean up"""
+        pass
+
+    def move_agents_to_waiting(self, agents):
+        """Mock moving to a waiting world"""
+        for agent in agents:
+            agent.mock_status = AssignState.STATUS_WAITING
+            agent.set_status(AssignState.STATUS_WAITING)
+            agent.conversation_id = 'waiting'
+
+    def disconnect_agent(self, worker_id, assignment_id):
+        """Set an agent to status disconnect, and all other agents to
+        partner disconnect. send them the correct message. Mocks
+        MTurkManager._handle_agent_disconnect
+        """
+        worker = self.id_to_agent[worker_id]
+        worker.disconnected = True
+        for agent in self.agents:
+            if not agent.disconnected:
+                agent.some_agent_disconnected = True
+
+    def worker_alive(self, worker_id, hit_id, assign_id):
+        """Mocks baseline worker_alive status changes for mock agents"""
+        agent = self.id_to_agent[worker_id]
+        if agent.mock_status == AssignState.STATUS_NONE:
+            agent.status = AssignState.STATUS_ONBOARDING
+            agent.set_status(AssignState.STATUS_ONBOARDING)
+            self.onboard_new_agent(agent)
+        else:
+            if agent.status in [AssignState.STATUS_ONBOARDING,
+                                AssignState.STATUS_IN_TASK]:
+                pass
+            elif (agent.status == AssignState.STATUS_DISCONNECT or
+                  agent.status == AssignState.STATUS_DONE or
+                  agent.status == AssignState.STATUS_EXPIRED or
+                  agent.status == AssignState.STATUS_RETURNED or
+                  agent.status == AssignState.STATUS_PARTNER_DISCONNECT):
+                # reconnect is an inactive command
+                data = agent.get_inactive_command_data()
+                self.send_command(worker_id, assign_id, data)
+
+    def on_new_message(self, worker_id, msg):
+        agent = self.id_to_agent[worker_id]
+        agent.put_data(msg.id, msg.data)
+        agent.append_message(msg.data)
+
+    def onboard_new_agent(self, agent):
+        """Creates an onboarding thread for the given agent"""
+        # get state variable in question
+        worker_id = agent.worker_id
+        assignment_id = agent.assignment_id
+
+        def _onboard_function(agent):
+            """Onboarding wrapper to set state to onboarding properly"""
+            if self.onboard_function:
+                agent.id = 'Onboarding'
+                print('onboard running!')
+                self.onboard_function(agent)
+
+            # once onboarding is done, move into a waiting world
+            self.move_agents_to_waiting([agent])
+            print(agent, " was moved over!!")
+
+        # Start the onboarding thread and run it
+        onboard_thread = threading.Thread(
+            target=_onboard_function,
+            args=(agent,),
+            name='onboard-{}-{}'.format(worker_id, assignment_id)
+        )
+        onboard_thread.daemon = True
+        onboard_thread.start()
+        return True
+
+    # MTurk Agent Interaction Functions #
+
+    def send_message(self, receiver_id, assignment_id, data,
+                     blocking=True, ack_func=None):
+        """'Send' a message directly by updating the queue of messages not
+        yet recieved that the agent can pull from
+        """
+        data = data.copy()  # Ensure data packet is sent in current state
+        data['type'] = data_model.MESSAGE_TYPE_MESSAGE
+        # Force messages to have a unique ID
+        if 'message_id' not in data:
+            data['message_id'] = str(uuid.uuid4())
+        conversation_id = None
+        agent = self.id_to_agent[receiver_id]
+        conversation_id = agent.conversation_id
+        event_id = shared_utils.generate_event_id(receiver_id)
+        packet = Packet(
+            event_id,
+            Packet.TYPE_MESSAGE,
+            'world',
+            receiver_id,
+            assignment_id,
+            data,
+            conversation_id=conversation_id,
+            blocking=blocking,
+            ack_func=ack_func
+        )
+
+        shared_utils.print_and_log(
+            logging.INFO,
+            'Manager sending: {}'.format(packet),
+            should_print=self.opt['verbose']
+        )
+        # Push message to restore queue and incoming queue
+        agent.append_message(packet.data)
+        agent.unread_messages.append(packet)
+        return data['message_id']
+
+    def send_command(self, receiver_id, assignment_id, data, blocking=True,
+                     ack_func=None):
+        """Commands aren't actually sent this way, as state updates are read"""
+        return None
+
+    # BELOW ARE STUBS THAT EXIST TO HOPEFULLY MAKE RUN FILES NOT CRASH
+    # NONE OF THEM DO ANYTHING (though some return success values)
+
+    def mark_workers_done(self, workers):
+        pass
+
+    def free_workers(self, workers):
+        pass
+
+    def get_agent_work_status(self, assignment_id):
+        pass
+
+    def get_qualification_list(self, qualifications=None):
+        return []
+
+    def create_additional_hits(self, num_hits, qualifications=None):
+        return 'fake_page_url'
+
+    def create_hits(self, qualifications=None):
+        return 'fake_page_url'
+
+    def get_hit(self, hit_id):
+        pass
+
+    def get_assignment(self, assignment_id):
+        pass
+
+    def get_assignments_for_hit(self, hit_id):
+        pass
+
+    def expire_all_unassigned_hits(self):
+        pass
+
+    def approve_work(self, assignment_id, override_rejection=False):
+        print('[mock] Assignment {} approved'.format(assignment_id))
+
+    def reject_work(self, assignment_id, reason):
+        print('[mock] Assignment {} rejected for {}'.format(
+            assignment_id, reason))
+
+    def approve_assignments_for_hit(self, hit_id, override_rejection=False):
+        print('[mock] HIT {} approved'.format(hit_id))
+
+    def block_worker(self, worker_id, reason):
+        print('[mock] Worker {} blocked for reason {}'.format(
+            worker_id, reason))
+
+    def soft_block_worker(self, worker_id, qual='block_qualification'):
+        print('[mock] Worker {} given qual {}'.format(worker_id, qual))
+
+    def un_soft_block_worker(self, worker_id, qual='block_qualification'):
+        print('[mock] Worker {} revoked qual {}'.format(worker_id, qual))
+
+    def give_worker_qualification(self, worker_id, qual_name, qual_value=None):
+        print('[mock] Worker {} given qual {}'.format(worker_id, qual_name))
+
+    def remove_worker_qualification(self, worker_id, qual_name, reason=''):
+        print('[mock] Worker {} revoked qual {}'.format(worker_id, qual_name))
+
+    def create_qualification(self, qualification_name, description,
+                             can_exist=True):
+        pass
+
+    def pay_bonus(self, worker_id, bonus_amount, assignment_id, reason,
+                  unique_request_token):
+        print('[mock] Worker {} paid bonus {}'.format(worker_id, bonus_amount))
+
+    def email_worker(self, worker_id, subject, message_text):
+        print('[mock] Worker {} emailed {}'.format(worker_id, message_text))
+        return {'success': True}

--- a/parlai/mturk/webapp/run_mocks/mock_turk_manager.py
+++ b/parlai/mturk/webapp/run_mocks/mock_turk_manager.py
@@ -36,6 +36,7 @@ class MockTurkManager():
         self.mturk_agent_ids = mturk_agent_ids
         self.has_run = False
         self.sandbox = True
+        self.db_logger = None
 
     # Required lifecycle functions below
     def setup_server(self, task_directory_path=None):

--- a/parlai/mturk/webapp/server.py
+++ b/parlai/mturk/webapp/server.py
@@ -559,11 +559,11 @@ class TaskRunHandler(BaseHandler):
             guess_loc = tasks[taskname].split('tasks/')[1]
             guess_class = '.'.join(guess_loc.split('/'))
             base_format = 'parlai.mturk.tasks.{}.run'
-            if 'parlai_internal' in guess_loc:
+            if 'parlai_internal' in tasks[taskname]:
                 base_format = 'parlai_internal.mturk.tasks.{}.run'
             task_find_location = base_format.format(guess_class)
             base_format = 'parlai.mturk.tasks.{}.task_config'
-            if 'parlai_internal' in guess_loc:
+            if 'parlai_internal' in tasks[taskname]:
                 base_format = 'parlai_internal.mturk.tasks.{}.task_config'
             config_find_location = base_format.format(guess_class)
             # Try to find the task at specified location


### PR DESCRIPTION
## Motivation
As of now it takes time to restart the PMT sandbox when attempting to iterate on a HIT's design. Any changes to the world or to the frontend require ~2 mins of build and launch time, and require copying links and opening tabs on MTurk sandbox. This PR adds functionality to be able to launch 'HITs' in the ParlAI webapp to demo the functionality of the task. The key goal of this was to be able to run these hits without a user having to have multiple `run.py` files or any special flags at all for that matter. Tasks can now be demo and worked on from within the webapp, and all of it is done in one browser tab.

### Screenshots
<img width="1055" alt="screen shot 2018-12-07 at 6 52 10 pm" src="https://user-images.githubusercontent.com/1276867/49689887-fccc9e80-faf5-11e8-842f-7bb91baf5fbb.png">
<img width="1365" alt="screen shot 2018-12-07 at 6 53 42 pm" src="https://user-images.githubusercontent.com/1276867/49689883-e6264780-faf5-11e8-9588-13bbe7d15413.png">
<img width="1364" alt="screen shot 2018-12-07 at 6 53 51 pm" src="https://user-images.githubusercontent.com/1276867/49689889-ffc78f00-faf5-11e8-9804-96c990822b68.png">


### Implementation Overview
- `MockTurkManager` and `MockTurkAgent` classes were created to mimic the interface/api of the regular `MTurkManager` and `MTurkAgent` classes while using an almost completely different local backend. Onboarding/task/pairing functionality is equivalent, but the rest has been entirely modified.
- Two new endpoints are added to the webapp server: `TaskSocketHandler` for instantiating the messaging socket, `TaskRunHandler` for launching the run of a task.
- The server launch was updated to first copy over all of the frontend content into local directories, and then the frontend is built. As of now this build step is now the slowest part of the process for running demo tasks, but I have plans to revisit the build to improve this in the future.

### Additional bug fixes
- Adds `jquery` import to all of the react frontend components, as this script should be included in the build rather than in the html.
- Changes default duration from `null` to `undefined` to preserve behavior of dropping duration from messages when it doesn't exist or when `is_review` is false.
- Changes imports of `task_config` to use the full module path import, as these `run` files are now being imported by the server on demand, and the relative module paths no longer work.

### Known issues I'm currently solving
- [x] Autoscroll doesn't happen on the webapp frontend when receiving messages.
- [x] Only way to get to a task demo page is directly by entering the url, there's no way to get there yet otherwise.
- [x] The system does not handle task_done state, so when the task is finished the system hangs
- [ ] ~~Only way to rebuild a particular frontend is to restart the whole server. It also rebuilds everything rather than only files and folders that have actually been changed, making the estimated feedback loop build time around 15 seconds, and this will only grow with more tasks.~~  (This will be a followup PR sometime in the future)