### PR TITLE
[MTurk] Opening up tests that failed on travis to try on circle

### DIFF
--- a/parlai/mturk/core/test/test_full_system.py
+++ b/parlai/mturk/core/test/test_full_system.py
@@ -439,7 +439,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         agent.wait_for_alive()
         agent.send_heartbeat()
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_successful_convo(self):
         manager = self.mturk_manager
 
@@ -502,7 +501,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
             [x for x in manager.socket_manager.run.values() if not x]
         ), 2, 2)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_disconnect_end(self):
         manager = self.mturk_manager
 
@@ -570,7 +568,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
             [x for x in manager.socket_manager.run.values() if not x]
         ), 2, 2)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_expire_onboarding(self):
         manager = self.mturk_manager
 
@@ -599,7 +596,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
             [x for x in manager.socket_manager.run.values() if not x]
         ), 1, 2)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_reconnect_complete(self):
         manager = self.mturk_manager
 
@@ -676,7 +672,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
             [x for x in manager.socket_manager.run.values() if not x]
         ), 2, 2)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_attempt_break_unique(self):
         manager = self.mturk_manager
         unique_worker_qual = 'is_unique_qual'
@@ -772,7 +767,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
             [x for x in manager.socket_manager.run.values() if not x]
         ), 3, 2)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_break_multi_convo(self):
         manager = self.mturk_manager
         manager.opt['allowed_conversations'] = 1
@@ -857,7 +851,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
             [x for x in manager.socket_manager.run.values() if not x]
         ), 3, 2)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_no_onboard_expire_waiting(self):
         manager = self.mturk_manager
         manager.set_onboard_function(None)
@@ -882,7 +875,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
             [x for x in manager.socket_manager.run.values() if not x]
         ), 1, 2)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_return_to_waiting_on_world_start(self):
         manager = self.mturk_manager
 

--- a/parlai/mturk/core/test/test_full_system.py
+++ b/parlai/mturk/core/test/test_full_system.py
@@ -13,7 +13,6 @@ from parlai.mturk.core.socket_manager import Packet, SocketManager
 from parlai.mturk.core.agents import AssignState
 from parlai.mturk.core.mturk_manager import MTurkManager
 from parlai.core.params import ParlaiParser
-import parlai.core.testing_utils as testing_utils
 
 import parlai.mturk.core.mturk_manager as MTurkManagerFile
 import parlai.mturk.core.data_model as data_model

--- a/parlai/mturk/core/test/test_mturk_manager.py
+++ b/parlai/mturk/core/test/test_mturk_manager.py
@@ -18,8 +18,6 @@ from parlai.mturk.core.socket_manager import SocketManager, Packet
 from parlai.core.params import ParlaiParser
 from websocket_server import WebsocketServer
 
-
-import parlai.core.testing_utils as testing_utils
 import parlai.mturk.core.mturk_manager as MTurkManagerFile
 import parlai.mturk.core.data_model as data_model
 
@@ -269,7 +267,6 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         manager.force_expire_hit.assert_called_once_with(
             self.agent_3.worker_id, self.agent_3.assignment_id)
 
