### PR TITLE
Forceful saving of dictionaries

### DIFF
--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -447,6 +447,9 @@ class FairseqAgent(TorchAgent):
                 del self.opt['override']
             json.dump(self.opt, handle)
 
+        # force save the dict
+        self.dict.save(path + '.dict', sort=False)
+
     def load(self, path):
         """Load using fairseq's checkpointing."""
         if self.trainer:

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -447,6 +447,9 @@ class FairseqAgent(TorchAgent):
                 del self.opt['override']
             json.dump(self.opt, handle)
 
+        # force save the dict
+        self.dict.save(path + '.dict', sort=True)
+
     def load(self, path):
         """Load using fairseq's checkpointing."""
         if self.trainer:

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -447,9 +447,6 @@ class FairseqAgent(TorchAgent):
                 del self.opt['override']
             json.dump(self.opt, handle)
 
-        # force save the dict
-        self.dict.save(path + '.dict')
-
     def load(self, path):
         """Load using fairseq's checkpointing."""
         if self.trainer:

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -448,7 +448,7 @@ class FairseqAgent(TorchAgent):
             json.dump(self.opt, handle)
 
         # force save the dict
-        self.dict.save(path + '.dict', sort=True)
+        self.dict.save(path + '.dict')
 
     def load(self, path):
         """Load using fairseq's checkpointing."""

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -168,10 +168,7 @@ class Seq2seqAgent(TorchGeneratorAgent):
         return super().batchify(*args, **kwargs)
 
     def state_dict(self):
-        """Get the model states for saving
-
-        Override to include longest_label
-        """
+        """Get the model states for saving. Overriden to include longest_label"""
         states = super().state_dict()
         if hasattr(self.model, 'module'):
             states['longest_label'] = self.model.module.longest_label

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -10,8 +10,6 @@ from .modules import Seq2seq, opt_to_kwargs
 import torch
 import torch.nn as nn
 
-import json
-
 
 class Seq2seqAgent(TorchGeneratorAgent):
     """Agent which takes an input sequence and produces an output sequence.

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -174,7 +174,7 @@ class Seq2seqAgent(TorchGeneratorAgent):
 
         Override to include longest_label
         """
-        states = super().get_state_dict()
+        states = super().get_save_dict()
         if hasattr(self.model, 'module'):
             states['longest_label'] = self.model.module.longest_label
         else:

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -169,29 +169,18 @@ class Seq2seqAgent(TorchGeneratorAgent):
         kwargs['sort'] = True  # need sorted for pack_padded
         return super().batchify(*args, **kwargs)
 
-    def save(self, path=None):
-        """Save model parameters if model_file is set."""
-        path = self.opt.get('model_file', None) if path is None else path
+    def get_save_dict(self):
+        """Get the model states for saving
 
-        if path and hasattr(self, 'model'):
-            model = {}
-            if hasattr(self.model, 'module'):
-                model['model'] = self.model.module.state_dict()
-                model['longest_label'] = self.model.module.longest_label
-            else:
-                model['model'] = self.model.state_dict()
-                model['longest_label'] = self.model.longest_label
-            model['optimizer'] = self.optimizer.state_dict()
-            model['optimizer_type'] = self.opt['optimizer']
+        Override to include longest_label
+        """
+        states = super().get_state_dict()
+        if hasattr(self.model, 'module'):
+            states['longest_label'] = self.model.module.longest_label
+        else:
+            states['longest_label'] = self.model.longest_label
 
-            with open(path, 'wb') as write:
-                torch.save(model, write)
-
-            # save opt file
-            with open(path + '.opt', 'w') as handle:
-                # save version string
-                self.opt['model_version'] = self.model_version()
-                json.dump(self.opt, handle)
+        return states
 
     def load(self, path):
         """Return opt and model states."""

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -167,12 +167,12 @@ class Seq2seqAgent(TorchGeneratorAgent):
         kwargs['sort'] = True  # need sorted for pack_padded
         return super().batchify(*args, **kwargs)
 
