### PR TITLE
clean form field after sending

### DIFF
--- a/parlai/mturk/core/react_server/dev/components/core_components.jsx
+++ b/parlai/mturk/core/react_server/dev/components/core_components.jsx
@@ -955,6 +955,11 @@ class FormResponse extends React.Component {
         { form_responses: response_data },
         () => this.setState({ sending: false })
       );
+      // clear answers once sent
+      this.setState(prevState => {
+        prevState['responses'].fill('');
+        return { responses: prevState['responses']};
+      });
     }
   }
 


### PR DESCRIPTION
Following up a remark from @ethanjperez in #1542 , 
the fields of the form were not clearing themselves after sending an answer.
They should do now.
<img width="1068" alt="Screen Shot 2019-04-02 at 11 57 13 AM" src="https://user-images.githubusercontent.com/4238961/55394244-25faba00-553f-11e9-9a5a-7a45cf820da3.png">
