### PR TITLE
[BERT] skip building dictionary

### DIFF
--- a/parlai/agents/bert_ranker/bert_dictionary.py
+++ b/parlai/agents/bert_ranker/bert_dictionary.py
@@ -17,12 +17,11 @@ import os
 
 
 class BertDictionaryAgent(DictionaryAgent):
-    """ Allow to use the Torch Agent with the wordpiece dictionary of Hugging Face.
+    """Allow to use the Torch Agent with the wordpiece dictionary of Hugging Face.
     """
-
     def __init__(self, opt):
         super().__init__(opt)
-        # initialize from voab path
+        # initialize from vocab path
         download(opt['datapath'])
         vocab_path = os.path.join(opt['datapath'], 'models', 'bert_models',
                                   VOCAB_PATH)
@@ -54,3 +53,6 @@ class BertDictionaryAgent(DictionaryAgent):
         idxs = [idx.item() for idx in tensor.cpu()]
         toks = self.tokenizer.convert_ids_to_tokens(idxs)
         return ' '.join(toks)
+
+    def act(self):
+        return {}

--- a/parlai/agents/bert_ranker/helpers.py
+++ b/parlai/agents/bert_ranker/helpers.py
@@ -64,6 +64,7 @@ def add_common_args(parser):
         learningrate=0.00005,
         eval_candidates='inline',
         candidates='batch',
+        dict_maxexes=0,  # skip building dictionary
     )
 
 

--- a/parlai/agents/bert_ranker/helpers.py
+++ b/parlai/agents/bert_ranker/helpers.py
@@ -64,7 +64,7 @@ def add_common_args(parser):
         learningrate=0.00005,
         eval_candidates='inline',
         candidates='batch',
-        dict_maxexes=0,  # skip building dictionary
+        dict_maxexs=0,  # skip building dictionary
     )
 
 

--- a/parlai/scripts/build_dict.py
+++ b/parlai/scripts/build_dict.py
@@ -108,7 +108,7 @@ def build_dict(opt, skip_if_built=False):
         print('[ running dictionary over data.. ]')
         log_time = TimeLogger()
         total = world_dict.num_examples()
-        if opt['dict_maxexs'] > 0:
+        if opt['dict_maxexs'] >= 0:
             total = min(total, opt['dict_maxexs'])
 
         log_every_n_secs = opt.get('log_every_n_secs', None)
@@ -121,7 +121,7 @@ def build_dict(opt, skip_if_built=False):
             pbar = None
         while not world_dict.epoch_done():
             cnt += 1
-            if cnt > opt['dict_maxexs'] and opt['dict_maxexs'] > 0:
+            if cnt > opt['dict_maxexs'] and opt['dict_maxexs'] >= 0:
                 print('Processed {} exs, moving on.'.format(opt['dict_maxexs']))
                 # don't wait too long...
                 break


### PR DESCRIPTION
BERT dictionary is already built so skip this step

Notes:
- How this works: if BERT agents add the "common args" from helpers, the dictionary should automatically skip being built since the maximum examples to pass through will be set to zero (otherwise, we override "act" to essentially do nothing)
- I considered setting this default in the BertDictionaryAgent (cleaner), but this would require many substantial changes to the way params are parsed
- On the above note, I noticed that in the typical setting of building a dictionary (called from train_model script), the following lines are never exectued because `dict_class` will not be set in params yet: https://github.com/facebookresearch/ParlAI/blob/10e3e271adfdc457dfe3895d17f93a870a76b603/parlai/scripts/build_dict.py#L48-L49
