### PR TITLE
[TRA] candidate ranking fix

### DIFF
--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -197,6 +197,7 @@ class TorchRankerAgent(TorchAgent):
             elif cand_vecs.dim() == 3:
                 cand_list = cands[i]
             if len(ordering) != len(cand_list):
+                # ignore padding
                 true_ordering = [x for x in ordering if x < len(cand_list)]
                 ordering = true_ordering
             cand_preds.append([cand_list[rank] for rank in ordering])

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -196,7 +196,11 @@ class TorchRankerAgent(TorchAgent):
                 cand_list = cands
             elif cand_vecs.dim() == 3:
                 cand_list = cands[i]
+            if len(ordering) != len(cand_list):
+                true_ordering = [x for x in ordering if x < len(cand_list)]
+                ordering = true_ordering
             cand_preds.append([cand_list[rank] for rank in ordering])
+
         preds = [cand_preds[i][0] for i in range(batchsize)]
         return Output(preds, cand_preds)
 


### PR DESCRIPTION
@jaseweston ran into an issue when elements in the batch had different numbers of label candidates. This is a fix to ignore the rank of "padding candidates" when ranking the label candidates.