### PR TITLE
Flag for adding newline to dict.

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -155,10 +155,6 @@ class DictionaryAgent(Agent):
             hidden=True,
             help='token to return for unavailable words')
         dictionary.add_argument(
-            '--add-newline-token', default=False, type='bool', hidden=True,
-            help='automatically add the newline token to the dictionary.'
-        )
-        dictionary.add_argument(
             '-tok', '--dict-tokenizer', default=DictionaryAgent.default_tok,
             help='Which tokenizer to use. Defaults to "split", which splits '
                  'on whitespace as well as recognizing basic punctuation. '
@@ -228,9 +224,6 @@ class DictionaryAgent(Agent):
                 # set special unknown word token
                 self.add_token(self.unk_token)
 
-            if self.opt.get('add_newline_token'):
-                self.add_token('__newln__')
-
             loaded = False
             # If data built via pytorch data teacher, we need to load prebuilt dict
             if opt.get('pytorch_teacher_task'):
@@ -296,9 +289,6 @@ class DictionaryAgent(Agent):
             if self.unk_token:
                 # fix count for unknown token to one billion
                 self.freq[self.unk_token] = 1000000000
-
-            if self.opt.get('add_newline_token'):
-                self.freq['__newln__'] = 999999999
 
             if opt.get('dict_file'):
                 self.save_path = opt['dict_file']

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -155,6 +155,10 @@ class DictionaryAgent(Agent):
             hidden=True,
             help='token to return for unavailable words')
         dictionary.add_argument(
+            '--add-newline-token', default=False, type='bool', hidden=True,
+            help='automatically add the newline token to the dictionary.'
+        )
+        dictionary.add_argument(
             '-tok', '--dict-tokenizer', default=DictionaryAgent.default_tok,
             help='Which tokenizer to use. Defaults to "split", which splits '
                  'on whitespace as well as recognizing basic punctuation. '
@@ -224,6 +228,9 @@ class DictionaryAgent(Agent):
                 # set special unknown word token
                 self.add_token(self.unk_token)
 
+            if self.opt.get('add_newline_token'):
+                self.add_token('__newln__')
+
             loaded = False
             # If data built via pytorch data teacher, we need to load prebuilt dict
             if opt.get('pytorch_teacher_task'):
@@ -289,6 +296,9 @@ class DictionaryAgent(Agent):
             if self.unk_token:
                 # fix count for unknown token to one billion
                 self.freq[self.unk_token] = 1000000000
+
+            if self.opt.get('add_newline_token'):
+                self.freq['__newln__'] = 999999999
 
             if opt.get('dict_file'):
                 self.save_path = opt['dict_file']

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -602,11 +602,9 @@ class ParlaiParser(argparse.ArgumentParser):
         for i in range(len(self.cli_args)):
             if self.cli_args[i] in option_strings_dict:
                 if self.cli_args[i] in store_true:
-                    self.overridable[option_strings_dict[self.cli_args[i]]] = \
-                        True
+                    self.overridable[option_strings_dict[self.cli_args[i]]] = True
                 elif self.cli_args[i] in store_false:
-                    self.overridable[option_strings_dict[self.cli_args[i]]] = \
-                        False
+                    self.overridable[option_strings_dict[self.cli_args[i]]] = False
                 elif i < len(self.cli_args) - 1 and self.cli_args[i + 1][:1] != '-':
                     key = option_strings_dict[self.cli_args[i]]
                     self.overridable[key] = self.opt[key]

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -475,7 +475,7 @@ class TorchAgent(Agent):
             help='Join history lines with this token, defaults to newline'
         )
         agent.add_argument(
-            '--add-delimiter-token', type='bool', default=True,
+            '--add-delimiter-token', type='bool', default=True, hidden=True,
             help='Add the history delimiter as an explicit token.'
         )
         # GPU arguments
@@ -492,6 +492,33 @@ class TorchAgent(Agent):
         )
 
         cls.dictionary_class().add_cmdline_args(argparser)
+
+    @classmethod
+    def upgrade_saved_opt(cls, old_opt):
+        """
+        Upgrade an old opt file loaded from disk.
+
+        This aims to facilitate backwards compatibility of old model files, while
+        encouraging better defaults to be used in the future. Namely, it enables
+        for command line defaults to be set to one value, but old models on disk
+        to expect another default value.
+
+        Subclasses may *extend* this behavior, but should always call the
+        super-class.
+
+        :param old_opt:
+            The stored options, as loaded directly from disk.
+        :return:
+            The upgraded options. (May be inplace)
+        """
+
+        if 'add_delimiter_token' not in old_opt:
+            # Old models didn't automatically insert the delimiter token into the
+            # dictionary
+            print('Option add_delimiter_token implied False')
+            old_opt['add_delimiter_token'] = False
+
+        return old_opt
 
     def __init__(self, opt, shared=None):
         """Initialize agent."""

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -471,8 +471,12 @@ class TorchAgent(Agent):
                  'useful for tasks that include some kind of context before '
                  'the actual utterance (e.g. squad, babi, personachat).')
         agent.add_argument(
-            '--delimiter', type=str, default='\n',
+            '--delimiter', type=str, default='__newln__',
             help='Join history lines with this token, defaults to newline'
+        )
+        agent.add_argument(
+            '--add-delimiter-token', type='bool', default=True,
+            help='Add the history delimiter as an explicit token.'
         )
         # GPU arguments
         # these gpu options are all mutually exclusive, and should error if the
@@ -500,6 +504,8 @@ class TorchAgent(Agent):
             if opt.get('person_tokens'):
                 self.dict[self.P1_TOKEN] = 999999999
                 self.dict[self.P2_TOKEN] = 999999998
+            if self.opt.get('add_delimiter_token') and self.opt.get('delimiter'):
+                self.dict[self.opt['delimiter']] = 999999997
         else:
             # copy initialized data from shared table
             self.opt = shared['opt']


### PR DESCRIPTION
This is something that bit @samhumeau and Marie-Anne before -- the dict agent is built using blind versions of the data, not the version processed by the agent. This means for tasks that don't naturally have newlines in them, the history delimiter will be an UNK token.

I'm not convinced this is the right solution, but just using this PR to raise the issue. I used this as a temporary hack to build one dictionary.