### PR TITLE
Ignore data/ when it is a symlink.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__/
 env/
 build/
 data/
+data
 logs/
 develop-eggs/
 dist/


### PR DESCRIPTION
I switched to a symlink for parlai/data to put all my large corpora in a better place. This makes it so git ignores that symlink.