### PR TITLE
Double start in transfromer

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -164,12 +164,6 @@ class Seq2seqAgent(TorchGeneratorAgent):
         if self.use_cuda:
             self.criterion.cuda()
 
-    def vectorize(self, *args, **kwargs):
-        """Override vectorize for seq2seq."""
-        kwargs['add_start'] = False  # model does this in module code
-        kwargs['add_end'] = True  # we do want this
-        return super().vectorize(*args, **kwargs)
-
     def batchify(self, *args, **kwargs):
         """Override batchify options for seq2seq."""
         kwargs['sort'] = True  # need sorted for pack_padded

--- a/parlai/core/testing_utils.py
+++ b/parlai/core/testing_utils.py
@@ -230,7 +230,7 @@ def download_unittest_models():
     model_filenames = [
         'seq2seq.tar.gz',
         'transformer_ranker.tar.gz',
-        'transformer_generator.tar.gz'
+        'transformer_generator2.tar.gz'
     ]
     with capture_output() as _:
-        download_models(opt, model_filenames, 'unittest')
+        download_models(opt, model_filenames, 'unittest', version='v2.0')

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -452,6 +452,12 @@ class TorchGeneratorAgent(TorchAgent):
             base[k] = round_sigfigs(v, 4)
         return base
 
+    def vectorize(self, *args, **kwargs):
+        """Override vectorize for generative models."""
+        kwargs['add_start'] = False  # model does this in module code
+        kwargs['add_end'] = True  # we do want this
+        return super().vectorize(*args, **kwargs)
+
     def _model_input(self, batch):
         """
         Creates the input (x) value for the model. Must return a tuple.

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -206,8 +206,8 @@ class TestTransformerGenerator(unittest.TestCase):
         stdout, valid, test = testing_utils.eval_model(dict(
             task='integration_tests:multipass',
             model='transformer/generator',
-            model_file='models:unittest/transformer_generator/model',
-            dict_file='models:unittest/transformer_generator/model.dict',
+            model_file='models:unittest/transformer_generator2/model',
+            dict_file='models:unittest/transformer_generator2/model.dict',
             rank_candidates=True,
             batch_size=64,
         ))


### PR DESCRIPTION
The current transformer/generator has a small bug where it has to learn to emit a start token at the beginning of sentence.

This breaks model backwards compatibility. YOLO because transformers are still beta.