### PR TITLE
Use a more sensible maxlen than 1.

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -603,7 +603,10 @@ class TorchGeneratorAgent(TorchAgent):
             )
         elif self.beam_size == 1:
             # greedy decode
-            _, preds, *_ = self.model(*self._model_input(batch), bsz=bsz)
+            maxlen = self.label_truncate or 256
+            _, preds, *_ = self.model(
+                *self._model_input(batch), bsz=bsz, maxlen=maxlen
+            )
         elif self.beam_size > 1:
             out = self.beam_search(
                 self.model,


### PR DESCRIPTION
Fixes #1629.

Issue is that longest_label is set to 1 for transformer and never stored in the state_dict. This doesn't come up during training because then longest_label is set up properly.

I've been wanting to deprecate longest_label so this is a hack around it.