### PR TITLE
Skip hogwild tests on local machines.

### DIFF
--- a/tests/test_hogwild.py
+++ b/tests/test_hogwild.py
@@ -10,6 +10,11 @@ from parlai.scripts.eval_model import eval_model
 import unittest
 import sys
 
+import torch
+
+
+SKIP_HOGWILD = torch.cuda.device_count() > 0
+
 
 class display_output(object):
     def __init__(self):
@@ -28,6 +33,7 @@ class display_output(object):
 class TestHogwild(unittest.TestCase):
     """Check that hogwild is doing the right number of examples."""
 
+    @unittest.skipIf(SKIP_HOGWILD, "No hogwild tests if GPUs are available.")
     def test_hogwild_train(self):
         """Test the trainer eval with numthreads > 1 and batchsize in [1,2,3]."""
         parser = setup_args()
@@ -68,6 +74,7 @@ class TestHogwild(unittest.TestCase):
             # restore sys.stdout
             sys.stdout = old_out
 
+    @unittest.skipIf(SKIP_HOGWILD, "No hogwild tests if GPUs are available.")
     def test_hogwild_eval(self):
         """Test eval with numthreads > 1 and batchsize in [1,2,3]."""
         parser = setup_args()

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -10,9 +10,11 @@ import contextlib
 import tempfile
 import os
 import shutil
+import torch
 
 from parlai.scripts.train_model import TrainLoop, setup_args
 
+SKIP_HOGWILD = torch.cuda.device_count() > 0
 BATCH_SIZE = 16
 NUM_EPOCHS = 10
 LR = 1
@@ -127,6 +129,8 @@ class TestSeq2Seq(unittest.TestCase):
 
 
 class TestHogwildSeq2seq(unittest.TestCase):
+
+    @unittest.skipIf(SKIP_HOGWILD, "No hogwild tests if GPUs are available.")
     def test_generation_multi(self):
         """This test uses a multi-turn task and multithreading."""
         stdout, valid, test = _mock_train(


### PR DESCRIPTION
The CUDA_VISIBLE_DEVICES bug has been back for a bit and I thought "why don't I disable these tests locally?"