### PR TITLE
Add chatbox UI for worker-to-worker messaging

### DIFF
--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -307,8 +307,11 @@ class ChatBox extends React.Component {
 class ChatNavbar extends React.Component {
 
   state = {
-    // TODO: replace hardcoded initial chat state with API integration
-    chat: [{msg: "hey", owner: 3}, {msg: "anyone else there?", owner: 3}]
+    // TODO: replace hardcoded initial chat state with some API integration
+    chat: [
+      {msg: "hey", owner: 3},
+      {msg: "anyone else there?", owner: 3},      
+    ]
   }
 
   render () {

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -203,7 +203,7 @@ class ChatBox extends React.Component {
   }
 
   componentDidMount() {
-    this.smoothlyAnimateToBottom();
+    this.instantlyJumpToBottom();
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -307,10 +307,13 @@ class ChatBox extends React.Component {
 class ChatNavbar extends React.Component {
 
   state = {
+    // TODO: replace hardcoded initial chat state with API integration
     chat: [{msg: "hey", owner: 3}, {msg: "anyone else there?", owner: 3}]
   }
 
   render () {
+    // const displayChatBox = true;
+    const displayChatBox = this.props.displayChatBox || false;
     let nav_style = {
       position: 'absolute', backgroundColor: '#EEEEEE', borderColor: '#e7e7e7',
       height: 46, top: 0, borderWidth: '0 0 1px', borderRadius: 0, right: 0,
@@ -320,10 +323,10 @@ class ChatNavbar extends React.Component {
       <div style={nav_style}>
         <ConnectionIndicator {...this.props} />
         <VolumeControl {...this.props} />
-        <ChatBox
+        {displayChatBox && <ChatBox
           off_chat_messages={this.state.chat}
           onMessageSend={(msg) => this.setState({chat: [...this.state.chat, {msg, owner: 0}]})}
-          has_new_message={2}/>
+          has_new_message={2}/> }
       </div>
     );
   }

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -190,40 +190,42 @@ class ChatBox extends React.Component {
     msg: ''
   }
 
-  scrollToBottom() {
+  smoothlyAnimateToBottom() {
     if (this.bottomAnchorRef) {
       this.bottomAnchorRef.scrollIntoView({ block: "end", behavior: 'smooth' });
     }
   }
 
-  jumpToBottom() {
+  instantlyJumpToBottom() {
     if (this.chatContainerRef) {
       this.chatContainerRef.scrollTop = this.chatContainerRef.scrollHeight;
     }
   }
 
   componentDidMount() {
-    this.scrollToBottom();
+    this.smoothlyAnimateToBottom();
   }
 
   componentDidUpdate(prevProps, prevState) {
-
+    // Use requestAnimationFrame to defer UI-based updates
+    // until the next browser paint
     if (prevState.hidden === true && this.state.hidden === false) {
-      requestAnimationFrame(() => this.jumpToBottom());
-    } else if (prevProps.off_chat_messages !== this.props.off_chat_messages) {
-      // cDU gets called before any renders, so let's defer the UI-based scroll update
-      // until after the layout is updated with the new chat message
       requestAnimationFrame(() => {
-        this.scrollToBottom();
+        this.instantlyJumpToBottom();
       });
-      
+    } else if (prevProps.off_chat_messages !== this.props.off_chat_messages) {
+      requestAnimationFrame(() => {
+        this.smoothlyAnimateToBottom();
+      });
     }
   }
 
+  // TODO: Replace with enhanced logic to determine if the
+  // chat message belongs to the current user.
   isOwnMessage = message => message.owner === 0;
 
   render() {
-    const unread = this.props.has_new_message;
+    const unreadCount = this.props.has_new_message;
     const messages = this.props.off_chat_messages || [];
 
     return <div style={{float: "right", marginRight: 7}}>
@@ -232,9 +234,9 @@ class ChatBox extends React.Component {
         ref={el => {this.buttonRef = el}}
       >
         Chat Messages&nbsp;
-        {!!unread &&
+        {!!unreadCount &&
           (<Badge style={{backgroundColor: "#d9534f", marginLeft: 3}}>
-            {unread}
+            {unreadCount}
           </Badge>)
         }
       </Button>
@@ -295,7 +297,6 @@ class ChatBox extends React.Component {
             </InputGroup>
           </FormGroup>
         </form>
-
       </Popover>
     </Overlay>
   </div>;


### PR DESCRIPTION
# Chat UI

This PR adds in client-side UI functionality for mturk workers to message each other while working on tasks.

<img width="592" alt="screen shot 2019-01-23 at 5 41 44 pm" src="https://user-images.githubusercontent.com/425059/51642104-2c185d00-1f36-11e9-8bf2-7064438e721f.png">

### Features
1. When the user enters a message, the chat list will automatically scroll to include the newly added in element, as expected. In other words, the list is appropriately anchored to the bottom as is common with most chat clients.
2. When the list is first opened, it is also anchored to the bottom so the most recent messages are displayed first.
3. Clicking anywhere on the page off of the chatbox, or on the button again will close the chatbox once opened.


### Integration Points

1. `<ChatNavBar />` accepts a prop called `displayChatBox` that will at a high level hide/show the chat feature.
2. Within the above component, `<ChatBox />` is a newly added controlled component that adds in the button/badge into the toolbar along with the chat message overlay. `ChatBox` accepts:
   - `off_chat_messages` an array of messages to display... the current working data model for this is: `{msg: string, owner: number}`
   - `onMessageSend`: the callback to execute when a message is typed in the chatbox and the user hits Send/enter.
   - `has_new_message`: the number of unread messages to display in the badge. (Note: we may also need to provide a callback here, e.g. onViewedMessages, so that the calling code can update this property)
