### PR TITLE
[MTurk] bug where first message sometimes dropped from use_db save

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -776,7 +776,6 @@ class MTurkManager():
                         conversation_id, sandbox=self.is_sandbox)
                 mturk_agent.clear_messages()
 
-
             # once onboarding is done, move into a waiting world
             self._move_agents_to_waiting([mturk_agent])
 

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -634,7 +634,6 @@ class MTurkManager():
             elif agent.get_status() == AssignState.STATUS_WAITING:
                 if self.is_task_world(conversation_id):
                     agent.set_status(AssignState.STATUS_IN_TASK)
-                    agent.clear_messages()
                     return
                 # Reconnecting in waiting is either the first reconnect after
                 # being told to wait or a waiting reconnect. Restore state if
@@ -775,6 +774,8 @@ class MTurkManager():
                     MTurkDataHandler.save_world_data(
                         save_data, self.task_group_id,
                         conversation_id, sandbox=self.is_sandbox)
+                mturk_agent.clear_messages()
+
 
             # once onboarding is done, move into a waiting world
             self._move_agents_to_waiting([mturk_agent])


### PR DESCRIPTION
Due to the location where messages would be cleared from agents, a glitch would occur sometimes where a double-reconnect event would lead the first message to be dropped from the message history. This would lead to it not being saved into the database, which was bad. Changing where we clear messages to occur immediately following the onboarding exit is a more consistent location that leads to results we can expect.