### PR TITLE
Adding dynamic forms to MTurk React data collection

### DIFF
--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -839,19 +839,26 @@ class FormResponse extends React.Component {
 
   tryMessageSend() {
     let form_elements = this.props.task_data["respond_with_form"];
-    let response_data = {};
+    let response_data = [];
     let response_text = "";
+    let all_response_filled = true;
     for (let ind in form_elements){
       let question = form_elements[ind]["question"];
       let response = this.state.responses[ind];
-      response_data[question] = response;
+      if (response == ''){
+        all_response_filled = false;
+      }
+      response_data.push({
+        "question": question,
+        "response": response
+      });
       response_text += question + ": " + response + "\n";
     }
 
-    if (this.state.textval != '' && this.props.active && !this.state.sending) {
+    if (all_response_filled && this.props.active && !this.state.sending) {
       this.setState({sending: true});
       this.props.onMessageSend(
-        response_text, response_data,
+        response_text, {"form_responses": response_data},
         () => this.setState({'sending': false}));
     }
   }
@@ -861,9 +868,11 @@ class FormResponse extends React.Component {
     const listFormElements= form_elements.map((form_elem, index) => {
         let question = form_elem["question"];
         if (form_elem["type"] == "choices"){
-          let choices = [<option></option>].concat(
-            form_elem["choices"].map((option_label) => {
-              return <option>{option_label}</option>
+          let choices = [<option key="empty_option"></option>].concat(
+            form_elem["choices"].map((option_label, index) => {
+              return <option key={"option_" + index.toString()}>
+                        {option_label}
+                      </option>
             }));
           return (<FormGroup>
                     <Col

--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -11,7 +11,7 @@ import ReactDOM from 'react-dom';
 import {
   FormControl, Button, ButtonGroup, InputGroup, FormGroup,
   MenuItem, DropdownButton, Badge, Popover, Overlay,
-  Nav, NavItem,
+  Nav, NavItem, Col,ControlLabel, Form,
 } from 'react-bootstrap';
 import Slider from 'rc-slider';
 import $ from 'jquery';
@@ -822,11 +822,140 @@ class TextResponse extends React.Component {
   }
 }
 
+class FormResponse extends React.Component {
+  // Provide a form-like interface to MTurk interface.
+
+  constructor(props) {
+    super(props);
+    // At this point it should be assumed that task_data
+    // has a field "respond_with_form"
+    let responses = []
+    for (let _ of this.props.task_data["respond_with_form"]){
+      responses.push('');
+    }
+    this.state = {'responses': responses, 'sending': false};
+  }
+
+
+  tryMessageSend() {
+    let form_elements = this.props.task_data["respond_with_form"];
+    let response_data = {};
+    let response_text = "";
+    for (let ind in form_elements){
+      let question = form_elements[ind]["question"];
+      let response = this.state.responses[ind];
+      response_data[question] = response;
+      response_text += question + ": " + response + "\n";
+    }
+
+    if (this.state.textval != '' && this.props.active && !this.state.sending) {
+      this.setState({sending: true});
+      this.props.onMessageSend(
+        response_text, response_data,
+        () => this.setState({'sending': false}));
+    }
+  }
+
+  render() {
+    let form_elements = this.props.task_data["respond_with_form"];
+    const listFormElements= form_elements.map((form_elem, index) => {
+        let question = form_elem["question"];
+        if (form_elem["type"] == "choices"){
+          let choices = [<option></option>].concat(
+            form_elem["choices"].map((option_label) => {
+              return <option>{option_label}</option>
+            }));
+          return (<FormGroup>
+                    <Col
+                      componentClass={ControlLabel}
+                      sm={6}
+                      style={{'fontSize': '16px'}}>
+                      {question}
+                    </Col>
+                    <Col sm={5}>
+                      <FormControl componentClass="select"
+                        style={{'fontSize': '16px'}}
+                        value={this.state.responses[index]}
+                        onChange={(e) => {
+                          var text = e.target.value;
+                          this.setState((prevState) => {
+                            let new_res = prevState["responses"];
+                            new_res[index] = text;
+                            return {responses: new_res}
+                          });
+                        }}>
+                        {choices}
+                      </FormControl>
+                    </Col>
+                  </FormGroup>);
+        }
+        return <FormGroup>
+                  <Col
+                    style={{'fontSize': '16px'}}
+                    componentClass={ControlLabel}
+                    sm={6}>
+                    {question}
+                  </Col>
+                  <Col sm={5}>
+                    <FormControl
+                      type="text"
+                      style={{'fontSize': '16px'}}
+                      value={this.state.responses[index]}
+                      onChange={(e) => {
+                        var text = e.target.value;
+                        this.setState((prevState) => {
+                          let new_res = prevState["responses"];
+                          new_res[index] = text;
+                          return {responses: new_res}
+                        });
+                      }}/>
+                  </Col>
+               </FormGroup>;
+      }
+    );
+    let submit_button = (
+      <Button
+        className="btn btn-primary"
+        style={{'height': '40px', 'width': '100px', 'fontSize': '16px'}}
+        id="id_send_msg_button"
+        disabled={
+          this.state.textval == '' || !this.props.active || this.state.sending}
+        onClick={() => this.tryMessageSend()}>
+          Send
+      </Button>
+    );
+
+    return (
+      <div
+        id="response-type-text-input"
+        className="response-type-module"
+        style={{'paddingTop': '15px',
+                'float': 'left',
+                'width': '100%',
+                'backgroundColor': '#eeeeee'}}>
+            <Form horizontal
+                style={{backgroundColor: '#eeeeee', paddingBottom: '10px'}}>
+              {listFormElements}
+              <FormGroup>
+                <Col sm={6}>
+                </Col>
+                <Col sm={5}>
+                  {submit_button}
+                </Col>
+             </FormGroup>
+            </Form>
+      </div>
+    );
+  }
+}
+
+
 class ResponsePane extends React.Component {
   render() {
     let v_id = this.props.v_id;
     let XDoneResponse = getCorrectComponent('XDoneResponse', v_id);
     let XTextResponse = getCorrectComponent('XTextResponse', v_id);
+    let XFormResponse = getCorrectComponent('XFormResponse', v_id);
     let XIdleResponse = getCorrectComponent('XIdleResponse', v_id);
 
     let response_pane = null;
@@ -839,10 +968,18 @@ class ResponsePane extends React.Component {
         break;
       case 'text_input':
       case 'waiting':
-        response_pane = <XTextResponse
-          {...this.props}
-          active={this.props.chat_state == 'text_input'}
-        />;
+        if (this.props.task_data && this.props.task_data["respond_with_form"]){
+          response_pane = <XFormResponse
+            {...this.props}
+            active={this.props.chat_state == 'text_input'}
+          />;
+        }
+        else{
+          response_pane = <XTextResponse
+            {...this.props}
+            active={this.props.chat_state == 'text_input'}
+          />;
+        }
         break;
       case 'idle':
       default:
@@ -961,7 +1098,7 @@ class LeftPane extends React.Component {
     };
     let XTaskDescription = getCorrectComponent('XTaskDescription', v_id);
     let pane_size = this.props.is_cover_page ? 'col-xs-12' : 'col-xs-4';
-    let has_context = this.props.task_data.last_update !== undefined;
+    let has_context = this.props.task_data.has_context;
     if (this.props.is_cover_page || !has_context) {
       return (
         <div id="left-pane" className={pane_size} style={frame_style}>
@@ -1104,6 +1241,7 @@ component_list = {
   'XRightPane': ['RightPane', RightPane],
   'XResponsePane': ['ResponsePane', ResponsePane],
   'XTextResponse': ['TextResponse', TextResponse],
+  'XFormResponse': ['FormResponse', FormResponse],
   'XDoneResponse': ['DoneResponse', DoneResponse],
   'XIdleResponse': ['IdleResponse', IdleResponse],
   'XDoneButton': ['DoneButton', DoneButton],

--- a/parlai/mturk/core/react_server/dev/components/socket_handler.jsx
+++ b/parlai/mturk/core/react_server/dev/components/socket_handler.jsx
@@ -400,7 +400,14 @@ class SocketHandler extends React.Component {
     this.state.displayed_messages.push(new_message_id);
     this.props.onNewMessage(message);
     if (message.task_data !== undefined) {
+      let has_context = false;
+      for (let key of Object.keys(message.task_data)){
+        if (key !== "respond_with_form"){
+          has_context = true;
+        }
+      }
       message.task_data.last_update = (new Date()).getTime();
+      message.task_data.has_context = has_context;
       this.props.onNewTaskData(message.task_data);
     }
     this.setState({displayed_messages: this.state.displayed_messages});


### PR DESCRIPTION
I noticed that most frontend overrides on the MTurk data collection was to add form-like input. This PR adds a way to dynamically create Forms while collecting data on MTurk. 

The form is created within python in `world.py`, and stored in `action["task_data"]["respond_with_form"]` (This has to be None whenever we don't need a form)

```python
action["task_data"] = {}
action["task_data"]["respond_with_form"] = None
if self.turns == 3:
    action['id'] = "System"
    action["text"] = ("Thanks for chatting 😻. Now please answer the "
                 "following questions to finish the hit 😃 !")
    action["task_data"]["respond_with_form"] = [
        {
            "type": "choices",
            "question": "How much did you enjoy talking to this user?",
            "choices": ["Not at all", "A little", "Somewhat", "A lot"]
        },
        {
            "type": "choices",
            "question": "Do you think this user is a bot or a human?",
            "choices": ["Definitely a bot", "Probably a bot", "Probably a human", "Definitely a human"]
        },
        {
            "type": "text",
            "question": "Enter any comment here",
        },
    ]
```

It will appear like so: 
<img width="1893" alt="Screen Shot 2019-03-11 at 9 51 59 PM" src="https://user-images.githubusercontent.com/4238961/54157734-355b7b80-4449-11e9-9a20-bdc04037ee6d.png">

Notice that the "type" ("choices" or "text") determine whether it's a multiple choices question or free form text.

Whenever ["respond_with_form"] is None, we show the classic text input like so:
<img width="1894" alt="Screen Shot 2019-03-11 at 9 51 20 PM" src="https://user-images.githubusercontent.com/4238961/54157796-53c17700-4449-11e9-8968-85385e199e73.png">

The structured result can be read in "task_data" on server side once the form is filled:
```bash
{
    "text": "How much did you enjoy talking to this user?: A lot\nDo you think this user is a bot or a human?: Definitely a bot\nEnter any comment here: Did you notice this is a form?\n",
    "task_data": {
        "How much did you enjoy talking to this user?": "A lot",
        "Do you think this user is a bot or a human?": "Definitely a bot",
        "Enter any comment here": "Did you notice this is a form?"
    },
    "id": "Worker",
    "message_id": "aec68468-f10f-46fd-93e1-5b7fd4263b5d",
    "episode_done": false,
    "duration": 27045
}
```
