### PR TITLE
[wip] Hybrid DataParallel/DDP

### DIFF
--- a/collect_env.py
+++ b/collect_env.py
@@ -1,0 +1,386 @@
+# This script outputs relevant system environment info
+# Run it with `python collect_env.py`.
+from __future__ import absolute_import, division, print_function, unicode_literals
+import re
+import subprocess
+import sys
+import os
+from collections import namedtuple
+
+try:
+    import torch
+    TORCH_AVAILABLE = True
+except (ImportError, NameError, AttributeError):
+    TORCH_AVAILABLE = False
+
+PY3 = sys.version_info >= (3, 0)
+
+# System Environment Information
+SystemEnv = namedtuple('SystemEnv', [
+    'torch_version',
+    'is_debug_build',
+    'cuda_compiled_version',
+    'gcc_version',
+    'cmake_version',
+    'os',
+    'python_version',
+    'is_cuda_available',
+    'cuda_runtime_version',
+    'nvidia_driver_version',
+    'nvidia_gpu_models',
+    'cudnn_version',
+    'pip_version',  # 'pip' or 'pip3'
+    'pip_packages',
+    'conda_packages',
+])
+
+
+def run(command):
+    """Returns (return-code, stdout, stderr)"""
+    p = subprocess.Popen(command, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, shell=True)
+    output, err = p.communicate()
+    rc = p.returncode
+    if PY3:
+        output = output.decode("utf-8")
+        err = err.decode("utf-8")
+    return rc, output.strip(), err.strip()
+
+
+def run_and_read_all(run_lambda, command):
+    """Runs command using run_lambda; reads and returns entire output if rc is 0"""
+    rc, out, _ = run_lambda(command)
+    if rc != 0:
+        return None
+    return out
+
+
+def run_and_parse_first_match(run_lambda, command, regex):
+    """Runs command using run_lambda, returns the first regex match if it exists"""
+    rc, out, _ = run_lambda(command)
+    if rc != 0:
+        return None
+    match = re.search(regex, out)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def get_conda_packages(run_lambda):
+    if get_platform() == 'win32':
+        grep_cmd = r'findstr /R "torch soumith mkl magma"'
+    else:
+        grep_cmd = r'grep "torch\|soumith\|mkl\|magma"'
+    conda = os.environ.get('CONDA_EXE', 'conda')
+    out = run_and_read_all(run_lambda, conda + ' list | ' + grep_cmd)
+    if out is None:
+        return out
+    # Comment starting at beginning of line
+    comment_regex = re.compile(r'^#.*\n')
+    return re.sub(comment_regex, '', out)
+
+
+def get_gcc_version(run_lambda):
+    return run_and_parse_first_match(run_lambda, 'gcc --version', r'gcc (.*)')
+
+
+def get_cmake_version(run_lambda):
+    return run_and_parse_first_match(run_lambda, 'cmake --version', r'cmake (.*)')
+
+
+def get_nvidia_driver_version(run_lambda):
+    if get_platform() == 'darwin':
+        cmd = 'kextstat | grep -i cuda'
+        return run_and_parse_first_match(run_lambda, cmd,
+                                         r'com[.]nvidia[.]CUDA [(](.*?)[)]')
+    smi = get_nvidia_smi()
+    return run_and_parse_first_match(run_lambda, smi, r'Driver Version: (.*?) ')
+
+
+def get_gpu_info(run_lambda):
+    if get_platform() == 'darwin':
+        if TORCH_AVAILABLE and torch.cuda.is_available():
+            return torch.cuda.get_device_name(None)
+        return None
+    smi = get_nvidia_smi()
+    uuid_regex = re.compile(r' \(UUID: .+?\)')
+    rc, out, _ = run_lambda(smi + ' -L')
+    if rc != 0:
+        return None
+    # Anonymize GPUs by removing their UUID
+    return re.sub(uuid_regex, '', out)
+
+
+def get_running_cuda_version(run_lambda):
+    return run_and_parse_first_match(run_lambda, 'nvcc --version', r'V(.*)$')
+
+
+def get_cudnn_version(run_lambda):
+    """This will return a list of libcudnn.so; it's hard to tell which one is being used"""
+    if get_platform() == 'win32':
+        cudnn_cmd = 'where /R "%CUDA_PATH%\\bin" cudnn*.dll'
+    elif get_platform() == 'darwin':
+        # CUDA libraries and drivers can be found in /usr/local/cuda/. See
+        # https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html#install
+        # https://docs.nvidia.com/deeplearning/sdk/cudnn-install/index.html#installmac
+        # Use CUDNN_LIBRARY when cudnn library is installed elsewhere.
+        cudnn_cmd = 'ls /usr/local/cuda/lib/libcudnn*'
+    else:
+        cudnn_cmd = 'ldconfig -p | grep libcudnn | rev | cut -d" " -f1 | rev'
+    rc, out, _ = run_lambda(cudnn_cmd)
+    # find will return 1 if there are permission errors or if not found
+    if len(out) == 0 or (rc != 1 and rc != 0):
+        l = os.environ.get('CUDNN_LIBRARY')
+        if l is not None and os.path.isfile(l):
+            return os.path.realpath(l)
+        return None
+    files = set()
+    for fn in out.split('\n'):
+        fn = os.path.realpath(fn)  # eliminate symbolic links
+        if os.path.isfile(fn):
+            files.add(fn)
+    if not files:
+        return None
+    # Alphabetize the result because the order is non-deterministic otherwise
+    files = list(sorted(files))
+    if len(files) == 1:
+        return files[0]
+    result = '\n'.join(files)
+    return 'Probably one of the following:\n{}'.format(result)
+
+
+def get_nvidia_smi():
+    # Note: nvidia-smi is currently available only on Windows and Linux
+    smi = 'nvidia-smi'
+    if get_platform() == 'win32':
+        smi = '"C:\\Program Files\\NVIDIA Corporation\\NVSMI\\%s"' % smi
+    return smi
+
+
+def get_platform():
+    if sys.platform.startswith('linux'):
+        return 'linux'
+    elif sys.platform.startswith('win32'):
+        return 'win32'
+    elif sys.platform.startswith('cygwin'):
+        return 'cygwin'
+    elif sys.platform.startswith('darwin'):
+        return 'darwin'
+    else:
+        return sys.platform
+
+
+def get_mac_version(run_lambda):
+    return run_and_parse_first_match(run_lambda, 'sw_vers -productVersion', r'(.*)')
+
+
+def get_windows_version(run_lambda):
+    return run_and_read_all(run_lambda, 'wmic os get Caption | findstr /v Caption')
+
+
+def get_lsb_version(run_lambda):
+    return run_and_parse_first_match(run_lambda, 'lsb_release -a', r'Description:\t(.*)')
+
+
+def check_release_file(run_lambda):
+    return run_and_parse_first_match(run_lambda, 'cat /etc/*-release',
+                                     r'PRETTY_NAME="(.*)"')
+
+
+def get_os(run_lambda):
+    platform = get_platform()
+
+    if platform == 'win32' or platform == 'cygwin':
+        return get_windows_version(run_lambda)
+
+    if platform == 'darwin':
+        version = get_mac_version(run_lambda)
+        if version is None:
+            return None
+        return 'Mac OSX {}'.format(version)
+
+    if platform == 'linux':
+        # Ubuntu/Debian based
+        desc = get_lsb_version(run_lambda)
+        if desc is not None:
+            return desc
+
+        # Try reading /etc/*-release
+        desc = check_release_file(run_lambda)
+        if desc is not None:
+            return desc
+
+        return platform
+
+    # Unknown platform
+    return platform
+
+
+def get_pip_packages(run_lambda):
+    # People generally have `pip` as `pip` or `pip3`
+    def run_with_pip(pip):
+        if get_platform() == 'win32':
+            grep_cmd = r'findstr /R "numpy torch"'
+        else:
+            grep_cmd = r'grep "torch\|numpy"'
+        return run_and_read_all(run_lambda, pip + ' list --format=freeze | ' + grep_cmd)
+
+    if not PY3:
+        return 'pip', run_with_pip('pip')
+
+    # Try to figure out if the user is running pip or pip3.
+    out2 = run_with_pip('pip')
+    out3 = run_with_pip('pip3')
+
+    num_pips = len([x for x in [out2, out3] if x is not None])
+    if num_pips == 0:
+        return 'pip', out2
+
+    if num_pips == 1:
+        if out2 is not None:
+            return 'pip', out2
+        return 'pip3', out3
+
+    # num_pips is 2. Return pip3 by default b/c that most likely
+    # is the one associated with Python 3
+    return 'pip3', out3
+
+
+def get_env_info():
+    run_lambda = run
+    pip_version, pip_list_output = get_pip_packages(run_lambda)
+
+    if TORCH_AVAILABLE:
+        version_str = torch.__version__
+        debug_mode_str = torch.version.debug
+        cuda_available_str = torch.cuda.is_available()
+        cuda_version_str = torch.version.cuda
+    else:
+        version_str = debug_mode_str = cuda_available_str = cuda_version_str = 'N/A'
+
+    return SystemEnv(
+        torch_version=version_str,
+        is_debug_build=debug_mode_str,
+        python_version='{}.{}'.format(sys.version_info[0], sys.version_info[1]),
+        is_cuda_available=cuda_available_str,
+        cuda_compiled_version=cuda_version_str,
+        cuda_runtime_version=get_running_cuda_version(run_lambda),
+        nvidia_gpu_models=get_gpu_info(run_lambda),
+        nvidia_driver_version=get_nvidia_driver_version(run_lambda),
+        cudnn_version=get_cudnn_version(run_lambda),
+        pip_version=pip_version,
+        pip_packages=pip_list_output,
+        conda_packages=get_conda_packages(run_lambda),
+        os=get_os(run_lambda),
+        gcc_version=get_gcc_version(run_lambda),
+        cmake_version=get_cmake_version(run_lambda),
+    )
+
+env_info_fmt = """
+PyTorch version: {torch_version}
+Is debug build: {is_debug_build}
+CUDA used to build PyTorch: {cuda_compiled_version}
+
+OS: {os}
+GCC version: {gcc_version}
+CMake version: {cmake_version}
+
+Python version: {python_version}
+Is CUDA available: {is_cuda_available}
+CUDA runtime version: {cuda_runtime_version}
+GPU models and configuration: {nvidia_gpu_models}
+Nvidia driver version: {nvidia_driver_version}
+cuDNN version: {cudnn_version}
+
+Versions of relevant libraries:
+{pip_packages}
+{conda_packages}
+""".strip()
+
+
+def pretty_str(envinfo):
+    def replace_nones(dct, replacement='Could not collect'):
+        for key in dct.keys():
+            if dct[key] is not None:
+                continue
+            dct[key] = replacement
+        return dct
+
+    def replace_bools(dct, true='Yes', false='No'):
+        for key in dct.keys():
+            if dct[key] is True:
+                dct[key] = true
+            elif dct[key] is False:
+                dct[key] = false
+        return dct
+
+    def prepend(text, tag='[prepend]'):
+        lines = text.split('\n')
+        updated_lines = [tag + line for line in lines]
+        return '\n'.join(updated_lines)
+
+    def replace_if_empty(text, replacement='No relevant packages'):
+        if text is not None and len(text) == 0:
+            return replacement
+        return text
+
+    def maybe_start_on_next_line(string):
+        # If `string` is multiline, prepend a \n to it.
+        if string is not None and len(string.split('\n')) > 1:
+            return '\n{}\n'.format(string)
+        return string
+
+    mutable_dict = envinfo._asdict()
+
+    # If nvidia_gpu_models is multiline, start on the next line
+    mutable_dict['nvidia_gpu_models'] = \
+        maybe_start_on_next_line(envinfo.nvidia_gpu_models)
+
+    # If the machine doesn't have CUDA, report some fields as 'No CUDA'
+    dynamic_cuda_fields = [
+        'cuda_runtime_version',
+        'nvidia_gpu_models',
+        'nvidia_driver_version',
+    ]
+    all_cuda_fields = dynamic_cuda_fields + ['cudnn_version']
+    all_dynamic_cuda_fields_missing = all(
+        mutable_dict[field] is None for field in dynamic_cuda_fields)
+    if TORCH_AVAILABLE and not torch.cuda.is_available() and all_dynamic_cuda_fields_missing:
+        for field in all_cuda_fields:
+            mutable_dict[field] = 'No CUDA'
+        if envinfo.cuda_compiled_version is None:
+            mutable_dict['cuda_compiled_version'] = 'None'
+
+    # Replace True with Yes, False with No
+    mutable_dict = replace_bools(mutable_dict)
+
+    # Replace all None objects with 'Could not collect'
+    mutable_dict = replace_nones(mutable_dict)
+
+    # If either of these are '', replace with 'No relevant packages'
+    mutable_dict['pip_packages'] = replace_if_empty(mutable_dict['pip_packages'])
+    mutable_dict['conda_packages'] = replace_if_empty(mutable_dict['conda_packages'])
+
+    # Tag conda and pip packages with a prefix
+    # If they were previously None, they'll show up as ie '[conda] Could not collect'
+    if mutable_dict['pip_packages']:
+        mutable_dict['pip_packages'] = prepend(mutable_dict['pip_packages'],
+                                               '[{}] '.format(envinfo.pip_version))
+    if mutable_dict['conda_packages']:
+        mutable_dict['conda_packages'] = prepend(mutable_dict['conda_packages'],
+                                                 '[conda] ')
+    return env_info_fmt.format(**mutable_dict)
+
+
+def get_pretty_env_info():
+    return pretty_str(get_env_info())
+
+
+def main():
+    print("Collecting environment information...")
+    output = get_pretty_env_info()
+    print(output)
+
+
+if __name__ == '__main__':
+    main()

