### PR TITLE
Refactor is_valid

### DIFF
--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -68,11 +68,6 @@ NON_OVERRIDABLE_ARGS = {
 }
 
 
-def _is_nonempty_observation(obs):
-    """Check if an observation has no tokens in it."""
-    return len(obs.get('text_vec', [])) > 0
-
-
 def _fairseq_opt_wrapper(opt, skip_pretrained_embedding_loading=False):
     """
     Marshalls from a dict to a argparse.Namespace object for API compatibility.
@@ -472,6 +467,11 @@ class FairseqAgent(TorchAgent):
         super().reset()
         self.reset_metrics()
 
+    def is_valid(self, obs):
+        """Override from TorchAgentselfself.
+        Check if an observation has no tokens in it."""
+        return len(obs.get('text_vec', [])) > 0
+
     def batchify(self, obs_batch):
         """
         Override parent batchify to set requirements for fairseq.
@@ -479,7 +479,7 @@ class FairseqAgent(TorchAgent):
         Fairseq depends on sorted batch inputs for a call to rnn.pad_packed_sequence.
         Fairseq models cannot handle zero length sentences
         """
-        return super().batchify(obs_batch, sort=True, is_valid=_is_nonempty_observation)
+        return super().batchify(obs_batch, sort=True)
 
     def _update_metrics(self, metrics, sample):
         if metrics is None:

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -468,7 +468,7 @@ class FairseqAgent(TorchAgent):
         self.reset_metrics()
 
     def is_valid(self, obs):
-        """Override from TorchAgentselfself.
+        """Override from TorchAgent.
         Check if an observation has no tokens in it."""
         return len(obs.get('text_vec', [])) > 0
 

--- a/parlai/agents/memnn/memnn.py
+++ b/parlai/agents/memnn/memnn.py
@@ -102,13 +102,13 @@ class MemnnAgent(TorchRankerAgent):
         kwargs['add_end'] = False
         return super().vectorize(*args, **kwargs)
 
-    def batchify(self, obs_batch, sort=False,
-                 is_valid=lambda obs: 'text_vec' in obs or 'image' in obs):
+    def batchify(self, obs_batch, sort=False):
         """Override so that we can add memories to the Batch object."""
-        batch = super().batchify(obs_batch, sort, is_valid)
+        batch = super().batchify(obs_batch, sort)
 
         # get valid observations
-        valid_obs = [(i, ex) for i, ex in enumerate(obs_batch) if is_valid(ex)]
+        valid_obs = [(i, ex) for i, ex in enumerate(obs_batch) if
+                     self.is_valid(ex)]
 
         if len(valid_obs) == 0:
             return batch

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -115,12 +115,12 @@ class TransformerRankerAgent(TorchRankerAgent):
             )
         return self.model
 
-    def batchify(self, obs_batch, sort=False,
-                 is_valid=lambda obs: 'text_vec' in obs or 'image' in obs):
+    def batchify(self, obs_batch, sort=False):
         """Override so that we can add memories to the Batch object."""
-        batch = super().batchify(obs_batch, sort, is_valid)
+        batch = super().batchify(obs_batch, sort)
         if self.opt['use_memories']:
-            valid_obs = [(i, ex) for i, ex in enumerate(obs_batch) if is_valid(ex)]
+            valid_obs = [(i, ex) for i, ex in enumerate(obs_batch) if
+                         self.is_valid(ex)]
             valid_inds, exs = zip(*valid_obs)
             mems = None
             if any('memory_vecs' in ex for ex in exs):

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -996,8 +996,10 @@ class TorchAgent(Agent):
         self._set_label_cands_vec(obs, add_start, add_end, label_truncate)
         return obs
 
