### PR TITLE
Allow model transfer weights in TGA

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -36,8 +36,6 @@ class Seq2seqAgent(TorchGeneratorAgent):
     def add_cmdline_args(cls, argparser):
         """Add command-line arguments specifically for this agent."""
         agent = argparser.add_argument_group('Seq2Seq Arguments')
-        agent.add_argument('--init-model', type=str, default=None,
-                           help='load dict/model/opts from this path')
         agent.add_argument('-hs', '--hiddensize', type=int, default=128,
                            help='size of the hidden layers')
         agent.add_argument('-esz', '--embeddingsize', type=int, default=128,

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -238,6 +238,8 @@ class TorchGeneratorAgent(TorchAgent):
     @classmethod
     def add_cmdline_args(cls, argparser):
         agent = argparser.add_argument_group('Torch Generator Agent')
+        agent.add_argument('--init-model', type=str, default=None,
+                           help='load dict/model/opts from this path')
         agent.add_argument('--beam-size', type=int, default=1,
                            help='Beam size, if 1 then greedy search')
         agent.add_argument('--beam-dot-log', type='bool', default=False, hidden=True,


### PR DESCRIPTION
Although a bunch of code handling `init_model` was already written, it currently wasn't supported by TGA because the command line parameter was only in seq2seq. This patch just moves it.