### PR TITLE
Use correct FastText CC vectors

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -28,6 +28,7 @@ from parlai.core.utils import (
     set_namedtuple_defaults, argsort, padded_tensor, warn_once, round_sigfigs
 )
 from parlai.core.distributed_utils import is_primary_worker
+from parlai.zoo.fasttext_cc_vectors.build import url as fasttext_cc_url
 
 try:
     import torch
@@ -531,8 +532,9 @@ class TorchAgent(Agent):
                                     'models:glove_vectors'))
         elif emb_type.startswith('fasttext_cc'):
             init = 'fasttext_cc'
-            embs = vocab.FastText(
-                language='en',
+            embs = vocab.Vectors(
+                name='crawl-300d-2M.vec',
+                url=fasttext_cc_url,
                 cache=modelzoo_path(self.opt.get('datapath'),
                                     'models:fasttext_cc_vectors'))
         elif emb_type.startswith('fasttext'):

--- a/parlai/zoo/fasttext_cc_vectors/build.py
+++ b/parlai/zoo/fasttext_cc_vectors/build.py
@@ -9,10 +9,11 @@
 
 import torchtext.vocab as vocab
 
+url='https://s3-us-west-1.amazonaws.com/fasttext-vectors/crawl-300d-2M.vec.zip',
 
 def download(datapath):
     vocab.Vectors(
         name='crawl-300d-2M.vec',
-        url='https://s3-us-west-1.amazonaws.com/fasttext-vectors/crawl-300d-2M.vec.zip',
+        url=url,
         cache=datapath + '/models/fasttext_cc_vectors'
     )


### PR DESCRIPTION
Previously, TorchAgent was using torchtext.vocab.FastText to initialize FastText CC vectors; this would actually lead to using FastText wiki vectors. This PR ensures that TorchAgent is using the correct pretrained embeddings.