### PR TITLE
[WIP] for rankers distributed accross gpus, allow to use candidates on the other GPUs as negatives.

### DIFF
--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -69,7 +69,9 @@ class TransformerRankerAgent(TorchRankerAgent):
                            help='If true, use the memories to help with predictions')
         agent.add_argument('--scores-norm', choices={'dot', 'sqrt', 'dim'},
                            default='dot', hidden=True)
-
+        agent.add_argument('--gather-from-other-nodes', type='bool', default=False,
+                           help='In distributed mode, collect candidates from'
+                                 'other nodes and concatenate them.')
         cls.dictionary_class().add_cmdline_args(argparser)
 
         super(TransformerRankerAgent, cls).add_cmdline_args(argparser)

--- a/parlai/core/distributed_utils.py
+++ b/parlai/core/distributed_utils.py
@@ -270,6 +270,7 @@ class DistributionConcatenation2DFunction(torch.autograd.Function):
     def forward(ctx, x, rank, world_size):
         ctx.save_for_backward(rank, world_size)
         gather_list = [x.new_zeros(x.size(0), x.size(1)) for _ in range(world_size)]
+        print(x.size())
         dist.all_gather(gather_list, x)
         y = torch.cat(gather_list, 0).contiguous()
         return y

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -120,7 +120,7 @@ class TorchRankerAgent(TorchAgent):
         # Update metrics
         self.metrics['loss'] += loss.item()
         self.metrics['examples'] += batchsize
-        _, ranks = scores.sort(1, descending=True)
+        _, ranks = scores[:, 0:len(cands)].sort(1, descending=True)
         for b in range(batchsize):
             rank = (ranks[b] == label_inds[b]).nonzero().item()
             self.metrics['rank'] += 1 + rank

--- a/tests/test_distributed_util.py
+++ b/tests/test_distributed_util.py
@@ -1,0 +1,139 @@
+import torch
+import torch.distributed as dist
+from parlai.core.distributed_utils import DistributionConcatenation2D
+import builtins
+import random
+import unittest
+import time
+
+WORLD_SIZE = 2
+
+def launch(my_function):
+    """ Launch a single function on 2 GPUS.
+        this function should take 2 parameters: rank and world_size
+    """
+    port = random.randint(32000, 48000)
+    spawncontext = torch.multiprocessing.spawn(
+        init_and_launch,
+        (WORLD_SIZE, my_function, port),
+        nprocs=WORLD_SIZE,
+        join=False,
+    )
+
+    try:
+        spawncontext.join()
+    except KeyboardInterrupt:
+        # tell the subprocesses to stop too
+        for p in spawncontext.processes:
+            if p.is_alive():
+                os.kill(p.pid, signal.SIGINT)
+
+def override_print(suppress=False, prefix=None):
+    """ Copied from ParlAI.
+    """
+    builtin_print = builtins.print
+    def new_print(*args, **kwargs):
+        if suppress:
+            return
+        elif prefix:
+            return builtin_print(prefix, *args, **kwargs)
+        else:
+            return builtin_print(*args, **kwargs)
+    builtins.print = new_print
+
+def init_and_launch(rank, world_size, my_function, port=61337, gpu=None, hostname='localhost'):
+    """ Copied from PARLAI
+    """
+
+    # Suppress output of workers except the main host.
+    print_prefix = ""
+    override_print(
+        suppress=rank != 0,
+        prefix=print_prefix
+    )
+
+    # perform distributed setup, ensuring all hosts are ready
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method="tcp://{}:{}".format(hostname, port),
+        world_size=WORLD_SIZE,
+        rank=rank,
+    )
+    print("Distributed group initialized")
+    my_function(rank, world_size)
+
+class DistributionConcatenation2DTestModule(torch.nn.Module):
+    """ An identity matrix followed by  DistributionConcatenation2D
+    """
+    def __init__(self, keep_self_first, dim):
+        super(DistributionConcatenation2DTestModule, self).__init__()
+        self.identity = torch.nn.Linear(dim, dim, bias=False)
+        torch.nn.init.eye_(self.identity.weight)
+        self.dist_concat = DistributionConcatenation2D(keep_self_first)
+
+    def forward(self, x):
+        return self.dist_concat(self.identity(x))
+
+
+def test_function_dist_concat(rank, world_size):
+    # first test
+    dim = 10
+    sub_batch_size = 40
+    torch.cuda.set_device(rank)
+    test_module = DistributionConcatenation2DTestModule(False, dim).cuda()
+    if dist.is_available() and dist.is_initialized():
+        test_module = torch.nn.parallel.DistributedDataParallel(
+            test_module,
+            device_ids=[rank],
+            broadcast_buffers=False,
+        )
+
+    value = rank + 1
+    x = torch.zeros(sub_batch_size, dim).cuda() + value
+    x.requires_grad=True
+    y = test_module(x)
+    assert y.size(0) == 2 * sub_batch_size, "Size of y is " % y.size(0)
+    assert y[0,0] == 1
+    assert y[-1,0] == 2
+    loss = torch.sum(y) * value
+    assert loss.item() == dim * sub_batch_size * 3 * value
+    loss.backward()
+    # the gradients of x should be 3 everywhere
+    assert x.grad[0][0].item() == 3, \
+        "The grad isn't right? %.3f" % x.grad[0][0].item()
+    # however the gradients of the identity matrix should be 180 (120+240/2),
+    # because DistributedDataParallel should have averaged them during
+    # the backward()
+    grad_identity = test_module.module.identity.weight.grad
+    assert grad_identity[0,0].item() == 180, \
+        "The grad isn't right? %.3f" % grad_identity[0][0].item()
+
+    # second test, this time with keep self_first = true
+    test_module = DistributionConcatenation2DTestModule(True, dim).cuda()
+    if dist.is_available() and dist.is_initialized():
+        test_module = torch.nn.parallel.DistributedDataParallel(
+            test_module,
+            device_ids=[rank],
+            broadcast_buffers=False,
+        )
+    x = torch.zeros(sub_batch_size, dim).cuda() + value
+    x.requires_grad=True
+    y = test_module(x)
+    assert y.size(0) == 2 * sub_batch_size, "Size of y is " % y.size(0)
+    assert y[0,0] == value
+    assert y[-1,0] == 3 - value
+    return True
+
+class TestDistConcat(unittest.TestCase):
+    """Basic tests on the built-in parlai Dictionary."""
+
+    def test_dist_concat_1(self):
+        if torch.cuda.device_count() < 2:
+            print("Sorry to execute this test you need to be on a machine with "
+                  " at least 2 GPUs")
+            return
+        launch(test_function_dist_concat)
+
+if __name__ == '__main__' :
+    unittest.main()


### PR DESCRIPTION
The core of it is DistributionConcatenation2D (see comments on it) that allow to concatenate several vectors from various GPU into one big (let's call it 'y') and then use y on all the GPUs. Gradients are back-propagated.

At the core of it there are 2 all_gather operations, one for forward pass and one for backward.