--- a/memtestcase.py
+++ b/memtestcase.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+
+#SBATCH --gres=gpu:2
+#SBATCH --job-name=distributed_example
+#SBATCH --partition=dev
+#SBATCH --nodes=1
+#SBATCH --time=0:10:00
+#SBATCH --ntasks-per-node=1
+#SBATCH --mem=8G
+#SBATCH --cpus-per-task=10
+
+import os
+import argparse
+import torch
+import torch.nn as nn
+import torch.distributed as td
+import torch.nn.parallel as tp
+
+START_BS = 8 * 1024
+
+# these don't matter, just constants meant to be a "big" model
+INPUT_SIZE = 8192
+HID_SIZE = 4096
+LAYERS = 8
+OUT_CLASSES = 4
+
+
+def wrap_dp(model):
+    return tp.DataParallel(model)
+
+
+def wrap_ddp(model):
+    td.init_process_group(
+        backend='nccl',
+        init_method='tcp://localhost:61337',
+        rank=0,
+        world_size=1
+    )
+    model = tp.DistributedDataParallel(
+        model,
+        device_ids=None,
+        broadcast_buffers=False,
+    )
+    return model
+
+
+def create_model(args):
+    model = nn.Sequential(
+        nn.Linear(INPUT_SIZE, HID_SIZE),
+        nn.ReLU(),
+    )
+    for i in range(LAYERS):
+        model.add_module('hidd' + str(i), nn.Linear(HID_SIZE, HID_SIZE))
+        model.add_module('relu' + str(i), nn.ReLU())
+    model.add_module('output', nn.Linear(HID_SIZE, OUT_CLASSES))
+    return model
+
+
+def fwbw(model, bs):
+    print('  Forward with bs  = {:-6d}'.format(bs))
+    X = torch.randn(bs, INPUT_SIZE).cuda()
+    torch.cuda.synchronize()
+    yhat = model(X)
+    torch.cuda.synchronize()
+    loss = yhat.sum()
+    torch.cuda.synchronize()
+    print('  Backward with bs = {:-6d}'.format(bs))
+    loss.backward()
+    torch.cuda.synchronize()
+    model.zero_grad()
+    torch.cuda.synchronize()
+
+
+def run_trial(args):
+    print('Conda PREFIX:', os.environ['CONDA_PREFIX'])
+    print('Torch version:', torch.version.__version__)
+    print('CUDA version:', torch.version.cuda)
+
+    model = create_model(args).cuda()
+    if args.mode == 'dp':
+        print('Wrapping in DataParallel')
+        model = wrap_dp(model)
+    elif args.mode == 'ddp_multi':
+        print('Wrapping in DistributedDataParallel (equiv to 1 proc per node)')
+        model = wrap_ddp(model)
+    elif args.mode == 'ddp_single':
+        print('Using a single GPU in distributed (equiv to 1 proc per gpu)')
+        torch.cuda.set_device(0)
+    elif args.mode == 'single':
+        print('Using a single GPU')
+        pass
+    else:
+        raise ValueError('--mode wrong')
+
+    bs = args.bs
+    times_oomed = 0
+    while times_oomed < args.ooms:
+        # continuously double the batch size until we OOM
+        try:
+            print('Step bs=', bs)
+            fwbw(model, bs)
+            print('FW/BW succeeded. Doubling BS')
+            bs *= 2
+        except RuntimeError as rerr:
+            if 'memory' not in str(rerr):
+                # not the exception we wanted
+                raise rerr
+            # okay, we found the memory error! Now try to run a NOOP pass
+            # for DDP nodes. Production example here:
+            # https://github.com/pytorch/fairseq/blob/3658fa329b8cb987d951b2e38ec86c44b9e1fea5/fairseq/trainer.py#L361-L368
+            times_oomed += 1
+            print('OOM #{}! Running through a tiny batch to catch up worker'.format(times_oomed))
+            fwbw(model, 2)
+            print('Succeeded on the oom batch.')
+            # start the doubling procedure again
+            bs = args.bs
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--mode', default='ddp', choices=('dp', 'ddp_multi', 'ddp_single', 'single'),
+        help='DataParallel, DistributedDataParallel, or single gpu'
+    )
+    parser.add_argument(
+        '--ooms', default=1, type=int,
+        help='Number of times to OOM'
+    )
+    parser.add_argument(
+        '--bs', default=START_BS, type=int,
+        help='Initial batch size',
+    )
+    args = parser.parse_args()
+    run_trial(args)
+    print('Test passed.')
+
+
+if __name__ == '__main__':
+    main()

