### PR TITLE
adding several options for aggregation

### DIFF
--- a/parlai/agents/bert_ranker/bi_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/bi_encoder_ranker.py
@@ -195,13 +195,15 @@ class BiEncoderModule(torch.nn.Module):
             BertModel.from_pretrained(opt['pretrained_path']),
             opt['out_dim'],
             add_transformer_layer=opt['add_transformer_layer'],
-            layer_pulled=opt['pull_from_layer']
+            layer_pulled=opt['pull_from_layer'],
+            aggregation=opt['bert_aggregation']
         )
         self.cand_encoder = BertWrapper(
             BertModel.from_pretrained(opt['pretrained_path']),
             opt['out_dim'],
             add_transformer_layer=opt['add_transformer_layer'],
-            layer_pulled=opt['pull_from_layer']
+            layer_pulled=opt['pull_from_layer'],
+            aggregation=opt['bert_aggregation']
         )
 
     def forward(self, token_idx_ctxt, segment_idx_ctxt, mask_ctxt,

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -47,7 +47,8 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
             BertModel.from_pretrained(self.pretrained_path),
             1,
             add_transformer_layer=self.opt['add_transformer_layer'],
-            layer_pulled=self.opt['pull_from_layer']
+            layer_pulled=self.opt['pull_from_layer'],
+            aggregation=opt['bert_aggregation']
         )
 
     def init_optim(self, params, optim_states=None, saved_optim_type=None):

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -48,7 +48,7 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
             1,
             add_transformer_layer=self.opt['add_transformer_layer'],
             layer_pulled=self.opt['pull_from_layer'],
-            aggregation=opt['bert_aggregation']
+            aggregation=self.opt['bert_aggregation']
         )
 
     def init_optim(self, params, optim_states=None, saved_optim_type=None):

--- a/parlai/agents/bert_ranker/helpers.py
+++ b/parlai/agents/bert_ranker/helpers.py
@@ -108,19 +108,19 @@ class BertWrapper(torch.nn.Module):
         if self.aggregation == "mean":
             #  consider the average of all the output except CLS.
             # obviously ignores masked elements
-            outputs_of_interest = layer_of_interest[:, 1:, :]
+            outputs_of_interest = embedding_layer[:, 1:, :]
             mask = attention_mask[:, 1:].float().unsqueeze(2)
             sumed_embeddings = torch.sum(outputs_of_interest * mask, dim=1)
             nb_elems = torch.sum(attention_mask[:, 1:].float(), dim=1).unsqueeze(1)
             embeddings = sumed_embeddings / nb_elems
         elif self.aggregation == "max":
             #  consider the max of all the output except CLS
-            outputs_of_interest = layer_of_interest[:, 1:, :]
+            outputs_of_interest = embedding_layer[:, 1:, :]
             mask = (attention_mask[:, 1:].float().unsqueeze(2) - 1) * 10000
             embeddings, _ = torch.max(outputs_of_interest + mask, dim=1)
         else:
             # easiest, we consider the output of "CLS" as the embedding
-            embeddings = layer_of_interest[:, 0, :]
+            embeddings = embedding_layer[:, 0, :]
 
         # We need this in case of dimensionality reduction
         result = self.additional_linear_layer(embeddings)

--- a/parlai/agents/bert_ranker/helpers.py
+++ b/parlai/agents/bert_ranker/helpers.py
@@ -51,6 +51,13 @@ def add_common_args(parser):
                             'all'],
                         help='Which part of the encoders do we optimize. '
                              '(Default: all_encoder_layers.)')
+    parser.add_argument('--bert-aggregation', type=str,
+                        default='first',
+                        choices=[
+                            'first',
+                            'max',
+                            'mean'],
+                        help='How do we transform a list of output into one')
     parser.set_defaults(
         label_truncate=300,
         text_truncate=300,
@@ -65,9 +72,11 @@ class BertWrapper(torch.nn.Module):
     """
 
     def __init__(self, bert_model, output_dim,
-                 add_transformer_layer=False, layer_pulled=-1):
+                 add_transformer_layer=False, layer_pulled=-1,
+                 aggregation="first"):
         super(BertWrapper, self).__init__()
         self.layer_pulled = layer_pulled
+        self.aggregation = aggregation
         self.add_transformer_layer = add_transformer_layer
         # deduce bert output dim from the size of embeddings
         bert_output_dim = bert_model.embeddings.word_embeddings.weight.size(1)
@@ -91,11 +100,31 @@ class BertWrapper(torch.nn.Module):
             extended_attention_mask = extended_attention_mask.to(
                 dtype=next(self.parameters()).dtype)  # fp16 compatibility
             extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
-            embeddings = self.additional_transformer_layer(
-                layer_of_interest, extended_attention_mask)[:, 0, :]
+            embedding_layer = self.additional_transformer_layer(
+                layer_of_interest, extended_attention_mask)
         else:
+            embedding_layer = layer_of_interest
+
+        if self.aggregation == "mean":
+            #  consider the average of all the output except CLS.
+            # obviously ignores masked elements
+            outputs_of_interest = layer_of_interest[:, 1:, :]
+            mask = attention_mask[:, 1:].float().unsqueeze(2)
+            sumed_embeddings = torch.sum(outputs_of_interest * mask, dim=1)
+            nb_elems = torch.sum(attention_mask[:, 1:].float(), dim=1).unsqueeze(1)
+            embeddings = sumed_embeddings / nb_elems
+        elif self.aggregation == "max":
+            #  consider the max of all the output except CLS
+            outputs_of_interest = layer_of_interest[:, 1:, :]
+            mask = (attention_mask[:, 1:].float().unsqueeze(2) - 1) * 10000
+            embeddings, _ = torch.max(outputs_of_interest + mask, dim=1)
+        else:
+            # easiest, we consider the output of "CLS" as the embedding
             embeddings = layer_of_interest[:, 0, :]
+
+        # We need this in case of dimensionality reduction
         result = self.additional_linear_layer(embeddings)
+
         # Sort of hack to make it work with distributed: this way the pooler layer
         # is used for grad computation, even though it does not change anything...
         # in practice, it just adds a very (768*768) x (768*batchsize) matmul


### PR DESCRIPTION
Right now in the bi-encoder we were taking the first output of Bert to reduce the sentence to a single vector. Added possibility to use the average over all the outputs, or the max (In all cases it is followed by a linear layer).

Results on convai2 valid set:
- first output 78.8
- mean: 79.9
- max: 78.1

Reproduce results with:
```
PYTHONPATH=. python -u parlai/scripts/train_model.py -pyt convai2  \
    -m parlai.agents.bert_ranker.bi_encoder_ranker:BiEncoderRankerAgent \
    --batchsize 128 --dict-file ./mydic --model-file mymodel   --eval-batchsize 128 \
    --learningrate 5e-5  --log_every_n_secs 20  --shuffle true --type-optimization all_encoder_layers \
    --lr-scheduler fixed  --lr-scheduler-patience 1 --lr-scheduler-decay 0.45  --data-parallel true \
    --truncate 300 --num-epochs 4.0  -veps 0.999 -vme 8000 --warmup_updates 200  \
    --bert-aggregation (mean|max|first)
```