### PR TITLE
Protecting the computation of the metrics against None candidates

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -182,9 +182,9 @@ class Metrics(object):
             cnts = {k: 0 for k in self.eval_pr}
             cnt = 0
             for c in text_cands:
-                if c is None:
-                    c = "__(Metric computation received None)__"
                 cnt += 1
+                if c is None:
+                    continue
                 if normalize_answer(c) in label_set:
                     for k in self.eval_pr:
                         if cnt <= k:

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -182,6 +182,8 @@ class Metrics(object):
             cnts = {k: 0 for k in self.eval_pr}
             cnt = 0
             for c in text_cands:
+                if c is None:
+                    c = "__(Metric computation received None)__"
                 cnt += 1
                 if normalize_answer(c) in label_set:
                     for k in self.eval_pr:


### PR DESCRIPTION
I was doing experiments with open subtitles, and during validation step I observed a bug in the metrics computation because some of the text candidates were None (that happens when you consider the other elements of the batch as candidates).