### PR TITLE
[Transformer Ranker] Add option to use DataParallel

### DIFF
--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -12,7 +12,6 @@ from .modules import TransformerMemNetModel
 from .modules import TransformerGeneratorModel
 
 import torch
-import math
 
 
 warn_once(


### PR DESCRIPTION
Add option to wrap your transformer ranker model with nn.DataParallel. To this end, we needed to move the scoring of candidates outside of the forward funciton.


Smaller changes included:
- `n-positions` is a function of `truncate`
-  add option to freeze embeddings

cc @EricMichaelSmith @samhumeau 