### PR TITLE
[MTurk][Easy] css for proper line breaks

### DIFF
--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -54,7 +54,7 @@ class ChatMessage extends React.Component {
         <div
           className={"alert " + alert_class} role="alert"
           style={{'float': float_loc, 'display': 'table'}}>
-          <span style={{'fontSize': '16px'}}>
+          <span style={{'fontSize': '16px', 'whiteSpace': 'pre-wrap'}}>
             <b>{this.props.agent_id}</b>: {this.props.message}
           </span>
           {duration}


### PR DESCRIPTION
Flagged in #1435 - we no longer replace `\n` tokens with `<br />` tags in the frontend as we used to do with the old django templates, and this has broken newline behavior for the new frontend. Thankfully a handy-dandy css attribute now turns this:
![screen shot 2019-02-08 at 10 55 48 am](https://user-images.githubusercontent.com/1276867/52489604-a67cea00-2b90-11e9-8ba1-e71e4980b508.png)
into this:
![screen shot 2019-02-08 at 10 55 42 am](https://user-images.githubusercontent.com/1276867/52489611-a977da80-2b90-11e9-8663-36a98e41e625.png)
without needing to render text as html with line break tags.

Fixes #1435