### PR TITLE
Update tutorial_basic.rst

### DIFF
--- a/docs/source/tutorial_basic.rst
+++ b/docs/source/tutorial_basic.rst
@@ -299,7 +299,7 @@ the labels aren't available:
             reply['text'] = ', '.join(self.observation['labels'])
         elif 'label_candidates' in self.observation:
             cands = self.observation['label_candidates']
-            reply['text'] = random.choice(cands)
+            reply['text'] = random.choice(list(cands))
         else:
             reply['text'] = "I don't know."
         return reply


### PR DESCRIPTION
Some of our data sets return sets as lists of choices for their labels. The canonical `random.choice` in the tutorial expects indexable collections.

Fixes #1398