### PR TITLE
Align both encoder with latest changes

### DIFF
--- a/parlai/agents/bert_ranker/both_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/both_encoder_ranker.py
@@ -6,7 +6,7 @@
 from .bert_dictionary import BertDictionaryAgent
 from .bi_encoder_ranker import BiEncoderRankerAgent
 from .cross_encoder_ranker import CrossEncoderRankerAgent
-from .helpers import add_common_args, surround
+from .helpers import add_common_args
 
 from parlai.core.torch_agent import TorchAgent, Output, Batch
 

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -395,6 +395,9 @@ class TorchRankerAgent(TorchAgent):
             cands = self.fixed_candidates
             cand_vecs = self.fixed_candidate_vecs
 
+            if self.opt.get('encode_candidate_vecs', False):
+                cand_vecs = self.fixed_candidate_encs
+
             if label_vecs is not None:
                 label_inds = label_vecs.new_empty((batchsize))
                 for i, label_vec in enumerate(label_vecs):

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -86,13 +86,13 @@ class TorchRankerAgent(TorchAgent):
 
         self.rank_loss = nn.CrossEntropyLoss(reduce=True, size_average=False)
 
-        # Vectorize and save fixed/vocab candidates once upfront if applicable
-        self.set_fixed_candidates(shared)
-        self.set_vocab_candidates(shared)
-
         if self.use_cuda:
             self.model.cuda()
             self.rank_loss.cuda()
+
+        # Vectorize and save fixed/vocab candidates once upfront if applicable
+        self.set_fixed_candidates(shared)
+        self.set_vocab_candidates(shared)
 
         if shared:
             # We don't use get here because hasattr is used on optimizer later.
@@ -539,7 +539,8 @@ class TorchRankerAgent(TorchAgent):
                         encs = self.load_candidates(
                             enc_path, cand_type='encodings')
                     else:
-                        encs = self.make_candidate_encs(vecs, path=enc_path)
+                        encs = self.make_candidate_encs(self.fixed_candidate_vecs,
+                                                        path=enc_path)
                         self.save_candidates(encs, path=enc_path,
                                              cand_type='encodings')
                     self.fixed_candidate_encs = encs
@@ -579,11 +580,12 @@ class TorchRankerAgent(TorchAgent):
 
     def make_candidate_encs(self, vecs, path):
         cand_encs = []
-        vec_batches = [vecs[i:i + 512] for i in range(0, len(vecs), 512)]
-        print("[ Vectorizing fixed candidates set from ({} batch(es) of up to 512) ]"
+        vec_batches = [vecs[i:i + 256] for i in range(0, len(vecs), 256)]
+        print("[ Vectorizing fixed candidates set from ({} batch(es) of up to 256) ]"
               "".format(len(vec_batches)))
-        for vec_batch in tqdm(vec_batches):
-            cand_encs.append(self.encode_candidates(vec_batch))
+        with torch.no_grad():
+            for vec_batch in tqdm(vec_batches):
+                cand_encs.append(self.encode_candidates(vec_batch))
         return torch.cat(cand_encs, 0)
 
     def vectorize_fixed_candidates(self, cands_batch):


### PR DESCRIPTION
made sure both encoder still worked as expected

In particular
- got rid of surround() now that vectorize_fixed_candidates() exists. 
- got rid of set_text_vec() 
- encode candidates with torch.no_grad()