-    def get_save_dict(self):
+    def state_dict(self):
         """Get the model states for saving
 
         Override to include longest_label
         """
-        states = super().get_save_dict()
+        states = super().state_dict()
         if hasattr(self.model, 'module'):
             states['longest_label'] = self.model.module.longest_label
         else:

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1340,6 +1340,7 @@ class TorchAgent(Agent):
 
         if path:
             if hasattr(self, 'dict'):  # force save dictionary
+                # TODO: Look into possibly overriding opt('dict_file') with new path
                 self.dict.save(path + '.dict', sort=False)
             states = self.state_dict()
             if states:  # anything found to save?

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1295,6 +1295,40 @@ class TorchAgent(Agent):
                               text_truncate=self.text_truncate,
                               label_truncate=self.label_truncate)
 
+    def get_save_dict(self):
+        """Get the state dict for saving
+
+        Override this method to include additional/different things when
+        saving the model
+        """
+        states = {}
+        if hasattr(self, 'model'):  # save model params
+            if hasattr(self.model, 'module'):
+                # did we wrap in a DistributedDataParallel
+                states['model'] = self.model.module.state_dict()
+            else:
+                states['model'] = self.model.state_dict()
+
+        if hasattr(self, 'optimizer'):  # save optimizer params
+            states['optimizer'] = self.optimizer.state_dict()
+            states['optimizer_type'] = self.opt['optimizer']
+
+        # lr scheduler
+        if torch.__version__.startswith('0.'):
+            warn_once(
+                "Must upgrade to Pytorch 1.0 to save the state of your "
+                "LR scheduler."
+            )
+        else:
+            states['number_training_updates'] = self._number_training_updates
+            if getattr(self, 'scheduler'):
+                states['lr_scheduler'] = self.scheduler.state_dict()
+                states['lr_scheduler_type'] = self.opt['lr_scheduler']
+            if getattr(self, 'warmup_scheduler'):
+                states['warmup_scheduler'] = self.warmup_scheduler.state_dict()
+
+        return states
+
     def save(self, path=None):
         """
         Save model parameters to path (or default to model_file arg).
@@ -1304,32 +1338,9 @@ class TorchAgent(Agent):
         path = self.opt.get('model_file', None) if path is None else path
 
         if path:
-            states = {}
-            if hasattr(self, 'model'):  # save model params
-                if hasattr(self.model, 'module'):
-                    # did we wrap in a DistributedDataParallel
-                    states['model'] = self.model.module.state_dict()
-                else:
-                    states['model'] = self.model.state_dict()
-
-            if hasattr(self, 'optimizer'):  # save optimizer params
-                states['optimizer'] = self.optimizer.state_dict()
-                states['optimizer_type'] = self.opt['optimizer']
-
-            # lr scheduler
-            if torch.__version__.startswith('0.'):
-                warn_once(
-                    "Must upgrade to Pytorch 1.0 to save the state of your "
-                    "LR scheduler."
-                )
-            else:
-                states['number_training_updates'] = self._number_training_updates
-                if getattr(self, 'scheduler'):
-                    states['lr_scheduler'] = self.scheduler.state_dict()
-                    states['lr_scheduler_type'] = self.opt['lr_scheduler']
-                if getattr(self, 'warmup_scheduler'):
-                    states['warmup_scheduler'] = self.warmup_scheduler.state_dict()
-
+            if hasattr(self, 'dict'):  # force save dictionary
+                self.dict.save(path + '.dict', sort=True)
+            states = self.get_state_dict()
             if states:  # anything found to save?
                 with open(path, 'wb') as write:
                     torch.save(states, write)

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1295,7 +1295,7 @@ class TorchAgent(Agent):
                               text_truncate=self.text_truncate,
                               label_truncate=self.label_truncate)
 
-    def get_save_dict(self):
+    def state_dict(self):
         """Get the state dict for saving
 
         Override this method for more specific saving.