-    def batchify(self, obs_batch, sort=False,
-                 is_valid=lambda obs: 'text_vec' in obs or 'image' in obs):
+    def is_valid(self, obs):
+        return 'text_vec' in obs or 'image' in obs
+
+    def batchify(self, obs_batch, sort=False):
         """Create a batch of valid observations from an unchecked batch.
 
         A valid observation is one that passes the lambda provided to the
@@ -1021,13 +1023,12 @@ class TorchAgent(Agent):
                           torch.nn.utils.rnn.pack_padded_sequence.
                           Uses the text vectors if available, otherwise uses
                           the label vectors if available.
-        :param is_valid:  Function that checks if 'text_vec' is in the
-                          observation, determines if an observation is valid
         """
         if len(obs_batch) == 0:
             return Batch()
 
-        valid_obs = [(i, ex) for i, ex in enumerate(obs_batch) if is_valid(ex)]
+        valid_obs = [(i, ex) for i, ex in enumerate(obs_batch) if
+                     self.is_valid(ex)]
 
         if len(valid_obs) == 0:
             return Batch()

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -47,6 +47,11 @@ class TorchRankerAgent(TorchAgent):
             help='Get predictions and calculate mean rank during the train '
                  'step. Turning this on may slow down training.'
         )
+        agent.add_argument(
+            '--ignore-bad-candidates', type='bool', default=False,
+            help='Ignore examples for which the label is not present in the '
+                 'label candidates. Default behavior results in RuntimeError. '
+        )
 
     def __init__(self, opt, shared=None):
         # Must call _get_model_file() first so that paths are updated if necessary
@@ -136,6 +141,28 @@ class TorchRankerAgent(TorchAgent):
         elif cand_vecs.dim() == 3:
             preds = [cands[i][ordering[0]] for i, ordering in enumerate(ranks)]
         return Output(preds)
+
+    def is_valid(self, obs):
+        """Override from TorchAgent."""
+        if not self.opt.get('ignore_bad_candidates', False):
+            return super().is_valid(obs)
+
+        good_ex = 'text_vec' in obs or 'image' in obs
+
+        # skip examples for which the set of label candidates do not
+        # contain the label
+        if 'labels_vec' in obs and 'label_candidates_vecs' in obs:
+            cand_vecs = obs['label_candidates_vecs']
+            label_vec = obs['labels_vec']
+            matches = [x for x in cand_vecs if torch.equal(x, label_vec)]
+            if len(matches) == 0:
+                warn_once(
+                    'At least one example has a set of label candidates that '
+                    'does not contain the label.'
+                )
+                good_ex = False
+
+        return good_ex
 
     def train_step(self, batch):
         """Train on a single batch of examples."""
@@ -303,7 +330,8 @@ class TorchRankerAgent(TorchAgent):
                     if cand_vecs[i].size(1) < len(label_vec):
                         label_vec = label_vec[0:cand_vecs[i].size(1)]
                     label_vec_pad[0:label_vec.size(0)] = label_vec
-                    label_inds[i] = self._find_match(cand_vecs[i], label_vec_pad)
+                    label_inds[i] = self._find_match(
+                        cand_vecs[i], label_vec_pad)
 
         elif source == 'fixed':
             warn_once(
@@ -338,7 +366,14 @@ class TorchRankerAgent(TorchAgent):
 
     @staticmethod
     def _find_match(cand_vecs, label_vec):
-        return ((cand_vecs == label_vec).sum(1) == cand_vecs.size(1)).nonzero()[0]
+        matches = ((cand_vecs == label_vec).sum(1) == cand_vecs.size(1)).nonzero()
+        if len(matches) > 0:
+            return matches[0]
+        raise RuntimeError(
+            'At least one of your examples has a set of label candidates '
+            'that does not contain the label. To ignore this error '
+            'set `--ignore-bad-candidates True`.'
+        )
 
     def share(self):
         """Share model parameters."""

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -147,7 +147,8 @@ class TorchRankerAgent(TorchAgent):
         if not self.opt.get('ignore_bad_candidates', False):
             return super().is_valid(obs)
 
-        good_ex = 'text_vec' in obs or 'image' in obs
+        if 'text_vec' not in obs and 'image' not in obs:
+            return False
 
         # skip examples for which the set of label candidates do not
         # contain the label
@@ -160,9 +161,9 @@ class TorchRankerAgent(TorchAgent):
                     'At least one example has a set of label candidates that '
                     'does not contain the label.'
                 )
