### PR TITLE
Skip empty text_vec examples in seq2seq.

### DIFF
--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -5,12 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 from parlai.core.torch_generator_agent import TorchGeneratorAgent
+from parlai.core.utils import warn_once
 from .modules import Seq2seq, opt_to_kwargs
 
 import torch
 import torch.nn as nn
 
 import json
+import warnings
 
 
 class Seq2seqAgent(TorchGeneratorAgent):
@@ -201,3 +203,6 @@ class Seq2seqAgent(TorchGeneratorAgent):
         if 'longest_label' in states:
             self.model.longest_label = states['longest_label']
         return states
+
+    def is_valid(self, obs):
+        return super().is_valid(obs) and obs['text_vec'].shape[0] > 0

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -13,6 +13,7 @@ The corpora are all randomly, but deterministically generated
 """
 
 from parlai.core.teachers import DialogTeacher
+import copy
 import random
 import itertools
 
@@ -169,6 +170,60 @@ class MultiturnNocandidateTeacher(MultiturnCandidateTeacher):
         raw = super().setup_data(fold)
         for (t, a, _r, _c), e in raw:
             yield (t, a), e
+
+
+class BadExampleTeacher(CandidateTeacher):
+    """
+    Teacher which produces a variety of examples that upset verify_data.py.
+
+    Useful for checking how models respond when the following assumptions are
+    violated:
+
+        0. text is empty string
+        1. missing text
+        2. label is empty string
+        3. missing label
+        4. label candidates is empty
+        5. label candidates contains an empty string
+        6. label isn't in the candidates
+        7. missing label candidates:
+    """
+    NUM_CASES = 8
+
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
+        # gross hack: override sub thing to force things the way we want
+        self.data.get = self._wrapperfn(self.data.get)
+
+    def _wrapperfn(self, oldget):
+        def newget(*args):
+            item, eod = oldget(*args)
+            item = copy.deepcopy(item)
+            newget.case = (newget.case + 1) % self.NUM_CASES
+            case = newget.case
+            # print(self.case)
+            if case == 0:
+                item['text'] = ''
+            elif case == 1:
+                del item['text']
+            elif case == 2:
+                item['labels'] = ['']
+            elif case == 3:
+                del item['labels']
+            elif case == 4:
+                item['label_candidates'] = []
+            elif case == 5:
+                item['label_candidates'] = tuple(list(item['label_candidates']) + [''])
+            elif case == 6:
+                item['label_candidates'] = list(item['label_candidates'])
+                item['label_candidates'].remove(item['labels'][0])
+                item['label_candidates'] = tuple(item['label_candidates'])
+            elif case == 7:
+                del item['label_candidates']
+            return item, eod
+
+        newget.case = random.randint(0, self.NUM_CASES)
+        return newget
 
 
 class DefaultTeacher(CandidateTeacher):

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -186,13 +186,17 @@ class BadExampleTeacher(CandidateTeacher):
         4. label candidates is empty
         5. label candidates contains an empty string
         6. label isn't in the candidates
-        7. missing label candidates:
+        7. missing label candidates
+
+    Note: this test may come to outlive its purpose in the future. When failing
+    this test, one should consider who is really at fault: the test, or the code.
     """
     NUM_CASES = 8
 
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
-        # gross hack: override sub thing to force things the way we want
+        # gross hack: override data.get to force things the way we want; otherwise
+        # we can't actually force some of these scenarios.
         self.data.get = self._wrapperfn(self.data.get)
 
     def _wrapperfn(self, oldget):
@@ -201,24 +205,30 @@ class BadExampleTeacher(CandidateTeacher):
             item = copy.deepcopy(item)
             newget.case = (newget.case + 1) % self.NUM_CASES
             case = newget.case
-            # print(self.case)
             if case == 0:
+                # empty string input
                 item['text'] = ''
             elif case == 1:
+                # not text input
                 del item['text']
             elif case == 2:
+                # empty string label
                 item['labels'] = ['']
             elif case == 3:
+                # no label
                 del item['labels']
             elif case == 4:
+                # no label candidates
                 item['label_candidates'] = []
             elif case == 5:
-                item['label_candidates'] = tuple(list(item['label_candidates']) + [''])
+                # extra empty string in labels
+                item['label_candidates'] = list(item['label_candidates']) + ['']
             elif case == 6:
+                # label candidates doesn't have the label
                 item['label_candidates'] = list(item['label_candidates'])
                 item['label_candidates'].remove(item['labels'][0])
-                item['label_candidates'] = tuple(item['label_candidates'])
             elif case == 7:
+                # no label candidates field
                 del item['label_candidates']
             return item, eod
 

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -106,6 +106,23 @@ class TestSeq2Seq(unittest.TestCase):
             "test ppl = {}\nLOG:\n{}".format(test['ppl'], stdout)
         )
 
+    def test_badinput(self):
+        """Ensures model doesn't crash on malformed inputs."""
+        stdout, _, _ = testing_utils.train_model(dict(
+            task='integration_tests:bad_example',
+            model='seq2seq',
+            lr=LR,
+            batchsize=10,
+            datatype='train:ordered:stream',
+            num_epochs=1,
+            numthreads=1,
+            no_cuda=True,
+            embeddingsize=16,
+            hiddensize=16,
+        ))
+        self.assertIn('valid:{', stdout)
+        self.assertIn('test:{', stdout)
+
 
 class TestHogwildSeq2seq(unittest.TestCase):
     @testing_utils.skipIfGPU

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -245,6 +245,22 @@ class TestTransformerGenerator(unittest.TestCase):
             'test f1 = {}\nLOG:\n{}'.format(test['f1'], stdout)
         )
 
+    def test_badinput(self):
+        """Ensures model doesn't crash on malformed inputs."""
+        stdout, _, _ = testing_utils.train_model(dict(
+            task='integration_tests:bad_example',
+            model='transformer/generator',
+            batchsize=10,
+            datatype='train:ordered:stream',
+            num_epochs=1,
+            numthreads=1,
+            no_cuda=True,
+            embeddingsize=16,
+            hiddensize=16,
+        ))
+        self.assertIn('valid:{', stdout)
+        self.assertIn('test:{', stdout)
+
 
 class TestLearningRateScheduler(unittest.TestCase):
     def test_resuming(self):


### PR DESCRIPTION
Fixes #1592.

Can't just add the `__START__` token everywhere for backwards compatibility. Datasets should be adding a `__SILENCE__` token equivalent, but they don't always do.

This might be affecting transformer/generator too. Haven't checked.

TODO:
- [x] check transformer/generator
- [x] add an integration test