### PR TITLE
Multiprocessing bug fix when importing PytorchDataTeacher

### DIFF
--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -35,8 +35,6 @@ class BatchSortCache(object):
     """
         Object that encapsulates the functionality of the batch sort cache.
 
-        Note: is now an object to restrict lock instantiation when not importing the file
-
         Maps episode length to dictionary with following keys:
             current_idx: which episode in the list are we at (if simply indexing
                 into list)
@@ -79,7 +77,8 @@ class BatchSortCache(object):
         def get_cache_size():
             '''Returns number of available episodes '''
             return sum(
-                len(v['ep_list']) - v['current_idx']for k, v in cls.length_to_eps.items()
+                len(v['ep_list']) - v['current_idx']
+                for k, v in cls.length_to_eps.items()
             )
 
         def get_available_buckets(bsz):
@@ -88,7 +87,8 @@ class BatchSortCache(object):
                 return {
                     k: v
                     for k, v in cls.length_to_eps.items()
-                    if not v['bucket_complete'] or len(v['ep_list']) - v['current_idx'] > 0
+                    if not v['bucket_complete']
+                    or len(v['ep_list']) - v['current_idx'] > 0
                 }
             else:
                 return {
@@ -241,7 +241,8 @@ class BatchSortCache(object):
                                     batch = ep_list
                                 elif num_eps - current_idx > 0:
                                     batch = ep_list[current_idx:]
-                                    cls.length_to_eps[length]['current_idx'] = num_eps - 1
+                                    cls.length_to_eps[length]['current_idx'] = \
+                                        num_eps - 1
                                 cls.length_to_eps[length]['bucket_complete'] = True
 
                     if batch is not None:

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -31,215 +31,228 @@ import ctypes
 from threading import Thread, Condition, RLock
 
 
-"""
-    BATCH SORT CACHE
+class BatchSortCache(object):
+    """
+        Object that encapsulates the functionality of the batch sort cache.
 
-    Maps episode length to dictionary with following keys:
-        current_idx: which episode in the list are we at (if simply indexing
-            into list)
-        ep_list: list of episodes of the length of the key
-        bucket_complete: if there are no more episodes left to consider in
-            the bucket
-"""
-# Maps episode length to list of episodes
-length_to_eps = {}
-# List of batches if popping batches
-batches = []
-# If all episodes have been loaded into memory
-load_complete = Value(ctypes.c_bool, False)
-# Lock to access batches
-batches_lock = Lock()
-# Lock to access length_to_eps
-cache_lock = Lock()
-# Lock for condition variables
-fill_cache_lock = RLock()
-# Condition notifying Loader to add to cache
-add_to_cache_cv = Condition(lock=fill_cache_lock)
-# Condition notifying teacher that cache has episodes
-cache_filled_cv = Condition(lock=fill_cache_lock)
+        Note: is now an object to restrict lock instantiation when not importing the file
 
