### PR TITLE
[MTurk] Populating the review flow with current worker stats

### DIFF
--- a/parlai/mturk/webapp/dev/app.jsx
+++ b/parlai/mturk/webapp/dev/app.jsx
@@ -1634,8 +1634,11 @@ class ReviewPanel extends React.Component {
   parseRawRuns(run_datas) {
     // Get reviewable assignments
     let assignments = []
+    let worker_information = {}
     for (const idx in run_datas) {
       assignments = assignments.concat(run_datas[idx].assignments);
+      worker_information = Object.assign(
+        worker_information, run_datas[idx].worker_details);
     }
     let assignments_remaining = 0;
     let reviewable_assigns = assignments.filter(
@@ -1648,6 +1651,7 @@ class ReviewPanel extends React.Component {
       if (assignments_by_worker[assign.worker_id] == undefined) {
         assignments_by_worker[assign.worker_id] = {
           assigns: [], bad_feedback: false, worker_id: assign.worker_id,
+          worker_data: worker_information[assign.worker_id],
         };
       }
 
@@ -1688,8 +1692,8 @@ class ReviewPanel extends React.Component {
     let workers_remaining = workers_left_order.map((w) => w.worker_id);
     let current_worker = workers_remaining.shift();
     let current_worker_stats = {
-      'approved': 0,
-      'rejected': 0,
+      'approved': assignments_by_worker[current_worker].worker_data.approved,
+      'rejected': assignments_by_worker[current_worker].worker_data.rejected,
       'remain': assignments_by_worker[current_worker].assigns.length
     }
     this.setState({
@@ -1793,10 +1797,11 @@ class ReviewPanel extends React.Component {
   nextWorker() {
     // Move to the next worker in the remaining workers list
     let current_worker = this.state.workers_remaining.shift();
+    let current_worker_state = this.state.assignments_by_worker[current_worker];
     let current_worker_stats = {
-      'approved': 0,
-      'rejected': 0,
-      'remain': this.state.assignments_by_worker[current_worker].assigns.length
+      'approved': current_worker_state.worker_data.approved,
+      'rejected': current_worker_state.worker_data.rejected,
+      'remain': current_worker_state.assigns.length
     }
     this.setState({
       current_worker: current_worker,

--- a/parlai/mturk/webapp/server.py
+++ b/parlai/mturk/webapp/server.py
@@ -302,14 +302,14 @@ class RunHandler(BaseHandler):
         processed_assignments = merge_assignments_with_pairings(
             assignments, pairings, 'task {}'.format(task_target))
 
-        workers = []
+        workers = set()
         # get feedback data and put into assignments if present
         for assignment in processed_assignments:
             assignment['received_feedback'] = None
             run_id = assignment['run_id']
             conversation_id = assignment['conversation_id']
             worker_id = assignment['worker_id']
-            workers.append(worker_id)
+            workers.add(worker_id)
             if conversation_id is not None:
                 task_data = MTurkDataHandler.get_conversation_data(
                     run_id, conversation_id, worker_id,

--- a/parlai/mturk/webapp/server.py
+++ b/parlai/mturk/webapp/server.py
@@ -302,12 +302,14 @@ class RunHandler(BaseHandler):
         processed_assignments = merge_assignments_with_pairings(
             assignments, pairings, 'task {}'.format(task_target))
 
+        workers = []
         # get feedback data and put into assignments if present
         for assignment in processed_assignments:
             assignment['received_feedback'] = None
             run_id = assignment['run_id']
             conversation_id = assignment['conversation_id']
             worker_id = assignment['worker_id']
+            workers.append(worker_id)
             if conversation_id is not None:
                 task_data = MTurkDataHandler.get_conversation_data(
                     run_id, conversation_id, worker_id,
@@ -316,11 +318,17 @@ class RunHandler(BaseHandler):
                     assignment['received_feedback'] = \
                         task_data['data'].get('received_feedback')
 
+        worker_data = {}
+        for worker in workers:
+            worker_data[worker] = \
+                row_to_dict(self.data_handler.get_worker_data(worker))
+
         run_details = row_to_dict(self.data_handler.get_run_data(task_target))
         # TODO implement run status determination
         run_details['run_status'] = 'unimplemented'
         data = {
             'run_details': run_details,
+            'worker_details': worker_data,
             'assignments': processed_assignments,
             'hits': processed_hits,
         }


### PR DESCRIPTION
# Motivation
When reviewing workers, knowing the previous acceptance and rejection statistics for a worker is helpful for being able to more quickly assess their work. 

# Implementation
From the webapp server perspective, when querying runs we now keep a list of all of the workers who have had a task in that run. We then query worker stats for each of those worker stats and add it to what we return. On the frontend we pull that data and use it to populate the accepted and rejected fields of the `worker_stats` object.