### PR TITLE
Broken pyt integration test

### DIFF
--- a/parlai/scripts/build_pytorch_data.py
+++ b/parlai/scripts/build_pytorch_data.py
@@ -26,7 +26,7 @@ from collections import deque
 
 
 def get_pyt_dict_file(opt):
-    if os.path.exists(opt.get('dict_file', '')):
+    if opt.get('dict_file') and os.path.exists(opt.get('dict_file', '')):
         return opt['dict_file']
     if not opt['pytorch_teacher_task']:
         opt['pytorch_teacher_task'] = opt['task']

--- a/parlai/tasks/vqa_v1/build.py
+++ b/parlai/tasks/vqa_v1/build.py
@@ -28,7 +28,7 @@ def build(opt):
         fname4 = 'Annotations_Val_mscoco.zip'
         fname5 = 'Annotations_Train_mscoco.zip'
 
-        url = 'http://visualqa.org/data/mscoco/vqa/'
+        url = 'https://s3.amazonaws.com/cvmlp/vqa/mscoco/vqa/'
         build_data.download(url + fname1, dpath, fname1)
         build_data.download(url + fname2, dpath, fname2)
         build_data.download(url + fname3, dpath, fname3)


### PR DESCRIPTION
Broken for two reasons:
- Edge case when there's no `--dict-file`, which causes a call to `os.path.exists(None)` and crashes
- I messed up merges for #1316 and #1335 which caused one to undo the other.