### PR TITLE
eval_ppl script use model dictionary by default

### DIFF
--- a/parlai/scripts/eval_ppl.py
+++ b/parlai/scripts/eval_ppl.py
@@ -246,4 +246,4 @@ if __name__ == '__main__':
     parser = setup_args()
     # try with --numthreads N to go fast
     opt = parser.parse_args()
-    eval_ppl(opt)
+    eval_ppl(opt, dict_file=opt.get('dict_file'))


### PR DESCRIPTION
the eval_ppl script should use the agent's dictionary by default if you are running this file
(if you're calling this from another script, as we do in `projects/convai2/eval_ppl.py`, then you'd provide your own argument)

this makes it easier to just quickly run a "truer" eval