### PR TITLE
[MTurk] Fix multiple processing of one alive

### DIFF
--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -7,6 +7,7 @@
 import boto3
 import os
 import json
+import re
 from datetime import datetime
 
 from botocore.exceptions import ClientError
@@ -374,7 +375,9 @@ def expire_hit(is_sandbox, hit_id):
 def setup_sns_topic(task_name, server_url, task_group_id):
     # Create the topic and subscribe to it so that our server receives notifs
     client = boto3.client('sns', region_name='us-east-1',)
-    response = client.create_topic(Name=task_name)
+    pattern = re.compile('[^a-zA-Z0-9_-]+')
+    filtered_task_name = pattern.sub('', task_name)
+    response = client.create_topic(Name=filtered_task_name)
     arn = response['TopicArn']
     topic_sub_url = \
         '{}/sns_posts?task_group_id={}'.format(server_url, task_group_id)

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -210,6 +210,10 @@ class SocketManager():
         self.last_sent_heartbeat_time = {}  # time of last heartbeat sent
         self.last_received_heartbeat = {}  # actual last received heartbeat
         self.pongs_without_heartbeat = {}
+        # TODO update processed packets to *ensure* only one execution per
+        # packet, as right now two threads can be spawned to process the
+        # same packet at the same time, as the packet is only added to this
+        # set after processing is complete.
         self.processed_packets = set()
         self.packet_map = {}
         self.alive = False

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -210,6 +210,7 @@ class SocketManager():
         self.last_sent_heartbeat_time = {}  # time of last heartbeat sent
         self.last_received_heartbeat = {}  # actual last received heartbeat
         self.pongs_without_heartbeat = {}
+        self.processed_packets = set()
         self.packet_map = {}
         self.alive = False
         self.is_shutdown = False
@@ -443,7 +444,13 @@ class SocketManager():
                 pong_conn_id = packet.get_receiver_connection_id()
                 if self.last_received_heartbeat[pong_conn_id] is not None:
                     self.pongs_without_heartbeat[pong_conn_id] += 1
+            elif packet_id in self.processed_packets:
+                # We don't want to re-process a packet that has already
+                # been recieved, but we do need to tell the sender it is ack'd
+                # re-acknowledge the packet was recieved and already processed
+                self._send_ack(packet)
             else:
+
                 # Remaining packet types need to be acknowledged
                 shared_utils.print_and_log(
                     logging.DEBUG,
@@ -457,6 +464,10 @@ class SocketManager():
 
                 # acknowledge the packet was recieved and processed
                 self._send_ack(packet)
+
+                # Note to self that this packet has already been processed,
+                # and shouldn't be processed again in the future
+                self.processed_packets.add(packet_id)
 
         def run_socket(*args):
             url_base_name = self.server_url.split('https://')[1]

--- a/parlai/mturk/tasks/convai2_model_eval/run.py
+++ b/parlai/mturk/tasks/convai2_model_eval/run.py
@@ -60,10 +60,10 @@ def main():
                                 ' test eval, default is %(default)s')
 
     # ADD MODEL ARGS HERE, UNCOMMENT TO USE KVMEMNN MODEL AS AN EXAMPLE
-    argparser.set_defaults(
-        model='projects.personachat.kvmemnn.kvmemnn:Kvmemnn',
-        model_file='models:convai2/kvmemnn/model',
-    )
+    # argparser.set_defaults(
+    #     model='projects.personachat.kvmemnn.kvmemnn:Kvmemnn',
+    #     model_file='models:convai2/kvmemnn/model',
+    # )
 
     opt = argparser.parse_args()
 

--- a/parlai/mturk/tasks/convai2_model_eval/run.py
+++ b/parlai/mturk/tasks/convai2_model_eval/run.py
@@ -60,10 +60,10 @@ def main():
                                 ' test eval, default is %(default)s')
 
     # ADD MODEL ARGS HERE, UNCOMMENT TO USE KVMEMNN MODEL AS AN EXAMPLE
-    # argparser.set_defaults(
-    #     model='projects.personachat.kvmemnn.kvmemnn:Kvmemnn',
-    #     model_file='models:convai2/kvmemnn/model',
-    # )
+    argparser.set_defaults(
+        model='projects.personachat.kvmemnn.kvmemnn:Kvmemnn',
+        model_file='models:convai2/kvmemnn/model',
+    )
 
     opt = argparser.parse_args()
 
@@ -110,6 +110,7 @@ def main():
                 agent_qualifications.append(MASTER_QUALIF_SDBOX)
             else:
                 agent_qualifications.append(MASTER_QUALIF)
+        mturk_manager.ready_to_accept_workers()
         mturk_manager.create_hits(qualifications=agent_qualifications)
 
         if not opt['is_sandbox']:
@@ -127,7 +128,6 @@ def main():
             world.parley()
             world.shutdown()
         mturk_manager.set_onboard_function(onboard_function=run_onboard)
-        mturk_manager.ready_to_accept_workers()
 
         def check_worker_eligibility(worker):
             return True

--- a/parlai/mturk/tasks/light/light_chat_eval/frontend/components/custom.jsx
+++ b/parlai/mturk/tasks/light/light_chat_eval/frontend/components/custom.jsx
@@ -154,14 +154,14 @@ class ActionInput extends React.Component {
         agent_id={this.props.task_data.agent_id}
         message={this.state.selectval}
         task_data={this.props.task_data.curr_message_context}
-        duration={this.props.is_review ? m.duration : undefined}/>;
+        duration={undefined}/>;
     } else {
       message = <ChatMessage
         is_self={true}
         agent_id={this.props.task_data.agent_id}
         message={this.props.task_data.text}
         task_data={{action: this.state.selectval}}
-        duration={this.props.is_review ? m.duration : undefined}/>;
+        duration={undefined}/>;
     }
 
     let select_label = 'Selection:';


### PR DESCRIPTION
## Motivation

Fixes #1567 (hopefully, awaiting testing from them as I haven't been able to reproduce)

## Description

As discovered in #1567, it's possible for the same alive message to be processed multiple times by `mturk_manager` if it was sent more than once before being fully acked. This is bad, as the ordering of `Alive 1 -> change conversation -> Alive 1 (duplicate)` can cause a task to instantly be marked as disconnected (via the path better explained in #1567's comment thread). 

## Implementation

This problem has been patched by adding a packet to a set following it being processed which prevents it from being forwarded to `mturk_manager` if it is received again. This is actually much nicer behavior that will allows us to drop some logic for idempotency for agents receiving messages (as a duplicate message event couldn't happen anymore). That being said, there is still a race condition present: should the socket listener spawn a thread for a first alive and get passed the set membership check, then be suspended for enough time for a resend of the same alive to get to the same point, both threads will have their respective processing functions called. The risk of this occurring is much much lower, however I intend to patch it out and have left a TODO for myself for later as the implementation is more complicated.

Also included in this PR is the fix to the 'Could not subscribe to sns channel' bug that appears to have been caused by Amazon changing limitations on the characters that could be passed to the channel at some point since I implemented it here. 

It also includes changing the order of `MTurkManager` lifecycle functions on the `convai2_model_eval` task to match the new standards.

It _also_ fixes lint on a LIGHT task, as the linting wasn't set up when that task got committed and I'd rather see passing tests.
