### PR TITLE
[Torch Ranker] faster metrics calculations

### DIFF
--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -119,7 +119,6 @@ class TorchRankerAgent(TorchAgent):
             targets = scores.new_empty(batchsize).long()
             targets = torch.arange(batchsize, out=targets)
             nb_ok = (scores.max(dim=1)[1] == targets).float().sum().item()
-            import pdb; pdb.set_trace()
             self.metrics['train_accuracy'] += nb_ok
             # calculate mean rank
             above_dot_prods = scores - scores.diag().view(-1, 1)

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -63,7 +63,7 @@ class TorchRankerAgent(TorchAgent):
             states = None
         else:
             self.metrics = {'loss': 0.0, 'examples': 0, 'rank': 0,
-                            'train_accuracy': 0}
+                            'train_accuracy': 0.0}
             self.build_model()
             if model_file:
                 print('Loading existing model parameters from ' + model_file)
@@ -162,7 +162,7 @@ class TorchRankerAgent(TorchAgent):
             return Output()
         if not self.opt.get('train_predict', False):
             warn_once(
-                "Some training metrics are ommitted for speed. Set the flag "
+                "Some training metrics are omitted for speed. Set the flag "
                 "`--train-predict` to calculate train metrics."
             )
             return Output()

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -110,7 +110,6 @@ class TorchRankerAgent(TorchAgent):
         raise NotImplementedError(
             'Abstract class: user must implement build_model()')
 
-
     def get_batch_train_metrics(self, scores):
         batchsize = scores.size(0)
         # get accuracy
@@ -123,9 +122,9 @@ class TorchRankerAgent(TorchAgent):
         rank = (above_dot_prods > 0).float().sum().item()
         self.metrics['rank'] += rank
 
-
-    def get_train_preds(self, scores):
+    def get_train_preds(self, scores, label_inds, cands, cand_vecs):
         # TODO: speed these calculations up
+        batchsize = scores.size(0)
         _, ranks = scores.sort(1, descending=True)
         for b in range(batchsize):
             rank = (ranks[b] == label_inds[b]).nonzero().item()
@@ -137,7 +136,6 @@ class TorchRankerAgent(TorchAgent):
         elif cand_vecs.dim() == 3:
             preds = [cands[i][ordering[0]] for i, ordering in enumerate(ranks)]
         return Output(preds)
-
 
     def train_step(self, batch):
         """Train on a single batch of examples."""
@@ -168,7 +166,7 @@ class TorchRankerAgent(TorchAgent):
                 "`--train-predict` to calculate train metrics."
             )
             return Output()
-        return self.get_train_preds(scores)
+        return self.get_train_preds(scores, label_inds, cands, cand_vecs)
 
     def eval_step(self, batch):
         """Evaluate a single batch of examples."""


### PR DESCRIPTION
Option to not calculate metrics at all during train time. If training with batch candidates, added a faster metrics calculation (resulting in a speedup ~1.4x).

