### PR TITLE
Add additional optimizers and optimizer params to torchagent

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -49,6 +49,7 @@ def str2bool(value):
     else:
         raise argparse.ArgumentTypeError('Boolean value expected.')
 
+
 def str2floats(s):
     """Look for single float or comma-separated floats."""
     return tuple(float(f) for f in s.split(','))

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -49,6 +49,10 @@ def str2bool(value):
     else:
         raise argparse.ArgumentTypeError('Boolean value expected.')
 
+def str2floats(s):
+    """Look for single float or comma-separated floats."""
+    return tuple(float(f) for f in s.split(','))
+
 
 def str2class(value):
     """From import path string, returns the class specified. For example, the
@@ -111,6 +115,7 @@ class ParlaiParser(argparse.ArgumentParser):
         super().__init__(description=description, allow_abbrev=False,
                          conflict_handler='resolve')
         self.register('type', 'bool', str2bool)
+        self.register('type', 'floats', str2floats)
         self.register('type', 'class', str2class)
         self.parlai_home = (os.path.dirname(os.path.dirname(os.path.dirname(
                             os.path.realpath(__file__)))))

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -158,7 +158,7 @@ class TorchAgent(Agent):
         """
         # first pull torch.optim in
         optims = {k.lower(): v for k, v in optim.__dict__.items()
-                      if not k.startswith('__') and k[0].isupper()}
+                  if not k.startswith('__') and k[0].isupper()}
 
         try:
             # https://openreview.net/pdf?id=S1fUpoR5FQ


### PR DESCRIPTION
is there a better way to set up the imports for OPTIM_OPTS?
we made that a class field so that subclasses can just add more if they want, but maybe there's a cleaner way

this adds --nus, --betas, --nesterov, and the qhm and qhadam optimizers from https://openreview.net/pdf?id=S1fUpoR5FQ