### PR TITLE
[MTurk] [Easy] javascript type silliness

### DIFF
--- a/parlai/mturk/core/react_server/dev/app.jsx
+++ b/parlai/mturk/core/react_server/dev/app.jsx
@@ -116,7 +116,7 @@ class MainApp extends React.Component {
   }
 
   onMessageSend(text, data, callback, is_system) {
-    if (text == '') {
+    if (text === '') {
       return;
     }
     this.socket_handler.handleQueueMessage(text, data, callback, is_system);

--- a/parlai/mturk/core/react_server/dev/components/socket_handler.jsx
+++ b/parlai/mturk/core/react_server/dev/components/socket_handler.jsx
@@ -389,7 +389,7 @@ class SocketHandler extends React.Component {
       message.text = '';
     }
     var agent_id = message.id;
-    var message_text = message.text.replace(/(?:\r\n|\r|\n)/g, '<br />');
+    var message_text = message.text;
     if (this.state.displayed_messages.indexOf(new_message_id) !== -1) {
       // This message has already been seen and put up into the chat
       log(new_message_id + ' was a repeat message', 1);


### PR DESCRIPTION
So javascript is annoying, and thinks that strings and ints might as well be the same thing. Furthermore it thinks `0 == ''` is `true`. So when sending messages containing only an integer value, if that value was 0 everything would freeze up. 

Even worse, refreshing with a text value that ends up parsed as a number would cause an `int.replace` call, which doesn't exist. Thankfully as of #1436 we don't need that replace anymore.