### PR TITLE
TA+PytorchDataTeacher truncation bug.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -625,12 +625,14 @@ class TorchAgent(Agent):
         tensor = torch.LongTensor(vec)
         return tensor
 
-    def _check_truncate(self, vec, truncate):
+    def _check_truncate(self, vec, truncate, truncate_left=False):
         """Check that vector is truncated correctly."""
         if truncate is None:
             return vec
         if len(vec) <= truncate:
             return vec
+        if truncate_left:
+            return vec[-truncate:]
         else:
             return vec[:truncate]
 
@@ -641,9 +643,9 @@ class TorchAgent(Agent):
 
         if 'text_vec' in obs:
             # check truncation of pre-computed vectors
-            obs['text_vec'] = self._check_truncate(obs['text_vec'], truncate)
+            obs['text_vec'] = self._check_truncate(obs['text_vec'], truncate, True)
             if split_lines and 'memory_vecs' in obs:
-                obs['memory_vecs'] = [self._check_truncate(m, truncate)
+                obs['memory_vecs'] = [self._check_truncate(m, truncate, True)
                                       for m in obs['memory_vecs']]
         elif 'text' in obs:
             # convert 'text' into tensor of dictionary indices


### PR DESCRIPTION
CC everyone, this one's tricky tricky tricky, and might affect you.

Generally speaking, `_check_truncate` is a no-op in most cases. The `text_vec` that we have is the one we did earlier, which is already truncated, so no big deal.

However, if you're using a pytorch teacher and built the data with `--pytorch-preprocess true`, then presumably you dropped off truncate so you could have the full history etc. At that point, `_check_truncate` is pretty important and actually does something!

TorchAgents, by default though, *left* truncate the dialogue history and memories, but *right* truncate the labels! However, `_check_truncate` was only ever right-side truncating, meaning that training with a preprocessed pytorch teacher was likely a different setup

If you're not truncating, then this doesn't affect you. If you're not using `-pyt`, this doesn't affect you.