### PR TITLE
Pyt Dict File

### DIFF
--- a/parlai/scripts/build_pytorch_data.py
+++ b/parlai/scripts/build_pytorch_data.py
@@ -28,7 +28,7 @@ from collections import deque
 def get_pyt_dict_file(opt):
     if opt.get('dict_file') and os.path.exists(opt.get('dict_file')):
         return opt['dict_file']
-    if opt.get('dict_file', None) is None and opt.get('model_file'):
+    if opt.get('dict_file') is None and opt.get('model_file'):
         return opt['model_file'] + '.dict'
     if not opt['pytorch_teacher_task']:
         opt['pytorch_teacher_task'] = opt['task']

--- a/parlai/scripts/build_pytorch_data.py
+++ b/parlai/scripts/build_pytorch_data.py
@@ -26,8 +26,10 @@ from collections import deque
 
 
 def get_pyt_dict_file(opt):
-    if os.path.exists(opt.get('dict_file', '')):
+    if opt.get('dict_file') and os.path.exists(opt.get('dict_file')):
         return opt['dict_file']
+    if opt.get('dict_file', None) is None and opt.get('model_file'):
+        return opt['model_file'] + '.dict'
     if not opt['pytorch_teacher_task']:
         opt['pytorch_teacher_task'] = opt['task']
     return os.path.join(


### PR DESCRIPTION
Ensures that if a model file is specified, we save the dictionary there (rather than the default PytorchDataTeacher file).

Integration tests pass on local machine.