### PR TITLE
SNLI task fix

### DIFF
--- a/parlai/tasks/multinli/agents.py
+++ b/parlai/tasks/multinli/agents.py
@@ -56,7 +56,7 @@ def setup_data(path):
             hypo = MULTINLI_HYPO_PREFIX + pair[MULTINLI_HYPO_KEY]
             answer = [pair[MULTINLI_ANSWER_KEY]]
 
-            if answer == '-':
+            if answer == ['-']:
                 continue
 
             question = premise + '\n' + hypo

--- a/parlai/tasks/snli/agents.py
+++ b/parlai/tasks/snli/agents.py
@@ -51,4 +51,4 @@ class DefaultTeacher(DialogTeacher):
         return setup_data(path)
 
     def label_candidates(self):
-        return ('entailment', 'contradiction', 'neutral', '-')
+        return ('entailment', 'contradiction', 'neutral')

--- a/parlai/tasks/snli/agents.py
+++ b/parlai/tasks/snli/agents.py
@@ -49,3 +49,6 @@ class DefaultTeacher(DialogTeacher):
 
     def setup_data(self, path):
         return setup_data(path)
+
+    def label_candidates(self):
+        return ('entailment', 'contradiction', 'neutral', '-')


### PR DESCRIPTION
This task breaks because often the label is not included in the label candidates. Fix by fixing label candidates.