### PR TITLE
[Torch Ranker Agent] Caching candidate encoding

### DIFF
--- a/docs/source/tutorial_torch_ranker_agent.rst
+++ b/docs/source/tutorial_torch_ranker_agent.rst
@@ -45,11 +45,13 @@ must implement the following functions:
 
 .. code-block:: python
 
-    def score_candidates(self, batch, cand_vecs):
+    def score_candidates(self, batch, cand_vecs, cand_encs=None):
         """This function takes in a Batch object as well as a Tensor of
         candidate vectors. It must return a list of scores corresponding to
         the likelihood that the candidate vector at that index is the
-        proper response.
+        proper response. If `cand_encs` is not None (when we cache the
+        encoding of the candidate vectors), you may use these instead of
+        calling self.model on `cand_vecs`.
         """
         pass
 

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -55,7 +55,7 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
                                             self.opt['type_optimization'],
                                             self.opt['learningrate'])
 
-    def score_candidates(self, batch, cand_vecs):
+    def score_candidates(self, batch, cand_vecs, cand_encs=None):
         # concatenate text and candidates (not so easy)
         # unpad and break
         nb_cands = cand_vecs.size()[1]

--- a/parlai/agents/memnn/memnn.py
+++ b/parlai/agents/memnn/memnn.py
@@ -83,7 +83,7 @@ class MemnnAgent(TorchRankerAgent):
         self.model = MemNN(len(self.dict), self.opt['embedding_size'],
                            padding_idx=self.NULL_IDX, **kwargs)
 
-    def score_candidates(self, batch, cand_vecs):
+    def score_candidates(self, batch, cand_vecs, cand_encs=None):
         mems = self._build_mems(batch.memory_vecs)
         scores = self.model(batch.text_vec, mems, cand_vecs)
         return scores

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -145,6 +145,8 @@ class TransformerMemNetModel(nn.Module):
     def encode_context_memory(self, context_w, memories_w):
         # [batch, d]
         if context_w is None:
+            # it's possible that only candidates were passed into the
+            # forward function, return None here for LHS representation 
             return None, None
 
         context_h = self.context_encoder(context_w)

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -146,7 +146,7 @@ class TransformerMemNetModel(nn.Module):
         # [batch, d]
         if context_w is None:
             # it's possible that only candidates were passed into the
-            # forward function, return None here for LHS representation 
+            # forward function, return None here for LHS representation
             return None, None
 
         context_h = self.context_encoder(context_w)

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -144,6 +144,9 @@ class TransformerMemNetModel(nn.Module):
 
     def encode_context_memory(self, context_w, memories_w):
         # [batch, d]
+        if context_w is None:
+            return None, None
+
         context_h = self.context_encoder(context_w)
 
         if memories_w is None:

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -172,7 +172,7 @@ class TransformerRankerAgent(TorchRankerAgent):
             mems=mems,
             cands=cand_vecs,
         )
-        
+
         if cand_encs is not None:
             cands_h = cand_encs
 

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -146,7 +146,16 @@ class TransformerRankerAgent(TorchRankerAgent):
             obs = self._vectorize_memories(obs)
         return obs
 
-    def score_candidates(self, batch, cand_vecs):
+    def encode_candidates(self, padded_cands):
+        _, cands = self.model(
+            xs=None,
+            mems=None,
+            cands=padded_cands,
+        )
+
+        return cands
+
+    def score_candidates(self, batch, cand_vecs, cand_encs=None):
         # convoluted check that not all memories are empty
         if (self.opt['use_memories'] and batch.memory_vecs is not None and
                 sum(len(m) for m in batch.memory_vecs)):
@@ -154,11 +163,18 @@ class TransformerRankerAgent(TorchRankerAgent):
         else:
             mems = None
 
+        if cand_encs is not None:
+            # we pre-encoded the candidates, do not re-encode here
+            cand_vecs = None
+
         context_h, cands_h = self.model(
             xs=batch.text_vec,
             mems=mems,
             cands=cand_vecs,
         )
+        
+        if cand_encs is not None:
+            cands_h = cand_encs
 
         scores = self._score(context_h, cands_h)
 

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -73,8 +73,6 @@ class TorchRankerAgent(TorchAgent):
         if shared:
             self.model = shared['model']
             self.metrics = shared['metrics']
-            self.vocab_candidates = shared['vocab_candidates']
-            self.vocab_candidate_vecs = shared['vocab_candidate_vecs']
             states = None
         else:
             self.metrics = {'loss': 0.0, 'examples': 0, 'rank': 0,

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -113,14 +113,14 @@ class TorchRankerAgent(TorchAgent):
             )
 
     def score_candidates(self, batch, cand_vecs, cand_encs=None):
-        """Given a batch and candidate set, return scores (for ranking).
+        """
+        Given a batch and candidate set, return scores (for ranking).
 
