### PR TITLE
No longer test a deprecated flag in hogwild.

### DIFF
--- a/tests/test_hogwild.py
+++ b/tests/test_hogwild.py
@@ -51,7 +51,6 @@ class TestHogwild(unittest.TestCase):
                 parser.set_defaults(numthreads=nt)
                 for bs in [1, 2, 3]:
                     parser.set_defaults(batchsize=bs)
-                    parser.set_defaults(batch_sort=(bs % 2 == 0))
                     tl = TrainLoop(parser)
                     report_valid, report_test = tl.train()
                     # test final valid and test evals
@@ -92,7 +91,6 @@ class TestHogwild(unittest.TestCase):
                 parser.set_defaults(numthreads=nt)
                 for bs in [1, 2, 3]:
                     parser.set_defaults(batchsize=bs)
-                    parser.set_defaults(batch_sort=(bs % 2 == 0))
                     report = eval_model(parser, printargs=False)
                     self.assertEqual(report['exs'], NUM_EXS)
         finally:


### PR DESCRIPTION
Mostly just gets rid of the annoying warnings when running tests.