### PR TITLE
[MTurk] [Easy] Disable logging by default if logging to a DB

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -129,7 +129,7 @@ class MTurkManager():
         self.is_shutdown = False
         self.use_db = use_db  # TODO enable always DB integration is complete
         self.db_logger = None
-        self.logging_permitted = False # Enables logging to parl.ai
+        self.logging_permitted = False  # Enables logging to parl.ai
         self.task_state = self.STATE_CREATED
         self._init_logging_config()
         self._assert_opts()

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -205,8 +205,11 @@ class MTurkManager():
 
     def _init_logging_config(self):
         """Initialize logging settings from the opt"""
-        shared_utils.set_is_debug(self.opt['is_debug'])
-        shared_utils.set_log_level(self.opt['log_level'])
+        if self.use_db:
+            shared_utils.disable_logging()
+        else:
+            shared_utils.set_is_debug(self.opt['is_debug'])
+            shared_utils.set_log_level(self.opt['log_level'])
 
     def _logging_permission_check(self):
         if self.is_test:

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -205,7 +205,7 @@ class MTurkManager():
 
     def _init_logging_config(self):
         """Initialize logging settings from the opt"""
-        if self.use_db:
+        if self.use_db and not self.opt['is_debug']:
             shared_utils.disable_logging()
         else:
             shared_utils.set_is_debug(self.opt['is_debug'])

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -126,12 +126,12 @@ class MTurkManager():
         self.is_test = is_test
         self.is_unique = False
         self.max_hits_per_worker = opt.get('max_hits_per_worker', 0)
-        self._init_logging_config()
         self.is_shutdown = False
         self.use_db = use_db  # TODO enable always DB integration is complete
         self.db_logger = None
-        self.logging_permitted = False
+        self.logging_permitted = False # Enables logging to parl.ai
         self.task_state = self.STATE_CREATED
+        self._init_logging_config()
         self._assert_opts()
 
     @staticmethod
@@ -147,7 +147,7 @@ class MTurkManager():
             'is_debug': False,
             'log_level': 30,
         }
-        manager = MTurkManager(opt, [])
+        manager = MTurkManager(opt, [], use_db=True)
         manager.is_shutdown = True
         mturk_utils.setup_aws_credentials()
         return manager

--- a/parlai/mturk/core/shared_utils.py
+++ b/parlai/mturk/core/shared_utils.py
@@ -39,6 +39,10 @@ def set_is_debug(is_debug):
     global debug
     debug = is_debug
 
+def disable_logging():
+    global logging_enabled
+    logging_enabled = False
+
 
 def print_and_log(level, message, should_print=False):
     if (logging_enabled and level >= log_level) or debug:

--- a/parlai/mturk/core/shared_utils.py
+++ b/parlai/mturk/core/shared_utils.py
@@ -39,6 +39,7 @@ def set_is_debug(is_debug):
     global debug
     debug = is_debug
 
+
 def disable_logging():
     global logging_enabled
     logging_enabled = False


### PR DESCRIPTION
## Context
Backend information logging for ParlAI-MTurk was incredibly important back when it was less stable. Now it just creates GB large log files for large runs and pollutes directories everywhere. When using `use_db` all the important info is being logged somewhere else now, so this disables logging to arbitrary log files when `use_db` is set.