### PR TITLE
[MTurk] [Magic] Logging to files again

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -205,7 +205,8 @@ class MTurkManager():
 
     def _init_logging_config(self):
         """Initialize logging settings from the opt"""
-        if self.use_db and not self.opt['is_debug']:
+        # TODO remove the false flag
+        if False and self.use_db and not self.opt['is_debug']:
             shared_utils.disable_logging()
         else:
             shared_utils.set_is_debug(self.opt['is_debug'])


### PR DESCRIPTION
Due to some decidedly horrific log-consuming computer demons that I seem to have stirred into a ravenous feeding frenzy with the seemingly innocuous changes in #1445, some task launches now fail indefinitely when launched on live but not on sandbox. The hungry demons appear to be holding `SocketManager` hostage in a realm that doesn't proceed under linear time, preventing alives from being acked, heartbeats from being sent, and thus really anything from happening. I don't have the bandwidth to initiate an exorcism right now, so I've chosen instead to step away from the goal of reducing log output noise for just long enough to work on a paper submission.

After editing this line, my runs returned to normal operating capacity.