@@ -1333,14 +1333,14 @@ class TorchAgent(Agent):
         Save model parameters to path (or default to model_file arg).
 
         Please try to refrain from overriding this function, and instead
-        override `get_save_dict(self)` for more specific saving.
+        override `state_dict(self)` for more specific saving.
         """
         path = self.opt.get('model_file', None) if path is None else path
 
         if path:
             if hasattr(self, 'dict'):  # force save dictionary
-                self.dict.save(path + '.dict', sort=True)
-            states = self.get_save_dict()
+                self.dict.save(path + '.dict')
+            states = self.state_dict()
             if states:  # anything found to save?
                 with open(path, 'wb') as write:
                     torch.save(states, write)

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1296,7 +1296,8 @@ class TorchAgent(Agent):
                               label_truncate=self.label_truncate)
 
     def state_dict(self):
-        """Get the state dict for saving
+        """
+        Get the state dict for saving
 
         Override this method for more specific saving.
         """

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1298,8 +1298,7 @@ class TorchAgent(Agent):
     def get_save_dict(self):
         """Get the state dict for saving
 
-        Override this method to include additional/different things when
-        saving the model
+        Override this method for more specific saving.
         """
         states = {}
         if hasattr(self, 'model'):  # save model params
@@ -1333,14 +1332,15 @@ class TorchAgent(Agent):
         """
         Save model parameters to path (or default to model_file arg).
 
-        Override this method for more specific saving.
+        Please try to refrain from overriding this function, and instead
+        override `get_save_dict(self)` for more specific saving.
         """
         path = self.opt.get('model_file', None) if path is None else path
 
         if path:
             if hasattr(self, 'dict'):  # force save dictionary
                 self.dict.save(path + '.dict', sort=True)
-            states = self.get_state_dict()
+            states = self.get_save_dict()
             if states:  # anything found to save?
                 with open(path, 'wb') as write:
                     torch.save(states, write)

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -497,8 +497,6 @@ class TorchAgent(Agent):
             # intitialize any important structures from scratch
             self.replies = {}  # past replies
             self.dict = self.dictionary_class()(opt)
-            if opt.get('model_file'):
-                self.dict.save(opt['model_file'] + '.dict')
             if opt.get('person_tokens'):
                 self.dict[self.P1_TOKEN] = 999999999
                 self.dict[self.P2_TOKEN] = 999999998
@@ -1340,6 +1338,8 @@ class TorchAgent(Agent):
         path = self.opt.get('model_file', None) if path is None else path
 
         if path:
+            if hasattr(self, 'dict'):  # force save dictionary
+                self.dict.save(path + '.dict', sort=False)
             states = self.state_dict()
             if states:  # anything found to save?
                 with open(path, 'wb') as write:

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -497,6 +497,8 @@ class TorchAgent(Agent):
             # intitialize any important structures from scratch
             self.replies = {}  # past replies
             self.dict = self.dictionary_class()(opt)
+            if opt.get('model_file'):
+                self.dict.save(opt['model_file'] + '.dict')
             if opt.get('person_tokens'):
                 self.dict[self.P1_TOKEN] = 999999999
                 self.dict[self.P2_TOKEN] = 999999998
@@ -1338,8 +1340,6 @@ class TorchAgent(Agent):
         path = self.opt.get('model_file', None) if path is None else path
 
         if path:
-            if hasattr(self, 'dict'):  # force save dictionary
-                self.dict.save(path + '.dict')
             states = self.state_dict()
             if states:  # anything found to save?
                 with open(path, 'wb') as write:


### PR DESCRIPTION
We now explicitly save a `/path/to/model.dict` file. This makes copying model files a more straightforward process, as you do not have to worry about any number of issues that may cause you to lose access to (or simply forget the location of) a specified dict file. 

This PR also moves the aggregation of the various model components to save to a new function, `get_save_dict`, which is what subclasses of `torch_agent` should override for more specific saving.