### PR TITLE
[MTurk] Evaluate chat partner on 2 person tasks

### DIFF
--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -321,7 +321,7 @@ class MTurkAgent(Agent):
             self.msg_queue.put(data)
 
     def flush_msg_queue(self):
-        """Clear all messages in the message queue"""
+        """Clear all messages in the message queue. Return flushed messages"""
         messages = []
         if self.msg_queue is None:
             return []

--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -181,6 +181,7 @@ class MTurkAgent(Agent):
         self.recieved_packets = {}
         self.creation_time = time.time()
         self.alived = True  # Used for restoring state after refresh
+        self.feedback = None
 
         self.msg_queue = Queue()
 
@@ -321,10 +322,12 @@ class MTurkAgent(Agent):
 
     def flush_msg_queue(self):
         """Clear all messages in the message queue"""
+        messages = []
         if self.msg_queue is None:
-            return
+            return []
         while not self.msg_queue.empty():
-            self.msg_queue.get()
+            messages.append(self.msg_queue.get())
+        return messages
 
     def reduce_state(self):
         """Cleans up resources related to maintaining complete state"""
@@ -638,6 +641,11 @@ class MTurkAgent(Agent):
             if did_complete and self.db_logger is not None:
                 self.db_logger.log_submit_assignment(
                     self.worker_id, self.assignment_id)
+            # Grab feedback message if it happens to exist
+            messages = self.flush_msg_queue()
+            for m in messages:
+                if m['text'] == '[PEER_REVIEW]':
+                    self.feedback = m['data']
             return did_complete
 
     def update_agent_id(self, agent_id):

--- a/parlai/mturk/core/mturk_data_handler.py
+++ b/parlai/mturk/core/mturk_data_handler.py
@@ -600,7 +600,7 @@ class MTurkDataHandler():
             results = c.fetchone()
             return results
 
-    def get_all_run_data(self, start=0, count=100):
+    def get_all_run_data(self, start=0, count=1000):
         """get all the run data for all task_group_ids."""
         with self.table_access_condition:
             conn = self._get_connection()

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -134,6 +134,7 @@ class MTurkManager():
         self.db_logger = None
         self.logging_permitted = False
         self.task_state = self.STATE_CREATED
+        self._assert_opts()
 
     @staticmethod
     def make_taskless_instance(is_sandbox=False):
@@ -154,6 +155,11 @@ class MTurkManager():
         return manager
 
     # Helpers and internal manager methods #
+
+    def _assert_opts(self):
+        """Manages ensuring everything about the passed in options make sense
+        in that they don't conflict in some way or another"""
+        pass
 
     def _init_state(self):
         """Initialize everything in the worker, task, and thread states"""
@@ -957,6 +963,7 @@ class MTurkManager():
         self.is_unique = self.opt['unique_worker']
         self.max_hits_per_worker = self.opt.get('max_hits_per_worker', 0)
         mturk_utils.create_hit_config(
+            opt=self.opt,
             task_description=self.opt['task_description'],
             unique_worker=self.is_unique,
             is_sandbox=self.opt['is_sandbox']
@@ -1518,6 +1525,7 @@ class MTurkManager():
         for _i in range(num_hits):
             mturk_page_url, hit_id, mturk_response = \
                 mturk_utils.create_hit_with_hit_type(
+                    opt=self.opt,
                     page_url=mturk_chat_url,
                     hit_type_id=hit_type_id,
                     num_assignments=1,

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -159,7 +159,15 @@ class MTurkManager():
     def _assert_opts(self):
         """Manages ensuring everything about the passed in options make sense
         in that they don't conflict in some way or another"""
-        pass
+        if self.opt.get('allow_reviews') and len(self.mturk_agent_ids) != 2:
+            shared_utils.print_and_log(
+                logging.WARN,
+                '[OPT CONFIGURATION ISSUE] '
+                'allow_reviews is currently only supported on 2 person tasks, '
+                'overriding this value to false.',
+                should_print=True
+            )
+            self.opt['allow_reviews'] = False
 
     def _init_state(self):
         """Initialize everything in the worker, task, and thread states"""

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -168,6 +168,19 @@ class MTurkManager():
                 should_print=True
             )
             self.opt['allow_reviews'] = False
+        if self.opt.get('frontend_version', 0) < 1:
+            # Ensure no react only features have been set
+            features = ['frame_height', 'allow_reviews', 'block_mobile']
+            for feat in features:
+                if self.opt.get(feat) is not None:
+                    shared_utils.print_and_log(
+                        logging.WARN,
+                        '[OPT CONFIGURATION ISSUE] '
+                        '{} only works when using the react frontend '
+                        '(frontend_version >= 1), so this option will be '
+                        'ignored'.format(feat),
+                        should_print=True
+                    )
 
     def _init_state(self):
         """Initialize everything in the worker, task, and thread states"""

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -19,8 +19,6 @@ aws_profile_name = 'parlai_mturk'
 client = None
 
 parent_dir = os.path.dirname(os.path.abspath(__file__))
-mturk_hit_frame_height = 650
-
 
 def setup_aws_credentials():
     try:
@@ -134,7 +132,7 @@ def check_mturk_balance(balance_needed, is_sandbox):
         return True
 
 
-def create_hit_config(task_description, unique_worker, is_sandbox):
+def create_hit_config(opt, task_description, unique_worker, is_sandbox):
     """Writes a HIT config to file"""
     mturk_submit_url = 'https://workersandbox.mturk.com/mturk/externalSubmit'
     if not is_sandbox:
@@ -144,7 +142,9 @@ def create_hit_config(task_description, unique_worker, is_sandbox):
         'is_sandbox': is_sandbox,
         'mturk_submit_url': mturk_submit_url,
         'unique_worker': unique_worker,
-        'frame_height': mturk_hit_frame_height
+        'frame_height': opt.get('frame_height', 650),
+        'allow_reviews': opt.get('allow_reviews', False),
+        'block_mobile': opt.get('block_mobile', True),
     }
     hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
     if os.path.exists(hit_config_file_path):
