### PR TITLE
with no_grad in evaluation step.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1205,7 +1205,10 @@ class TorchAgent(Agent):
         if is_training:
             output = self.train_step(batch)
         else:
-            output = self.eval_step(batch)
+            with torch.no_grad():
+                # save memory and compute by disabling autograd.
+                # use `with torch.enable_grad()` to gain back graidients.
+                output = self.eval_step(batch)
 
         if output is None:
             self.replies['batch_reply'] = None


### PR DESCRIPTION
Agents generally call `self.model.eval()` in their `eval_step`, so we're accurately computing dropout etc. However, without explicitly disabling the autograd infrastructure, we're wasting memory and compute. This is particularly noticeable when running beam search.

It makes sense to just have a torch nograd around the call to eval step. This will disable it, by default for everyone and probably prevent some headaches later. Users can manually reenable grads using

```python
with torch.enable_grad():
    pass
```