### PR TITLE
check if dist is avail before checking for init

### DIFF
--- a/parlai/core/distributed_utils.py
+++ b/parlai/core/distributed_utils.py
@@ -53,7 +53,7 @@ def is_distributed():
     """
     Returns True if we are in distributed mode.
     """
-    return TORCH_AVAILABLE and dist.is_initialized()
+    return TORCH_AVAILABLE and dist.is_available() and dist.is_initialized()
 
 
 def num_workers():


### PR DESCRIPTION
I have pytorch 1.0.0 installed so should be up to date but for some reason got this issue.

```
Traceback (most recent call last):
  File "examples/train_model.py", line 16, in <module>
    TrainLoop(opt).train()
  File "/Users/ahm/ParlAI/parlai/scripts/train_model.py", line 203, in __init__
    build_dict(opt, skip_if_built=True)
  File "/Users/ahm/ParlAI/parlai/scripts/build_dict.py", line 63, in build_dict
    if is_distributed():
  File "/Users/ahm/ParlAI/parlai/core/distributed_utils.py", line 56, in is_distributed
    return TORCH_AVAILABLE and dist.is_initialized()
AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
```

maskrcnn benchmark project fixed it with this method, so reproducing this here.
https://github.com/facebookresearch/maskrcnn-benchmark/issues/280

(this is running on my mac so maybe happens on non-gpu system.)