### PR TITLE
Support --reset-optimizer in fairseq.

### DIFF
--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -455,7 +455,7 @@ class FairseqAgent(TorchAgent):
     def load(self, path):
         """Load using fairseq's checkpointing."""
         if self.trainer:
-            old_options = self.trainer.load_checkpoint(path)
+            old_options = self.trainer.load_checkpoint(path, self.args.reset_optimizer)
             self._check_opts_unchanged(old_options, self.opt)
         else:
             load_model_state(path, self.model)


### PR DESCRIPTION
Minor fairseq bugfix, where you would crash if you changed optimizers. Just need to pass along a CLI parameter.