### PR TITLE
Fix nightly CPU tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,7 @@ jobs:
       - installtorchcpu
       - run:
           name: All nightly CPU tests
+          no_output_timeout: 30m
           command: python setup.py test -s tests.suites.nightly_cpu -v
 
   deploy_website:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,6 @@ workflows:
       - lint
       - datatests
       - unittests
-      - nightly_cpu_tests
       - deploy_website:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,7 @@ workflows:
       - lint
       - datatests
       - unittests
+      - nightly_cpu_tests
       - deploy_website:
           filters:
             branches:

--- a/parlai/core/testing_utils.py
+++ b/parlai/core/testing_utils.py
@@ -8,6 +8,7 @@
 General utilities for helping writing ParlAI unit and integration tests.
 """
 
+import sys
 import os
 import unittest
 import contextlib
@@ -125,12 +126,12 @@ def git_changed_files(skip_nonexisting=True):
 
 
 class TeeStringIO(io.StringIO):
-    def __init__(self, *args, backupstream=None):
-        self.stream = backupstream
+    def __init__(self, *args, stream=None):
+        self.stream = stream
         super().__init__(*args)
 
     def write(self, data):
-        if self.stream:
+        if DEBUG and self.stream:
             self.stream.write(data)
         super().write(data)
 
@@ -149,13 +150,9 @@ def capture_output():
     >>> output.getvalue()
     'hello'
     """
-    if DEBUG:
-        yield
-    else:
-        import sys
-        sio = TeeStringIO(backupstream=sys.stdout)
-        with contextlib.redirect_stdout(sio), contextlib.redirect_stderr(sio):
-            yield sio
+    sio = TeeStringIO(backupstream=sys.stdout)
+    with contextlib.redirect_stdout(sio), contextlib.redirect_stderr(sio):
+        yield sio
 
 
 @contextlib.contextmanager

--- a/parlai/core/testing_utils.py
+++ b/parlai/core/testing_utils.py
@@ -126,8 +126,11 @@ def git_changed_files(skip_nonexisting=True):
 
 
 class TeeStringIO(io.StringIO):
-    def __init__(self, *args, stream=None):
-        self.stream = stream
+    """
+    StringIO which also prints to stdout.
+    """
+    def __init__(self, *args):
+        self.stream = sys.stdout
         super().__init__(*args)
 
     def write(self, data):
@@ -150,7 +153,7 @@ def capture_output():
     >>> output.getvalue()
     'hello'
     """
-    sio = TeeStringIO(backupstream=sys.stdout)
+    sio = TeeStringIO()
     with contextlib.redirect_stdout(sio), contextlib.redirect_stderr(sio):
         yield sio
 

--- a/parlai/core/testing_utils.py
+++ b/parlai/core/testing_utils.py
@@ -124,6 +124,17 @@ def git_changed_files(skip_nonexisting=True):
     return filenames
 
 
+class TeeStringIO(io.StringIO):
+    def __init__(self, *args, backupstream=None):
+        self.stream = backupstream
+        super().__init__(*args)
+
+    def write(self, data):
+        if self.stream:
+            self.stream.write(data)
+        super().write(data)
+
+
 @contextlib.contextmanager
 def capture_output():
     """
@@ -141,7 +152,8 @@ def capture_output():
     if DEBUG:
         yield
     else:
-        sio = io.StringIO()
+        import sys
+        sio = TeeStringIO(backupstream=sys.stdout)
         with contextlib.redirect_stdout(sio), contextlib.redirect_stderr(sio):
             yield sio
 

--- a/tests/nightly/cpu/test_pytorch_data_teacher_integration.py
+++ b/tests/nightly/cpu/test_pytorch_data_teacher_integration.py
@@ -15,6 +15,7 @@ parser_defaults = {
     'batchsize': 32,
     'momentum':  0.9,
     'validation_every_n_secs': 30,
+    'log_every_n_secs': 10,
     'batch_length_range': 5,
 }
 

