### PR TITLE
[MTurk] Fixing the blocking bug that caused SocketManager to get stuck

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -205,7 +205,8 @@ class MTurkManager():
 
     def _init_logging_config(self):
         """Initialize logging settings from the opt"""
-        if self.use_db and not self.opt['is_debug']:
+        # TODO remove the false flag
+        if False and self.use_db and not self.opt['is_debug']:
             shared_utils.disable_logging()
         else:
             shared_utils.set_is_debug(self.opt['is_debug'])

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -206,7 +206,7 @@ class MTurkManager():
     def _init_logging_config(self):
         """Initialize logging settings from the opt"""
         # TODO remove the false flag
-        if False and self.use_db and not self.opt['is_debug']:
+        if self.use_db and not self.opt['is_debug']:
             shared_utils.disable_logging()
         else:
             shared_utils.set_is_debug(self.opt['is_debug'])

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -518,8 +518,7 @@ class SocketManager():
         t, packet = packet_item
         if time.time() > t:
             return False  # Exceeded blocking time
-        if packet.status in [Packet.STATUS_ACK, Packet.STATUS_FAIL,
-                             Packet.STATUS_DONE]:
+        if packet.status in [Packet.STATUS_ACK, Packet.STATUS_FAIL]:
             return False  # No longer in blocking status
         return True
 

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -204,6 +204,7 @@ class SocketManager():
         self.listen_thread = None
         self.send_thread = None
         self.queues = {}
+        self.blocking_packets = {}  # connection_id to blocking packet map
         self.threads = {}
         self.run = {}
         self.last_sent_heartbeat_time = {}  # time of last heartbeat sent
@@ -322,11 +323,10 @@ class SocketManager():
         if packet.requires_ack:
             if packet.blocking:
                 # Put the packet right back into its place to prevent sending
-                # other packets, then block
+                # other packets, then block that connection
                 self._safe_put(connection_id, (send_time, packet))
                 t = time.time() + self.ACK_TIME[packet.type]
-                while time.time() < t and packet.status != Packet.STATUS_ACK:
-                    time.sleep(shared_utils.THREAD_SHORT_SLEEP)
+                self.blocking_packets[connection_id] = (t, packet)
             else:
                 # non-blocking ack: add ack-check to queue
                 t = time.time() + self.ACK_TIME[packet.type]
@@ -513,6 +513,16 @@ class SocketManager():
         self.send_thread.daemon = True
         self.send_thread.start()
 
+    def packet_should_block(self, packet_item):
+        """Helper function to determine if a packet is still blocking"""
+        t, packet = packet_item
+        if time.time() > t:
+            return False  # Exceeded blocking time
+        if packet.status in [Packet.STATUS_ACK, Packet.STATUS_FAIL,
+                             Packet.STATUS_DONE]:
+            return False  # No longer in blocking status
+        return True
+
     def channel_thread(self):
         """Handler thread for monitoring all channels"""
         # while the thread is still alive
@@ -540,6 +550,12 @@ class SocketManager():
                     if connection_id not in self.queues:
                         self.run[connection_id] = False
                         break
+                    if self.blocking_packets.get(connection_id) is not None:
+                        packet_item = self.blocking_packets[connection_id]
+                        if not self.packet_should_block(packet_item):
+                            self.blocking_packets[connection_id] = None
+                        else:
+                            continue
                     try:
                         # Get first item in the queue, check if can send it yet
                         item = self.queues[connection_id].get(block=False)


### PR DESCRIPTION
Turns out the demons mentioned in #1459 were my own, caused not by #1445, but by #1429. It seems that logging had synchronized packet states in a way that reduced the rate of occurrence for a disconnect bug that would lead all queues to stop sending messages other than un-acked commands to clients that were already dead. It was *I* who caused SocketManager to stop doing it's main duty and spend all of its existence on trying to wake the undead. 

The bug hit on the run that I mentioned in #1459, and thanks to logs being already on I saw what started happening.

Now rather than blocking on what is actually the main socket thread for ack (as I had overlooked my previous architecture change in #1213), I simply mark connections as having a potentially blocking packet, and then skip that connection in the queue if I'm still waiting for an ack.