### PR TITLE
Fix for prebuilt dict for PytorchDataTeacher

### DIFF
--- a/parlai/scripts/build_pytorch_data.py
+++ b/parlai/scripts/build_pytorch_data.py
@@ -26,6 +26,8 @@ from collections import deque
 
 
 def get_pyt_dict_file(opt):
+    if os.path.exists(opt.get('dict_file', '')):
+        return opt['dict_file']
     if not opt['pytorch_teacher_task']:
         opt['pytorch_teacher_task'] = opt['task']
     return os.path.join(


### PR DESCRIPTION
Does not build a new dictionary if one is already built for specified task when using `PytorchDataTeacher`