--- a/parlai/agents/bert_ranker/bi_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/bi_encoder_ranker.py
@@ -40,11 +40,6 @@ class BiEncoderRankerAgent(TorchRankerAgent):
 
         super().__init__(opt, shared)
         # it's easier for now to use DataParallel when
-        self.data_parallel = opt.get('data_parallel') and self.use_cuda
-        if self.data_parallel:
-            self.model = torch.nn.DataParallel(self.model)
-        if is_distributed():
-            raise ValueError('Cannot combine --data-parallel and distributed mode')
         self.NULL_IDX = self.dict.pad_idx
         self.START_IDX = self.dict.start_idx
         self.END_IDX = self.dict.end_idx

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -36,11 +36,6 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
 
         super().__init__(opt, shared)
         # it's easier for now to use DataParallel when
-        self.data_parallel = opt.get('data_parallel') and self.use_cuda
-        if self.data_parallel:
-            self.model = torch.nn.DataParallel(self.model)
-        if is_distributed():
-            raise ValueError('Cannot combine --data-parallel and distributed mode')
         self.clip = -1
         self.NULL_IDX = self.dict.pad_idx
         self.START_IDX = self.dict.start_idx

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -90,17 +90,6 @@ class TransformerRankerAgent(TorchRankerAgent):
 
         return agent
 
