### PR TITLE
Multitask task weights 

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -214,6 +214,7 @@ class MultiTaskTeacher(Teacher):
         return self.tasks[self.task_idx].observe(observation)
 
     def act(self):
+        import pdb; pdb.set_trace()
         if self.new_task:
             self.new_task = False
             if self.random:

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -194,7 +194,7 @@ class MultiTaskTeacher(Teacher):
         self.task_choices = range(len(self.tasks))
         weights = self.opt.get('multitask_weights', [1])
         sum = 0
-        for i, w in enumerate(self.tasks):
+        for i in self.task_choices:
             if len(weights) > i:
                 weight = weights[i]
             else:

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -189,6 +189,18 @@ class MultiTaskTeacher(Teacher):
         self.task_idx = -1
         self.new_task = True
         self.random = opt.get('datatype') == 'train'
+        # Make multi-task task probabilities.
+        self.cum_task_weights = [1] * len(self.tasks)
+        self.task_choices = range(len(self.tasks))
+        weights = self.opt.get('multitask_weights', [1])
+        sum = 0
+        for i, w in enumerate(self.tasks):
+            if len(weights) > i:
+                weight = weights[i]
+            else:
+                weight = 1
+            self.cum_task_weights[i] = weight + sum
+            sum += weight
 
     def num_examples(self):
         if not hasattr(self, 'num_exs'):
@@ -218,7 +230,8 @@ class MultiTaskTeacher(Teacher):
             self.new_task = False
             if self.random:
                 # select random teacher
-                self.task_idx = random.randrange(len(self.tasks))
+                self.task_idx = random.choices(
+                    self.task_choices, cum_weights=self.cum_task_weights)[0]
             else:
                 # do at most one full loop looking for unfinished task
                 for _ in range(len(self.tasks)):

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -214,7 +214,6 @@ class MultiTaskTeacher(Teacher):
         return self.tasks[self.task_idx].observe(observation)
 
     def act(self):
-        import pdb; pdb.set_trace()
         if self.new_task:
             self.new_task = False
             if self.random:

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -337,6 +337,12 @@ class ParlaiParser(argparse.ArgumentParser):
             hidden=True,
             help='default (False) moves labels in valid and test sets to the '
                  'eval_labels field. If True, they are hidden completely.')
+        parlai.add_argument(
+            '-mtw', '--multitask-weights', type='floats', default=[1],
+            help='list of floats, one for each task, specifying '
+            'the probability of drawing the task in multitask case',
+            hidden=True
+        )
         batch = self.add_argument_group('Batching Arguments')
         batch.add_argument(
             '-bs', '--batchsize', default=1, type=int,

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -447,10 +447,8 @@ class MultiWorld(World):
         self.task_choices = range(len(self.worlds))
         sum = 0
         for i, w in enumerate(self.worlds):
-            agents = w.get_agents()
-            weight = 1
-            if len(agents) > 0:
-                weight = float(agents[0].opt.get('taskweight', 1))
+            weight = float(w.opt.get('taskweight', 1))
+            print(weight)
             self.cum_task_weights[i] = weight + sum
             sum += weight
 

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -441,8 +441,6 @@ class MultiWorld(World):
         self.parleys = -1
         self.random = opt.get('datatype', None) == 'train'
         # Make multi-task task probabilities.
-        # These come from the 'taskweight' param (if it exists)
-        #  in the teacher from each world (assumed to be agent 0).
         self.cum_task_weights = [1] * len(self.worlds)
         self.task_choices = range(len(self.worlds))
         weights = self.opt.get('multitask_weights', [1])

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -441,8 +441,8 @@ class MultiWorld(World):
         self.parleys = -1
         self.random = opt.get('datatype', None) == 'train'
         # Make multi-task task probabilities.
-        # These come from the 'taskweight' param (if it exists) in the teacher from each world,
-        # (assumed to be agent 0).
+        # These come from the 'taskweight' param (if it exists)
+        #  in the teacher from each world (assumed to be agent 0).
         self.cum_task_weights = [1] * len(self.worlds)
         self.task_choices = range(len(self.worlds))
         sum = 0

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -445,9 +445,13 @@ class MultiWorld(World):
         #  in the teacher from each world (assumed to be agent 0).
         self.cum_task_weights = [1] * len(self.worlds)
         self.task_choices = range(len(self.worlds))
+        weights = self.opt.get('multitask_weights', [1])
         sum = 0
         for i, w in enumerate(self.worlds):
-            weight = float(w.opt.get('taskweight', 1))
+            if len(weights) > i:
+                weight = weights[i]
+            else:
+                weight = 1
             self.cum_task_weights[i] = weight + sum
             sum += weight
 

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -440,8 +440,9 @@ class MultiWorld(World):
         self.new_world = True
         self.parleys = -1
         self.random = opt.get('datatype', None) == 'train'
-        # Make multi-task task probabilities
-        # from first agents 'taskweight' param (if it exists).
+        # Make multi-task task probabilities.
+        # These come from the 'taskweight' param (if it exists) in the teacher from each world,
+        # (assumed to be agent 0).
         self.cum_task_weights = [1] * len(self.worlds)
         self.task_choices = range(len(self.worlds))
         sum = 0
@@ -499,7 +500,8 @@ class MultiWorld(World):
             self.parleys = 0
             if self.random:
                 # select random world
-                self.world_idx = random.choices(self.task_choices, cum_weights=self.cum_task_weights)[0]
+                self.world_idx = random.choices(
+                    self.task_choices, cum_weights=self.cum_task_weights)[0]
             else:
                 # do at most one full loop looking for unfinished world
                 for _ in range(len(self.worlds)):

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -445,7 +445,7 @@ class MultiWorld(World):
         self.task_choices = range(len(self.worlds))
         weights = self.opt.get('multitask_weights', [1])
         sum = 0
-        for i, w in enumerate(self.worlds):
+        for i in self.task_choices:
             if len(weights) > i:
                 weight = weights[i]
             else:

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -448,7 +448,6 @@ class MultiWorld(World):
         sum = 0
         for i, w in enumerate(self.worlds):
             weight = float(w.opt.get('taskweight', 1))
-            print(weight)
             self.cum_task_weights[i] = weight + sum
             sum += weight
 

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -107,7 +107,6 @@ def setup_args(parser=None):
                        help='use a shared copy of the agent for validation. '
                             'this will eventually default to True, but '
                             'currently defaults to False.')
-                       
     TensorboardLogger.add_cmdline_args(parser)
     parser = setup_dict_args(parser)
     return parser

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -107,6 +107,7 @@ def setup_args(parser=None):
                        help='use a shared copy of the agent for validation. '
                             'this will eventually default to True, but '
                             'currently defaults to False.')
+                       
     TensorboardLogger.add_cmdline_args(parser)
     parser = setup_dict_args(parser)
     return parser


### PR DESCRIPTION
Can train with different weights per task (does a parlay with a probability based on the given task weights), e.g.:

python examples/display_data.py  -t personachat,squad -dt train --multitask_weights 1,10

would upweight squad 10:1  versus personachat