### PR TITLE
[MTurk] Loosening timeout restrictions

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -574,7 +574,12 @@ class MTurkManager():
             agent = self.worker_manager._get_agent(worker_id, assign_id)
             agent.log_reconnect()
             agent.alived = True
-            conversation_id = agent.conversation_id
+            if agent.conversation_id is not None and \
+                    conversation_id is not None:
+                # agent.conversation_id is None is used in testing
+                # conversation_id is None one a fresh reconnect event, where
+                # we need to restore state somehow
+                conversation_id = agent.conversation_id
             if agent.get_status() == AssignState.STATUS_NONE:
                 # See if assigned an onboarding world, update state if so
                 if self.is_onboarding_world(conversation_id):

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -576,9 +576,9 @@ class MTurkManager():
             agent.alived = True
             if agent.conversation_id is not None and \
                     conversation_id is not None:
-                # agent.conversation_id is None is used in testing
-                # conversation_id is None one a fresh reconnect event, where
-                # we need to restore state somehow
+                # agent.conversation_id is None is used in testing.
+                # conversation_id is None on a fresh reconnect event, where
+                # we need to restore state somehow and shouldn't just inherit
                 conversation_id = agent.conversation_id
             if agent.get_status() == AssignState.STATUS_NONE:
                 # See if assigned an onboarding world, update state if so

--- a/parlai/mturk/core/react_server/dev/components/socket_handler.jsx
+++ b/parlai/mturk/core/react_server/dev/components/socket_handler.jsx
@@ -42,13 +42,13 @@ const TYPE_ALIVE = 'alive';
 /* ================= Local Constants ================= */
 
 const SEND_THREAD_REFRESH = 100;
-const ACK_WAIT_TIME = 300; // Check for acknowledge every 0.3 seconds
+const ACK_WAIT_TIME = 2000; // Check for acknowledge every 2 seconds
 const STATUS_ACK = 'ack';
 const STATUS_INIT = 'init';
 const STATUS_SENT = 'sent';
-const CONNECTION_DEAD_MISSING_PONGS = 15;
-const REFRESH_SOCKET_MISSING_PONGS = 5;
-const HEARTBEAT_TIME = 2000;  // One heartbeat every 2 seconds
+const CONNECTION_DEAD_MISSING_PONGS = 25;
+const REFRESH_SOCKET_MISSING_PONGS = 10;
+const HEARTBEAT_TIME = 4000;  // One heartbeat every 4 seconds
 
 
 /* ============== Priority Queue Data Structure ============== */

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -161,13 +161,13 @@ class SocketManager():
     """
 
     # Time to acknowledge different message types
-    ACK_TIME = {Packet.TYPE_ALIVE: 2,
-                Packet.TYPE_MESSAGE: 0.5}
+    ACK_TIME = {Packet.TYPE_ALIVE: 4,
+                Packet.TYPE_MESSAGE: 4}
 
     # Default pongs without heartbeat before socket considered dead
-    DEF_MISSED_PONGS = 10
-    HEARTBEAT_RATE = 2
-    DEF_DEAD_TIME = 20
+    DEF_MISSED_PONGS = 20
+    HEARTBEAT_RATE = 4
+    DEF_DEAD_TIME = 30
 
     def __init__(self, server_url, port, alive_callback, message_callback,
                  socket_dead_callback, task_group_id,

--- a/parlai/mturk/core/test/test_full_system.py
+++ b/parlai/mturk/core/test/test_full_system.py
@@ -637,7 +637,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
             lambda: agent_2.worker_id in self.worlds_agents, True, 2)
         self.assertIn(agent_1.worker_id, self.worlds_agents)
 
-        # Simulate reconnect
+        # Simulate reconnect to task
         stored_conv_id = agent_2.conversation_id
         stored_agent_id = agent_2.id
         agent_2.conversation_id = None
@@ -647,7 +647,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         assert_equal_by(lambda: len(
             [p for p in agent_2.message_packet
              if p.data['text'] == data_model.COMMAND_RESTORE_STATE]
-        ), 1, 2)
+        ), 1, 4)
         self.assertEqual(agent_2.id, stored_agent_id)
         self.assertEqual(agent_2.conversation_id, stored_conv_id)
 


### PR DESCRIPTION
## Summary
Mostly the title. Tight restrictions on the required ack times for both heartbeats and actual messages led some workers to disconnect much more frequently than was necessary, as technically their connections were stable enough to work on the task. Loosening the bounds makes it possible for more workers to work uninterrupted. 

As an aside, this does increase the time it will take for a worker to notice that the ParlAI-hosting server (not the heroku one) has gone down and interrupted a task from 45 seconds to up to 90 in the worst case, which isn't the best experience but having more workers able to work without issues most definitely outweighs that edge case.

This PR also fixes some tests that were broken during the dual world fix.