### PR TITLE
[MTurk] Forcing dummy custom dist to be included

### DIFF
--- a/parlai/mturk/core/react_server/dev/components/built_custom_components/dist/custom.jsx
+++ b/parlai/mturk/core/react_server/dev/components/built_custom_components/dist/custom.jsx
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+module.exports = {
+  // XWantedComponentName: {'agent_id': ReplacementComponentForAgent},
+};


### PR DESCRIPTION
The react frontend would not be built properly without this file, which existed locally for me but was ignored by `.gitignore`