-    def __init__(self, opt, shared=None):
-        super().__init__(opt, shared)
-        self.data_parallel = opt.get('data_parallel') and self.use_cuda
-        if self.data_parallel:
-            from parlai.core.distributed_utils import is_distributed
-            if is_distributed():
-                raise ValueError(
-                    'Cannot combine --data-parallel and distributed mode'
-                )
-            self.model = torch.nn.DataParallel(self.model)
-
     def _score(self, output, cands):
         if cands.dim() == 2:
             return torch.matmul(output, cands.t())

--- a/parlai/core/distributed_utils.py
+++ b/parlai/core/distributed_utils.py
@@ -222,6 +222,7 @@ def distributed_wrapper(model, gpu=None):
 
     if gpu == -1:
         device_ids = None
+        print("Using all devices")
     elif isinstance(gpu, int):
         device_ids = [gpu]
     else:
@@ -230,5 +231,5 @@ def distributed_wrapper(model, gpu=None):
     return torch.nn.parallel.DistributedDataParallel(
         model,
         device_ids=device_ids,
-        # broadcast_buffers=False,
+        broadcast_buffers=False,
     )

--- a/parlai/core/distributed_utils.py
+++ b/parlai/core/distributed_utils.py
@@ -201,3 +201,34 @@ def sync_object(data, max_size=16384):
             )
 
     return data
