### PR TITLE
[BERT] dictionary bug fix

### DIFF
--- a/parlai/agents/bert_ranker/bert_dictionary.py
+++ b/parlai/agents/bert_ranker/bert_dictionary.py
@@ -34,9 +34,14 @@ class BertDictionaryAgent(DictionaryAgent):
         self.end_idx = self.tokenizer.convert_tokens_to_ids(['[SEP]'])[
             0]  # should be 102
         self.pad_idx = self.tokenizer.convert_tokens_to_ids(['[PAD]'])[0]  # should be 0
+        # set tok2ind for special tokens
         self.tok2ind[self.start_token] = self.start_idx
         self.tok2ind[self.end_token] = self.end_idx
         self.tok2ind[self.null_token] = self.pad_idx
+        # set ind2tok for special tokens
+        self.ind2tok[self.start_idx] = self.start_token
+        self.ind2tok[self.end_idx] = self.end_token
+        self.ind2tok[self.pad_idx] = self.null_token
 
     def txt2vec(self, text, vec_type=list):
         tokens = self.tokenizer.tokenize(text)

--- a/parlai/agents/bert_ranker/bert_dictionary.py
+++ b/parlai/agents/bert_ranker/bert_dictionary.py
@@ -34,9 +34,9 @@ class BertDictionaryAgent(DictionaryAgent):
         self.end_idx = self.tokenizer.convert_tokens_to_ids(['[SEP]'])[
             0]  # should be 102
         self.pad_idx = self.tokenizer.convert_tokens_to_ids(['[PAD]'])[0]  # should be 0
-        self[self.start_token] = self.start_idx
-        self[self.end_token] = self.end_idx
-        self[self.null_token] = self.pad_idx
+        self.tok2ind[self.start_token] = self.start_idx
+        self.tok2ind[self.end_token] = self.end_idx
+        self.tok2ind[self.null_token] = self.pad_idx
 
     def txt2vec(self, text, vec_type=list):
         tokens = self.tokenizer.tokenize(text)

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -533,7 +533,7 @@ class TorchRankerAgent(TorchAgent):
                     else:
                         encs = self.make_candidate_encs(vecs, path=enc_path)
                         self.save_candidates(encs, path=enc_path,
-                                                 cand_type='encodings')
+                                             cand_type='encodings')
                     self.fixed_candidate_encs = encs
                     if self.use_cuda:
                         self.fixed_candidate_encs = self.fixed_candidate_encs.cuda()


### PR DESCRIPTION
BERT was not setting the start/end/null token indices properly, causing some things to be tokenized incorrectly (namely, fixed candidates).