### PR TITLE
change default parameters for Bert

### DIFF
--- a/parlai/agents/bert_ranker/bert_dictionary.py
+++ b/parlai/agents/bert_ranker/bert_dictionary.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 from parlai.core.dict import DictionaryAgent
+from parlai.zoo.bert.build import download
 try:
     from pytorch_pretrained_bert import BertTokenizer
 except ImportError:
@@ -22,6 +23,7 @@ class BertDictionaryAgent(DictionaryAgent):
     def __init__(self, opt):
         super().__init__(opt)
         # initialize from voab path
+        download(opt['datapath'])
         vocab_path = os.path.join(opt['datapath'], 'models', 'bert_models',
                                   VOCAB_PATH)
         self.tokenizer = BertTokenizer.from_pretrained(vocab_path)

--- a/parlai/agents/bert_ranker/helpers.py
+++ b/parlai/agents/bert_ranker/helpers.py
@@ -42,7 +42,7 @@ def add_common_args(parser):
                         'multiple gpus. NOTE This is incompatible'
                         ' with distributed training')
     parser.add_argument('--type-optimization', type=str,
-                        default='additional_layers',
+                        default='all_encoder_layers',
                         choices=[
                             'additional_layers',
                             'top_layer',
@@ -50,7 +50,7 @@ def add_common_args(parser):
                             'all_encoder_layers',
                             'all'],
                         help='Which part of the encoders do we optimize. '
-                             '(Default: the top one.)')
+                             '(Default: all_encoder_layers.)')
     parser.set_defaults(
         label_truncate=300,
         text_truncate=300,


### PR DESCRIPTION
So last night, if I got it right:

1) @jaseweston was very sad when he realized  that by default, bert_ranker only fine-tunes the top layer which leads to sub-optimal results, meaning he might have to re-run a ton of experiments.

2) @jaseweston was very happy when he realized  that he actually used `--type-optimization all_encoder_layers` without remembering it.

To avoid more emotional rollercoaster, I suggest we switch this parameter to the one that led to the best results on convai2.

Also I added a download() part in the bert_dictionary, I think that is missing.