### PR TITLE
Fix beam search for seq2seq.

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -626,7 +626,7 @@ class TorchGeneratorAgent(TorchAgent):
 
             score, incr_state = model.decoder(decoder_input, encoder_states, incr_state)
             # only need the final hidden state to make the word prediction
-            score = score[:, -1, :]
+            score = score[:, -1:, :]
             score = model.output(score)
             # score contains softmax scores for bsz * beam_size samples
             score = score.view(bsz, beam_size, -1)

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -88,6 +88,43 @@ class TestSeq2Seq(unittest.TestCase):
             "test ppl = {}\nLOG:\n{}".format(test['ppl'], stdout)
         )
 
+    def test_beamsearch(self):
+        """Ensures beam search can generate the correct response"""
+        stdout, valid, test = _mock_train(
+            task='integration_tests:NocandidateTeacher',
+            model='seq2seq',
+            lr=LR,
+            batchsize=BATCH_SIZE,
+            # beam search should work much faster than regular
+            num_epochs=BATCH_SIZE // 2,
+            numthreads=1,
+            no_cuda=True,
+            embeddingsize=16,
+            hiddensize=16,
+            rnn_class='gru',
+            attention='general',
+            gradient_clip=1.0,
+            dropout=0.0,
+            lookuptable='all',
+            beam_size=4,
+        )
+
+        self.assertTrue(
+            valid['bleu'] > 0.95,
+            "valid bleu = {}\nLOG:\n{}".format(valid['bleu'], stdout)
+        )
+        self.assertTrue(
+            test['bleu'] > 0.95,
+            "test bleu = {}\nLOG:\n{}".format(test['bleu'], stdout)
+        )
+        self.assertTrue(
+            valid['ppl'] < 1.2,
+            "valid ppl = {}\nLOG:\n{}".format(valid['ppl'], stdout)
+        )
+        self.assertTrue(
+            test['ppl'] < 1.2,
+            "test ppl = {}\nLOG:\n{}".format(test['ppl'], stdout)
+        )
 
 class TestHogwildSeq2seq(unittest.TestCase):
     def test_generation_multi(self):

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -95,8 +95,7 @@ class TestSeq2Seq(unittest.TestCase):
             model='seq2seq',
             lr=LR,
             batchsize=BATCH_SIZE,
-            # beam search should work much faster than regular
-            num_epochs=BATCH_SIZE // 2,
+            num_epochs=NUM_EPOCHS,
             numthreads=1,
             no_cuda=True,
             embeddingsize=16,

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -126,6 +126,7 @@ class TestSeq2Seq(unittest.TestCase):
             "test ppl = {}\nLOG:\n{}".format(test['ppl'], stdout)
         )
 
+
 class TestHogwildSeq2seq(unittest.TestCase):
     def test_generation_multi(self):
         """This test uses a multi-turn task and multithreading."""


### PR DESCRIPTION
Beam search was broken for seq2seq, due to mismatch in expected tensor dimensions. It worked in transformer.

This fix does not require any alteration of model files.