-        :param batch:       a Batch object (defined in torch_agent.py)
-        :param cand_vecs:   padded and tokenized candidates
-        :param cand_encs:   encoded candidates, if these are passed in to the
-                            function (in cases where we cache the candidate
-                            encodings), you do not need to call self.model
-                            on cand_vecs
+        :param Batch batch: a Batch object (defined in torch_agent.py)
+        :param LongTensor cand_vecs: padded and tokenized candidates
+        :param FloatTensor cand_encs: encoded candidates, if these are passed
+            into the function (in cases where we cache the candidate
+            encodings), you do not need to call self.model on cand_vecs
         """
         raise NotImplementedError(
             'Abstract class: user must implement score()')

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -73,8 +73,6 @@ class TorchRankerAgent(TorchAgent):
         if shared:
             self.model = shared['model']
             self.metrics = shared['metrics']
-            self.fixed_candidates = shared['fixed_candidates']
-            self.fixed_candidate_vecs = shared['fixed_candidate_vecs']
             self.vocab_candidates = shared['vocab_candidates']
             self.vocab_candidate_vecs = shared['vocab_candidate_vecs']
             states = None
@@ -87,9 +85,6 @@ class TorchRankerAgent(TorchAgent):
                 states = self.load(init_model)
             else:
                 states = {}
-            # Vectorize and save fixed/vocab candidates once upfront if applicable
-            self.set_fixed_candidates(shared)
-            self.set_vocab_candidates(shared)
 
         self.rank_loss = nn.CrossEntropyLoss(reduce=True, size_average=False)
         if self.use_cuda:
@@ -119,8 +114,16 @@ class TorchRankerAgent(TorchAgent):
                 broadcast_buffers=False,
             )
 
-    def score_candidates(self, batch, cand_vecs):
-        """Given a batch and candidate set, return scores (for ranking)"""
+    def score_candidates(self, batch, cand_vecs, cand_encs=None):
+        """Given a batch and candidate set, return scores (for ranking).
+
+        :param batch:       a Batch object (defined in torch_agent.py)
+        :param cand_vecs:   padded and tokenized candidates
+        :param cand_encs:   encoded candidates, if these are passed in to the
+                            function (in cases where we cache the candidate
+                            encodings), you do not need to call self.model
+                            on cand_vecs
+        """
         raise NotImplementedError(
             'Abstract class: user must implement score()')
 
@@ -189,6 +192,7 @@ class TorchRankerAgent(TorchAgent):
 
         cands, cand_vecs, label_inds = self._build_candidates(
             batch, source=self.opt['candidates'], mode='train')
+
         scores = self.score_candidates(batch, cand_vecs)
         _, ranks = scores.sort(1, descending=True)
 
@@ -227,7 +231,16 @@ class TorchRankerAgent(TorchAgent):
         cands, cand_vecs, label_inds = self._build_candidates(
             batch, source=self.opt['eval_candidates'], mode='eval')
 
-        scores = self.score_candidates(batch, cand_vecs)
+        cand_encs = None
+        if self.opt['encode_candidate_vecs']:
+            # if we cached candidate encodings for a fixed list of candidates,
+            # pass those into the score_candidates function
+            if self.opt['eval_candidates'] == 'fixed':
+                cand_encs = self.fixed_candidate_encs
+            elif self.opt['eval_candidates'] == 'vocab':
+                cand_encs = self.vocab_candidate_encs
+
+        scores = self.score_candidates(batch, cand_vecs, cand_encs=cand_encs)
         _, ranks = scores.sort(1, descending=True)
 
         # Update metrics
@@ -409,9 +422,6 @@ class TorchRankerAgent(TorchAgent):
             cands = self.fixed_candidates
             cand_vecs = self.fixed_candidate_vecs
 
-            if self.opt.get('encode_candidate_vecs', False):
-                cand_vecs = self.fixed_candidate_encs
-
             if label_vecs is not None:
                 label_inds = label_vecs.new_empty((batchsize))
                 for i, label_vec in enumerate(label_vecs):
@@ -459,6 +469,7 @@ class TorchRankerAgent(TorchAgent):
         shared['metrics'] = self.metrics
         shared['fixed_candidates'] = self.fixed_candidates
         shared['fixed_candidate_vecs'] = self.fixed_candidate_vecs
+        shared['fixed_candidate_encs'] = self.fixed_candidate_encs
         shared['vocab_candidates'] = self.vocab_candidates
         shared['vocab_candidate_vecs'] = self.vocab_candidate_vecs
         shared['optimizer'] = self.optimizer
@@ -533,6 +544,7 @@ class TorchRankerAgent(TorchAgent):
         if shared:
             self.fixed_candidates = shared['fixed_candidates']
             self.fixed_candidate_vecs = shared['fixed_candidate_vecs']
+            self.fixed_candidate_encs = shared['fixed_candidate_encs']
         else:
             opt = self.opt
             cand_path = opt['fixed_candidates_path']


### PR DESCRIPTION
Change the `score_candidates` API to possibly have `cand_encs` passed in. This occurs in the case when we want to cache the candidate encodings (possibly when using fixed or vocab candidates). The eval_step in TRA will pass these into score_candidates. It is then up to the model to implement `score_candidates`. See the BiEncoderRanker agent or TransformerRanker agent to see how this is implemented.

Also included, bug fix caused by conflicts in #1404.

cc @samhumeau  