@@ -321,7 +321,7 @@ def create_hit_type(hit_title, hit_description, hit_keywords, hit_reward,
     return hit_type_id
 
 
-def create_hit_with_hit_type(page_url, hit_type_id, num_assignments,
+def create_hit_with_hit_type(opt, page_url, hit_type_id, num_assignments,
                              is_sandbox):
     """Creates the actual HIT given the type and page to direct clients to"""
     page_url = page_url.replace('&', '&amp;')
@@ -334,7 +334,7 @@ def create_hit_with_hit_type(page_url, hit_type_id, num_assignments,
             '<ExternalURL>{}</ExternalURL>'  # noqa: E131
             '<FrameHeight>{}</FrameHeight>'
         '</ExternalQuestion>'
-        ''.format(amazon_ext_url, page_url, mturk_hit_frame_height)
+        ''.format(amazon_ext_url, page_url, opt.get('frame_height', 650))
     )
 
     client = get_mturk_client(is_sandbox)

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -20,6 +20,7 @@ client = None
 
 parent_dir = os.path.dirname(os.path.abspath(__file__))
 
+
 def setup_aws_credentials():
     try:
         # Use existing credentials

--- a/parlai/mturk/core/react_server/dev/app.jsx
+++ b/parlai/mturk/core/react_server/dev/app.jsx
@@ -185,6 +185,7 @@ class MainApp extends React.Component {
           allDoneCallback={() => allDoneCallback()}
           volume={this.state.volume}
           onVolumeChange={(v) => this.setState({volume: v})}
+          display_feedback={DISPLAY_FEEDBACK}
         />
         <MTurkSubmitForm
           assignment_id={this.state.assignment_id}

--- a/parlai/mturk/core/react_server/dev/app.jsx
+++ b/parlai/mturk/core/react_server/dev/app.jsx
@@ -69,7 +69,7 @@ class MainApp extends React.Component {
     this.state = {
       task_description: null,
       mturk_submit_url: null,
-      frame_height: 650,
+      frame_height: FRAME_HEIGHT,
       socket_status: null,
       hit_id: HIT_ID, // gotten from template
       assignment_id: ASSIGNMENT_ID, // gotten from template
@@ -96,7 +96,7 @@ class MainApp extends React.Component {
 
   handleIncomingHITData(data) {
     let task_description = data['task_description'];
-    if (isMobile() && block_mobile) {
+    if (isMobile() && BLOCK_MOBILE) {
       task_description = (
         "<h1>Sorry, this task cannot be completed on mobile devices. " +
         "Please use a computer.</h1><br>Task Description follows:<br>" +
@@ -115,11 +115,11 @@ class MainApp extends React.Component {
     getHitConfig((data) => this.handleIncomingHITData(data));
   }
 
-  onMessageSend(text, data, callback) {
+  onMessageSend(text, data, callback, is_system) {
     if (text == '') {
       return;
     }
-    this.socket_handler.handleQueueMessage(text, data, callback);
+    this.socket_handler.handleQueueMessage(text, data, callback, is_system);
   }
 
   render() {
@@ -171,7 +171,7 @@ class MainApp extends React.Component {
           task_done={this.state.task_done}
           done_text={this.state.done_text}
           chat_state={this.state.chat_state}
-          onMessageSend={(m, d, c) => this.onMessageSend(m, d, c)}
+          onMessageSend={(m, d, c, s) => this.onMessageSend(m, d, c, s)}
           socket_status={this.state.socket_status}
           messages={this.state.messages}
           agent_id={this.state.agent_id}

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {FormControl, Button} from 'react-bootstrap';
+import {FormControl, Button, ButtonGroup} from 'react-bootstrap';
 import Slider from 'rc-slider';
 import $ from 'jquery';
 
@@ -315,16 +315,58 @@ class IdleResponse extends React.Component {
 class DoneButton extends React.Component {
   // This component is responsible for initiating the click
   // on the mturk form's submit button.
+  constructor(props) {
+    super(props);
+    this.state = {
+      'current_button': null,
+      'submitted': false,
+      'text': '',
+      'dropdown_value': null,
+
+    };
+  }
+
   render() {
+    let review_flow = null;
+    if (this.props.display_feedback) {
+      let dropdown = null;
+      let other_input = null;
+      if (this.state.current_button < 3) {
+        // show bad feedback dropdown
+      } else if (this.state.current_button > 3) {
+        // show good feedback dropdown
+      }
+      if (dropdown != null && dropdown_value == 'other') {
+        // show other text input box
+      }
+      review_flow = (
+        <div>
+          Rate your chat partner (fully optional):
+          <ButtonGroup>
+            <Button>1</Button>
+            <Button>2</Button>
+            <Button>3</Button>
+            <Button>4</Button>
+            <Button>5</Button>
+          </ButtonGroup>
+          {dropdown}
+          {other_input}
+          <Button>Submit</Button>
+        </div>
+      );
+    }
     return (
-      <button
-        id="done-button" type="button"
-        className="btn btn-primary btn-lg"
-        onClick={() => this.props.allDoneCallback()}>
-          <span
-            className="glyphicon glyphicon-ok-circle"
-            aria-hidden="true" /> Done with this HIT
-      </button>
+      <div>
+        <button
+          id="done-button" type="button"
+          className="btn btn-primary btn-lg"
+          onClick={() => this.props.allDoneCallback()}>
+            <span
+              className="glyphicon glyphicon-ok-circle"
+              aria-hidden="true" /> Done with this HIT
+        </button>
+        {review_buttons}
+      </div>
     );
   }
 }

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -446,7 +446,7 @@ class ReviewButtons extends React.Component {
     let disable_submit = (this.state.submitting || current_rating == null);
     let review_flow = (
       <div>
-        Rate your chat partner (fully optional & confidential. 3 is average):
+        Rate your chat partner (fully optional & confidential):
         <br />
         <ButtonGroup>
           {buttons}

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -8,7 +8,10 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {FormControl, Button, ButtonGroup} from 'react-bootstrap';
+import {
+  FormControl, Button, ButtonGroup, InputGroup, MenuItem, DropdownButton,
+  OverlayTrigger, Tooltip
+} from 'react-bootstrap';
 import Slider from 'rc-slider';
 import $ from 'jquery';
 
@@ -261,6 +264,12 @@ class ChatPane extends React.Component {
     return this.props.frame_height - bottom_height;
   }
 
+  handleResize() {
+    if (this.getChatHeight() != this.state.chat_height) {
+      this.setState({chat_height: this.getChatHeight()});
+    }
+  }
+
   render () {
     let v_id = this.props.v_id;
     let XMessageList = getCorrectComponent('XMessageList', v_id);
@@ -278,9 +287,7 @@ class ChatPane extends React.Component {
     };
 
     window.setTimeout(() => {
-      if (this.getChatHeight() != this.state.chat_height) {
-        this.setState({chat_height: this.getChatHeight()});
-      }
+      this.handleResize()
     }, 10);
 
     top_pane_style['height'] = (this.state.chat_height) + 'px'
@@ -312,66 +319,195 @@ class IdleResponse extends React.Component {
   }
 }
 
-class DoneButton extends React.Component {
-  // This component is responsible for initiating the click
-  // on the mturk form's submit button.
+class ReviewButtons extends React.Component {
+  GOOD_REASONS = [
+    'not specified',
+    'Interesting/Creative',
+    'other',
+  ]
+
+  BAD_REASONS = [
+    'not specified',
+    "Didn't understand task",
+    "Bad grammar/spelling",
+    "Total nonsense",
+    "slow responder",
+    'other',
+  ]
+
+  RATING_VALUES = [1, 2, 3, 4, 5]
+
+  RATING_TITLES = [
+    'Terrible', 'Bad', 'Average/Good',
+    'Great', 'Above and Beyond'
+  ]
+
   constructor(props) {
     super(props);
     this.state = {
-      'current_button': null,
+      'current_rating': null,
+      'submitting': false,
       'submitted': false,
       'text': '',
-      'dropdown_value': null,
-
+      'dropdown_value': 'not specified',
     };
   }
 
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    this.props.onInputResize();
+  }
+
+  render() {
+    // Create basic button selector
+    let current_rating = this.state.current_rating;
+    let button_vals = this.RATING_VALUES;
+    let rating_titles = this.RATING_TITLES;
+    let buttons = button_vals.map (
+      (v) => {
+        let use_style = 'info';
+        if (v < 3) {
+          use_style = 'danger';
+        } else if (v > 3) {
+          use_style = 'success'
+        }
+
+        let tooltip = <Tooltip id={"tooltip-"+v}>{rating_titles[v-1]}</Tooltip>;
+        return (
+          <OverlayTrigger
+            placement="top" overlay={tooltip} key={'select-rating-' + v}>
+            <Button
+              onClick={() => this.setState({
+                'current_rating': v,
+                'text': '',
+                'dropdown_value': 'not specified',
+              })}
+              bsStyle={current_rating == v ? use_style : 'default'}
+              disabled={this.state.submitting}
+            >
+              {v}
+            </Button>
+          </OverlayTrigger>
+        );
+      }
+    )
+
+    // Dropdown and other only appear in some cases
+    let dropdown = null;
+    let other_input = null;
+    let reason_input = null;
+    if (current_rating != null && current_rating != 3) {
+      let options = current_rating > 3 ? this.GOOD_REASONS : this.BAD_REASONS;
+      let dropdown_vals = options.map((opt) => (
+        <MenuItem
+          key={'dropdown-item-' + opt}
+          eventKey={opt}
+          onSelect={(key) => this.setState({dropdown_value: key, text: ''})}
+        >
+          {opt}
+        </MenuItem>
+      ))
+      dropdown = (
+        <DropdownButton
+          dropup={true}
+          componentClass={InputGroup.Button}
+          title={this.state.dropdown_value}
+          id={'review-dropdown'}
+          disabled={this.state.submitting}
+        >
+          {dropdown_vals}
+        </DropdownButton>
+      );
+    }
+
+    // Create other text
+    if (dropdown != null && this.state.dropdown_value == 'other') {
+      // Optional input for if the user says other
+      other_input = <FormControl
+        type="text"
+        placeholder="Enter reason (optional)"
+        value={this.state.text}
+        onChange={(t) => this.setState({text: t.target.value})}
+        disabled={this.state.submitting}
+      />;
+    }
+    if (dropdown != null) {
+      reason_input = <div style={{marginBottom: '8px'}}>
+        Give a reason for your rating (optional):
+        <InputGroup>
+          {dropdown}
+          {other_input}
+        </InputGroup>
+      </div>
+    }
+
+    // Assemble flow components
+    let disable_submit = (this.state.submitting || current_rating == null);
+    let review_flow = (
+      <div>
+        Rate your chat partner (fully optional & confidential. 3 is average):
+        <br />
+        <ButtonGroup>
+          {buttons}
+        </ButtonGroup>
+        {reason_input}
+        <div style={{marginBottom: '8px'}}>
+          <Button
+            disabled={disable_submit}
+            onClick={() => {
+              this.setState({'submitting': true})
+              let feedback_data = {
+                rating: this.state.current_rating,
+                reason_category: this.state.dropdown_value,
+                reason: this.state.text,
+              }
+              this.props.onMessageSend(
+                '[PEER_REVIEW]',
+                feedback_data,
+                () => this.setState({submitted: true}),
+                true, // This is a system message, shouldn't be put in feed
+              )
+            }}
+          >
+            {this.state.submitted ? 'Submitted!' : 'Submit review'}
+          </Button> (press this before Done to submit feedback)
+        </div>
+      </div>
+    );
+    return review_flow;
+  }
+}
+
+class DoneButton extends React.Component {
+  // This component is responsible for initiating the click
+  // on the mturk form's submit button.
   render() {
     let review_flow = null;
     if (this.props.display_feedback) {
-      let dropdown = null;
-      let other_input = null;
-      if (this.state.current_button < 3) {
-        // show bad feedback dropdown
-      } else if (this.state.current_button > 3) {
-        // show good feedback dropdown
-      }
-      if (dropdown != null && dropdown_value == 'other') {
-        // show other text input box
-      }
-      review_flow = (
-        <div>
-          Rate your chat partner (fully optional):
-          <ButtonGroup>
-            <Button>1</Button>
-            <Button>2</Button>
-            <Button>3</Button>
-            <Button>4</Button>
-            <Button>5</Button>
-          </ButtonGroup>
-          {dropdown}
-          {other_input}
-          <Button>Submit</Button>
-        </div>
-      );
+      review_flow = <ReviewButtons {...this.props} />;
     }
     return (
       <div>
-        <button
-          id="done-button" type="button"
-          className="btn btn-primary btn-lg"
-          onClick={() => this.props.allDoneCallback()}>
-            <span
-              className="glyphicon glyphicon-ok-circle"
-              aria-hidden="true" /> Done with this HIT
-        </button>
-        {review_buttons}
+        {review_flow}
+        <div>
+          <button
+            id="done-button" type="button"
+            className="btn btn-primary btn-lg"
+            onClick={() => this.props.allDoneCallback()}>
+              <span
+                className="glyphicon glyphicon-ok-circle"
+                aria-hidden="true" /> Done with this HIT
+          </button>
+        </div>
       </div>
     );
   }
 }
 
 class DoneResponse extends React.Component {
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    this.props.onInputResize();
+  }
+
   render () {
     let v_id = this.props.v_id;
     let XDoneButton = getCorrectComponent('XDoneButton', v_id);
@@ -421,6 +557,7 @@ class TextResponse extends React.Component {
     if (this.props.active && !prevProps.active) {
       $("input#id_text_input").focus();
     }
+    this.props.onInputResize();
   }
 
   tryMessageSend() {
@@ -532,6 +669,14 @@ class ResponsePane extends React.Component {
 }
 
 class RightPane extends React.Component {
+  handleResize() {
+    if (this.chat_pane !== undefined) {
+      if (this.chat_pane.handleResize !== undefined) {
+        this.chat_pane.handleResize();
+      }
+    }
+  }
+
   render () {
     let v_id = this.props.v_id;
     let XChatPane = getCorrectComponent('XChatPane', v_id);
@@ -545,8 +690,12 @@ class RightPane extends React.Component {
 
     return (
       <div id="right-pane" style={right_pane}>
-        <XChatPane message_count={this.props.messages.length} {...this.props} />
-        <XResponsePane {...this.props} />
+        <XChatPane
+          message_count={this.props.messages.length}
+          {...this.props}
+          ref={(pane) => {this.chat_pane = pane}}
+        />
+        <XResponsePane {...this.props} onInputResize={() => this.handleResize()}/>
       </div>
     );
   }

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -386,6 +386,7 @@ class ReviewButtons extends React.Component {
             })}
             bsStyle={current_rating == v ? use_style : 'default'}
             disabled={this.state.submitting}
+            key={'button-rating-' + v}
           >
             {rating_titles[v-1]}
           </Button>

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -320,25 +320,25 @@ class IdleResponse extends React.Component {
 
 class ReviewButtons extends React.Component {
   GOOD_REASONS = [
-    'Not specified',
-    'Interesting/Creative',
-    'Other',
+    "Not specified",
+    "Interesting/Creative",
+    "Other",
   ]
 
   BAD_REASONS = [
-    'Not specified',
+    "Not specified",
     "Didn't understand task",
     "Bad grammar/spelling",
     "Total nonsense",
     "Slow responder",
-    'Other',
+    "Other",
   ]
 
   RATING_VALUES = [1, 2, 3, 4, 5]
 
   RATING_TITLES = [
-    'Terrible', 'Bad', 'Average/Good',
-    'Great', 'Above and Beyond'
+    "Terrible", "Bad", "Average/Good",
+    "Great", "Above and Beyond"
   ]
 
   constructor(props) {

--- a/parlai/mturk/core/react_server/dev/components/socket_handler.jsx
+++ b/parlai/mturk/core/react_server/dev/components/socket_handler.jsx
@@ -289,8 +289,10 @@ class SocketHandler extends React.Component {
       true,
       true,
       (msg) => {
-        this.props.messages.push(msg.data);
-        this.props.onSuccessfulSend();
+        if (!is_system) {
+          this.props.messages.push(msg.data);
+          this.props.onSuccessfulSend();
+        }
         if (callback !== undefined) {
           callback();
         }

--- a/parlai/mturk/core/react_server/server/server.js
+++ b/parlai/mturk/core/react_server/server/server.js
@@ -219,13 +219,22 @@ app.post('/sns_posts', async function (req, res, next) {
 // Renders the chat page by setting up the template_context given the
 // sent params for the request
 app.get('/chat_index', async function (req, res) {
+  var config_vars = _load_hit_config();
+  var frame_height = config_vars.frame_height || 650;
+  var allow_reviews = config_vars.allow_reviews || false;
+  var block_mobile = config_vars.block_mobile;
+  block_mobile = (block_mobile === undefined) ? true : block_mobile;
+
   var params = req.query;
   var template_context = {
     worker_id: params['workerId'],
     hit_id: params['hitId'],
     task_group_id: params['task_group_id'],
     assignment_id: params['assignmentId'],
-    is_cover_page: params['assignmentId'] == 'ASSIGNMENT_ID_NOT_AVAILABLE'
+    is_cover_page: params['assignmentId'] == 'ASSIGNMENT_ID_NOT_AVAILABLE',
+    allow_reviews: allow_reviews,
+    frame_height: frame_height,
+    block_mobile: block_mobile
   };
 
   res.render('index.html', template_context);

--- a/parlai/mturk/core/react_server/server/static/index.html
+++ b/parlai/mturk/core/react_server/server/static/index.html
@@ -26,8 +26,9 @@ LICENSE file in the root directory of this source tree.
     var ASSIGNMENT_ID = "{{assignment_id}}";
     var HIT_ID = "{{hit_id}}";
     var TASK_GROUP_ID = "{{task_group_id}}";
-    var DISPLAY_FEEDBACK = true; //TODO "{{display_feedback}}"
-    var block_mobile = true;
+    var DISPLAY_FEEDBACK = ("{{allow_reviews}}" === 'true');
+    var FRAME_HEIGHT = {{frame_height}};
+    var BLOCK_MOBILE = ("{{block_mobile}}" === 'true');
 
     </script>
   </head>

--- a/parlai/mturk/core/react_server/server/static/index.html
+++ b/parlai/mturk/core/react_server/server/static/index.html
@@ -22,10 +22,11 @@ LICENSE file in the root directory of this source tree.
 
     var verbosity = 4;
     var IS_COVER_PAGE = ("{{is_cover_page}}" === 'true');
-    var WORKER_ID = "{{worker_id}}"
-    var ASSIGNMENT_ID = "{{assignment_id}}"
-    var HIT_ID = "{{hit_id}}"
-    var TASK_GROUP_ID = "{{task_group_id}}"
+    var WORKER_ID = "{{worker_id}}";
+    var ASSIGNMENT_ID = "{{assignment_id}}";
+    var HIT_ID = "{{hit_id}}";
+    var TASK_GROUP_ID = "{{task_group_id}}";
+    var DISPLAY_FEEDBACK = true; //TODO "{{display_feedback}}"
     var block_mobile = true;
 
     </script>

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -216,7 +216,7 @@ class SocketManager():
         self.is_shutdown = False
         self.send_lock = threading.Condition()
         self.packet_map_lock = threading.Condition()
-        self.worker_assign_ids = {} # mapping from connection id to pair
+        self.worker_assign_ids = {}  # mapping from connection id to pair
 
         # setup the socket
         self._setup_socket()

--- a/parlai/mturk/core/test/test_mturk_manager.py
+++ b/parlai/mturk/core/test/test_mturk_manager.py
@@ -1452,8 +1452,9 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         mturk_utils.subscribe_to_hits.assert_called_with(
             fake_hit, manager.is_sandbox, manager.topic_arn)
         self.assertEqual(
-            len(mturk_utils.create_hit_with_hit_type.call_args_list), 6)
+            len(mturk_utils.create_hit_with_hit_type.call_args_list), 5)
         mturk_utils.create_hit_with_hit_type.assert_called_with(
+            opt=manager.opt,
             page_url=mturk_chat_url,
             hit_type_id=fake_hit,
             num_assignments=1,

--- a/parlai/mturk/core/test/test_mturk_manager.py
+++ b/parlai/mturk/core/test/test_mturk_manager.py
@@ -1452,7 +1452,7 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         mturk_utils.subscribe_to_hits.assert_called_with(
             fake_hit, manager.is_sandbox, manager.topic_arn)
         self.assertEqual(
-            len(mturk_utils.create_hit_with_hit_type.call_args_list), 5)
+            len(mturk_utils.create_hit_with_hit_type.call_args_list), 6)
         mturk_utils.create_hit_with_hit_type.assert_called_with(
             page_url=mturk_chat_url,
             hit_type_id=fake_hit,

--- a/parlai/mturk/core/worlds.py
+++ b/parlai/mturk/core/worlds.py
@@ -20,11 +20,15 @@ class MTurkDataWorld(World):
         }
 
         for agent in workers:
+            messages = agent.get_messages()
+            # filter out peer feedback
+            save_messages = [m for m in messages
+                             if m['text'] != '[PEER_REVIEW]']
             save_data['worker_data'][agent.worker_id] = {
                 'worker_id': agent.worker_id,
                 'agent_id': agent.id,
                 'assignment_id': agent.assignment_id,
-                'messages': agent.get_messages(),
+                'messages': save_messages,
                 'given_feedback': agent.feedback,
             }
 

--- a/parlai/mturk/core/worlds.py
+++ b/parlai/mturk/core/worlds.py
@@ -25,7 +25,16 @@ class MTurkDataWorld(World):
                 'agent_id': agent.id,
                 'assignment_id': agent.assignment_id,
                 'messages': agent.get_messages(),
+                'given_feedback': agent.feedback,
             }
+
+        # In simple pairing case, attach the feedback right here
+        if len(workers) == 2:
+            data = save_data['worker_data']
+            a_0 = workers[0]
+            a_1 = workers[1]
+            data[a_0.worker_id]['gotten_feedback'] = a_1.feedback
+            data[a_1.worker_id]['gotten_feedback'] = a_0.feedback
 
         return save_data
 

--- a/parlai/mturk/core/worlds.py
+++ b/parlai/mturk/core/worlds.py
@@ -37,8 +37,8 @@ class MTurkDataWorld(World):
             data = save_data['worker_data']
             a_0 = workers[0]
             a_1 = workers[1]
-            data[a_0.worker_id]['gotten_feedback'] = a_1.feedback
-            data[a_1.worker_id]['gotten_feedback'] = a_0.feedback
+            data[a_0.worker_id]['received_feedback'] = a_1.feedback
+            data[a_1.worker_id]['received_feedback'] = a_0.feedback
 
         return save_data
 

--- a/parlai/mturk/tasks/multi_agent_dialog/run.py
+++ b/parlai/mturk/tasks/multi_agent_dialog/run.py
@@ -74,7 +74,7 @@ def main():
             mturk_agent_2 = workers[1]
 
             # Create the local human agents
-            human_agent_1 = LocalHumanAgent(opt=None)
+            human_agent_1 = LocalHumanAgent(opt={})
             human_agent_1.id = human_agent_1_id
 
             world = MTurkMultiAgentDialogWorld(

--- a/parlai/mturk/tasks/qa_data_collection/task_config.py
+++ b/parlai/mturk/tasks/qa_data_collection/task_config.py
@@ -8,9 +8,6 @@
 
 task_config = {}
 
-task_config['frontend_version'] = 1
-task_config['allow_reviews'] = True
-
 """A short and descriptive title about the kind of task the HIT contains.
 On the Amazon Mechanical Turk web site, the HIT title appears in search results,
 and everywhere the HIT is mentioned.

--- a/parlai/mturk/tasks/qa_data_collection/task_config.py
+++ b/parlai/mturk/tasks/qa_data_collection/task_config.py
@@ -8,6 +8,8 @@
 
 task_config = {}
 
+task_config['frontend_version'] = 1
+task_config['allow_reviews'] = True
 
 """A short and descriptive title about the kind of task the HIT contains.
 On the Amazon Mechanical Turk web site, the HIT title appears in search results,

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -1342,7 +1342,7 @@ class AssignmentView extends React.Component {
     }).catch((err) => {
       // Custom react module not found
       this.props.setCustomComponents({});
-    );
+    });
   }
 
   getOnboardingChat() {
@@ -1842,14 +1842,13 @@ class DemoTaskPanel extends React.Component {
             this.setState({
               task_loading: false, task_config: result.task_config});
           }).catch((err) => {
-          // Custom react module not found
-          if (result.task_config.frame_height === undefined) {
-            result.task_config.frame_height = 650;
-          }
-          this.setState({
-            task_loading: false, task_config: result.task_config});
-          );
-
+            // Custom react module not found
+            if (result.task_config.frame_height === undefined) {
+              result.task_config.frame_height = 650;
+            }
+            this.setState({
+              task_loading: false, task_config: result.task_config});
+          });
         },
         (error) => {
           this.setState({

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -1334,17 +1334,15 @@ class AssignmentView extends React.Component {
   constructor(props) {
     super(props);
     let task_name = props.data.task_name;
-    try {
-      import(
-        /* webpackMode: "eager" */
-        `./task_components/${task_name}/components/custom.jsx`
-      ).then((custom) => {
-        this.props.setCustomComponents(custom.default);
-      });
-    } catch (err) {
+    import(
+      /* webpackMode: "eager" */
+      `./task_components/${task_name}/components/custom.jsx`
+    ).then((custom) => {
+      this.props.setCustomComponents(custom.default);
+    }).catch((err) => {
       // Custom react module not found
       this.props.setCustomComponents({});
-    }
+    );
   }
 
   getOnboardingChat() {
@@ -1833,26 +1831,24 @@ class DemoTaskPanel extends React.Component {
       .then(
         (result) => {
           this.handleNewData(result);
-          try {
-            import(
-              /* webpackMode: "eager" */
-              `./task_components/${this.props.task_id}/components/custom.jsx`
-            ).then((custom) => {
-              setCustomComponents(custom.default);
-              if (result.task_config.frame_height === undefined) {
-                result.task_config.frame_height = 650;
-              }
-              this.setState({
-                task_loading: false, task_config: result.task_config});
-            });
-          } catch (err) {
-            // Custom react module not found
+          import(
+            /* webpackMode: "eager" */
+            `./task_components/${this.props.task_id}/components/custom.jsx`
+          ).then((custom) => {
+            setCustomComponents(custom.default);
             if (result.task_config.frame_height === undefined) {
               result.task_config.frame_height = 650;
             }
             this.setState({
               task_loading: false, task_config: result.task_config});
+          }).catch((err) => {
+          // Custom react module not found
+          if (result.task_config.frame_height === undefined) {
+            result.task_config.frame_height = 650;
           }
+          this.setState({
+            task_loading: false, task_config: result.task_config});
+          );
 
         },
         (error) => {

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -802,7 +802,7 @@ class AssignmentFeedback extends React.Component {
       <Panel
         id="assignment_instruction_div"
         bsStyle={bsStyle}
-        defaultExpanded={given_feedback || gotten_feedback}>
+        defaultExpanded={!!(given_feedback || gotten_feedback)}>
         <Panel.Heading>
           <Panel.Title componentClass="h3" toggle>
             Feedback

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -1334,12 +1334,17 @@ class AssignmentView extends React.Component {
   constructor(props) {
     super(props);
     let task_name = props.data.task_name;
-    import(
-      /* webpackMode: "eager" */
-      `./task_components/${task_name}/components/custom.jsx`
-    ).then((custom) => {
-      this.props.setCustomComponents(custom.default);
-    });
+    try {
+      import(
+        /* webpackMode: "eager" */
+        `./task_components/${task_name}/components/custom.jsx`
+      ).then((custom) => {
+        this.props.setCustomComponents(custom.default);
+      });
+    } catch (err) {
+      // Custom react module not found
+      this.props.setCustomComponents({});
+    }
   }
 
   getOnboardingChat() {

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -757,12 +757,12 @@ class AssignmentFeedback extends React.Component {
     var content = null;
     var bsStyle = null;
     let given_feedback = null;
-    let gotten_feedback = null;
+    let received_feedback = null;
     if (review_data !== undefined) {
       given_feedback = review_data.given_feedback;
-      gotten_feedback = review_data.gotten_feedback;
+      received_feedback = review_data.received_feedback;
     }
-    if (!given_feedback && !gotten_feedback) {
+    if (!given_feedback && !received_feedback) {
       content = "No feedback is associated with this assignment."
       bsStyle = "default"
     } else {
@@ -778,22 +778,22 @@ class AssignmentFeedback extends React.Component {
         };
         given_feedback_content = <XReviewButtons init_state={init_state} />;
       }
-      let gotten_feedback_content = <span>No provided feedback</span>;
-      if (gotten_feedback !== undefined) {
+      let received_feedback_content = <span>No provided feedback</span>;
+      if (received_feedback !== undefined) {
         let init_state = {
-          'current_rating': gotten_feedback.rating,
+          'current_rating': received_feedback.rating,
           'submitting': true,
           'submitted': true,
-          'text': gotten_feedback.reason,
-          'dropdown_value': gotten_feedback.reason_category,
+          'text': received_feedback.reason,
+          'dropdown_value': received_feedback.reason_category,
         };
-        gotten_feedback_content = <XReviewButtons init_state={init_state} />;
+        received_feedback_content = <XReviewButtons init_state={init_state} />;
       }
       content = <div>
         <h1>Given feedback</h1>
         {given_feedback_content}
         <h1>Received feedback</h1>
-        {gotten_feedback_content}
+        {received_feedback_content}
       </div>;
       bsStyle = "info"
     }
@@ -802,7 +802,7 @@ class AssignmentFeedback extends React.Component {
       <Panel
         id="assignment_instruction_div"
         bsStyle={bsStyle}
-        defaultExpanded={!!(given_feedback || gotten_feedback)}>
+        defaultExpanded={!!(given_feedback || received_feedback)}>
         <Panel.Heading>
           <Panel.Title componentClass="h3" toggle>
             Feedback

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -753,7 +753,6 @@ class RunPanel extends React.Component {
 
 class AssignmentFeedback extends React.Component {
   render() {
-    console.log(this.props.data);
     let review_data = this.props.data.task.data;
     var content = null;
     var bsStyle = null;
@@ -802,7 +801,8 @@ class AssignmentFeedback extends React.Component {
     return (
       <Panel
         id="assignment_instruction_div"
-        bsStyle={bsStyle}>
+        bsStyle={bsStyle}
+        defaultExpanded={given_feedback || gotten_feedback}>
         <Panel.Heading>
           <Panel.Title componentClass="h3" toggle>
             Feedback

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -127,7 +127,6 @@ class ChatDisplay extends React.Component {
       <Panel
         id="message_display_div"
         bsStyle="info"
-        style={{float: 'right', 'width': '58%'}}
         defaultExpanded>
         <Panel.Heading>
           <Panel.Title componentClass="h3" toggle>
@@ -752,6 +751,73 @@ class RunPanel extends React.Component {
   }
 }
 
+class AssignmentFeedback extends React.Component {
+  render() {
+    console.log(this.props.data);
+    let review_data = this.props.data.task.data;
+    var content = null;
+    var bsStyle = null;
+    let given_feedback = null;
+    let gotten_feedback = null;
+    if (review_data !== undefined) {
+      given_feedback = review_data.given_feedback;
+      gotten_feedback = review_data.gotten_feedback;
+    }
+    if (!given_feedback && !gotten_feedback) {
+      content = "No feedback is associated with this assignment."
+      bsStyle = "default"
+    } else {
+      let XReviewButtons = getCorrectComponent('XReviewButtons', null);
+      let given_feedback_content = <span>No provided feedback</span>;
+      if (given_feedback !== undefined) {
+        let init_state = {
+          'current_rating': given_feedback.rating,
+          'submitting': true,
+          'submitted': true,
+          'text': given_feedback.reason,
+          'dropdown_value': given_feedback.reason_category,
+        };
+        given_feedback_content = <XReviewButtons init_state={init_state} />;
+      }
+      let gotten_feedback_content = <span>No provided feedback</span>;
+      if (gotten_feedback !== undefined) {
+        let init_state = {
+          'current_rating': gotten_feedback.rating,
+          'submitting': true,
+          'submitted': true,
+          'text': gotten_feedback.reason,
+          'dropdown_value': gotten_feedback.reason_category,
+        };
+        gotten_feedback_content = <XReviewButtons init_state={init_state} />;
+      }
+      content = <div>
+        <h1>Given feedback</h1>
+        {given_feedback_content}
+        <h1>Received feedback</h1>
+        {gotten_feedback_content}
+      </div>;
+      bsStyle = "info"
+    }
+
+    return (
+      <Panel
+        id="assignment_instruction_div"
+        bsStyle={bsStyle}>
+        <Panel.Heading>
+          <Panel.Title componentClass="h3" toggle>
+            Feedback
+          </Panel.Title>
+        </Panel.Heading>
+        <Panel.Collapse>
+          <Panel.Body>
+            {content}
+          </Panel.Body>
+        </Panel.Collapse>
+      </Panel>
+    );
+  }
+}
+
 class AssignmentInstructions extends React.Component {
   render() {
     let instructions = this.props.data;
@@ -769,8 +835,7 @@ class AssignmentInstructions extends React.Component {
     return (
       <Panel
         id="assignment_instruction_div"
-        bsStyle={bsStyle}
-        style={{float: 'left', 'width': '40%'}}>
+        bsStyle={bsStyle}>
         <Panel.Heading>
           <Panel.Title componentClass="h3" toggle>
             Task Instructions
@@ -1281,9 +1346,7 @@ class AssignmentView extends React.Component {
     let onboard_data = this.props.data.onboarding;
     if (onboard_data === null) {
       return (
-        <Panel
-          id="message_display_div_onboarding"
-          style={{float: 'right', 'width': '58%'}}>
+        <Panel id="message_display_div_onboarding">
           <Panel.Heading>
             <Panel.Title componentClass="h3" toggle>
               Onboarding Chat Window
@@ -1395,17 +1458,24 @@ class AssignmentPanel extends React.Component {
         <AssignmentTable
           data={[this.state.data.assignment_details]}
           title={'State info for this assignment'}/>
-        <AssignmentInstructions
-          data={[this.state.data.assignment_instructions]}
-          custom_components={this.state.custom_components}/>
-        <AssignmentView
-          data={this.state.data.assignment_content}
-          title={'Assignment Content'}
-          custom_components={this.state.custom_components}
-          setCustomComponents={(module) => {
-            setCustomComponents(module);
-            this.setState({custom_components: module});
-          }}/>
+        <div id='left-assign-pane' style={{float: 'left', 'width': '40%'}}>
+          <AssignmentInstructions
+            data={[this.state.data.assignment_instructions]}
+            custom_components={this.state.custom_components}/>
+          <AssignmentFeedback
+            data={this.state.data.assignment_content}
+            custom_components={this.state.custom_components}/>
+        </div>
+        <div id='right-assign-pane' style={{float: 'right', 'width': '58%'}}>
+          <AssignmentView
+            data={this.state.data.assignment_content}
+            title={'Assignment Content'}
+            custom_components={this.state.custom_components}
+            setCustomComponents={(module) => {
+              setCustomComponents(module);
+              this.setState({custom_components: module});
+            }}/>
+        </div>
         <AssignmentReviewer
           data={this.state.data.assignment_details}
           onUpdate={() => this.fetchRunData()}/>

--- a/parlai/mturk/webapp/static/index.html
+++ b/parlai/mturk/webapp/static/index.html
@@ -20,6 +20,12 @@ LICENSE file in the root directory of this source tree.
     // Set the initial URL to be able to provide the actual location in
     // the app people want to go to
     var URL_DESTINATION = '{{escape(initial_location)}}'
+
+    // Set a number of default values for MTURK runs.
+    // TODO pull from task configs rather than hard code here :)
+    var DISPLAY_FEEDBACK = false;
+    var FRAME_HEIGHT = 650;
+    var BLOCK_MOBILE = false;
     </script>
   </head>
 


### PR DESCRIPTION
## Description/motivation
In order to isolate particular high and low quality examples it's useful to get feedback on individual interactions between workers, rated by the workers themselves rather than via hand review. It remains to be seen how noisy this rating data will be, but chances are it will at least be useful. Workers in the past have asked for this functionality as they don't like having others not put effort into the work as it degrades the platform for those who do.

## Implementation
- A new react component `ReviewButtons` was added to the `core_components.jsx` file. This component handles submitting feedback through the regular message channel over the socket (a system message). It then reports the action to its parent `DoneButton` in order to get the done button to show. It is treated as an extension of the done button for tasks that have enabled `allow_reviews` in their `task_config`.
- On agent, the agent queue is flushed once the HIT is submitted in order to extract potential feedback messages that were sent after the world ended. These are then put into the `agent.feedback` field.
- `MTurkDataWorld` was updated to extract the feedback from an agent, and then put it into the saved data as `given_feedback`. It also strips the command message from the saved messages, and attaches the partner's feedback as `gotten_feedback`
- An `AssignmentFeedback` component was added to the ParlAI MTurk webapp, which serves the purpose of displaying the `ReviewButtons` component with the feedback found in the saved data. 
- Moves the components displayed in the assignment view in the webapp into left and right panes in order to add the feedback panel into the flow in a place that makes sense.
- Adds an `_assert_opts` call to `MTurkManager` to ensure that the options being passed are compatible with one another (as, for example, `allow_reviews` only works with the react frontend). This warning is printed before the user hits enter to confirm task launching.
- Fixes behavior for react socket messaging when `is_system` is true to prevent system messages from being appended into the chat flow.

## Screenshots
### Note : screens were taken before I removed "3 is average" guidance
### Worker view
#### Neutral
![screen shot 2018-12-19 at 12 08 42 pm](https://user-images.githubusercontent.com/1276867/50247226-4db97e00-03a5-11e9-8002-000462bbfa0c.png)
#### Positive
![screen shot 2018-12-19 at 12 09 11 pm](https://user-images.githubusercontent.com/1276867/50247229-53af5f00-03a5-11e9-8c67-6d5d3d429e93.png)
![screen shot 2018-12-19 at 12 14 41 pm](https://user-images.githubusercontent.com/1276867/50247277-72adf100-03a5-11e9-9283-1b72ae648e18.png)
#### Negative
![screen shot 2018-12-19 at 12 08 52 pm](https://user-images.githubusercontent.com/1276867/50247263-69248900-03a5-11e9-932c-3f57571d6266.png)
![screen shot 2018-12-19 at 12 09 00 pm](https://user-images.githubusercontent.com/1276867/50247248-5f9b2100-03a5-11e9-9c1e-40c45bb41f07.png)
#### Decline feedback
![screen shot 2018-12-19 at 12 10 20 pm](https://user-images.githubusercontent.com/1276867/50247308-848f9400-03a5-11e9-9136-f25ac91cbbc9.png)
#### Submit feedback
![screen shot 2018-12-19 at 12 15 03 pm](https://user-images.githubusercontent.com/1276867/50247318-89ecde80-03a5-11e9-921b-7f04a074d9df.png)
### Webapp view
#### No feedback
![screen shot 2018-12-19 at 12 25 16 pm](https://user-images.githubusercontent.com/1276867/50247339-9c671800-03a5-11e9-8ec9-f536ebadcf03.png)
#### With feedback
![screen shot 2018-12-19 at 12 26 48 pm](https://user-images.githubusercontent.com/1276867/50247363-ae48bb00-03a5-11e9-9638-247470735d3f.png)
### Opt warnings
#### `allow_reviews` on a task where the number of people is not 2
![screen shot 2018-12-19 at 12 34 48 pm](https://user-images.githubusercontent.com/1276867/50247415-cfa9a700-03a5-11e9-8ac8-aef2172e798e.png)
#### `allow_reviews` on a task not running react frontend
![screen shot 2018-12-19 at 12 35 25 pm](https://user-images.githubusercontent.com/1276867/50247462-f1a32980-03a5-11e9-98ac-30f606830fc1.png)

## Additional fixes 
- Frame height is now set in `task_config` for react frontend tasks, defaults to 650 (and stays 650 for tasks without react frontend).
- `block_mobile` is added to the same flow of configuring in `task_config`
- The above two fixes require sending opts to the `create_hit_config` function (as well as `create_hit_with_hit_type`) so that these values can be extracted.
- `onInputResize` and callbacks have been added to input components on the frontend as a method to call when the input size changes, as this allows the chat window to resize as well to stay in `frame_height` without any other changes.