### PR TITLE
Fix bug in PytorchDataTeacher Deserialize

### DIFF
--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -420,7 +420,8 @@ def deserialize(obj):
     """
         Deserializes lists into Tensors
     """
-    for key in obj:
+    keys = list(obj.keys())
+    for key in keys:
         if type(obj[key]) is dict and obj[key].get('deserialized_tensor', False):
             dtype = STR_TO_TORCH_DTYPE[obj[key]['type']]
             val = obj[key]['value']


### PR DESCRIPTION
Surfaced by #1539, there was an issue with deserialize in pytorch data teacher (specifically, deleting a key while iterating through a dict)

Tested via process in #1539 to confirm that this fixes the issue.

