### PR TITLE
[Messenger] observing personas

### DIFF
--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -42,6 +42,7 @@ class MessengerAgent(Agent):
                 self.id,
                 act['payload'],
                 act.get('quick_replies', None),
+                act.get('persona_id', None)
             )
         else:
             if act['id'] != '':
@@ -51,6 +52,7 @@ class MessengerAgent(Agent):
             resp = self.manager.observe_message(
                 self.id, msg,
                 act.get('quick_replies', None),
+                act.get('persona_id', None)
             )
         try:
             mid = resp[0]['message_id']

--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -63,9 +63,9 @@ class MessengerAgent(Agent):
                 '{} could not be extracted to an observed message'.format(resp)
             )
 
-    def observe_typing_on(self):
+    def observe_typing_on(self, persona_id=None):
         """Allow agent to observe typing indicator"""
-        self.manager.message_sender.typing_on(self.id)
+        self.manager.message_sender.typing_on(self.id, persona_id=persona_id)
 
     def put_data(self, message):
         """Put data into the message queue if it hasn't already been seen"""

--- a/parlai/messenger/core/messenger_manager.py
+++ b/parlai/messenger/core/messenger_manager.py
@@ -642,15 +642,19 @@ class MessengerManager():
 
     # Agent Interaction Functions #
 
-    def observe_message(self, receiver_id, text, quick_replies=None):
+    def observe_message(self, receiver_id, text, quick_replies=None,
+                        persona_id=None):
         """Send a message through the message manager"""
         return self.message_sender.send_fb_message(receiver_id, text, True,
-                                                   quick_replies=quick_replies)
+                                                   quick_replies=quick_replies,
+                                                   persona_id=persona_id)
 
-    def observe_payload(self, receiver_id, data, quick_replies=None):
+    def observe_payload(self, receiver_id, data, quick_replies=None,
+                        persona_id=None):
         """Send a payload through the message manager"""
         return self.message_sender.send_fb_payload(receiver_id, data,
-                                                   quick_replies=None)
+                                                   quick_replies=quick_replies,
+                                                   persona_id=persona_id)
 
     def upload_attachment(self, payload):
         """Uploads an attachment and returns an attachment ID


### PR DESCRIPTION
completing work from #1306 

This allows messenger agents to see personas; must include persona_id in `persona_id` field in an act that an agent observes.