### PR TITLE
Fix infinite loop in test_new_tasks for some tasks

### DIFF
--- a/parlai/tasks/babi/agents.py
+++ b/parlai/tasks/babi/agents.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from parlai.core.teachers import FbDialogTeacher
-from parlai.core.agents import MultiTaskTeacher
+import parlai.core.agents as core_agents
 from .build import build
 
 import copy
@@ -76,7 +76,7 @@ class Task10kTeacher(FbDialogTeacher):
 
 
 # By default train on all tasks at once.
-class All1kTeacher(MultiTaskTeacher):
+class All1kTeacher(core_agents.MultiTaskTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['task'] = ','.join('babi:Task1k:%d' % (i + 1) for i in range(20))
@@ -84,7 +84,7 @@ class All1kTeacher(MultiTaskTeacher):
 
 
 # By default train on all tasks at once.
-class All10kTeacher(MultiTaskTeacher):
+class All10kTeacher(core_agents.MultiTaskTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['task'] = ','.join('babi:Task10k:%d' % (i + 1) for i in range(20))

--- a/parlai/tasks/cbt/agents.py
+++ b/parlai/tasks/cbt/agents.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from parlai.core.teachers import FbDialogTeacher
-from parlai.core.agents import MultiTaskTeacher
+import parlai.core.agents as core_agents
 from .build import build
 
 import copy
@@ -57,7 +57,7 @@ class PTeacher(FbDialogTeacher):
 
 
 # By default train on all tasks at once.
-class DefaultTeacher(MultiTaskTeacher):
+class DefaultTeacher(core_agents.MultiTaskTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['task'] = 'cbt:NE,cbt:CN,cbt:V,cbt:P'

--- a/parlai/tasks/dialog_babi/agents.py
+++ b/parlai/tasks/dialog_babi/agents.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from parlai.core.teachers import FbDialogTeacher
-from parlai.core.agents import MultiTaskTeacher
+import parlai.core.agents as core_agents
 from .build import build
 
 import copy
@@ -67,7 +67,7 @@ class TaskTeacher(FbDialogTeacher):
 
 
 # By default train on all tasks at once.
-class DefaultTeacher(MultiTaskTeacher):
+class DefaultTeacher(core_agents.MultiTaskTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['task'] = ','.join('dialog_babi:Task:%d' % (i + 1)

--- a/parlai/tasks/moviedialog/agents.py
+++ b/parlai/tasks/moviedialog/agents.py
@@ -18,7 +18,7 @@ Task 4: Dialogs discussing Movies from Reddit (the /r/movies SubReddit).
 """
 
 from parlai.core.teachers import FbDialogTeacher
-from parlai.core.agents import MultiTaskTeacher
+import parlai.core.agents as core_agents
 from .build import build
 
 import copy
@@ -87,7 +87,7 @@ class TaskTeacher(FbDialogTeacher):
 
 
 # By default train on all tasks at once.
-class DefaultTeacher(MultiTaskTeacher):
+class DefaultTeacher(core_agents.MultiTaskTeacher):
     """By default will load teacher with all four tasks."""
 
     def __init__(self, opt, shared=None):

--- a/parlai/tasks/personalized_dialog/agents.py
+++ b/parlai/tasks/personalized_dialog/agents.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from parlai.core.teachers import FbDialogTeacher
-from parlai.core.agents import MultiTaskTeacher
+import parlai.core.agents as core_agents
 from .build import build
 
 import copy
@@ -74,7 +74,7 @@ class SmallTaskTeacher(FbDialogTeacher):
 
 # python <script.py> -t personalized_dialog:AllFull
 # By default train on all tasks at once.
-class AllFullTeacher(MultiTaskTeacher):
+class AllFullTeacher(core_agents.MultiTaskTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['task'] = ','.join('personalized_dialog:FullTask:%d' % (i + 1)
@@ -88,7 +88,7 @@ class AllFullTeacher(MultiTaskTeacher):
 
 # python <script.py> -t personalized_dialog:AllSmall
 # By default train on all tasks at once.
-class AllSmallTeacher(MultiTaskTeacher):
+class AllSmallTeacher(core_agents.MultiTaskTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['task'] = ','.join('personalized_dialog:SmallTask:%d' % (i + 1)

--- a/parlai/tasks/self_feeding/agents.py
+++ b/parlai/tasks/self_feeding/agents.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from .build import build
 
-from parlai.core.agents import MultiTaskTeacher
+import parlai.core.agents as core_agents
 from parlai.core.teachers import ParlAIDialogTeacher
 from projects.self_feeding.utils import add_person_tokens
 
@@ -156,7 +156,7 @@ class SelfFeedingTeacher(ParlAIDialogTeacher):
                 self.episodes.append([episode])
 
 
-class SelfFeedingMTLTeacher(MultiTaskTeacher):
+class SelfFeedingMTLTeacher(core_agents.MultiTaskTeacher):
     """Creates a teacher that is actually a set of teachers each based on
     a task string--each of these teachers will get called in turn,
     either randomly or in order.

--- a/parlai/tasks/triviaqa/agents.py
+++ b/parlai/tasks/triviaqa/agents.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from parlai.core.teachers import DialogTeacher
-from parlai.core.agents import MultiTaskTeacher
+import parlai.core.agents as core_agents
 from .build import build
 
 import copy
@@ -122,14 +122,14 @@ class VerifiedWikipediaTeacher(WikipediaTeacher):
         super().__init__(opt, shared)
 
 
-class VerifiedTeacher(MultiTaskTeacher):
+class VerifiedTeacher(core_agents.MultiTaskTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['task'] = 'triviaqa:VerifiedWikipedia,triviaqa:VerifiedWeb'
         super().__init__(opt, shared)
 
 
-class DefaultTeacher(MultiTaskTeacher):
+class DefaultTeacher(core_agents.MultiTaskTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['task'] = 'triviaqa:wikipedia,triviaqa:web'

--- a/tests/datatests/test_new_tasks.py
+++ b/tests/datatests/test_new_tasks.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import importlib.util
+import traceback
 import unittest
 
 import parlai.core.teachers as teach_module
@@ -34,6 +35,7 @@ class TestNewTasks(unittest.TestCase):
         if not changed_task_files:
             return
 
+        found_errors = False
         for file in changed_task_files:
             task = file.split('/')[-2]
             module_name = "%s.tasks.%s.agents" % ('parlai', task)
@@ -58,16 +60,23 @@ class TestNewTasks(unittest.TestCase):
                 parser = setup_args()
                 opt = parser.parse_args(args=['--task', subt], print_args=False)
                 opt['task'] = subt
-                with testing_utils.capture_output():
-                    text, log = verify(opt, print_parser=False)
+                try:
+                    with testing_utils.capture_output():
+                        text, log = verify(opt, print_parser=False)
+                except Exception as e:
+                    found_errors = True
+                    traceback.print_exc()
+                    print("Got above exception in {}".format(subt))
                 for key in KEYS:
-                    self.assertEqual(
-                        log[key],
-                        0,
-                        'There are {} {} in this task.'.format(
+                    if log[key] != 0:
+                        print('There are {} {} in {}.'.format(
                             log[key],
-                            log
+                            log,
+                            subt,
                         ))
+                        found_errors = True
+
+        self.assertFalse(found_errors, "Errors were found.")
 
 
 if __name__ == '__main__':

--- a/tests/datatests/test_new_tasks.py
+++ b/tests/datatests/test_new_tasks.py
@@ -63,7 +63,7 @@ class TestNewTasks(unittest.TestCase):
                 try:
                     with testing_utils.capture_output():
                         text, log = verify(opt, print_parser=False)
-                except Exception as e:
+                except Exception:
                     found_errors = True
                     traceback.print_exc()
                     print("Got above exception in {}".format(subt))

--- a/tests/datatests/test_new_tasks.py
+++ b/tests/datatests/test_new_tasks.py
@@ -71,7 +71,7 @@ class TestNewTasks(unittest.TestCase):
                     if log[key] != 0:
                         print('There are {} {} in {}.'.format(
                             log[key],
-                            log,
+                            key,
                             subt,
                         ))
                         found_errors = True


### PR DESCRIPTION
test_new_tasks blindly iterates through all the tasks, which sometimes caused an infinite loop.

The problem was when we had imported a MultiTaskTeacher, which is done in some tasks. This causes a MultiTaskTeacher which tries to import MultiTaskTeacher, causing an infinite loop. This fix just makes sure MultiTaskTeacher isn't in the module directly, so that it isn't called by test_new_tasks. This isn't really a fix, so much as a bandaid so new copy-pasta doesn't have this problem.

This PR also makes it so that test_new_tasks checks all tasks and prints all errors, rather than just failing on the very first one. This can accelerate testing when multiple teachers are being introduced.

This PR does not pass test_new_tasks because some older tasks simply don't pass. I'm deferring fixing them for now.