+
+
+def distributed_wrapper(model, gpu=None):
+    """
+    Prepare a model for distributed training.
+
+    If not in distributed mode, this is a nop
+
+    :param model:
+        A torch nn.Module. Generally the model you want to parallelize
+    :param gpu:
+        An int referring to which GPU should be used for this instance. If -1,
+        all GPUs on the machine are used.
+    :return:
+        The distributed model
+    """
+    if not is_distributed():
+        return model
+
+    if gpu == -1:
+        device_ids = None
+    elif isinstance(gpu, int):
+        device_ids = [gpu]
+    else:
+        raise ValueError('Invalid input gpu={}'.format(gpu))
+
+    return torch.nn.parallel.DistributedDataParallel(
+        model,
+        device_ids=device_ids,
+        # broadcast_buffers=False,
+    )

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -14,7 +14,7 @@ from itertools import islice
 from parlai.core.torch_agent import TorchAgent, Output
 from parlai.core.thread_utils import SharedTable
 from parlai.core.utils import round_sigfigs, padded_3d, warn_once, padded_tensor
-from parlai.core.distributed_utils import is_distributed
+from parlai.core.distributed_utils import is_distributed, distributed_wrapper
 
 
 class TorchRankerAgent(TorchAgent):
@@ -118,11 +118,7 @@ class TorchRankerAgent(TorchAgent):
             self.build_lr_scheduler(states)
 
         if shared is None and is_distributed():
