### PR TITLE
[MTurk] Fixing message sends to properly block send queue

### DIFF
--- a/parlai/mturk/core/mturk_data_handler.py
+++ b/parlai/mturk/core/mturk_data_handler.py
@@ -729,6 +729,7 @@ class MTurkDataHandler():
 
     @staticmethod
     def get_conversation_data(task_group_id, conv_id, worker_id, is_sandbox):
+        '''A poorly named function that gets conversation data for a worker'''
         result = {
             'had_data_dir': False,
             'had_run_dir': False,
@@ -760,5 +761,37 @@ class MTurkDataHandler():
         result['had_worker_file'] = True
         with open(target_filename, 'r') as target_file:
             result['data'] = json.load(target_file)
-        print(result)
+
         return result
+
+    @staticmethod
+    def get_full_conversation_data(task_group_id, conv_id, is_sandbox):
+        '''Gets all conversation data saved for a world'''
+        target = 'sandbox' if is_sandbox else 'live'
+        return_data = {
+            'custom_data': {},
+            'worker_data': {},
+        }
+
+        target_dir = os.path.join(
+            data_dir, target, task_group_id, conv_id)
+        target_dir_custom = os.path.join(target_dir, 'custom')
+        custom_file = os.path.join(target_dir_custom, 'data.json')
+        if os.path.exists(custom_file):
+            custom_data = {}
+            with open(custom_file, 'r') as infile:
+                custom_data = json.load(infile)
+            pickle_file = os.path.join(target_dir_custom, 'data.pickle')
+            if os.path.exists(pickle_file):
+                with open(pickle_file, 'rb') as infile:
+                    custom_data['needs-pickle'] = pickle.load(infile)
+            return_data['custom_data'] = custom_data
+
+        target_dir_workers = os.path.join(target_dir, 'workers')
+        for w_file in os.listdir(target_dir_workers):
+            w_id = w_file.split('.json')[0]
+            worker_file = os.path.join(target_dir_workers, w_file)
+            with open(worker_file, 'r') as infile:
+                return_data['worker_data'][w_id] = json.load(infile)
+
+        return return_data

--- a/parlai/mturk/core/mturk_data_handler.py
+++ b/parlai/mturk/core/mturk_data_handler.py
@@ -729,7 +729,7 @@ class MTurkDataHandler():
 
     @staticmethod
     def get_conversation_data(task_group_id, conv_id, worker_id, is_sandbox):
-        '''A poorly named function that gets conversation data for a worker'''
+        """A poorly named function that gets conversation data for a worker"""
         result = {
             'had_data_dir': False,
             'had_run_dir': False,
@@ -766,7 +766,7 @@ class MTurkDataHandler():
 
     @staticmethod
     def get_full_conversation_data(task_group_id, conv_id, is_sandbox):
-        '''Gets all conversation data saved for a world'''
+        """Gets all conversation data saved for a world"""
         target = 'sandbox' if is_sandbox else 'live'
         return_data = {
             'custom_data': {},

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -322,8 +322,11 @@ class SocketManager():
         if packet.requires_ack:
             if packet.blocking:
                 # Put the packet right back into its place to prevent sending
-                # other packets
+                # other packets, then block
                 self._safe_put(connection_id, (send_time, packet))
+                t = time.time() + self.ACK_TIME[packet.type]
+                while time.time() < t and packet.status != Packet.STATUS_ACK:
+                    time.sleep(0.2)
             else:
                 # non-blocking ack: add ack-check to queue
                 t = time.time() + self.ACK_TIME[packet.type]

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -326,7 +326,7 @@ class SocketManager():
                 self._safe_put(connection_id, (send_time, packet))
                 t = time.time() + self.ACK_TIME[packet.type]
                 while time.time() < t and packet.status != Packet.STATUS_ACK:
-                    time.sleep(0.2)
+                    time.sleep(shared_utils.THREAD_SHORT_SLEEP)
             else:
                 # non-blocking ack: add ack-check to queue
                 t = time.time() + self.ACK_TIME[packet.type]


### PR DESCRIPTION
## Summary
We used to send a flurry of messages for important packet types until they were acknowledged. This flurry was unintentional and sometimes overwhelming for slower connections. This PR turns off the faucet.

It also includes a missing function from the data handler to retrieve a conversation's data rather than a specific worker's data from a conversation.

## Implementation
This is a really long-standing bug that has skirted out from reviews since the design of the messaging system. In order to maintain strict message ordering for blocking messages, they would be reinserted into the send queue with the original send time. This meant no other messages would be able to cut in line in the way that nonblocking messages can be (as you just add the ack time to the send time and put it back into the queue). Unfortunately we didn't actually block the thread to wait for any amount of time, so the sending thread would send a blocking message, put it back in the queue, and then almost immediately send it again as it hadn't been acknowledged. We'd successfully prevent sending _other_ messages, but not prevent sending the same message over and over in a packet-based socket assault.

The implementation for the `get_full_conversation_data` function is merely the inverse of `save_world_data`.