### PR TITLE
Iterative beam search in TorchGeneratorAgent

### DIFF
--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -453,7 +453,7 @@ class OutputLayer(nn.Module):
             scores = F.linear(e, self.weight, self.bias)
 
         if self.padding_idx >= 0:
-            scores[:, :, self.padding_idx] = -NEAR_INF
+            scores[:, self.padding_idx] = -NEAR_INF
 
         return scores
 

--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -453,7 +453,7 @@ class OutputLayer(nn.Module):
             scores = F.linear(e, self.weight, self.bias)
 
         if self.padding_idx >= 0:
-            scores[:, self.padding_idx] = -NEAR_INF
+            scores[:, :, self.padding_idx] = -NEAR_INF
 
         return scores
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -642,7 +642,7 @@ class TorchGeneratorAgent(TorchAgent):
 
             score, incr_state = model.decoder(decoder_input, encoder_states, incr_state)
             # only need the final hidden state to make the word prediction
-            score = score[:, -1, :].unsqueeze(1)
+            score = score[:, -1:, :]
             score = model.output(score)
             # score contains softmax scores for bsz * beam_size samples
             score = score.view(bsz, beam_size, -1)

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -613,7 +613,7 @@ class TorchGeneratorAgent(TorchAgent):
         """
         bsz = len(batch.text_lengths)
         if num_iterations > 1:
-            if bsz == 1:
+            if bsz != 1:
                 raise ValueError('num_iterations > 1 requires bsz == 1')
             encoder_states = model.encoder(batch.text_vec.expand([num_iterations, -1]))
             bsz = num_iterations


### PR DESCRIPTION
With added arguments `beam-num-iterations`, `beam-min-distance` user can turn it on. This now only supports batch size 1. It can be done with mini-batches, it can be extended for that later.

Multiple iterations are implemented as a mini-batch beam, so very little change in the agent code as well as in the Beam class code.

Right now it just returns the best candidate given the logprob score, but intended to be changed by the user in any way (with external re-ranker, any other piece of code).