### PR TITLE
[Messenger] Get rid of resource warnings

### DIFF
--- a/parlai/messenger/core/message_sender.py
+++ b/parlai/messenger/core/message_sender.py
@@ -315,21 +315,20 @@ class MessageSender():
                     }
                 }
             }
-            f = open(payload['filename'], 'rb')
-            filedata = {
-                "filedata": (
-                    payload['filename'],
-                    f,
-                    payload['type'] + '/' + payload['format']
+            with open(payload['filename'], 'rb') as f:
+                filedata = {
+                    "filedata": (
+                        payload['filename'],
+                        f,
+                        payload['type'] + '/' + payload['format']
+                    )
+                }
+                response = requests.post(
+                    api_address,
+                    params=self.auth_args,
+                    data={"message": json.dumps(message)},
+                    files=filedata
                 )
-            }
-            response = requests.post(
-                api_address,
-                params=self.auth_args,
-                data={"message": json.dumps(message)},
-                files=filedata
-            )
-            f.close()
         result = response.json()
         shared_utils.print_and_log(
             logging.INFO,

--- a/parlai/messenger/core/message_sender.py
+++ b/parlai/messenger/core/message_sender.py
@@ -315,10 +315,11 @@ class MessageSender():
                     }
                 }
             }
+            f = open(payload['filename'], 'rb')
             filedata = {
                 "filedata": (
                     payload['filename'],
-                    open(payload['filename'], 'rb'),
+                    f,
                     payload['type'] + '/' + payload['format']
                 )
             }
@@ -328,6 +329,7 @@ class MessageSender():
                 data={"message": json.dumps(message)},
                 files=filedata
             )
+            f.close()
         result = response.json()
         shared_utils.print_and_log(
             logging.INFO,

--- a/parlai/messenger/core/message_sender.py
+++ b/parlai/messenger/core/message_sender.py
@@ -323,12 +323,12 @@ class MessageSender():
                         payload['type'] + '/' + payload['format']
                     )
                 }
-                response = requests.post(
-                    api_address,
-                    params=self.auth_args,
-                    data={"message": json.dumps(message)},
-                    files=filedata
-                )
+            response = requests.post(
+                api_address,
+                params=self.auth_args,
+                data={"message": json.dumps(message)},
+                files=filedata
+            )
         result = response.json()
         shared_utils.print_and_log(
             logging.INFO,


### PR DESCRIPTION
Currently, when uploading attachments, there are a ton of warnings printed about unclosed resources; this makes sure the files are opened and closed safely to remove these warnings.