### PR TITLE
Resume learning rate scheduling.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -357,11 +357,17 @@ class TorchAgent(Agent):
                             if isinstance(v, torch.Tensor):
                                 state[k] = v.cuda()
 
-    def build_lr_scheduler(self, states=None):
+    def build_lr_scheduler(self, states=None, hard_reset=False):
         """
         Create the learning rate scheduler, and assign it to self.scheduler.
-
         This scheduler will be updated upon a call to receive_metrics.
+
+        May also create self.warmup_scheduler if set.
+
+        :param state_dict states: Possible state_dict provided by model
+            checkpoint, for restoring LR state
+        :param bool hard_reset: If true, the LR scheduler should ignore the
+            state dictionary.
         """
         if self.opt.get('warmup_updates', -1) > 0:
             def _warmup_lr(step):
@@ -425,8 +431,8 @@ class TorchAgent(Agent):
                 .format(self.opt.get('lr_scheduler'))
             )
 
-        # load from states if possible
-        if states is None:
+        # load from states if possible. don't use them if explicitly told not to
+        if states is None or hard_reset:
             states = {}
 
         if self.scheduler and 'lr_scheduler' in states:

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -362,7 +362,7 @@ class TorchAgent(Agent):
         Create the learning rate scheduler, and assign it to self.scheduler.
         This scheduler will be updated upon a call to receive_metrics.
 
-        May also create self.warmup_scheduler if set.
+        May also create self.warmup_scheduler, if appropriate.
 
         :param state_dict states: Possible state_dict provided by model
             checkpoint, for restoring LR state
@@ -431,16 +431,27 @@ class TorchAgent(Agent):
                 .format(self.opt.get('lr_scheduler'))
             )
 
-        # load from states if possible. don't use them if explicitly told not to
-        if states is None or hard_reset:
+        # time to load LR state from the checkpoint, if possible.
+        if states is None:
+            # first make sure there are no null pointers
             states = {}
 
+        if states and states.get('lr_scheduler_type') != self.opt['lr_scheduler']:
+            # the LR scheduler changed, start things fresh
+            warn_once("LR scheduler is different from saved. Starting fresh!")
+            hard_reset = True
+
+        if hard_reset:
+            # We're not going to use the LR schedule, let's just exit
+            return
+
+        # do the actual loading (if possible)
+        if 'number_training_updates' in states:
+            self._number_training_updates = states['number_training_updates']
         if self.scheduler and 'lr_scheduler' in states:
             self.scheduler.load_state_dict(states['lr_scheduler'])
         if states.get('warmup_scheduler') and getattr(self, 'warmup_scheduler'):
             self.warmup_scheduler.load_state_dict(states['warmup_scheduler'])
-        if 'number_training_updates' in states:
-            self._number_training_updates = states['number_training_updates']
 
     def report(self):
         metrics = {}
@@ -1032,13 +1043,16 @@ class TorchAgent(Agent):
                     states['model'] = self.model.module.state_dict()
                 else:
                     states['model'] = self.model.state_dict()
+
             if hasattr(self, 'optimizer'):  # save optimizer params
                 states['optimizer'] = self.optimizer.state_dict()
+                states['optimizer_type'] = self.opt['optimizer']
 
             # lr scheduler
             states['number_training_updates'] = self._number_training_updates
             if getattr(self, 'scheduler'):
                 states['lr_scheduler'] = self.scheduler.state_dict()
+                states['lr_scheduler_type'] = self.opt['lr_scheduler']
             if getattr(self, 'warmup_scheduler'):
                 states['warmup_scheduler'] = self.warmup_scheduler.state_dict()
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -324,7 +324,7 @@ class TorchGeneratorAgent(TorchAgent):
                 broadcast_buffers=False,
             )
 
-        if shared is None and 'train' in opt.get('datatype', ''):
+        if 'train' in opt.get('datatype', ''):
             # do this regardless of share state, but don't
             self.init_optim(
                 [p for p in self.model.parameters() if p.requires_grad],

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -259,19 +259,21 @@ class TorchGeneratorAgent(TorchAgent):
 
     def __init__(self, opt, shared=None):
         init_model = None
+        is_finetune = False
         if not shared:  # only do this on first setup
             # first check load path in case we need to override paths
             if opt.get('init_model') and os.path.isfile(opt['init_model']):
                 # check first for 'init_model' for loading model from file
                 init_model = opt['init_model']
+                is_finetune = True
             if opt.get('model_file') and os.path.isfile(opt['model_file']):
                 # next check for 'model_file', this would override init_model
                 init_model = opt['model_file']
+                is_finetune = False
 
             if init_model is not None:
                 # if we are loading a model, should load its dict too
-                if (os.path.isfile(init_model + '.dict') or
-                        opt['dict_file'] is None):
+                if os.path.isfile(init_model + '.dict') or opt['dict_file'] is None:
                     opt['dict_file'] = init_model + '.dict'
         super().__init__(opt, shared)
 
@@ -331,7 +333,7 @@ class TorchGeneratorAgent(TorchAgent):
                 optim_states=states.get('optimizer'),
                 saved_optim_type=states.get('optimizer_type')
             )
-            self.build_lr_scheduler(states)
+            self.build_lr_scheduler(states, hard_reset=is_finetune)
 
         self.reset()
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -324,14 +324,14 @@ class TorchGeneratorAgent(TorchAgent):
                 broadcast_buffers=False,
             )
 
-        if 'train' in opt.get('datatype', ''):
+        if shared is None and 'train' in opt.get('datatype', ''):
             # do this regardless of share state, but don't
             self.init_optim(
                 [p for p in self.model.parameters() if p.requires_grad],
                 optim_states=states.get('optimizer'),
                 saved_optim_type=states.get('optimizer_type')
             )
-            self.build_lr_scheduler()
+            self.build_lr_scheduler(states)
 
         self.reset()
 

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -1035,4 +1035,4 @@ def warn_once(msg, warningtype=None):
     global _seen_warnings
     if msg not in _seen_warnings:
         _seen_warnings.add(msg)
-        warnings.warn(msg, warningtype)
+        warnings.warn(msg, warningtype, stacklevel=2)


### PR DESCRIPTION
Before, if your job was interrupted (e.g. by slurm) and resumed, the LR scheduler would start fresh. This has been a long standing issue. Solution is usually to use a non-preemptable queue, but that lowers throughput.

Issues with this patch that should be resolved before accepting:
- [x] I believe in the case of fine-tuning, we'd really like the LR scheduler to reset.
- [x] Manually switching to a new LR scheduler will probably throw errors.

This patch also just cleans up the Transformer Test a little bit.