### PR TITLE
Allow images to be sent in Messenger

### DIFF
--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -149,7 +149,8 @@ class MessengerAgent(Agent):
                                'Please try with a text-only message.',
                        'episode_done': True}
                 self.observe(act)
-            elif not msg.get('text'):
+            elif (not msg.get('text')
+                  and not (msg.get('image_url') or msg.get('attachment_url'))):
                 # Do not allow agent to send empty strings
                 msg = None
 

--- a/parlai/messenger/core/agents.py
+++ b/parlai/messenger/core/agents.py
@@ -93,6 +93,9 @@ class MessengerAgent(Agent):
                 'sticker_sender': message.get('sticker_sender', None),
                 'img_attempt': img_attempt,
             }
+            if img_attempt and self.data.get('allow_images', False):
+                action['image_url'] = message['message'].get('image_url')
+                action['attachment_url'] = message['message'].get('attachment_url')
             self.msg_queue.put(action)
 
     def set_stored_data(self):
@@ -137,7 +140,7 @@ class MessengerAgent(Agent):
         # Get a new message, if it's not None reset the timeout
         msg = self.get_new_act_message()
         if msg is not None:
-            if msg.get('img_attempt'):
+            if msg.get('img_attempt') and not self.data.get('allow_images', False):
                 # Let agent know that they cannot send images if they
                 # attempted to send one
                 msg = None


### PR DESCRIPTION
There are some cases where we would like to allow people on messenger to send images to our bots. For now, it would be good to at least be able to specify in an agent's `data` whether to allow images to be sent. 