### PR TITLE
Safeguards around using invsqrt lr scheduling without warmup.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -410,10 +410,10 @@ class TorchAgent(Agent):
                     '--lr-scheduler invsqrt requires setting --warmup-updates'
                 )
             warmup_updates = self.opt['warmup_updates']
-            decay_factor = np.sqrt(warmup_updates)
+            decay_factor = np.sqrt(max(1, warmup_updates))
 
             def _invsqrt_lr(step):
-                return decay_factor / np.sqrt(step)
+                return decay_factor / np.sqrt(max(1, step))
 
             self.scheduler = optim.lr_scheduler.LambdaLR(
                 self.optimizer,


### PR DESCRIPTION
if someone tried to use `--lr-scheduler invsqrt` but didn't provide a `--warmup-updates` argument, they'd have a bad time.