### PR TITLE
Fixing argument name mismatch for MemNN

### DIFF
--- a/parlai/agents/memnn/modules.py
+++ b/parlai/agents/memnn/modules.py
@@ -13,7 +13,7 @@ from functools import lru_cache
 def opt_to_kwargs(opt):
     """Get kwargs for seq2seq from opt."""
     kwargs = {}
-    for k in ['mem_size', 'time_features', 'position_encoding', 'hops']:
+    for k in ['memsize', 'time_features', 'position_encoding', 'hops']:
         if k in opt:
             kwargs[k] = opt[k]
     return kwargs
@@ -24,7 +24,7 @@ class MemNN(nn.Module):
 
     def __init__(
         self, num_features, embedding_size, hops=1,
-        mem_size=32, time_features=False, position_encoding=False,
+        memsize=32, time_features=False, position_encoding=False,
         dropout=0, padding_idx=0,
     ):
         """Initialize memnn model.
@@ -39,9 +39,9 @@ class MemNN(nn.Module):
         # time features: we learn an embedding for each memory slot
         self.extra_features = 0
         if time_features:
-            self.extra_features += mem_size
+            self.extra_features += memsize
             self.time_features = torch.LongTensor(
-                range(num_features, num_features + mem_size))
+                range(num_features, num_features + memsize))
 
         def embedding(use_extra_feats=True):
             if use_extra_feats:


### PR DESCRIPTION
The command line argument for controling the memory size is
called `memsize` [[1](https://github.com/lematt1991/ParlAI/blob/master/parlai/agents/memnn/memnn.py#L36)], but the kwarg in the MemNN modules is
`mem_size`, so only the default value of 32 gets passed in.