+        Maps episode length to dictionary with following keys:
+            current_idx: which episode in the list are we at (if simply indexing
+                into list)
+            ep_list: list of episodes of the length of the key
+            bucket_complete: if there are no more episodes left to consider in
+                the bucket
+    """
+    @classmethod
+    def create(cls):
+        if not hasattr(cls, 'length_to_eps'):
+            # Maps episode length to list of episodes
+            cls.length_to_eps = {}
+        if not hasattr(cls, 'batches'):
+            # List of batches if popping batches
+            cls.batches = []
+        if not hasattr(cls, 'load_complete'):
+            # If all episodes have been loaded into memory
+            cls.load_complete = Value(ctypes.c_bool, False)
+        if not hasattr(cls, 'batches_lock'):
+            # Lock to access batches
+            cls.batches_lock = Lock()
+        if not hasattr(cls, 'cache_lock'):
+            # Lock to access length_to_eps
+            cls.cache_lock = Lock()
+        if not hasattr(cls, 'fill_cache_lock'):
+            # Lock for condition variables
+            cls.fill_cache_lock = RLock()
+        if not hasattr(cls, 'add_to_cache_cv'):
+            # Condition notifying Loader to add to cache
+            cls.add_to_cache_cv = Condition(lock=cls.fill_cache_lock)
+        if not hasattr(cls, 'cache_filled_cv'):
+            # Condition notifying teacher that cache has episodes
+            cls.cache_filled_cv = Condition(lock=cls.fill_cache_lock)
 
-def batch_cache(function):
-    max_cache_size = 10000  # Max unseen eps
-    min_cache_size = 1000  # Min unseen eps
+    @classmethod
+    def batch_cache(cls, function):
+        max_cache_size = 10000  # Max unseen eps
+        min_cache_size = 1000  # Min unseen eps
 
-    def get_cache_size():
-        '''Returns number of available episodes '''
-        return sum(
-            len(v['ep_list']) - v['current_idx']for k, v in length_to_eps.items()
-        )
+        def get_cache_size():
+            '''Returns number of available episodes '''
+            return sum(
+                len(v['ep_list']) - v['current_idx']for k, v in cls.length_to_eps.items()
+            )
 
-    def get_available_buckets(bsz):
-        '''Returns buckets where there are enough episodes for a batch'''
-        if load_complete.value:
-            return {
-                k: v
-                for k, v in length_to_eps.items()
-                if not v['bucket_complete'] or len(v['ep_list']) - v['current_idx'] > 0
-            }
-        else:
-            return {
-                k: v
-                for k, v in length_to_eps.items()
-                if len(v['ep_list']) - v['current_idx'] >= bsz
-            }
+        def get_available_buckets(bsz):
+            '''Returns buckets where there are enough episodes for a batch'''
+            if cls.load_complete.value:
+                return {
+                    k: v
+                    for k, v in cls.length_to_eps.items()
+                    if not v['bucket_complete'] or len(v['ep_list']) - v['current_idx'] > 0
+                }
+            else:
+                return {
+                    k: v
+                    for k, v in cls.length_to_eps.items()
+                    if len(v['ep_list']) - v['current_idx'] >= bsz
+                }
 
-    def reset():
-        '''Resets the indices into the buckets'''
-        with cache_lock:
-            for idx in length_to_eps:
-                length_to_eps[idx]['current_idx'] = 0
-                length_to_eps[idx]['bucket_complete'] = False
+        def reset():
+            '''Resets the indices into the buckets'''
+            with cls.cache_lock:
+                for idx in cls.length_to_eps:
+                    cls.length_to_eps[idx]['current_idx'] = 0
+                    cls.length_to_eps[idx]['bucket_complete'] = False
 
-    def consolidate(caller):
-        '''Consolidate remaining episodes into batches'''
-        load_complete.value = True
-        bsz = caller.bsz
-        batch = []
-        sorted_lengths = sorted(length_to_eps.keys())
-        with cache_lock:
-            if caller.batch_cache_type == 'index':
-                for length in sorted_lengths:
-                    current_idx = length_to_eps[length]['current_idx']
-                    ep_list = length_to_eps[length]['ep_list']
-                    unseen_eps = ep_list[current_idx:]
-                    length_to_eps[length]['ep_list'] = ep_list[:current_idx]
-                    batch = unseen_eps + batch
-                    while len(batch) >= bsz:
-                        length_to_eps[length]['ep_list'] += batch[:bsz]
-                        batch = batch[bsz:]
-                if len(batch) > 0:
-                    length_to_eps[-1] = {
+        def consolidate(caller):
+            '''Consolidate remaining episodes into batches'''
+            cls.load_complete.value = True
+            bsz = caller.bsz
+            batch = []
+            sorted_lengths = sorted(cls.length_to_eps.keys())
+            with cls.cache_lock:
+                if caller.batch_cache_type == 'index':
+                    for length in sorted_lengths:
+                        current_idx = cls.length_to_eps[length]['current_idx']
+                        ep_list = cls.length_to_eps[length]['ep_list']
+                        unseen_eps = ep_list[current_idx:]
+                        cls.length_to_eps[length]['ep_list'] = ep_list[:current_idx]
+                        batch = unseen_eps + batch
+                        while len(batch) >= bsz:
+                            cls.length_to_eps[length]['ep_list'] += batch[:bsz]
+                            batch = batch[bsz:]
+                    if len(batch) > 0:
+                        cls.length_to_eps[-1] = {
+                            'current_idx': 0,
+                            'ep_list': batch,
+                            'bucket_complete': False
+                        }
+                elif caller.batch_cache_type == 'pop':
+                    for length in sorted_lengths:
+                        batch += cls.length_to_eps[length]['ep_list']
+                    with cls.batches_lock:
+                        while len(batch) >= bsz:
+                            cls.batches.append(batch[:bsz])
+                            batch = batch[bsz:]
+                    if len(batch) > 0:
+                        with cls.batches_lock:
+                            cls.batches.append(batch)
+
+        def flatten(l):
+            '''Helper function for flattening a list'''
+            return [item for sublist in l for item in sublist]
+
+        def ep_length(val):
+            '''Determines the length of an episode, given the specified value'''
+            if isinstance(val, (int, bytes, bool)):
+                return 1
+            if isinstance(val, str):
+                return len(val.split(' '))
+            if isinstance(val, (collections.Mapping,
+                                collections.Sequence,
+                                torch.Tensor)):
+                if (isinstance(val, collections.Mapping) and
+                        val.get('deserialized_tensor', False)):
+                    return len(val['value'])
+                return len(val)
+
+        def put_in_cache(ep_idx, episode, caller):
+            '''Put episode `ep_idx` into cache'''
+            length = ep_length(episode[caller.batch_sort_field])
+            lengths = [length] + flatten([
+                [length + i, length + (i * -1)]
+                for i in range(1, caller.batch_length_range)
+            ])
+            lengths = [max(i, 1) for i in lengths]
+            in_cache = False
+            for l in lengths:
+                if l in cls.length_to_eps:
+                    with cls.cache_lock:
+                        cls.length_to_eps[l]['ep_list'] += [(ep_idx, episode)]
+                    in_cache = True
+                    break
+            if not in_cache:
+                with cls.cache_lock:
+                    cls.length_to_eps[length] = {
                         'current_idx': 0,
-                        'ep_list': batch,
+                        'ep_list': [(ep_idx, episode)],
                         'bucket_complete': False
                     }
-            elif caller.batch_cache_type == 'pop':
-                for length in sorted_lengths:
-                    batch += length_to_eps[length]['ep_list']
-                with batches_lock:
-                    while len(batch) >= bsz:
-                        batches.append(batch[:bsz])
-                        batch = batch[bsz:]
-                if len(batch) > 0:
-                    with batches_lock:
-                        batches.append(batch)
+            if ep_idx == caller.dataset.num_episodes() - 1:
+                consolidate(caller)
+                with cls.add_to_cache_cv:
+                    cls.cache_filled_cv.notify_all()
 
-    def flatten(l):
-        '''Helper function for flattening a list'''
-        return [item for sublist in l for item in sublist]
+        @wraps(function)
+        def wrapper(*args):
+            caller = args[0]
+            batch_sort = caller.batch_sort
+            batch_cache_type = caller.batch_cache_type
+            bsz = caller.bsz
+            if not batch_sort or not caller.datatype.startswith('train'):
+                return function(*args)
+            # If Loader, put episodes in cache
+            if isinstance(caller, LoaderProcess):
+                with cls.add_to_cache_cv:
+                    while (get_cache_size() >= max_cache_size and
+                            len(get_available_buckets(bsz)) > 0):
+                        cls.cache_filled_cv.notify_all()
+                        cls.add_to_cache_cv.wait()
+                idx_and_batch = function(*args)
+                if idx_and_batch is None:
+                    return None
+                for ep_index, ep in idx_and_batch[1]:
+                    put_in_cache(ep_index, ep, caller)
+                return idx_and_batch
+            # If teacher, return batch of episodes
+            else:
+                teacher = caller
+                num_batches = teacher.num_batches
+                while True:
+                    with cls.cache_filled_cv:
+                        while (not cls.load_complete.value and
+                                (get_cache_size() <= min_cache_size or
+                                    len(get_available_buckets(bsz)) == 0)):
+                            cls.add_to_cache_cv.notify()
+                            cls.cache_filled_cv.wait()
+                            available_buckets = get_available_buckets(bsz)
+                    if cls.load_complete.value and batch_cache_type == 'pop':
+                        return teacher.batch_idx + 1, random.choice(cls.batches)
+                    batch = None
+                    available_buckets = get_available_buckets(bsz)
+                    if len(available_buckets) != 0:
+                        # Pick length index at random
+                        length = random.choice(list(available_buckets.keys()))
+                        with cls.cache_lock:
+                            current_idx = cls.length_to_eps[length]['current_idx']
+                            ep_list = cls.length_to_eps[length]['ep_list']
+                            num_eps = len(ep_list)
+                            if num_eps - current_idx >= bsz:
+                                if batch_cache_type == 'pop':
+                                    batch = ep_list[:bsz]
+                                    cls.length_to_eps[length]['ep_list'] = ep_list[bsz:]
+                                else:
+                                    batch = ep_list[current_idx: current_idx + bsz]
+                                    cls.length_to_eps[length]['current_idx'] = (
+                                        current_idx + bsz
+                                    )
+                            elif cls.load_complete.value and num_eps > 0:
+                                if batch_cache_type == 'pop':
+                                    batch = ep_list
+                                elif num_eps - current_idx > 0:
+                                    batch = ep_list[current_idx:]
+                                    cls.length_to_eps[length]['current_idx'] = num_eps - 1
+                                cls.length_to_eps[length]['bucket_complete'] = True
 
-    def ep_length(val):
-        '''Determines the length of an episode, given the specified value'''
-        if isinstance(val, (int, bytes, bool)):
-            return 1
-        if isinstance(val, str):
-            return len(val.split(' '))
-        if isinstance(val, (collections.Mapping,
-                            collections.Sequence,
-                            torch.Tensor)):
-            if (isinstance(val, collections.Mapping) and
-                    val.get('deserialized_tensor', False)):
-                return len(val['value'])
-            return len(val)
+                    if batch is not None:
+                        if batch_cache_type == 'pop':
+                            with cls.batches_lock:
+                                cls.batches.append(batch)
+                        elif teacher.batch_idx + 1 >= num_batches:
+                            reset()
+                        return teacher.batch_idx + 1, batch
 
-    def put_in_cache(ep_idx, episode, caller):
-        '''Put episode `ep_idx` into cache'''
-        length = ep_length(episode[caller.batch_sort_field])
-        lengths = [length] + flatten([
-            [length + i, length + (i * -1)]
-            for i in range(1, caller.batch_length_range)
-        ])
-        lengths = [max(i, 1) for i in lengths]
-        in_cache = False
-        for l in lengths:
-            if l in length_to_eps:
-                with cache_lock:
-                    length_to_eps[l]['ep_list'] += [(ep_idx, episode)]
-                in_cache = True
-                break
-        if not in_cache:
-            with cache_lock:
-                length_to_eps[length] = {
-                    'current_idx': 0,
-                    'ep_list': [(ep_idx, episode)],
-                    'bucket_complete': False
-                }
-        if ep_idx == caller.dataset.num_episodes() - 1:
-            consolidate(caller)
-            with add_to_cache_cv:
-                cache_filled_cv.notify_all()
-
-    @wraps(function)
-    def wrapper(*args):
-        caller = args[0]
-        batch_sort = caller.batch_sort
-        batch_cache_type = caller.batch_cache_type
-        bsz = caller.bsz
-        if not batch_sort or not caller.datatype.startswith('train'):
-            return function(*args)
-        # If Loader, put episodes in cache
-        if isinstance(caller, LoaderProcess):
-            with add_to_cache_cv:
-                while (get_cache_size() >= max_cache_size and
-                        len(get_available_buckets(bsz)) > 0):
-                    cache_filled_cv.notify_all()
-                    add_to_cache_cv.wait()
-            idx_and_batch = function(*args)
-            if idx_and_batch is None:
-                return None
-            for ep_index, ep in idx_and_batch[1]:
-                put_in_cache(ep_index, ep, caller)
-            return idx_and_batch
-        # If teacher, return batch of episodes
-        else:
-            teacher = caller
-            num_batches = teacher.num_batches
-            while True:
-                with cache_filled_cv:
-                    while (not load_complete.value and
-                            (get_cache_size() <= min_cache_size or
-                                len(get_available_buckets(bsz)) == 0)):
-                        add_to_cache_cv.notify()
-                        cache_filled_cv.wait()
-                        available_buckets = get_available_buckets(bsz)
-                if load_complete.value and batch_cache_type == 'pop':
-                    return teacher.batch_idx + 1, random.choice(batches)
-                batch = None
-                available_buckets = get_available_buckets(bsz)
-                if len(available_buckets) != 0:
-                    # Pick length index at random
-                    length = random.choice(list(available_buckets.keys()))
-                    with cache_lock:
-                        current_idx = length_to_eps[length]['current_idx']
-                        ep_list = length_to_eps[length]['ep_list']
-                        num_eps = len(ep_list)
-                        if num_eps - current_idx >= bsz:
-                            if batch_cache_type == 'pop':
-                                batch = ep_list[:bsz]
-                                length_to_eps[length]['ep_list'] = ep_list[bsz:]
-                            else:
-                                batch = ep_list[current_idx: current_idx + bsz]
-                                length_to_eps[length]['current_idx'] = (
-                                    current_idx + bsz
-                                )
-                        elif load_complete.value and num_eps > 0:
-                            if batch_cache_type == 'pop':
-                                batch = ep_list
-                            elif num_eps - current_idx > 0:
-                                batch = ep_list[current_idx:]
-                                length_to_eps[length]['current_idx'] = num_eps - 1
-                            length_to_eps[length]['bucket_complete'] = True
-
-                if batch is not None:
-                    if batch_cache_type == 'pop':
-                        with batches_lock:
-                            batches.append(batch)
-                    elif teacher.batch_idx + 1 >= num_batches:
-                        reset()
-                    return teacher.batch_idx + 1, batch
-
-    return wrapper
+        return wrapper
 
 
 # Get Datasets from the options
@@ -356,7 +369,7 @@ class LoaderProcess(Thread):
             if idx_and_batch is None:
                 return
 
-    @batch_cache
+    @BatchSortCache.batch_cache
     def load_next(self):
         try:
             return next(self.data)
@@ -557,6 +570,7 @@ class PytorchDataTeacher(FixedDialogTeacher):
                         ('stream' in self.datatype and not opt.get('shuffle')))
 
         if not shared:
+            BatchSortCache.create()
             if len(dataset_classes) > 1:
                 datasets = []
                 for class_name, collate_fn, task_name in dataset_classes:
@@ -655,7 +669,7 @@ class PytorchDataTeacher(FixedDialogTeacher):
                 epoch_done = True
         return ex, epoch_done
 
-    @batch_cache
+    @BatchSortCache.batch_cache
     def get_next_batch(self):
         # employs a cache to see if there is a batch of equal size ready
         batch = next(self.data)


### PR DESCRIPTION
As @stephenroller pointed out, importing this class would instantiate RLocks, Locks, and Values, which are threading objects and which lead to resource leaks in some cases. This PR moves the batch sort cache logic into its own object, `BatchSortCache`, with class variables, so that the locks are only instantiated when _using_ the PytorchDataTeacher.

Notes:
- Now, when running this [toy script](https://gist.github.com/stephenroller/a7be312cfc22fd5eb4fd8ed91dda2520), no warnings are printed. 
- Full testing of this change in #1317 will ensure that nothing actually breaks (note that I tested the batch sort cache locally and yielded appropriate results)
- No actual batch sort logic changes here; only moving the whole logic into its own class.