-                good_ex = False
+                return False
 
-        return good_ex
+        return True
 
     def train_step(self, batch):
         """Train on a single batch of examples."""

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -360,7 +360,6 @@ class TestTorchAgent(unittest.TestCase):
             self.assertIsNone(batch.candidate_vecs)
             self.assertIsNone(batch.image)
 
-
             # is_valid should check for text_vec
             def is_valid(obs):
                 return 'text_vec' in obs

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -345,7 +345,11 @@ class TestTorchAgent(unittest.TestCase):
                                                 add_start=False, add_end=False))
 
             # is_valid should map to nothing
-            batch = agent.batchify(obs_batch, is_valid=lambda x: False)
+            def is_valid(obs):
+                return False
+            agent.is_valid = is_valid
+
+            batch = agent.batchify(obs_batch)
             self.assertIsNone(batch.text_vec)
             self.assertIsNone(batch.text_lengths)
             self.assertIsNone(batch.label_vec)
@@ -355,6 +359,12 @@ class TestTorchAgent(unittest.TestCase):
             self.assertIsNone(batch.candidates)
             self.assertIsNone(batch.candidate_vecs)
             self.assertIsNone(batch.image)
+
+
+            # is_valid should check for text_vec
+            def is_valid(obs):
+                return 'text_vec' in obs
+            agent.is_valid = is_valid
 
             batch = agent.batchify(obs_vecs)
             # which fields were filled vs should be empty?
@@ -403,9 +413,12 @@ class TestTorchAgent(unittest.TestCase):
             for vec in new_vecs:
                 vec.pop('text')
                 vec.pop('text_vec')
-            batch = agent.batchify(new_vecs, sort=True,
-                                   is_valid=(lambda obs: 'labels_vec' in obs or
-                                             'eval_labels_vec' in obs))
+
+            def is_valid(obs):
+                return 'labels_vec' in obs or 'eval_labels_vec' in obs
+            agent.is_valid = is_valid
+
+            batch = agent.batchify(new_vecs, sort=True)
             self.assertIsNone(batch.text_vec)
             self.assertIsNone(batch.text_lengths)
             self.assertIsNotNone(batch.label_vec)
@@ -419,9 +432,12 @@ class TestTorchAgent(unittest.TestCase):
             self.assertEqual(batch.labels, [labs[i] for i in [1, 2, 0]])
             self.assertEqual(list(batch.valid_indices), [1, 2, 0])
 
-            # test lambda
-            batch = agent.batchify(obs_vecs, is_valid=(
-                lambda obs: 'text_vec' in obs and len(obs['text_vec']) < 3))
+            # test is_valid
+            def is_valid(obs):
+                return 'text_vec' in obs and len(obs['text_vec']) < 3
+            agent.is_valid = is_valid
+
+            batch = agent.batchify(obs_vecs)
             self.assertEqual(batch.text_vec.tolist(), [[1, 2]])
             self.assertEqual(batch.text_lengths, [2])
             self.assertEqual(batch.label_vec.tolist(), [[1, 2]])
@@ -440,8 +456,13 @@ class TestTorchAgent(unittest.TestCase):
             agent.vectorize({'label_candidates': ['Fa', 'So', 'La', 'Ti']},
                             agent.history),
         ]
-        batch = agent.batchify(
-            obs_cands, is_valid=lambda obs: 'label_candidates_vecs' in obs)
+
+        # is_valid should check for label candidates vecs
+        def is_valid(obs):
+            return 'label_candidates_vecs' in obs
+        agent.is_valid = is_valid
+
+        batch = agent.batchify(obs_cands)
         self.assertTrue(agent.rank_candidates, 'Agent not set up to rank.')
         self.assertIsNone(batch.text_vec)
         self.assertIsNone(batch.text_lengths)


### PR DESCRIPTION
Refactor is valid to be a method belonging to the class so we can more easily override this behavior.

In Torch Ranker Agent, add an option to skip examples for which the set of label candidates do not contain the labels. This defaults to `False`, and prints a better warning when this happens.