-            self.model = torch.nn.parallel.DistributedDataParallel(
-                self.model,
-                device_ids=[self.opt['gpu']],
-                broadcast_buffers=False,
-            )
+            self.model = distributed_wrapper(self.model, self.opt['gpu'])
 
     def score_candidates(self, batch, cand_vecs, cand_encs=None):
         """

--- a/parlai/scripts/hybrid_train.py
+++ b/parlai/scripts/hybrid_train.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Distributed training script. NOT MEANT TO BE CALLED DIRECTLY BY USER.
+
+This script is meant to be in conjunction with
+`SLURM <https://slurm.schedmd.com/>`, which provides environmental variables
+describing the environment.
+
+An example sbatch script is below, for a 2-host, 8-GPU setup (16 total gpus):
+
+.. code-block:: bash\n\n
+
+  #!/bin/sh
+  #SBATCH --job-name=distributed_example
+  #SBATCH --output=/path/to/savepoint/stdout.%j
+  #SBATCH --error=/path/to/savepoint/stderr.%j
+  #SBATCH --partition=priority
+  #SBATCH --nodes=2
+  #SBATCH --time=0:10:00
+  #SBATCH --signal=SIGINT
+  #SBATCH --gres=gpu:8
+  #SBATCH --ntasks-per-node=1  # differs from distributed
+  #SBATCH --mem=64G
+  #SBATCH --cpus-per-task=10
+  srun python -u -m parlai.scripts.distributed_train \
+    -m seq2seq -t convai2 --dict-file /path/to/dict-file
+
+"""
+
+import os
+import socket
+import subprocess
+
+import parlai.scripts.train_model as single_train
+from parlai.scripts.multiprocessing_train import multiprocess_train
+
+
+def main():
+    # double check we're using SLURM
+    node_list = os.environ.get('SLURM_JOB_NODELIST')
+    if node_list is None:
+        raise RuntimeError(
+            'Does not appear to be in a SLURM environment. '
+            'You should not call this script directly; see launch_distributed.py'
+        )
+
+    parser = single_train.setup_args()
+    parser.add_distributed_training_args()
+    parser.add_argument('--port', type=int, default=61337, help='TCP port number')
+    opt = parser.parse_args(print_args=(os.environ['SLURM_PROCID'] == '0'))
+
+    # We can determine the init method automatically for Slurm.
+    try:
+        # Figure out the main host, and which rank we are.
+        hostnames = subprocess.check_output(
+            ['scontrol', 'show', 'hostnames', node_list]
+        )
+        main_host = hostnames.split()[0].decode('utf-8')
+        distributed_rank = int(os.environ['SLURM_PROCID'])
+        port = opt['port']
+        print(
+            'Initializing host {} as rank {}'
+            .format(socket.gethostname(), distributed_rank)
+        )
+        # Begin distributed training
+        multiprocess_train(distributed_rank, opt, port, -1, main_host)
+    except subprocess.CalledProcessError as e:
+        # scontrol failed
+        raise e
+    except FileNotFoundError:
+        # Slurm is not installed
+        raise RuntimeError('SLURM does not appear to be installed.')
+
+
+if __name__ == '__main__':
+    main()

