### PR TITLE
[TRA] vectorizing label candidates fix

### DIFF
--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -295,8 +295,8 @@ class TorchRankerAgent(TorchAgent):
         obs = args[0]
         cands_key = ('candidates' if 'labels' in obs else
                      'eval_candidates' if 'eval_labels' in obs else None)
-        if (cands_key is None or
-                self.opt[cands_key] not in ['inline', 'batch-all-cands']):
+        if (cands_key is not None and self.opt[cands_key] not in
+                ['inline', 'batch-all-cands']):
             # vectorize label candidates if and only if we are using inline
             # candidates
             return obs


### PR DESCRIPTION
Let's vectorize label candidates if there are no labels present. 

This indicates that we are likely in "interactive mode". If label candidates don't exist, nothing happens anyway (we check for this in `_set_label_cands_vec`).