### PR TITLE
[MTurk] Moving to new host domain following migration

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -54,8 +54,8 @@ SNS_ASSIGN_ABANDONDED = 'AssignmentAbandoned'
 SNS_ASSIGN_SUBMITTED = 'AssignmentSubmitted'
 SNS_ASSIGN_RETURNED = 'AssignmentReturned'
 
-PARLAI_MTURK_NOTICE_URL = 'http://www.parl.ai/mturk/mturk_notice/'
-PARLAI_MTURK_UPLOAD_URL = 'http://www.parl.ai/mturk/mturk_stats/'
+PARLAI_MTURK_NOTICE_URL = 'http://mturk.parl.ai/mturk/mturk_notice/'
+PARLAI_MTURK_UPLOAD_URL = 'http://mturk.parl.ai/mturk/mturk_stats/'
 PARLAI_CRED_DIR = os.path.expanduser('~/.parlai')
 PARLAI_MTURK_LOG_PERMISSION_FILE = \
     os.path.join(PARLAI_CRED_DIR, 'mturk_log_permission.pickle')


### PR DESCRIPTION
I've finished the migration, and set up the server at a new domain. This now routes to the correct place. 

Due to the short window here, I anticipate breaking behavior for anyone who hasn't updated ParlAI since I've added exception handling around the query to `mturk_notices`. Little can be done to remedy this on our timeframe. Once this is in I'll be swapping the rest of the DNS over as well.