### PR TITLE
Training support for preemption.

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -23,6 +23,11 @@ Examples
 # TODO List:
 # * More logging (e.g. to files), make things prettier.
 
+import numpy as np
+import os
+import signal
+import json
+
 from parlai.core.agents import create_agent, create_agent_from_shared
 from parlai.core.worlds import create_task
 from parlai.core.params import ParlaiParser
@@ -32,9 +37,7 @@ from parlai.scripts.build_dict import build_dict, setup_args as setup_dict_args
 from parlai.core.distributed_utils import (
     sync_object, is_primary_worker, all_gather_list, is_distributed, num_workers
 )
-import numpy as np
 from parlai.scripts.build_pytorch_data import get_pyt_dict_file
-import os
 
 
 def setup_args(parser=None):
@@ -191,13 +194,20 @@ def save_best_valid(model_file, best_valid):
 
 class TrainLoop():
     def __init__(self, opt):
+        # if python is called from a non-interactive shell, like a bash script,
+        # it will by-default ignore SIGINTs, and KeyboardInterrupt exceptions are
+        # not produced. This line brings them back
+        signal.signal(signal.SIGINT, signal.default_int_handler)
+
         if isinstance(opt, ParlaiParser):
             print('[ Deprecated Warning: TrainLoop should be passed opt not Parser ]')
             opt = opt.parse_args()
         # Possibly load from checkpoint
+        trainstats_suffix = '.trainstats'  # we might load training statistics from here
         if opt['load_from_checkpoint'] and opt.get('model_file') and os.path.isfile(
                 opt['model_file'] + '.checkpoint'):
             opt['init_model'] = opt['model_file'] + '.checkpoint'
+            trainstats_suffix = '.checkpoint.trainstats'
         # Possibly build a dictionary (not all models do this).
         if opt['dict_build_first'] and 'dict_file' in opt:
             # If data built via pytorch data teacher, we need to load prebuilt dict
@@ -210,6 +220,7 @@ class TrainLoop():
         # Create model and assign it to the specified task
         self.agent = create_agent(opt)
         self.world = create_task(opt, self.agent)
+        # set up timers
         self.train_time = Timer()
         self.validate_time = Timer()
         self.log_time = Timer()
@@ -242,8 +253,58 @@ class TrainLoop():
         self.saved = False
         self.valid_world = None
         self.opt = opt
+
+        # we may have been preempted, make sure we note that amount
+        self._preempted_epochs = 0.0
+        if (
+            opt.get('model_file') and
+            os.path.isfile(opt['model_file'] + trainstats_suffix)
+        ):
+            # looks like we were preempted. make sure we load up our total
+            # training stats, etc
+            with open(opt['model_file'] + '.trainstats') as ts:
+                obj = json.load(ts)
+                self._preempted_epochs = obj.get('total_epochs', 0)
+                self.train_time.total = obj.get('train_time', 0)
+                self.impatience = obj.get('impatience', 0)
+
         if opt['tensorboard_log'] is True:
             self.writer = TensorboardLogger(opt)
+
+    def save_model(self, suffix=None):
+        if not is_primary_worker():
+            # never do IO as a non-primary worker
+            return
+        if not self.opt.get('model_file'):
+            # nothing to save to, just exit
+            return
+
+        fn = self.opt['model_file']
+        if suffix:
+            fn += suffix
+        while True:
+            # don't ever let a ctrl-c interrupt saving
+            try:
+                self.agent.save(fn)
+                self._save_train_stats(suffix)
+                break
+            except KeyboardInterrupt:
+                pass
+
+    def _save_train_stats(self, suffix=None):
+        fn = self.opt['model_file']
+        if suffix:
+            fn += suffix
+        fn += '.trainstats'
+        with open(fn, 'w') as f:
+            json.dump({
+                'train_time': self.train_time.time(),
+                'total_epochs': (
+                    self._preempted_epochs +
+                    num_workers() * self.world.get_total_epochs()
+                ),
+                'impatience': self.impatience,
+            }, f)
 
     def validate(self):
         opt = self.opt
@@ -268,7 +329,7 @@ class TrainLoop():
         ):
             print("[ saving model checkpoint: " +
                   opt['model_file'] + ".checkpoint ]")
-            self.agent.save(opt['model_file'] + '.checkpoint')
+            self.save_model('.checkpoint')
 
         # send valid metrics to agent if the agent wants them
         if hasattr(self.agent, 'receive_metrics'):
@@ -296,7 +357,7 @@ class TrainLoop():
             self.impatience = 0
             if opt.get('model_file') and is_primary_worker():
                 print("[ saving best valid model: " + opt['model_file'] + " ]")
-                self.agent.save(opt['model_file'])
+                self.save_model()
                 print("[ saving best valid metric: " +
                       opt['model_file'] + ".best_valid ]")
                 save_best_valid(opt['model_file'], self.best_valid)
@@ -431,7 +492,10 @@ class TrainLoop():
                 self.parleys += 1
 
                 # get the total training examples done, compute epochs
-                self._total_epochs = num_workers() * self.world.get_total_epochs()
+                self._total_epochs = (
+                    self._preempted_epochs +
+                    num_workers() * self.world.get_total_epochs()
+                )
                 exs_per_epoch = self.world.num_examples()
                 self._total_exs = int(np.round(self._total_epochs * exs_per_epoch))
 
@@ -470,12 +534,12 @@ class TrainLoop():
                     print("[ saving model checkpoint: {}.checkpoint".format(
                         opt['model_file']
                     ))
-                    self.agent.save(opt['model_file'] + '.checkpoint')
+                    self.save_model('.checkpoint')
                     self.save_time.reset()
 
         if not self.saved and is_primary_worker():
             # save agent
-            self.agent.save(opt['model_file'])
+            self.save_model()
         elif opt.get('model_file'):
             # reload best validation model
             self.agent = create_agent(opt)

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -262,7 +262,7 @@ class TrainLoop():
         ):
             # looks like we were preempted. make sure we load up our total
             # training stats, etc
-            with open(opt['model_file'] + '.trainstats') as ts:
+            with open(opt['model_file'] + trainstats_suffix) as ts:
                 obj = json.load(ts)
                 self._preempted_epochs = obj.get('total_epochs', 0)
                 self.train_time.total = obj.get('train_time', 0)


### PR DESCRIPTION
Would appreciate some extra brain cycles from y'all on this.

The scenario we're trying to capture is:

1. Ctrl-C is pressed.
2. The trainer has 30-60 seconds to shutdown as cleanly as possible. Running a full validation and saving is risky, so ideally we'd like to *be able to restore anytime.
3. You're forcefully quit (kill -9).
4. The *exact same command* is run again. The trainer should attempt to restore any state needed.

These events can happen *at any moment*. To be careful, I catch keyboard interrupts around model.save.

In an effort to do this, I now store a `.trainstats` file. This stores the current training time, number of epochs processed, and the validation patience. That way we can load back up from where we are. There's some nuance around loading from checkpoint vs loading from validation, but I think I cover both those cases. If anyone could think about whether I cover anything.

The downside is that SLURM sends the exact same message whether you're being killed or whether you're being preempted; as such, the launch script will requeue your job even if it runs out of SLURM time. As such, the current default parameter settings for trainloop will cause an infinite loop! @jaseweston points out we should probably change *some* default. His suggestion was `--max-training-time` could be 24 hours by default.