### PR TITLE
Adding context support to the MTurk ecosystem.

### DIFF
--- a/parlai/mturk/core/agents.py
+++ b/parlai/mturk/core/agents.py
@@ -643,7 +643,7 @@ class MTurkAgent(Agent):
             messages = self.flush_msg_queue()
             for m in messages:
                 if m['text'] == '[PEER_REVIEW]':
-                    self.feedback = m['data']
+                    self.feedback = m['task_data']
             return did_complete
 
     def update_agent_id(self, agent_id):

--- a/parlai/mturk/core/react_server/dev/app.jsx
+++ b/parlai/mturk/core/react_server/dev/app.jsx
@@ -83,7 +83,7 @@ class MainApp extends React.Component {
       task_done: false,
       messages: [],
       agent_id: 'NewWorker',
-      context: {},
+      task_data: {},
       volume: 1 // min volume is 0, max is 1, TODO pull from local-storage?
     };
   }
@@ -126,7 +126,14 @@ class MainApp extends React.Component {
     let socket_handler = null;
     if (!this.state.is_cover_page) {
       socket_handler = <SocketHandler
-        onMessageUpdate={() => this.setState({messages: this.state.messages})}
+        onMessageUpdate={(new_message) => {
+          this.state.messages.push(new_message);
+          this.setState({messages: this.state.messages});
+
+        }}
+        onNewTaskData={(new_task_data) => this.setState(
+          {task_data: Object.assign(this.state.task_data, new_task_data)}
+        )}
         onRequestMessage={() => this.setState({chat_state: 'text_input'})}
         onTaskDone={() => this.setState({
           task_done: true, chat_state: 'done', done_text: ''
@@ -179,7 +186,7 @@ class MainApp extends React.Component {
           initialization_status={this.state.initialization_status}
           is_cover_page={this.state.is_cover_page}
           frame_height={this.state.frame_height}
-          context={this.state.context}
+          task_data={this.state.task_data}
           world_state={this.state.world_state}
           v_id={this.state.agent_id}
           allDoneCallback={() => allDoneCallback()}

--- a/parlai/mturk/core/react_server/dev/app.jsx
+++ b/parlai/mturk/core/react_server/dev/app.jsx
@@ -126,7 +126,7 @@ class MainApp extends React.Component {
     let socket_handler = null;
     if (!this.state.is_cover_page) {
       socket_handler = <SocketHandler
-        onMessageUpdate={(new_message) => {
+        onNewMessage={(new_message) => {
           this.state.messages.push(new_message);
           this.setState({messages: this.state.messages});
 

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -73,12 +73,12 @@ class MessageList extends React.Component {
     // the m.id field.
     let XChatMessage = getCorrectComponent('XChatMessage', this.props.v_id);
     let onClickMessage = this.props.onClickMessage;
-    if (onClickMessage === undefined) {
+    if (typeof onClickMessage !== 'function') {
       onClickMessage = (idx) => {};
     }
     return messages.map(
       (m, idx) =>
-        <div key={m.message_id} onClick={() => this.props.onClickMessage(idx)}>
+        <div key={m.message_id} onClick={() => onClickMessage(idx)}>
           <XChatMessage
             is_self={m.id == agent_id}
             agent_id={m.id}

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -72,15 +72,21 @@ class MessageList extends React.Component {
     // on the thread - agent_ids for the sender of a message exist in
     // the m.id field.
     let XChatMessage = getCorrectComponent('XChatMessage', this.props.v_id);
+    let onClickMessage = this.props.onClickMessage;
+    if (onClickMessage === undefined) {
+      onClickMessage = (idx) => {};
+    }
     return messages.map(
-      m => <XChatMessage
-        key={m.message_id}
-        is_self={m.id == agent_id}
-        agent_id={m.id}
-        message={m.text}
-        task_data={m.task_data}
-        message_id={m.message_id}
-        duration={this.props.is_review ? m.duration : undefined}/>
+      (m, idx) =>
+        <div key={m.message_id} onClick={() => this.props.onClickMessage(idx)}>
+          <XChatMessage
+            is_self={m.id == agent_id}
+            agent_id={m.id}
+            message={m.text}
+            task_data={m.task_data}
+            message_id={m.message_id}
+            duration={this.props.is_review ? m.duration : undefined}/>
+        </div>
     );
   }
 
@@ -777,7 +783,8 @@ class ContextView extends React.Component {
       'To render context here, write or select a ContextView ' +
       'that can render your task_data, or write the desired ' +
       'content into the task_data.html field of your act');
-    if (this.props.task_data.html !== undefined) {
+    if (this.props.task_data !== undefined &&
+        this.props.task_data.html !== undefined) {
       context = this.props.task_data.html;
     }
     return (

--- a/parlai/mturk/core/react_server/dev/components/socket_handler.jsx
+++ b/parlai/mturk/core/react_server/dev/components/socket_handler.jsx
@@ -268,7 +268,7 @@ class SocketHandler extends React.Component {
 
   // Required function - The BaseApp class will call this function to enqueue
   // packet sends that are requested by the frontend user (worker)
-  handleQueueMessage(text, data, callback, is_system=false) {
+  handleQueueMessage(text, task_data, callback, is_system=false) {
     let new_message_id = uuidv4();
     let duration = null;
     if (!is_system && this.state.message_request_time != null) {
@@ -280,7 +280,7 @@ class SocketHandler extends React.Component {
       TYPE_MESSAGE,
       {
         text: text,
-        data: data,
+        task_data: task_data,
         id: this.props.agent_id,
         message_id: new_message_id,
         episode_done: false,
@@ -398,9 +398,12 @@ class SocketHandler extends React.Component {
 
     log('New message, ' + new_message_id + ' from agent ' + agent_id, 1);
     this.state.displayed_messages.push(new_message_id);
-    this.props.messages.push(message);
-    this.setState({displayed_messages: this.state.displayed_messages})
-    this.props.onMessageUpdate();
+    this.props.onNewMessage(message);
+    if (message.task_data !== undefined) {
+      message.task_data.last_update = (new Date()).getTime();
+      this.props.onNewTaskData(message.task_data);
+    }
+    this.setState({displayed_messages: this.state.displayed_messages});
   }
 
   // Handle incoming command messages

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -770,7 +770,7 @@ class AssignmentFeedback extends React.Component {
     } else {
       let XReviewButtons = getCorrectComponent('XReviewButtons', null);
       let given_feedback_content = <span>No provided feedback</span>;
-      if (given_feedback !== undefined) {
+      if (!!given_feedback) {
         let init_state = {
           'current_rating': given_feedback.rating,
           'submitting': true,
@@ -781,7 +781,7 @@ class AssignmentFeedback extends React.Component {
         given_feedback_content = <XReviewButtons init_state={init_state} />;
       }
       let received_feedback_content = <span>No provided feedback</span>;
-      if (received_feedback !== undefined) {
+      if (!!received_feedback) {
         let init_state = {
           'current_rating': received_feedback.rating,
           'submitting': true,

--- a/parlai/mturk/webapp/run_mocks/mock_turk_manager.py
+++ b/parlai/mturk/webapp/run_mocks/mock_turk_manager.py
@@ -121,7 +121,15 @@ class MockTurkManager():
             agent.set_status(AssignState.STATUS_IN_TASK)
             agent.conversation_id = 'in_task'
 
-        task_function(mturk_manager=self, opt=self.opt, workers=agents)
+        try:
+            task_function(mturk_manager=self, opt=self.opt, workers=agents)
+        except Exception as e:
+            import sys
+            import traceback
+            print (e)
+            traceback.print_exc(file=sys.stdout)
+            raise e
+
         for agent in agents:
             agent.mock_status = AssignState.STATUS_DONE
             agent.set_status(AssignState.STATUS_DONE)


### PR DESCRIPTION
## Summary

In anticipation of #1327, and as one of the prime motivations for me to be working on that in the first place, I've added a more mature form of context handling to the ParlAI MTurk client.

## Implementation

The basic idea here is to leverage the component swapping nature of the PMT react frontend to allow tasks to define a context-rendering component, and then for an agent to observe context in `act['task_data']` and have it magically fed to the context component. This `task_data` is later stored with the message, and can be retrieved both when reviewing tasks and when saving the task into a dataset. As a baseline implementation, people can put raw HTML into `act['task_data']['html']` to have that content rendered without needing to create a `custom.jsx` file at all, but when I migrate some of our existing tasks to frontend v1.0 with context, I'll be demonstrating custom components. This version only allows for the 2-panel context approach, where the left panel is given tabs for task instructions and context. Down the road I'll support 3-panel context for those that want task instructions up at all times.

## Changes
### Major contributions
- Added `onClickMessage` prop to `MessageList` to handle updating the 'currently selected message index', which is used by the webapp to display relevant context.
- Creates `ContextView` that renders arbitrary html if it is provided.
- Adds `ContextView` into a tab of the left pane if `task_data` is updated. This is managed by tracking the `last_update` time of the context window. `last_update` is also used to force select the context tab upon receiving new context as a method for denoting that context has changed. (Maybe an animation flash or something might be more appropriate for that? will re-investigate down the road). If there is no `task_data` the tabulations don't change at all.
- Creates `AssignmentContext` view for the ParlAI webapp task review window. This pulls `task_data` context from the main webapp.
- Adds `task_data` management to the mock agents in the webapp, building context up from the list of messages received by the agent.
### Minor fixes
- Consolidates all data objects containing context into `task_data` throughout the PMT frontend for consistency with #1327 
- Updates `SocketHandler` function props to better follow the react style of updating state at the highest level rather than having subcomponents alter state of an above component. Better to follow react best practices!
- Changes the display type of the left panel to flex and updates children to better 
- Fixed some truthiness checks in the feedback display panel that would break it if one person didn't give feedback but the other did.
- Wraps `MockTurkManager`'s main evaluation loop in error checking code to print useful stack traces when something goes wrong rather than just failing, which makes sense as the webapp is used as a debug and development environment.
- Fixes a null dereference bug in the webapp server caused by the `MockTurkManager` taking more time than expected to start up and attach.

## Screenshots
### Chat window with context tab
(tested both in ParlAI Webapp and MTurk sandbox)
![screen shot 2019-01-17 at 2 39 43 pm](https://user-images.githubusercontent.com/1276867/51346390-8a8f9800-1a6b-11e9-8f24-a084118cccf3.png)
### Review panel in webapp
(clicking a message updates the context window to display the context the worker had when sending that message)
![screen shot 2019-01-17 at 3 08 29 pm](https://user-images.githubusercontent.com/1276867/51346494-d2162400-1a6b-11e9-94c6-607719a5d718.png)

 