### PR TITLE
Fixes with pyteacher and distributed training.

### DIFF
--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -438,7 +438,6 @@ def process(ex_or_batch):
     ParlAI Implementations of Pytorch Datasets
 """
 
-
 class StreamDataset(Dataset):
     """A Pytorch Dataset utilizing streaming"""
     def __init__(self, opt):
@@ -455,6 +454,8 @@ class StreamDataset(Dataset):
 
     def __getitem__(self, index):
         if self.ordered or not self.training:
+            if not hasattr(self, 'data_gen'):
+                self.data_gen = self._read_episode()
             while True:
                 idx, ep = next(self.data_gen)
                 if idx == index:
@@ -481,6 +482,11 @@ class StreamDataset(Dataset):
             self.num_exs = lengths['num_exs']
         with open(self.char_index_file) as char:
             self.char_index = json.load(char)
+
+    def _data_generator(self):
+        while True:
+            for idx, episode in self._read_episode():
+                yield idx, episode
 
     def _read_episode(self):
         read = open(self.datafile)

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -445,7 +445,6 @@ class StreamDataset(Dataset):
         self.opt = opt
         self.datatype = opt.get('datatype')
         self.datapath = build_data(self.opt)
-        self.data_gen = self._data_generator()
         self.length_datafile = os.path.join(self.datapath, 'data_length')
         self.char_index_file = os.path.join(self.datapath, 'char_index')
         self.datafile = os.path.join(self.datapath, 'data')
@@ -482,11 +481,6 @@ class StreamDataset(Dataset):
             self.num_exs = lengths['num_exs']
         with open(self.char_index_file) as char:
             self.char_index = json.load(char)
-
-    def _data_generator(self):
-        while True:
-            for idx, episode in self._read_episode():
-                yield idx, episode
 
     def _read_episode(self):
         read = open(self.datafile)
@@ -531,7 +525,6 @@ class ParlAIDataset(Dataset):
             self.num_exs = lengths['num_exs']
 
     def _setup_data(self):
-        print('----------\n[ loading pytorch data ]\n----------')
         self.data = []
         with open(self.datafile) as f:
             for line in f:

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -438,6 +438,7 @@ def process(ex_or_batch):
     ParlAI Implementations of Pytorch Datasets
 """
 
+
 class StreamDataset(Dataset):
     """A Pytorch Dataset utilizing streaming"""
     def __init__(self, opt):

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -122,7 +122,13 @@ def load_eval_world(agent, opt, datatype):
         datatype += ':stream'
     opt = opt.copy()
     opt['datatype'] = datatype
+    if opt.get('pytorch_teacher_task'):
+        # never use pytorch teachers for evaluation
+        # but don't forget what we were normally using
+        opt['task'] = opt['pytorch_teacher_task']
+        del opt['pytorch_teacher_task']
     if opt.get('evaltask'):
+        # if a different eval task is specified, use it.
         opt['task'] = opt['evaltask']
     if opt.get('eval_batchsize'):
         # override eval time batchsize


### PR DESCRIPTION
- Don't use `-pyt` at validation time
- Get rid of a the _data_generator field. This didn't seem to actually be used, and wasn't pickleable. This made for problems with respect to combining pyt with distributed training in some cases.