### PR TITLE
[MTurk] Wrapping requests to parl.ai to prevent site-based outages

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -54,8 +54,8 @@ SNS_ASSIGN_ABANDONDED = 'AssignmentAbandoned'
 SNS_ASSIGN_SUBMITTED = 'AssignmentSubmitted'
 SNS_ASSIGN_RETURNED = 'AssignmentReturned'
 
-PARLAI_MTURK_NOTICE_URL = 'http://www.parl.ai/mturk/mturk_notice/'
-PARLAI_MTURK_UPLOAD_URL = 'http://www.parl.ai/mturk/mturk_stats/'
+PARLAI_MTURK_NOTICE_URL = 'http://parl.ai/mturk/mturk_notice/'
+PARLAI_MTURK_UPLOAD_URL = 'http://parl.ai/mturk/mturk_stats/'
 PARLAI_CRED_DIR = os.path.expanduser('~/.parlai')
 PARLAI_MTURK_LOG_PERMISSION_FILE = \
     os.path.join(PARLAI_CRED_DIR, 'mturk_log_permission.pickle')
@@ -277,7 +277,14 @@ class MTurkManager():
         worker_data = self.worker_manager.get_worker_data_package()
         data = {'worker_data': worker_data}
         headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-        requests.post(PARLAI_MTURK_UPLOAD_URL, json=data, headers=headers)
+        try:
+            requests.post(PARLAI_MTURK_UPLOAD_URL, json=data, headers=headers)
+        except Exception:
+            shared_utils.print_and_log(
+                logging.WARNING,
+                "Unable to log worker statistics to parl.ai",
+                should_print=True,
+            )
 
     def _maintain_hit_status(self):
         def update_status():
@@ -997,13 +1004,19 @@ class MTurkManager():
             except Exception:
                 # not all users will be drawing configs from internal settings
                 pass
-            resp = requests.post(notice_url)
-            warnings = resp.json()
-            for warn in warnings:
-                print('Notice: ' + warn)
-                accept = input('Continue? (Y/n): ')
+            try:
+                resp = requests.post(notice_url)
+                warnings = resp.json()
+                for warn in warnings:
+                    print('Notice: ' + warn)
+                    accept = input('Continue? (Y/n): ')
+                    if accept == 'n':
+                        raise SystemExit('Additional notice was rejected.')
+            except Exception:
+                print('Unable to query warnings from the parl.ai website.')
+                accept = input('Continue without checking warnings? (Y/n): ')
                 if accept == 'n':
-                    raise SystemExit('Additional notice was rejected.')
+                    raise SystemExit('Aborted.')
 
         self.logging_permitted = self._logging_permission_check()
 

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -54,8 +54,8 @@ SNS_ASSIGN_ABANDONDED = 'AssignmentAbandoned'
 SNS_ASSIGN_SUBMITTED = 'AssignmentSubmitted'
 SNS_ASSIGN_RETURNED = 'AssignmentReturned'
 
-PARLAI_MTURK_NOTICE_URL = 'http://parl.ai/mturk/mturk_notice/'
-PARLAI_MTURK_UPLOAD_URL = 'http://parl.ai/mturk/mturk_stats/'
+PARLAI_MTURK_NOTICE_URL = 'http://www.parl.ai/mturk/mturk_notice/'
+PARLAI_MTURK_UPLOAD_URL = 'http://www.parl.ai/mturk/mturk_stats/'
 PARLAI_CRED_DIR = os.path.expanduser('~/.parlai')
 PARLAI_MTURK_LOG_PERMISSION_FILE = \
     os.path.join(PARLAI_CRED_DIR, 'mturk_log_permission.pickle')

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -282,7 +282,7 @@ class MTurkManager():
         except Exception:
             shared_utils.print_and_log(
                 logging.WARNING,
-                "Unable to log worker statistics to parl.ai",
+                'Unable to log worker statistics to parl.ai',
                 should_print=True,
             )
 


### PR DESCRIPTION
Right now if the parlai webserver goes down, it's impossible to launch an MTurk job without manually overriding some exceptions. This is obviously bad behavior, so I've added try/excepts to handle when the request fails.