### PR TITLE
Fix Dict Saving

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -525,7 +525,7 @@ class DictionaryAgent(Agent):
 
         make_dir(os.path.dirname(filename))
         with open(filename, 'a' if append else 'w') as write:
-            for i in range(len(self.ind2tok)):
+            for i in self.ind2tok.keys():
                 tok = self.ind2tok[i]
                 cnt = self.freq[tok]
                 write.write('{tok}\t{cnt}\n'.format(tok=escape(tok), cnt=cnt))


### PR DESCRIPTION
Dict saving used to iterate over the length of the `ind2tok` dictionary; however, this fails if certain tokens are added at different indices (e.g. `CLS` in bert is `101`). We now iterate over the dict keys