### PR TITLE
Missing dict file

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -38,6 +38,7 @@ This module also provides a utility method:
 """
 
 from parlai.core.build_data import modelzoo_path
+from parlai.core.utils import warn_once
 from .metrics import Metrics, aggregate_metrics
 import copy
 import importlib
@@ -397,7 +398,7 @@ def load_agent_module(opt):
             old_dict_file = new_opt['dict_file']
             new_opt['dict_file'] = model_file + '.dict'
         if not os.path.isfile(new_opt['dict_file']):
-            raise RuntimeError(
+            warn_once(
                 'WARNING: Neither the specified dict file ({}) nor the '
                 '`model_file`.dict file ({}) exists, check to make sure either '
                 'is correct'.format(old_dict_file, new_opt['dict_file'])

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -401,7 +401,8 @@ def load_agent_module(opt):
             warn_once(
                 'WARNING: Neither the specified dict file ({}) nor the '
                 '`model_file`.dict file ({}) exists, check to make sure either '
-                'is correct'.format(old_dict_file, new_opt['dict_file'])
+                'is correct. This may manifest as a shape mismatch later '
+                'on.'.format(old_dict_file, new_opt['dict_file'])
             )
         model_class = get_agent_module(new_opt['model'])
 


### PR DESCRIPTION
Related to #1594.

Let's (loudly) warn instead of raising a RuntimeError, some models do not require us building a dictionary (like the TFIDF retriever and BERT models).