### PR TITLE
[MTurk] Small MTurk fixes

### DIFF
--- a/parlai/messenger/tasks/qa_data_collection/run.py
+++ b/parlai/messenger/tasks/qa_data_collection/run.py
@@ -27,7 +27,7 @@ def main():
     class_name = 'DefaultTeacher'
     my_module = importlib.import_module(module_name)
     task_class = getattr(my_module, class_name)
-    task_opt = {}
+    task_opt = opt.copy()
     task_opt['datatype'] = 'train'
     task_opt['datapath'] = opt['datapath']
 

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -650,7 +650,7 @@ class TextResponse extends React.Component {
         placeholder="Please enter here..."
         onKeyPress={(e) => this.handleKeyPress(e)}
         onChange={(e) => this.setState({textval: e.target.value})}
-        disabled={!this.props.active}/>
+        disabled={!this.props.active || this.state.sending}/>
     );
 
     let submit_button = (
@@ -658,7 +658,8 @@ class TextResponse extends React.Component {
         className="btn btn-primary"
         style={submit_style}
         id="id_send_msg_button"
-        disabled={this.state.textval == '' || !this.props.active || this.state.sending}
+        disabled={
+          this.state.textval == '' || !this.props.active || this.state.sending}
         onClick={() => this.tryMessageSend()}>
           Send
       </Button>

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -593,7 +593,7 @@ class DoneResponse extends React.Component {
 class TextResponse extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {'textval': ''};
+    this.state = {'textval': '', 'sending': false};
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
@@ -607,9 +607,11 @@ class TextResponse extends React.Component {
   }
 
   tryMessageSend() {
-    if (this.state.textval != '' && this.props.active) {
+    if (this.state.textval != '' && this.props.active && !this.state.sending) {
+      this.setState({sending: true});
       this.props.onMessageSend(
-        this.state.textval, {}, () => this.setState({textval: ''}));
+        this.state.textval, {},
+        () => this.setState({textval: '', 'sending': false}));
     }
   }
 
@@ -656,7 +658,7 @@ class TextResponse extends React.Component {
         className="btn btn-primary"
         style={submit_style}
         id="id_send_msg_button"
-        disabled={this.state.textval == '' || !this.props.active}
+        disabled={this.state.textval == '' || !this.props.active || this.state.sending}
         onClick={() => this.tryMessageSend()}>
           Send
       </Button>

--- a/parlai/mturk/core/worlds.py
+++ b/parlai/mturk/core/worlds.py
@@ -23,7 +23,7 @@ class MTurkDataWorld(World):
             messages = agent.get_messages()
             # filter out peer feedback
             save_messages = [m for m in messages
-                             if m['text'] != '[PEER_REVIEW]']
+                             if m.get('text') != '[PEER_REVIEW]']
             save_data['worker_data'][agent.worker_id] = {
                 'worker_id': agent.worker_id,
                 'agent_id': agent.id,

--- a/parlai/mturk/tasks/react_task_demo/react_custom_no_extra_deps/frontend/components/custom.jsx
+++ b/parlai/mturk/tasks/react_task_demo/react_custom_no_extra_deps/frontend/components/custom.jsx
@@ -38,19 +38,25 @@ class EvaluatorIdleResponse extends React.Component {
 class NumericResponse extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {'textval': ''};
+    this.state = {'textval': '', 'sending': false};
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
+    // Only change in the active status of this component should cause a
+    // focus event. Not having this would make the focus occur on every
+    // state update (including things like volume changes)
     if (this.props.active && !prevProps.active) {
       $("input#id_text_input").focus();
     }
+    this.props.onInputResize();
   }
 
   tryMessageSend() {
-    if (this.state.textval != '' && this.props.active) {
+    if (this.state.textval != '' && this.props.active && !this.state.sending) {
+      this.setState({sending: true});
       this.props.onMessageSend(
-        this.state.textval, {}, () => this.setState({textval: ''}));
+        this.state.textval, {},
+        () => this.setState({textval: '', 'sending': false}));
     }
   }
 
@@ -97,7 +103,7 @@ class NumericResponse extends React.Component {
         placeholder="Please enter here..."
         onKeyPress={(e) => this.handleKeyPress(e)}
         onChange={(e) => this.updateValue(e.target.value)}
-        disabled={!this.props.active}/>
+        disabled={!this.props.active || this.state.sending}/>
     );
 
     // TODO attach send message callback
@@ -106,7 +112,8 @@ class NumericResponse extends React.Component {
         className="btn btn-primary"
         style={submit_style}
         id="id_send_msg_button"
-        disabled={this.state.textval == '' || !this.props.active}
+        disabled={
+          this.state.textval == '' || !this.props.active || this.state.sending}
         onClick={() => this.tryMessageSend()}>
           Send
       </Button>
@@ -129,13 +136,14 @@ class NumericResponse extends React.Component {
 class EvaluationResponse extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {'textval': ''};
+    this.state = {'textval': '', sending: false};
   }
 
   tryMessageSend(value) {
-    if (this.props.active) {
+    if (this.props.active && !this.state.sending) {
+      this.setState({sending: true});
       this.props.onMessageSend(
-        value, {}, () => this.setState({textval: ''}));
+        value, {}, () => this.setState({textval: '', sending: false}));
     }
   }
 
@@ -162,7 +170,7 @@ class EvaluationResponse extends React.Component {
         className="btn btn-danger"
         style={submit_style}
         id="id_reject_chat_button"
-        disabled={!this.props.active}
+        disabled={!this.props.active || this.state.sending}
         onClick={() => this.tryMessageSend('reject')}>
           Reject
       </Button>
@@ -173,7 +181,7 @@ class EvaluationResponse extends React.Component {
         className="btn btn-success"
         style={submit_style}
         id="id_approve_chat_button"
-        disabled={!this.props.active}
+        disabled={!this.props.active || this.state.sending}
         onClick={() => this.tryMessageSend('approve')}>
           Approve
       </Button>

--- a/parlai/mturk/tasks/react_task_demo/react_custom_with_deps/frontend/components/custom.jsx
+++ b/parlai/mturk/tasks/react_task_demo/react_custom_with_deps/frontend/components/custom.jsx
@@ -38,19 +38,25 @@ class EvaluatorIdleResponse extends React.Component {
 class NumericResponse extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {'textval': ''};
+    this.state = {'textval': '', 'sending': false};
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
+    // Only change in the active status of this component should cause a
+    // focus event. Not having this would make the focus occur on every
+    // state update (including things like volume changes)
     if (this.props.active && !prevProps.active) {
       $("input#id_text_input").focus();
     }
+    this.props.onInputResize();
   }
 
   tryMessageSend() {
-    if (this.state.textval != '' && this.props.active) {
+    if (this.state.textval != '' && this.props.active && !this.state.sending) {
+      this.setState({sending: true});
       this.props.onMessageSend(
-        this.state.textval, {}, () => this.setState({textval: ''}));
+        this.state.textval, {},
+        () => this.setState({textval: '', 'sending': false}));
     }
   }
 
@@ -97,7 +103,7 @@ class NumericResponse extends React.Component {
         placeholder="Please enter here..."
         onKeyPress={(e) => this.handleKeyPress(e)}
         onChange={(e) => this.updateValue(e.target.value)}
-        disabled={!this.props.active}/>
+        disabled={!this.props.active || this.state.sending}/>
     );
 
     // TODO attach send message callback
@@ -106,7 +112,8 @@ class NumericResponse extends React.Component {
         className="btn btn-primary"
         style={submit_style}
         id="id_send_msg_button"
-        disabled={this.state.textval == '' || !this.props.active}
+        disabled={
+          this.state.textval == '' || !this.props.active || this.state.sending}
         onClick={() => this.tryMessageSend()}>
           Send
       </Button>
@@ -129,13 +136,14 @@ class NumericResponse extends React.Component {
 class EvaluationResponse extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {'textval': ''};
+    this.state = {'textval': '', sending: false};
   }
 
   tryMessageSend(value) {
-    if (this.props.active) {
+    if (this.props.active && !this.state.sending) {
+      this.setState({sending: true});
       this.props.onMessageSend(
-        value, {}, () => this.setState({textval: ''}));
+        value, {}, () => this.setState({textval: '', sending: false}));
     }
   }
 
@@ -162,7 +170,7 @@ class EvaluationResponse extends React.Component {
         className="btn btn-danger"
         style={submit_style}
         id="id_reject_chat_button"
-        disabled={!this.props.active}
+        disabled={!this.props.active || this.state.sending}
         onClick={() => this.tryMessageSend('reject')}>
           Reject
       </Button>
@@ -173,7 +181,7 @@ class EvaluationResponse extends React.Component {
         className="btn btn-success"
         style={submit_style}
         id="id_approve_chat_button"
-        disabled={!this.props.active}
+        disabled={!this.props.active || this.state.sending}
         onClick={() => this.tryMessageSend('approve')}>
           Approve
       </Button>


### PR DESCRIPTION
Ran into two bugs while working with the new react frontend and peer feedback systems. 

The first is that if somebody mashes enter or the send button pretty fast (or has a really slow connection) the react frontend would allow doublesends. This is fixed by giving all inputs a message sending state that disables sending new messages.
The second is related to a world saving data - if any messages didn't have a 'text' field, the saving code would break while trying to filter out peer feedback messages. This is fixed by using `get` rather than a direct access.

Tested by running `qa_data_collection`, `react_custom_no_extra_deps`, and an internal task.