### PR TITLE
Multi review flow

### DIFF
--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -144,6 +144,8 @@ def create_hit_config(opt, task_description, unique_worker, is_sandbox):
         'frame_height': opt.get('frame_height', 650),
         'allow_reviews': opt.get('allow_reviews', False),
         'block_mobile': opt.get('block_mobile', True),
+        # Populate the chat pane title from chat_title, defaulting to the 
+        # hit_title if the task provides no chat_title
         'chat_title': opt.get('chat_title', opt.get('hit_tile', 'Live Chat')),
     }
     hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -146,7 +146,7 @@ def create_hit_config(opt, task_description, unique_worker, is_sandbox):
         'block_mobile': opt.get('block_mobile', True),
         # Populate the chat pane title from chat_title, defaulting to the 
         # hit_title if the task provides no chat_title
-        'chat_title': opt.get('chat_title', opt.get('hit_tile', 'Live Chat')),
+        'chat_title': opt.get('chat_title', opt.get('hit_title', 'Live Chat')),
     }
     hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
     if os.path.exists(hit_config_file_path):

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -144,6 +144,7 @@ def create_hit_config(opt, task_description, unique_worker, is_sandbox):
         'frame_height': opt.get('frame_height', 650),
         'allow_reviews': opt.get('allow_reviews', False),
         'block_mobile': opt.get('block_mobile', True),
+        'chat_title': opt.get('chat_title', opt.get('hit_tile', 'Live Chat')),
     }
     hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
     if os.path.exists(hit_config_file_path):

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -144,7 +144,7 @@ def create_hit_config(opt, task_description, unique_worker, is_sandbox):
         'frame_height': opt.get('frame_height', 650),
         'allow_reviews': opt.get('allow_reviews', False),
         'block_mobile': opt.get('block_mobile', True),
-        # Populate the chat pane title from chat_title, defaulting to the 
+        # Populate the chat pane title from chat_title, defaulting to the
         # hit_title if the task provides no chat_title
         'chat_title': opt.get('chat_title', opt.get('hit_title', 'Live Chat')),
     }

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -1770,19 +1770,60 @@ class ReviewPanel extends React.Component {
     return current_worker;
   }
 