--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -45,6 +45,7 @@ def multiprocess_train(rank, opt, port=61337, gpu=None, hostname='localhost'):
         multiple distributed training setups on the same machine.
     :param int gpu: Which GPU to use. Defaults to using rank and local devices,
         but must be manually specified when using many-hosts.
+        TODO UPDATE
     :param str hostname: Hostname of the main server.
     """
     # Set per-host options
@@ -70,7 +71,10 @@ def multiprocess_train(rank, opt, port=61337, gpu=None, hostname='localhost'):
     )
 
     # perform distributed setup, ensuring all hosts are ready
-    torch.cuda.set_device(opt['gpu'])
+    if gpu != -1:
+        assert isinstance(gpu, int)
+        import ipdb; ipdb.set_trace()
+        torch.cuda.set_device(opt['gpu'])
     dist.init_process_group(
         backend="nccl",
         init_method="tcp://{}:{}".format(hostname, port),

--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -73,7 +73,6 @@ def multiprocess_train(rank, opt, port=61337, gpu=None, hostname='localhost'):
     # perform distributed setup, ensuring all hosts are ready
     if gpu != -1:
         assert isinstance(gpu, int)
-        import ipdb; ipdb.set_trace()
         torch.cuda.set_device(opt['gpu'])
     dist.init_process_group(
         backend="nccl",

--- a/run.sh
+++ b/run.sh
@@ -2,16 +2,6 @@
 
 nvidia-smi
 
-. /public/apps/anaconda3/5.0.1/etc/profile.d/conda.sh
-
-
-echo
-echo "======================================================================="
-echo "Activating pytorch nightly"
-echo "======================================================================="
-conda deactivate
-conda activate nightly
-echo
 echo "Collect env"
 echo "------------------------------------------------------------"
 python collect_env.py

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+nvidia-smi
+
+. /public/apps/anaconda3/5.0.1/etc/profile.d/conda.sh
+
+
+echo
+echo "======================================================================="
+echo "Activating pytorch nightly"
+echo "======================================================================="
+conda deactivate
+conda activate nightly
+echo
+echo "Collect env"
+echo "------------------------------------------------------------"
+python collect_env.py
+echo
+
+for mode in single dp ddp_single ddp_multi
+do
+    echo "Running mode=$mode"
+    echo "------------------------------------------------------------"
+    python -u memtestcase.py --mode=$mode 2>&1
+    echo
+done
+
+


### PR DESCRIPTION
Work in progress, you can ignore for now.

DistributedDataParallel has a mode where it acts like a DataParallel locally, but still broadcast gradients across all workers. This allows for a sort of "hybrid" training, where a local machine can use all GPUs for `-cands batch` negative samples, but still get the speedup from using multiple workers. Also can be run locally on one machine where it just behaves like DataParallel, getting rid of the need for having both code paths.

This is a "simpler" solution to the idea proposed by #1416. I suspect it will work well since individuals have reported there can be a sweet spot with number of negative candidates.

Issues:
- [x] DDP in this mode is broken internal fairseq env 20190211 (hard crashes). [cc @myleott] Fixed in torch stable (1.0.1post2).
- [ ] Cannot recover from a CUDA OOM. Need to file a bug with pytorch. For some reason, catching the RuntimeError doesn't clear any CUDA memory. This results in the dummy pass also OOMing, making the error unrecoverable. Frustratingly, this happens even when using only a world size of 1.
- [x] Make a minimum test case. File a pytorch bug.