### PR TITLE
Add an explicit --n-positions argument

### DIFF
--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -26,13 +26,17 @@ def add_common_cmdline_args(argparser):
     argparser.add_argument('-esz', '--embedding-size', type=int, default=300,
                            help='Size of all embedding layers')
     argparser.add_argument('-nl', '--n-layers', type=int, default=2)
-    argparser.add_argument('-hid', '--ffn-size', type=int, default=300,
+    argparser.add_argument('-hs', '--ffn-size', type=int, default=300,
                            help='Hidden size of the FFN layers')
     argparser.add_argument('--attention-dropout', type=float, default=0.0)
     argparser.add_argument('--relu-dropout', type=float, default=0.0)
-    argparser.add_argument('--n-heads', type=int, default=2)
+    argparser.add_argument('--n-heads', type=int, default=2,
+                           help='Number of multihead attention heads')
     argparser.add_argument('--learn-positional-embeddings', type='bool', default=False)
     argparser.add_argument('--embeddings-scale', type='bool', default=True)
+    argparser.add_argument('--n-positions', type=int, default=None,
+                           help='Number of positional embeddings to learn. Defaults '
+                                'to truncate or 1024 if not provided.')
 
 
 class Transformer(Agent):

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -26,7 +26,7 @@ def add_common_cmdline_args(argparser):
     argparser.add_argument('-esz', '--embedding-size', type=int, default=300,
                            help='Size of all embedding layers')
     argparser.add_argument('-nl', '--n-layers', type=int, default=2)
-    argparser.add_argument('-hs', '--ffn-size', type=int, default=300,
+    argparser.add_argument('-hid', '--ffn-size', type=int, default=300,
                            help='Hidden size of the FFN layers')
     argparser.add_argument('--attention-dropout', type=float, default=0.0)
     argparser.add_argument('--relu-dropout', type=float, default=0.0)
@@ -34,7 +34,7 @@ def add_common_cmdline_args(argparser):
                            help='Number of multihead attention heads')
     argparser.add_argument('--learn-positional-embeddings', type='bool', default=False)
     argparser.add_argument('--embeddings-scale', type='bool', default=True)
-    argparser.add_argument('--n-positions', type=int, default=None,
+    argparser.add_argument('--n-positions', type=int, default=None, hidden=True,
                            help='Number of positional embeddings to learn. Defaults '
                                 'to truncate or 1024 if not provided.')
 


### PR DESCRIPTION
For backwards compatibility with some models trained with the default 1024. Using --n-positions now completely overrides truncate variants.

If left unspecified, still uses truncate or 1024 as safe defaults as needed.