-    @testing_utils.skipIfCircleCI
     def test_socket_setup(self):
         '''Basic socket setup should fail when not in correct state,
         but succeed otherwise
@@ -283,7 +280,6 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         self.mturk_manager._setup_socket()
         self.assertIsInstance(self.mturk_manager.socket_manager, SocketManager)
 
-    @testing_utils.skipIfCircleCI
     def test_worker_alive(self):
         # Setup for test
         manager = self.mturk_manager
@@ -555,7 +551,6 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
             manager.force_expire_hit.assert_not_called()
             manager.send_command.assert_called_once()
 
-    @testing_utils.skipIfCircleCI
     def test_mturk_messages(self):
         '''Ensure incoming messages work as expected'''
         # Setup for test
@@ -1165,7 +1160,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         self.mturk_manager.shutdown()
         self.fake_socket.close()
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_socket_dead(self):
         '''Test all states of socket dead calls'''
         manager = self.mturk_manager
@@ -1255,7 +1249,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         self.assertFalse(agent.disconnected)
         manager._handle_agent_disconnect.assert_not_called()
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_send_message_command(self):
         manager = self.mturk_manager
         agent = self.agent_1
@@ -1295,7 +1288,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         self.assertEqual(packet.data['message_id'], message_id)
         self.assertEqual(packet.data['type'], data_model.MESSAGE_TYPE_MESSAGE)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_free_workers(self):
         manager = self.mturk_manager
         manager.socket_manager.close_channel = mock.MagicMock()
@@ -1303,7 +1295,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         manager.socket_manager.close_channel.assert_called_once_with(
             self.agent_1.get_connection_id())
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_force_expire_hit(self):
         manager = self.mturk_manager
         agent = self.agent_1
@@ -1362,7 +1353,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
             agent.get_connection_id())
         test_ack_function.assert_called()
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_get_qualifications(self):
         manager = self.mturk_manager
         mturk_utils = MTurkManagerFile.mturk_utils
@@ -1425,7 +1415,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
 
         self.assertListEqual(qualifications, manager.qualifications)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_create_additional_hits(self):
         manager = self.mturk_manager
         manager.opt['hit_title'] = 'test_hit_title'
@@ -1462,7 +1451,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         self.assertEqual(len(manager.hit_id_list), 5)
         self.assertEqual(hit_url, 'page_url')
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_expire_all_hits(self):
         manager = self.mturk_manager
         worker_manager = manager.worker_manager
@@ -1486,7 +1474,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
                     break
             self.assertTrue(found)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_qualification_management(self):
         manager = self.mturk_manager
         test_qual_name = 'test_qual'
@@ -1531,7 +1518,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         result = manager.create_qualification(other_qual_name, '')
         self.assertEqual(result, success_id)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_partner_disconnect(self):
         manager = self.mturk_manager
         manager.send_command = mock.MagicMock()
@@ -1545,7 +1531,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         self.assertEqual(assignment_id, self.agent_1.assignment_id)
         self.assertDictEqual(data, self.agent_1.get_inactive_command_data())
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_restore_state(self):
         manager = self.mturk_manager
         worker_manager = manager.worker_manager
@@ -1578,7 +1563,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         self.assertListEqual(data['messages'], agent.get_messages())
         self.assertEqual(data['text'], data_model.COMMAND_RESTORE_STATE)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_expire_onboarding(self):
         manager = self.mturk_manager
         manager.force_expire_hit = mock.MagicMock()

--- a/parlai/mturk/core/test/test_socket_manager.py
+++ b/parlai/mturk/core/test/test_socket_manager.py
@@ -8,7 +8,6 @@ import unittest
 import time
 import uuid
 from unittest import mock
-import parlai.core.testing_utils as testing_utils
 from parlai.mturk.core.socket_manager import Packet, SocketManager
 from parlai.mturk.core.agents import AssignState
 
@@ -447,7 +446,6 @@ class TestSocketManagerSetupAndFunctions(unittest.TestCase):
     def tearDown(self):
         self.fake_socket.close()
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_init_and_reg_shutdown(self):
         '''Test initialization of a socket manager'''
         self.assertFalse(self.fake_socket.connected)
@@ -482,7 +480,6 @@ class TestSocketManagerSetupAndFunctions(unittest.TestCase):
                 "than {}".format(val_func(), val)
             time.sleep(0.1)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_init_and_socket_shutdown(self):
         '''Test initialization of a socket manager with a failed shutdown'''
         self.assertFalse(self.fake_socket.connected)
@@ -519,7 +516,6 @@ class TestSocketManagerSetupAndFunctions(unittest.TestCase):
         self.assertFalse(nop_called)
         socket_manager.shutdown()
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_init_and_socket_shutdown_then_restart(self):
         '''Test restoring connection to a socket'''
         self.assertFalse(self.fake_socket.connected)
@@ -653,7 +649,6 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         self.socket_manager.shutdown()
         self.fake_socket.close()
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_init_state(self):
         '''Ensure all of the initial state of the socket_manager is ready'''
         self.assertEqual(self.socket_manager.server_url, 'https://127.0.0.1')
@@ -679,7 +674,6 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         self.assertFalse(self.socket_manager.is_shutdown)
         self.assertEqual(self.socket_manager.get_my_sender_id(), self.WORLD_ID)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_needed_heartbeat(self):
         '''Ensure needed heartbeat sends heartbeats at the right time'''
         self.socket_manager._safe_send = mock.MagicMock()
@@ -729,7 +723,6 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         self.assertEqual(used_packet.requires_ack, False)
         self.assertEqual(used_packet.blocking, False)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_ack_send(self):
         '''Ensure acks are being properly created and sent'''
         self.socket_manager._safe_send = mock.MagicMock()
@@ -761,7 +754,6 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         send_thread.start()
         time.sleep(0.02)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_blocking_ack_packet_send(self):
         '''Checks to see if ack'ed blocking packets are working properly'''
         self.socket_manager._safe_send = mock.MagicMock()
@@ -790,7 +782,6 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         self.socket_manager._safe_send.assert_not_called()
         self.socket_manager._safe_put.assert_not_called()
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_non_blocking_ack_packet_send(self):
         '''Checks to see if ack'ed non-blocking packets are working'''
         self.socket_manager._safe_send = mock.MagicMock()
@@ -823,7 +814,6 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         self.assertDictEqual(used_packet_dict['content'],
                              self.MESSAGE_SEND_PACKET_3.as_dict())
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_non_ack_packet_send(self):
         '''Checks to see if non-ack'ed packets are working'''
         self.socket_manager._safe_send = mock.MagicMock()
@@ -846,7 +836,6 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         self.assertDictEqual(used_packet_dict['content'],
                              self.MESSAGE_SEND_PACKET_2.as_dict())
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_simple_packet_channel_management(self):
         '''Ensure that channels are created, managed, and then removed
         as expected
@@ -909,7 +898,6 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         time.sleep(0.1)
         self.assertEqual(len(self.socket_manager.queues), 0)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_safe_put(self):
         '''Test safe put and queue retrieval mechanisms'''
         self.socket_manager._send_packet = mock.MagicMock()
@@ -987,7 +975,6 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         self.socket_manager.shutdown()
         self.fake_socket.close()
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_alive_send_and_disconnect(self):
         acked_packet = None
         incoming_hb = None
@@ -1064,7 +1051,6 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         self.assertEqual(self.dead_assignment_id, TEST_ASSIGNMENT_ID_1)
         self.assertGreater(hb_count, 1)
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_failed_ack_resend(self):
         '''Ensures when a message from the manager is dropped, it gets
         retried until it works as long as there hasn't been a disconnect
@@ -1140,7 +1126,6 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
             6,
         )
 
-    @testing_utils.skipIfCircleCI('CircleCI fails socket setup')
     def test_one_agent_disconnect_other_alive(self):
         acked_packet = None
         incoming_hb = None


### PR DESCRIPTION
Certain tests were failing on travis because the socket couldn't be properly opened. Maybe having circle means we won't run into this issue?