--- a/tests/nightly/cpu/test_pytorch_data_teacher_integration.py
+++ b/tests/nightly/cpu/test_pytorch_data_teacher_integration.py
@@ -22,8 +22,8 @@ parser_defaults = {
     'dropout': 0.0,
     'gradient_clip': 1.0,
     'lookuptable': 'all',
-    'num_epochs': 20,
-    'validate_every_n_epochs': 5,
+    'num_epochs': 50,
+    'validation_every_n_epochs': 5,
     'log_every_n_secs': 1,
     'batch_length_range': 5,
 }

--- a/tests/nightly/cpu/test_pytorch_data_teacher_integration.py
+++ b/tests/nightly/cpu/test_pytorch_data_teacher_integration.py
@@ -28,6 +28,7 @@ parser_defaults = {
     'batch_length_range': 5,
 }
 
+
 def solved_task(str_output, valid, test):
     return (
         valid['ppl'] < 1.3 and

--- a/tests/nightly/cpu/test_pytorch_data_teacher_integration.py
+++ b/tests/nightly/cpu/test_pytorch_data_teacher_integration.py
@@ -13,22 +13,12 @@ parser_defaults = {
     'model': 'seq2seq',
     'pytorch_teacher_task': 'babi:task10k:1',
     'batchsize': 32,
-    'optimizer':  'adam',
-    'embeddingsize': 32,
-    'hiddensize': 256,
-    'learningrate': 1e-3,
-    'gradient_clip': 0.0,
-    'validation_every_n_epochs': 0.5,
-    'num_epochs': 20,
+    'momentum':  0.9,
+    'validation_every_n_secs': 30,
     'batch_length_range': 5,
-    'attention': 'general',
-    'rnn_class': 'gru',
-    'lookuptable': 'all',
-    'no_cuda': True,
 }
 
-
-def solved_task(str_output, valid, test):
+def solved_task(str_output):
     return '[ task solved! stopping. ]' in str_output
 
 

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -20,7 +20,7 @@ class TestSeq2Seq(unittest.TestCase):
         stdout, valid, test = testing_utils.train_model(dict(
             task='integration_tests:candidate',
             model='seq2seq',
-            lr=LR,
+            learningrate=LR,
             batchsize=BATCH_SIZE,
             num_epochs=NUM_EPOCHS,
             numthreads=1,
@@ -45,7 +45,7 @@ class TestSeq2Seq(unittest.TestCase):
         stdout, valid, test = testing_utils.train_model(dict(
             task='integration_tests:nocandidate',
             model='seq2seq',
-            lr=LR,
+            learningrate=LR,
             batchsize=BATCH_SIZE,
             num_epochs=NUM_EPOCHS,
             numthreads=1,
@@ -74,7 +74,7 @@ class TestSeq2Seq(unittest.TestCase):
         stdout, valid, test = testing_utils.train_model(dict(
             task='integration_tests:nocandidate',
             model='seq2seq',
-            lr=LR,
+            learningrate=LR,
             batchsize=BATCH_SIZE,
             num_epochs=NUM_EPOCHS,
             numthreads=1,
@@ -111,7 +111,7 @@ class TestSeq2Seq(unittest.TestCase):
         stdout, _, _ = testing_utils.train_model(dict(
             task='integration_tests:bad_example',
             model='seq2seq',
-            lr=LR,
+            learningrate=LR,
             batchsize=10,
             datatype='train:ordered:stream',
             num_epochs=1,
@@ -131,7 +131,7 @@ class TestHogwildSeq2seq(unittest.TestCase):
         stdout, valid, test = testing_utils.train_model(dict(
             task='integration_tests:multiturn_nocandidate',
             model='seq2seq',
-            lr=LR,
+            learningrate=LR,
             batchsize=BATCH_SIZE,
             num_epochs=NUM_EPOCHS * 2,
             numthreads=2,


### PR DESCRIPTION
- Ensures nightly CPU tests are given plenty of timeout
- Enables Teeing the captured stdout, which is very helpful when debugging a particular test. Sam and I had discussed this at one point
- Fixup the pytorch test so it runs much faster and has a looser requirement for "task solved".
- Realized seq2seq tests weren't using the LR parameter properly. NBD because the default was the same, but should fix this.