### PR TITLE
Accumulated gradients options.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -220,7 +220,7 @@ class TorchAgent(Agent):
         )
         agent.add_argument(
             '--update-freq', type=int, default=-1, hidden=True,
-            help='Accumulate gradients N times before performing a backward.'
+            help='Accumulate gradients N times before performing an optimizer.step().'
         )
         # preprocessing arguments
         agent.add_argument(

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -218,7 +218,10 @@ class TorchAgent(Agent):
                  'this value. Linearly adjusted up to 1.0 across --warmup-updates '
                  'steps.'
         )
-
+        agent.add_argument(
+            '--update-freq', type=int, default=-1, hidden=True,
+            help='Accumulate gradients N times before performing a backward.'
+        )
         # preprocessing arguments
         agent.add_argument(
             '-rc', '--rank-candidates', type='bool', default=False,
@@ -300,6 +303,8 @@ class TorchAgent(Agent):
         self.START_IDX = self.dict[self.dict.start_token]
         self.END_IDX = self.dict[self.dict.end_token]
 
+        # for gradient acumulation
+        self._number_grad_accum = 0
         # for the LR scheduler
         self._number_training_updates = 0
         # fixed random seed
@@ -1077,10 +1082,19 @@ class TorchAgent(Agent):
     def update_params(self):
         """
         Perform step of optimization, clipping gradients and adjusting LR
-        schedule if needed.
+        schedule if needed. Gradient accumulation is also performed if agent
+        is called with --update-freq.
 
         It is recommended (but not forced) that you call this in train_step.
         """
+        update_freq = self.opt.get('update_freq', 1)
+        if update_freq > 1:
+            # we're doing gradient accumulation, so we don't only want to step
+            # every N updates instead
+            self._number_grad_accum = (self._number_grad_accum + 1) % update_freq
+            if self._number_grad_accum != 0:
+                return
+
         # keep track up number of steps, compute warmup factor
         self._number_training_updates += 1
 
@@ -1103,6 +1117,11 @@ class TorchAgent(Agent):
         """
         Zero out optimizer.
 
-        It is recommended you call this in train_step.
+        It is recommended you call this in train_step. It automatically handles
+        gradient accumulation if agent is called with --update-freq.
         """
+        if self._number_grad_accum != 0:
+            # if we're accumulating gradients, don't actually zero things out yet.
+            return
+
         self.optimizer.zero_grad()


### PR DESCRIPTION
This is roughly equivalent to the `+cumul` option described in [this paper](https://arxiv.org/abs/1806.00187).

Essentially you just only call `optimizer.step()` and `optimizer.zero_grad()` every _n_ minibatches instead of every minibatch. The result is gradients accumulate and you get a "pseudo-batch" that's _n_ times larger (and so you can use a larger LR):

I measured a ~44% training speedup with `--update-freq 16`:

Off (`--update-freq 1 -lr 1e-4 -opt adam`):
```
[loading fbdialog data:/private/home/roller/working/parlai/data/ConvAI2/train_self_original.txt]
[ training... ]
[ time:10.0s total_exs:11904 epochs:0.09 time_left:101.0s ] {'exs': 11904, 'lr': 0.0001, 'num_updates': 186, 'token_acc': 0.1599, 'loss': 7.238, 'ppl': 1392.0}
[ time:20.0s total_exs:23232 epochs:0.18 time_left:94.0s ] {'exs': 11328, 'lr': 0.0001, 'num_updates': 363, 'token_acc': 0.2387, 'loss': 5.213, 'ppl': 183.6}
[ time:30.0s total_exs:33600 epochs:0.26 time_left:88.0s ] {'exs': 10368, 'lr': 0.0001, 'num_updates': 525, 'token_acc': 0.2665, 'loss': 4.787, 'ppl': 119.9}
[ time:40.0s total_exs:45952 epochs:0.35 time_left:75.0s ] {'exs': 12352, 'lr': 0.0001, 'num_updates': 718, 'token_acc': 0.2853, 'loss': 4.586, 'ppl': 98.13}
[ time:50.0s total_exs:57984 epochs:0.44 time_left:64.0s ] {'exs': 12032, 'lr': 0.0001, 'num_updates': 906, 'token_acc': 0.2972, 'loss': 4.461, 'ppl': 86.54}
[ time:60.0s total_exs:66304 epochs:0.5 time_left:60.0s ] {'exs': 8320, 'lr': 0.0001, 'num_updates': 1036, 'token_acc': 0.3071, 'loss': 4.372, 'ppl': 79.23}
[ time:70.0s total_exs:74304 epochs:0.57 time_left:54.0s ] {'exs': 8000, 'lr': 0.0001, 'num_updates': 1161, 'token_acc': 0.3097, 'loss': 4.338, 'ppl': 76.54}
[ time:80.0s total_exs:83200 epochs:0.63 time_left:47.0s ] {'exs': 8896, 'lr': 0.0001, 'num_updates': 1300, 'token_acc': 0.3124, 'loss': 4.292, 'ppl': 73.1}
[ time:90.0s total_exs:93248 epochs:0.71 time_left:37.0s ] {'exs': 10048, 'lr': 0.0001, 'num_updates': 1457, 'token_acc': 0.3202, 'loss': 4.237, 'ppl': 69.22}
[ time:100.0s total_exs:102400 epochs:0.78 time_left:29.0s ] {'exs': 9152, 'lr': 0.0001, 'num_updates': 1600, 'token_acc': 0.3212, 'loss': 4.211, 'ppl': 67.42}
[ time:110.0s total_exs:109760 epochs:0.84 time_left:22.0s ] {'exs': 7360, 'lr': 0.0001, 'num_updates': 1715, 'token_acc': 0.3274, 'loss': 4.159, 'ppl': 64.0}
[ time:120.0s total_exs:118336 epochs:0.9 time_left:14.0s ] {'exs': 8576, 'lr': 0.0001, 'num_updates': 1849, 'token_acc': 0.3303, 'loss': 4.119, 'ppl': 61.47}
[ time:130.0s total_exs:127680 epochs:0.97 time_left:4.0s ] {'exs': 9344, 'lr': 0.0001, 'num_updates': 1995, 'token_acc': 0.3265, 'loss': 4.135, 'ppl': 62.49}
[ time:133.0s total_exs:131456 epochs:1.0 time_left:0s ] {'exs': 3776, 'lr': 0.0001, 'num_updates': 2054, 'token_acc': 0.3286, 'loss': 4.119, 'ppl': 61.53}
[ num_epochs completed:1.0 time elapsed:133.85705614089966s ]
[creating task(s): convai2]
[loading fbdialog data:/private/home/roller/working/parlai/data/ConvAI2/valid_self_original.txt]
[ running eval: valid ]
/private/home/roller/working/parlai/parlai/core/utils.py:1038: RuntimeWarning: --skip-generation does not produce accurate metrics beyond ppl
  warnings.warn(msg, warningtype)
valid:{'exs': 7801, 'accuracy': 0.0001282, 'f1': 0.2383, 'bleu': 0.003702, 'lr': 0.0001, 'num_updates': 2054, 'token_acc': 0.33, 'loss': 4.177, 'ppl': 65.16}
```

On (`--update-freq 16 -lr 16e-4 -opt adam`):
```
[loading fbdialog data:/private/home/roller/working/parlai/data/ConvAI2/train_self_original.txt]
[ training... ]
[ time:10.0s total_exs:17344 epochs:0.13 time_left:66.0s ] {'exs': 17344, 'lr': 0.0016, 'num_updates': 16, 'token_acc': 0.1307, 'loss': 7.415, 'ppl': 1660.0}
[ time:20.0s total_exs:35264 epochs:0.27 time_left:55.0s ] {'exs': 17920, 'lr': 0.0016, 'num_updates': 34, 'token_acc': 0.1908, 'loss': 5.231, 'ppl': 186.9}
[ time:30.0s total_exs:52928 epochs:0.4 time_left:45.0s ] {'exs': 17664, 'lr': 0.0016, 'num_updates': 51, 'token_acc': 0.2423, 'loss': 4.809, 'ppl': 122.6}
[ time:40.0s total_exs:70848 epochs:0.54 time_left:35.0s ] {'exs': 17920, 'lr': 0.0016, 'num_updates': 69, 'token_acc': 0.2782, 'loss': 4.51, 'ppl': 90.96}
[ time:50.0s total_exs:88704 epochs:0.67 time_left:25.0s ] {'exs': 17856, 'lr': 0.0016, 'num_updates': 86, 'token_acc': 0.3037, 'loss': 4.268, 'ppl': 71.36}
[ time:60.0s total_exs:106560 epochs:0.81 time_left:15.0s ] {'exs': 17856, 'lr': 0.0016, 'num_updates': 104, 'token_acc': 0.3182, 'loss': 4.111, 'ppl': 60.98}
[ time:70.0s total_exs:124416 epochs:0.95 time_left:4.0s ] {'exs': 17856, 'lr': 0.0016, 'num_updates': 121, 'token_acc': 0.3296, 'loss': 3.966, 'ppl': 52.78}
[ time:74.0s total_exs:131456 epochs:1.0 time_left:0s ] {'exs': 7040, 'lr': 0.0016, 'num_updates': 128, 'token_acc': 0.333, 'loss': 3.933, 'ppl': 51.06}
[ num_epochs completed:1.0 time elapsed:74.03592562675476s ]
[creating task(s): convai2]
[loading fbdialog data:/private/home/roller/working/parlai/data/ConvAI2/valid_self_original.txt]
[ running eval: valid ]
/private/home/roller/working/parlai/parlai/core/utils.py:1038: RuntimeWarning: --skip-generation does not produce accurate metrics beyond ppl
  warnings.warn(msg, warningtype)
valid:{'exs': 7801, 'accuracy': 0, 'f1': 0.2457, 'bleu': 0.004395, 'lr': 0.0016, 'num_updates': 128, 'token_acc': 0.3346, 'loss': 4.018, 'ppl': 55.56}
```