### PR TITLE
Fix issue with subclassing classmethod

### DIFF
--- a/parlai/agents/example_seq2seq/example_seq2seq.py
+++ b/parlai/agents/example_seq2seq/example_seq2seq.py
@@ -82,10 +82,10 @@ class ExampleSeq2seqAgent(TorchAgent):
     <http://pytorch.org/tutorials/intermediate/seq2seq_translation_tutorial.html>`_.
     """
 
-    @staticmethod
-    def add_cmdline_args(argparser):
+    @classmethod
+    def add_cmdline_args(cls, argparser):
         """Add command-line arguments specifically for this agent."""
-        TorchAgent.add_cmdline_args(argparser)
+        super(ExampleSeq2seqAgent, cls).add_cmdline_args(argparser)
         agent = argparser.add_argument_group('Seq2Seq Arguments')
         agent.add_argument('-hs', '--hiddensize', type=int, default=128,
                            help='size of the hidden layers')

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -228,9 +228,6 @@ class FairseqAgent(TorchAgent):
         """Add command-line arguments specifically for this agent."""
         # first we need to add the general torch agent operations
         super(FairseqAgent, cls).add_cmdline_args(argparser)
-        # Dictionary construction stuff. Using the subclass in case we end up
-        # needing any fairseq specific things
-        cls.dictionary_class().add_cmdline_args(argparser)
 
         # let's store any defaults that were overridden
         old_defaults = argparser._defaults

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -227,7 +227,7 @@ class FairseqAgent(TorchAgent):
     def add_cmdline_args(cls, argparser):
         """Add command-line arguments specifically for this agent."""
         # first we need to add the general torch agent operations
-        TorchAgent.add_cmdline_args(argparser)
+        super(FairseqAgent, cls).add_cmdline_args(argparser)
         # Dictionary construction stuff. Using the subclass in case we end up
         # needing any fairseq specific things
         cls.dictionary_class().add_cmdline_args(argparser)

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -88,8 +88,7 @@ class Seq2seqAgent(TorchGeneratorAgent):
         agent.add_argument('-idr', '--input-dropout', type=float, default=0.0,
                            help='Probability of replacing tokens with UNK in training.')
 
-        super(cls, Seq2seqAgent).add_cmdline_args(argparser)
-        Seq2seqAgent.dictionary_class().add_cmdline_args(argparser)
+        super(Seq2seqAgent, cls).add_cmdline_args(argparser)
         return agent
 
     @staticmethod

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -72,7 +72,7 @@ class TransformerRankerAgent(TorchRankerAgent):
 
         cls.dictionary_class().add_cmdline_args(argparser)
 
-        super(cls, TransformerRankerAgent).add_cmdline_args(argparser)
+        super(TransformerRankerAgent, cls).add_cmdline_args(argparser)
         return agent
 
     def build_model(self, states=None):

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -118,7 +118,7 @@ class TransformerGeneratorAgent(TorchGeneratorAgent):
         add_common_cmdline_args(agent)
         cls.dictionary_class().add_cmdline_args(argparser)
 
-        super(cls, TransformerGeneratorAgent).add_cmdline_args(argparser)
+        super(TransformerGeneratorAgent, cls).add_cmdline_args(argparser)
         return agent
 
     def build_model(self, states=None):

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -16,9 +16,9 @@ from parlai.core.distributed_utils import is_distributed
 
 
 class TorchRankerAgent(TorchAgent):
-    @staticmethod
-    def add_cmdline_args(argparser):
-        TorchAgent.add_cmdline_args(argparser)
+    @classmethod
+    def add_cmdline_args(cls, argparser):
+        super(TorchRankerAgent, cls).add_cmdline_args(argparser)
         agent = argparser.add_argument_group('TorchRankerAgent')
         agent.add_argument(
             '-cands', '--candidates', type=str, default='inline',

--- a/tests/test_ta_inheritence.py
+++ b/tests/test_ta_inheritence.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Inheritence around add_cmdline_args can be tricky. This serves as an
+example, and verifies inheritence is behaving correctly.
+"""
+
+import unittest
+from parlai.core.params import ParlaiParser
+from parlai.core.torch_generator_agent import TorchGeneratorAgent
+
+
+class FakeDict(object):
+    @classmethod
+    def add_cmdline_args(cls, parser):
+        parser.add_argument('--dictarg', default='d')
+
+
+class SubClassA(TorchGeneratorAgent):
+    @classmethod
+    def dictionary_class(cls):
+        return FakeDict
+
+    @classmethod
+    def add_cmdline_args(cls, parser):
+        parser.add_argument('--withclassinheritence', default='a')
+        super(SubClassA, cls).add_cmdline_args(parser)
+
+
+class SubClassB(SubClassA):
+    @classmethod
+    def add_cmdline_args(cls, parser):
+        parser.add_argument('--withoutclassinheritence', default='b')
+
+
+class TestInheritence(unittest.TestCase):
+    def test_subclassA(self):
+        """Verify that class A does contain the super args."""
+        parser = ParlaiParser(add_model_args=True)
+        opt = parser.parse_args(
+            args=['--model', 'tests.test_ta_inheritence:SubClassA'],
+            print_args=False
+        )
+        self.assertEqual('a', opt.get('withclassinheritence'))
+        # make sure we have the dictionary arg
+        self.assertEqual('d', opt.get('dictarg'))
+        # something that torch agent has
+        self.assertIn('no_cuda', opt)
+        # something torch generator agent has
+        self.assertIn('beam_size', opt)
+
+    def test_subclassB(self):
+        """Verify that class B does not contain the super args."""
+        parser = ParlaiParser(add_model_args=True)
+        opt = parser.parse_args(
+            args=['--model', 'tests.test_ta_inheritence:SubClassB'],
+            print_args=False
+        )
+        self.assertEqual('b', opt.get('withoutclassinheritence'))
+        # make sure we don't have the dictionary now
+        self.assertNotIn('dictarg', opt)
+        # something the parent has
+        self.assertNotIn('withclassinheritence', opt)
+        # something that torch agent has
+        self.assertNotIn('no_cuda', opt)
+        # something torch generator agent has
+        self.assertNotIn('beam_size', opt)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
To avoid a `TypeError: super(type, obj): obj must be an instance or subtype of type` error when subclassing `TransformerRankerAgent`

For reference:
- https://stackoverflow.com/questions/1269217/calling-a-base-classs-classmethod-in-python
- https://stackoverflow.com/questions/15291302/how-to-call-a-parent-classs-classmethod-from-an-overridden-classmethod-in-pyt
- https://github.com/facebookresearch/ParlAI/blob/master/parlai/core/torch_generator_agent.py#L257