### PR TITLE
[MTurk] [Easy] Should not print debug by default

### DIFF
--- a/parlai/mturk/core/shared_utils.py
+++ b/parlai/mturk/core/shared_utils.py
@@ -16,7 +16,7 @@ THREAD_MTURK_POLLING_SLEEP = 10
 
 logger = None
 logging_enabled = True
-debug = True
+debug = False
 log_level = logging.ERROR
 
 if logging_enabled:


### PR DESCRIPTION
My changes in #1445 neglected the fact that this old debug flag has been set to true for a full generation of this code. This turns the flag back off like it belongs.