### PR TITLE
Drop CLS token from label in bert.

### DIFF
--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -26,6 +26,8 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
 
     def __init__(self, opt, shared=None):
         # download pretrained models
+        if opt['candidates'] != 'inline':
+            raise ValueError('Cross encoder requires --candidates inline')
         download(opt['datapath'])
         self.pretrained_path = os.path.join(opt['datapath'], 'models',
                                             'bert_models', MODEL_PATH)

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -66,7 +66,6 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
             1).expand(-1, nb_cands, -1).contiguous().view(nb_cands * size_batch, -1)
         segments_context = tokens_context * 0
 
-        # remove the start token ["CLS"] from candidates
         tokens_cands = cand_vecs.view(nb_cands * size_batch, -1)
         segments_cands = tokens_cands * 0 + 1
         all_tokens = torch.cat([tokens_context, tokens_cands], 1)
@@ -87,3 +86,15 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
             obs['text_vec'] = surround(obs['text_vec'], self.START_IDX,
                                        self.END_IDX)
         return obs
+
+    def _set_label_vec(self, *args, **kwargs):
+        # don't put the CLS token in labels
+        kwargs['add_start'] = False
+        kwargs['add_end'] = True
+        return super()._set_label_vec(*args, **kwargs)
+
+    def _set_label_cands_vec(self, *args, **kwargs):
+        # don't put the CLS token in labels
+        kwargs['add_start'] = False
+        kwargs['add_end'] = True
+        return super()._set_label_cands_vec(*args, **kwargs)

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -16,8 +16,10 @@ import torch
 
 
 class CrossEncoderRankerAgent(TorchRankerAgent):
-    """ TorchRankerAgent implementation of the crossencoder.
-        It is a standalone Agent. It might be called by the Both Encoder.
+    """
+    BERT Cross-encoder, which leverages the the 2-sentence training setup of BERT.
+
+    It might be called by the Both Encoder.
     """
 
     @staticmethod

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1077,8 +1077,12 @@ class TorchAgent(Agent):
             'cands_vec' fields added.
         """
         self._set_text_vec(obs, history, text_truncate)
-        self._set_label_vec(obs, add_start, add_end, label_truncate)
-        self._set_label_cands_vec(obs, add_start, add_end, label_truncate)
+        self._set_label_vec(
+            obs, add_start=add_start, add_end=add_end, truncate=label_truncate
+        )
+        self._set_label_cands_vec(
+            obs, add_start=add_start, add_end=add_end, truncate=label_truncate
+        )
         return obs
 
     def is_valid(self, obs):


### PR DESCRIPTION
Pulled this out of #1472 because it made more sense on its own.

The comment in the code was misleading, and so I updated the code to be a bit more like what it *should* be. Breaks backwards compatibility with any other cross encoder models trained so far though

Also adds a value error around `-cands`. Maybe that is overly aggressive though.