+  approveAssignment(assign_id) {
+    postData('/approve/' + assign_id)
+      .then(res => res.json())
+      .then(
+        (result) => {console.log(assign_id + ' approved')},
+        (error) => {
+          this.setState({
+            submitting: false,
+          });
+          console.log(error);
+          window.alert('Submitting review failed. Error logged to console');
+        }
+      )
+  }
+
+  approveAllForWorker() {
+    let current_worker = this.state.current_worker;
+    let assignments = this.state.assignments_by_worker[current_worker].assigns;
+    let current_assignment = this.state.current_assignment;
+    this.approveAssignment(current_assignment);
+    let total_assigns = 1 + assignments.length;
+    while (assignments.length > 0) {
+        current_assignment = assignments.shift();
+        this.approveAssignment(current_assignment.assignment_id);
+    }
+    this.setState({
+      assignments_by_worker: this.state.assignments_by_worker,
+      assignments_remaining: this.state.assignments_remaining - total_assigns,
+    });
+    this.state.current_worker_stats.remain = 0;
+    this.nextAssignment();
+  }
+
   getReviewOverview() {
     let worker_stats = this.state.current_worker_stats;
     let current_worker = this.state.current_worker;
     let workers_remaining = this.state.workers_remaining;
     let assignments_remaining = this.state.assignments_remaining;
 
-    let start_button = null;
+    let action_button = null;
     if (this.state.current_assignment == null) {
-      start_button = <Button
+      action_button = <Button
         bsStyle="primary"
         onClick={() => this.nextAssignment()}>
         Get Started!
       </Button>
+    } else if (worker_stats.approved > 0){
+      action_button = <div>
+        <Button
+          bsStyle="primary"
+          onClick={() => this.approveAllForWorker()}>
+          Approve Rest For Worker
+        </Button>
+      </div>
     }
 
     return (
@@ -1810,7 +1851,7 @@ class ReviewPanel extends React.Component {
           <p>
             Total Assignments remaining: {assignments_remaining}
           </p>
-          {start_button}
+          {action_button}
         </Panel.Body>
       </Panel>
     );

--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -1638,6 +1638,8 @@ class ReviewPanel extends React.Component {
 
       assignments_remaining += 1;
       if (!!assign.received_feedback && assign.received_feedback.rating < 3) {
+        // Feedback below 3 was rated as "below average", 
+        // so we want to prioritize it as important to see
         assignments_by_worker[assign.worker_id].bad_feedback = true;
         assignments_by_worker[assign.worker_id].assigns.unshift(assign);
       } else {

--- a/parlai/mturk/webapp/server.py
+++ b/parlai/mturk/webapp/server.py
@@ -379,54 +379,49 @@ class AssignmentHandler(BaseHandler):
         self.data_handler = app.data_handler
 
     def get(self, assignment_target):
+        # Extract assignment
+        assignments = [self.data_handler.get_assignment_data(
+            assignment_target)]
+        pairings = self.data_handler.get_pairings_for_assignment(
+            assignment_target)
+        processed_assignments = merge_assignments_with_pairings(
+            assignments, pairings, 'assignment {}'.format(assignment_target))
+        assignment = processed_assignments[0]
+
+        # Get assignment details to retrieve assignment content
+        run_id = assignment['run_id']
+        onboarding_id = assignment['onboarding_id']
+        conversation_id = assignment['conversation_id']
+        worker_id = assignment['worker_id']
+
+        onboard_data = None
+        if onboarding_id is not None:
+            onboard_data = MTurkDataHandler.get_conversation_data(
+                run_id, onboarding_id, worker_id, self.state['is_sandbox'])
+
+        assignment_content = {
+            'onboarding': onboard_data,
+            'task': MTurkDataHandler.get_conversation_data(
+                run_id, conversation_id, worker_id, self.state['is_sandbox']),
+            'task_name': '_'.join(run_id.split('_')[:-1]),
+        }
+
+        # Get assignment instruction html. This can be much improved
+        task_name = '_'.join(run_id.split('_')[:-1])
         try:
-            # Extract assignment
-            assignments = [self.data_handler.get_assignment_data(
-                assignment_target)]
-            pairings = self.data_handler.get_pairings_for_assignment(
-                assignment_target)
-            processed_assignments = merge_assignments_with_pairings(
-                assignments, pairings, 'assignment {}'.format(assignment_target))
-            assignment = processed_assignments[0]
+            # Try to find the task at specified location
+            t = get_config_module(task_name)
+            task_instructions = t.task_config['task_description']
+        except ImportError:
+            task_instructions = None
 
-            # Get assignment details to retrieve assignment content
-            run_id = assignment['run_id']
-            onboarding_id = assignment['onboarding_id']
-            conversation_id = assignment['conversation_id']
-            worker_id = assignment['worker_id']
+        data = {
+            'assignment_details': assignment,
+            'assignment_content': assignment_content,
+            'assignment_instructions': task_instructions,
+        }
 
-            onboard_data = None
-            if onboarding_id is not None:
-                onboard_data = MTurkDataHandler.get_conversation_data(
-                    run_id, onboarding_id, worker_id, self.state['is_sandbox'])
-
-            assignment_content = {
-                'onboarding': onboard_data,
-                'task': MTurkDataHandler.get_conversation_data(
-                    run_id, conversation_id, worker_id, self.state['is_sandbox']),
-                'task_name': '_'.join(run_id.split('_')[:-1]),
-            }
-
-            # Get assignment instruction html. This can be much improved
-            task_name = '_'.join(run_id.split('_')[:-1])
-            try:
-                # Try to find the task at specified location
-                t = get_config_module(task_name)
-                task_instructions = t.task_config['task_description']
-            except ImportError:
-                task_instructions = None
-
-            data = {
-                'assignment_details': assignment,
-                'assignment_content': assignment_content,
-                'assignment_instructions': task_instructions,
-            }
-
-            self.write(json.dumps(data))
-        except Exception as e:
-            import traceback
-            traceback.print_exc();
-            raise(e)
+        self.write(json.dumps(data))
 
 
 class ApprovalHandler(BaseHandler):


### PR DESCRIPTION
## Summary 
Adds a review flow that steps through all assignments for a task in order by worker, first surfacing tasks that have been reported by other workers. 

![screen shot 2019-01-25 at 5 16 01 pm](https://user-images.githubusercontent.com/1276867/51775881-2dc45b00-20c5-11e9-9f18-95f2ca37dc0d.png)

## Implementation
Leverages the existing `AssignmentPanel` component to render the assignment given by `ReviewPanel`. Rendering the review page will load all of the assignment details for that run, filter them by review-ability,  group them by worker, and then sort them by first if the worker has received any negative feedback and then by number of assignments per worker, finally storing in `assignments_by_worker`. 
The UI flow then triggers `nextAssignment` whenever the current assignment is viewed, which steps through the list. If at least one assignment is approved for a worker you can approve the rest.