### PR TITLE
Update FastText URLs.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -845,18 +845,12 @@ class TorchAgent(Agent):
                                     'models:glove_vectors'))
         elif emb_type.startswith('fasttext_cc'):
             init = 'fasttext_cc'
-            from parlai.zoo.fasttext_cc_vectors.build import url as fasttext_cc_url
-            embs = vocab.Vectors(
-                name='crawl-300d-2M.vec',
-                url=fasttext_cc_url,
-                cache=modelzoo_path(self.opt.get('datapath'),
-                                    'models:fasttext_cc_vectors'))
+            from parlai.zoo.fasttext_cc_vectors.build import download
+            embs = download(self.opt.get('datapath'))
         elif emb_type.startswith('fasttext'):
             init = 'fasttext'
-            embs = vocab.FastText(
-                language='en',
-                cache=modelzoo_path(self.opt.get('datapath'),
-                                    'models:fasttext_vectors'))
+            from parlai.zoo.fasttext_vectors.build import download
+            embs = download(self.opt.get('datapath'))
         else:
             raise RuntimeError('embedding type {} not implemented. check arg, '
                                'submit PR to this function, or override it.'

--- a/parlai/zoo/fasttext_cc_vectors/build.py
+++ b/parlai/zoo/fasttext_cc_vectors/build.py
@@ -8,13 +8,14 @@
 """
 
 import torchtext.vocab as vocab
+from parlai.core.build_data import modelzoo_path
 
-url = 'https://s3-us-west-1.amazonaws.com/fasttext-vectors/crawl-300d-2M.vec.zip'
+URL = 'https://dl.fbaipublicfiles.com/fasttext/vectors-english/crawl-300d-2M.vec.zip'
 
 
 def download(datapath):
-    vocab.Vectors(
+    return vocab.Vectors(
         name='crawl-300d-2M.vec',
-        url=url,
-        cache=datapath + '/models/fasttext_cc_vectors'
+        url=URL,
+        cache=modelzoo_path(datapath, 'models:fasttext_cc_vectors'),
     )

--- a/parlai/zoo/fasttext_vectors/build.py
+++ b/parlai/zoo/fasttext_vectors/build.py
@@ -11,6 +11,7 @@ from parlai.core.build_data import modelzoo_path
 
 URL = 'https://dl.fbaipublicfiles.com/fasttext/vectors-wiki/wiki.en.vec'
 
+
 def download(datapath):
     return vocab.Vectors(
         name='wiki.en.vec',

--- a/parlai/zoo/fasttext_vectors/build.py
+++ b/parlai/zoo/fasttext_vectors/build.py
@@ -7,7 +7,13 @@
 """
 
 import torchtext.vocab as vocab
+from parlai.core.build_data import modelzoo_path
 
+URL = 'https://dl.fbaipublicfiles.com/fasttext/vectors-wiki/wiki.en.vec'
 
 def download(datapath):
-    vocab.FastText(language='en', cache=datapath + '/models/fasttext_vectors')
+    return vocab.Vectors(
+        name='wiki.en.vec',
+        url=URL,
+        cache=modelzoo_path(datapath, 'models:fasttext_vectors'),
+    )


### PR DESCRIPTION
Fixes #1587. pytorch/text#521 might not be merged quickly, so updating the URLs within ParlAI.

Took the liberty of trying to better reuse code in torch text, but I'm not sure the result is actually cleaner. Opinions welcome.