### PR TITLE
[MTurk] Adding scaling to HIT_MULT

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -26,8 +26,21 @@ import parlai.mturk.core.shared_utils as shared_utils
 # Timeout before cancelling a world start
 WORLD_START_TIMEOUT = 11
 
-# Multiplier to apply when creating hits to ensure worker availibility
-HIT_MULT = 1.5
+# Multiplier to apply when creating hits to ensure worker availibility. As the
+# number of HITs increases, this decreases
+HIT_MULT_SCALE = [
+    # At more than 1000 HITS, most workers will become 'regulars', and we can
+    # discount the occasional disconnects from being a large portion of workers
+    (1000, 1.05),
+    # Between 1000 and 100 HITs, disconnecting workers take a bit more of an
+    # impact, so we scale a bit higher
+    (100, 1.1),
+    # Under 100 hits, we should prepare for a larger proportion of workers that
+    # try
+    (10, 1.25),
+    # Under 10 hits, we need more to ensure one worker doesn't take all
+    (0, 1.5),
+]
 
 # 6 minute timeout to ensure only one thread updates the time logs.
 # Those update once daily in a 3 minute window
@@ -114,8 +127,16 @@ class MTurkManager():
         self.agent_pool_change_condition = threading.Condition()
         self.onboard_function = None
         self.num_conversations = opt['num_conversations']
+
+        # Determine the correct number of hits to be launching
+        base_required_hits = self.num_conversations * len(self.mturk_agent_ids)
+        for hit_amount, hit_mult in HIT_MULT_SCALE:
+            if base_required_hits > hit_amount:
+                self.hit_mult = hit_mult
+                break
+
         self.required_hits = math.ceil(
-            self.num_conversations * len(self.mturk_agent_ids) * HIT_MULT
+            base_required_hits * self.hit_mult
         )
         self.minimum_messages = opt.get('min_messages', 0)
         self.auto_approve_delay = \
@@ -895,7 +916,7 @@ class MTurkManager():
                 'Enough HITs will be created to fulfill {} times the '
                 'number of conversations requested, extra HITs will be expired'
                 ' once the desired conversations {}.'
-                ''.format(HIT_MULT, fin_word),
+                ''.format(self.hit_mult, fin_word),
                 should_print=True,
             )
         else:
@@ -904,7 +925,7 @@ class MTurkManager():
                 'Enough HITs will be launched over time '
                 'up to a max of {} times the amount requested until the '
                 'desired number of conversations {}.'
-                ''.format(HIT_MULT, fin_word),
+                ''.format(self.hit_mult, fin_word),
                 should_print=True,
             )
         input('Please press Enter to continue... ')
@@ -941,7 +962,7 @@ class MTurkManager():
         if ((not self.opt['is_sandbox']) and
                 (total_cost > 100 or self.opt['reward'] > 1)):
             confirm_string = '$%.2f' % total_cost
-            expected_cost = total_cost / HIT_MULT
+            expected_cost = total_cost / self.hit_mult
             expected_string = '$%.2f' % expected_cost
             shared_utils.print_and_log(
                 logging.INFO,

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -131,7 +131,7 @@ class MTurkManager():
         # Determine the correct number of hits to be launching
         base_required_hits = self.num_conversations * len(self.mturk_agent_ids)
         for hit_amount, hit_mult in HIT_MULT_SCALE:
-            if base_required_hits > hit_amount:
+            if base_required_hits >= hit_amount:
                 self.hit_mult = hit_mult
                 break
 


### PR DESCRIPTION
# Motivation
Back in the day, we launched all of the HITs at once and created extras to ensure workers didn't take too many all at once. Nowadays, hits are released gradually based on `max_connections`, so the initial reasons for holding extra HITs no longer stands. 1.5x is thus an unrealistic amount to be suggesting that a job will cost

# Implementation
This expands the `HIT_MULT` into 4 buckets that better reflect the upper bound of costs based on experienced disconnect rates as the number of HITs scale up.

# Testing
Launched sandbox jobs in each bucket, asserted the requested $ amount was correct.