### PR TITLE
[MTurk] Fixing onboarding test possibly

### DIFF
--- a/parlai/mturk/core/dev/test/test_full_system.py
+++ b/parlai/mturk/core/dev/test/test_full_system.py
@@ -570,7 +570,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def test_expire_onboarding(self):
         manager = self.mturk_manager
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -585,12 +584,15 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
         manager._expire_onboarding_pool()
 
-        self.onboarding_agents[agent_1.worker_id] = True
-
         assert_equal_by(lambda: len(
             [p for p in agent_1.message_packet
              if p.data['text'] == data_model.COMMAND_EXPIRE_HIT]
         ), 1, 10)
+
+        self.onboarding_agents[agent_1.worker_id] = True
+
+        self.assertEqual(
+            agent_1_object.get_status(), AssignState.STATUS_EXPIRED)
 
         # Assert sockets are closed
         assert_equal_by(lambda: len(

--- a/parlai/mturk/core/dev/test/test_full_system.py
+++ b/parlai/mturk/core/dev/test/test_full_system.py
@@ -420,7 +420,8 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def onboard_agent(self, worker):
         self.onboarding_agents[worker.worker_id] = False
-        while self.onboarding_agents[worker.worker_id] is False:
+        while ((worker.worker_id in self.onboarding_agents) and
+                (self.onboarding_agents[worker.worker_id] is False)):
             time.sleep(0.05)
         return
 
@@ -569,12 +570,13 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def test_expire_onboarding(self):
         manager = self.mturk_manager
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
         self.alive_agent(agent_1)
         assert_equal_by(
-            lambda: agent_1.worker_id in self.onboarding_agents, True, 2)
+            lambda: agent_1.worker_id in self.onboarding_agents, True, 5)
         agent_1_object = manager.worker_manager.get_agent_for_assignment(
             agent_1.assignment_id)
         self.assertFalse(self.onboarding_agents[agent_1.worker_id])
@@ -588,15 +590,16 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         assert_equal_by(lambda: len(
             [p for p in agent_1.message_packet
              if p.data['text'] == data_model.COMMAND_EXPIRE_HIT]
-        ), 1, 2)
+        ), 1, 5)
 
         # Assert sockets are closed
         assert_equal_by(lambda: len(
             [x for x in manager.socket_manager.run.values() if not x]
-        ), 1, 2)
+        ), 1, 5)
 
     def test_reconnect_complete(self):
         manager = self.mturk_manager
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -677,6 +680,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         manager.is_unique = True
         manager.opt['unique_qual_name'] = unique_worker_qual
         manager.unique_qual_name = unique_worker_qual
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -769,6 +773,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
     def test_break_multi_convo(self):
         manager = self.mturk_manager
         manager.opt['allowed_conversations'] = 1
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -876,6 +881,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def test_return_to_waiting_on_world_start(self):
         manager = self.mturk_manager
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1

--- a/parlai/mturk/core/dev/test/test_full_system.py
+++ b/parlai/mturk/core/dev/test/test_full_system.py
@@ -576,7 +576,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         agent_1 = self.agent_1
         self.alive_agent(agent_1)
         assert_equal_by(
-            lambda: agent_1.worker_id in self.onboarding_agents, True, 5)
+            lambda: agent_1.worker_id in self.onboarding_agents, True, 10)
         agent_1_object = manager.worker_manager.get_agent_for_assignment(
             agent_1.assignment_id)
         self.assertFalse(self.onboarding_agents[agent_1.worker_id])
@@ -590,16 +590,15 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         assert_equal_by(lambda: len(
             [p for p in agent_1.message_packet
              if p.data['text'] == data_model.COMMAND_EXPIRE_HIT]
-        ), 1, 5)
+        ), 1, 10)
 
         # Assert sockets are closed
         assert_equal_by(lambda: len(
             [x for x in manager.socket_manager.run.values() if not x]
-        ), 1, 5)
+        ), 1, 10)
 
     def test_reconnect_complete(self):
         manager = self.mturk_manager
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -680,7 +679,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         manager.is_unique = True
         manager.opt['unique_qual_name'] = unique_worker_qual
         manager.unique_qual_name = unique_worker_qual
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -773,7 +771,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
     def test_break_multi_convo(self):
         manager = self.mturk_manager
         manager.opt['allowed_conversations'] = 1
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -881,7 +878,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def test_return_to_waiting_on_world_start(self):
         manager = self.mturk_manager
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1

--- a/parlai/mturk/core/legacy_2018/test/test_full_system.py
+++ b/parlai/mturk/core/legacy_2018/test/test_full_system.py
@@ -570,7 +570,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def test_expire_onboarding(self):
         manager = self.mturk_manager
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -585,12 +584,15 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
         manager._expire_onboarding_pool()
 
-        self.onboarding_agents[agent_1.worker_id] = True
-
         assert_equal_by(lambda: len(
             [p for p in agent_1.message_packet
              if p.data['text'] == data_model.COMMAND_EXPIRE_HIT]
         ), 1, 10)
+
+        self.onboarding_agents[agent_1.worker_id] = True
+
+        self.assertEqual(
+            agent_1_object.get_status(), AssignState.STATUS_EXPIRED)
 
         # Assert sockets are closed
         assert_equal_by(lambda: len(

--- a/parlai/mturk/core/legacy_2018/test/test_full_system.py
+++ b/parlai/mturk/core/legacy_2018/test/test_full_system.py
@@ -420,7 +420,8 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def onboard_agent(self, worker):
         self.onboarding_agents[worker.worker_id] = False
-        while self.onboarding_agents[worker.worker_id] is False:
+        while ((worker.worker_id in self.onboarding_agents) and
+                (self.onboarding_agents[worker.worker_id] is False)):
             time.sleep(0.05)
         return
 
@@ -569,12 +570,13 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def test_expire_onboarding(self):
         manager = self.mturk_manager
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
         self.alive_agent(agent_1)
         assert_equal_by(
-            lambda: agent_1.worker_id in self.onboarding_agents, True, 2)
+            lambda: agent_1.worker_id in self.onboarding_agents, True, 5)
         agent_1_object = manager.worker_manager.get_agent_for_assignment(
             agent_1.assignment_id)
         self.assertFalse(self.onboarding_agents[agent_1.worker_id])
@@ -588,15 +590,16 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         assert_equal_by(lambda: len(
             [p for p in agent_1.message_packet
              if p.data['text'] == data_model.COMMAND_EXPIRE_HIT]
-        ), 1, 2)
+        ), 1, 5)
 
         # Assert sockets are closed
         assert_equal_by(lambda: len(
             [x for x in manager.socket_manager.run.values() if not x]
-        ), 1, 2)
+        ), 1, 5)
 
     def test_reconnect_complete(self):
         manager = self.mturk_manager
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -677,6 +680,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         manager.is_unique = True
         manager.opt['unique_qual_name'] = unique_worker_qual
         manager.unique_qual_name = unique_worker_qual
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -769,6 +773,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
     def test_break_multi_convo(self):
         manager = self.mturk_manager
         manager.opt['allowed_conversations'] = 1
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -876,6 +881,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def test_return_to_waiting_on_world_start(self):
         manager = self.mturk_manager
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1

--- a/parlai/mturk/core/legacy_2018/test/test_full_system.py
+++ b/parlai/mturk/core/legacy_2018/test/test_full_system.py
@@ -576,7 +576,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         agent_1 = self.agent_1
         self.alive_agent(agent_1)
         assert_equal_by(
-            lambda: agent_1.worker_id in self.onboarding_agents, True, 5)
+            lambda: agent_1.worker_id in self.onboarding_agents, True, 10)
         agent_1_object = manager.worker_manager.get_agent_for_assignment(
             agent_1.assignment_id)
         self.assertFalse(self.onboarding_agents[agent_1.worker_id])
@@ -590,16 +590,15 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         assert_equal_by(lambda: len(
             [p for p in agent_1.message_packet
              if p.data['text'] == data_model.COMMAND_EXPIRE_HIT]
-        ), 1, 5)
+        ), 1, 10)
 
         # Assert sockets are closed
         assert_equal_by(lambda: len(
             [x for x in manager.socket_manager.run.values() if not x]
-        ), 1, 5)
+        ), 1, 10)
 
     def test_reconnect_complete(self):
         manager = self.mturk_manager
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -680,7 +679,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         manager.is_unique = True
         manager.opt['unique_qual_name'] = unique_worker_qual
         manager.unique_qual_name = unique_worker_qual
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -773,7 +771,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
     def test_break_multi_convo(self):
         manager = self.mturk_manager
         manager.opt['allowed_conversations'] = 1
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -881,7 +878,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def test_return_to_waiting_on_world_start(self):
         manager = self.mturk_manager
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1

--- a/parlai/mturk/core/test/test_full_system.py
+++ b/parlai/mturk/core/test/test_full_system.py
@@ -570,7 +570,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def test_expire_onboarding(self):
         manager = self.mturk_manager
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -585,12 +584,15 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
         manager._expire_onboarding_pool()
 
-        self.onboarding_agents[agent_1.worker_id] = True
-
         assert_equal_by(lambda: len(
             [p for p in agent_1.message_packet
              if p.data['text'] == data_model.COMMAND_EXPIRE_HIT]
         ), 1, 10)
+
+        self.onboarding_agents[agent_1.worker_id] = True
+
+        self.assertEqual(
+            agent_1_object.get_status(), AssignState.STATUS_EXPIRED)
 
         # Assert sockets are closed
         assert_equal_by(lambda: len(

--- a/parlai/mturk/core/test/test_full_system.py
+++ b/parlai/mturk/core/test/test_full_system.py
@@ -13,7 +13,6 @@ from parlai.mturk.core.socket_manager import Packet, SocketManager
 from parlai.mturk.core.agents import AssignState
 from parlai.mturk.core.mturk_manager import MTurkManager
 from parlai.core.params import ParlaiParser
-import parlai.core.testing_utils as testing_utils
 
 import parlai.mturk.core.mturk_manager as MTurkManagerFile
 import parlai.mturk.core.data_model as data_model
@@ -421,7 +420,8 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def onboard_agent(self, worker):
         self.onboarding_agents[worker.worker_id] = False
-        while self.onboarding_agents[worker.worker_id] is False:
+        while ((worker.worker_id in self.onboarding_agents) and
+                (self.onboarding_agents[worker.worker_id] is False)):
             time.sleep(0.05)
         return
 
@@ -568,9 +568,9 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
             [x for x in manager.socket_manager.run.values() if not x]
         ), 2, 2)
 
-    @testing_utils.retry(ntries=3)
     def test_expire_onboarding(self):
         manager = self.mturk_manager
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -599,6 +599,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def test_reconnect_complete(self):
         manager = self.mturk_manager
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -679,6 +680,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         manager.is_unique = True
         manager.opt['unique_qual_name'] = unique_worker_qual
         manager.unique_qual_name = unique_worker_qual
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -771,6 +773,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
     def test_break_multi_convo(self):
         manager = self.mturk_manager
         manager.opt['allowed_conversations'] = 1
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -878,6 +881,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def test_return_to_waiting_on_world_start(self):
         manager = self.mturk_manager
+        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1

--- a/parlai/mturk/core/test/test_full_system.py
+++ b/parlai/mturk/core/test/test_full_system.py
@@ -576,7 +576,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         agent_1 = self.agent_1
         self.alive_agent(agent_1)
         assert_equal_by(
-            lambda: agent_1.worker_id in self.onboarding_agents, True, 5)
+            lambda: agent_1.worker_id in self.onboarding_agents, True, 10)
         agent_1_object = manager.worker_manager.get_agent_for_assignment(
             agent_1.assignment_id)
         self.assertFalse(self.onboarding_agents[agent_1.worker_id])
@@ -590,16 +590,15 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         assert_equal_by(lambda: len(
             [p for p in agent_1.message_packet
              if p.data['text'] == data_model.COMMAND_EXPIRE_HIT]
-        ), 1, 5)
+        ), 1, 10)
 
         # Assert sockets are closed
         assert_equal_by(lambda: len(
             [x for x in manager.socket_manager.run.values() if not x]
-        ), 1, 5)
+        ), 1, 10)
 
     def test_reconnect_complete(self):
         manager = self.mturk_manager
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -680,7 +679,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         manager.is_unique = True
         manager.opt['unique_qual_name'] = unique_worker_qual
         manager.unique_qual_name = unique_worker_qual
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -773,7 +771,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
     def test_break_multi_convo(self):
         manager = self.mturk_manager
         manager.opt['allowed_conversations'] = 1
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -881,7 +878,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
     def test_return_to_waiting_on_world_start(self):
         manager = self.mturk_manager
-        self.onboarding_agents = {}
 
         # Alive first agent
         agent_1 = self.agent_1


### PR DESCRIPTION
Ran this a lot locally, going to try to have it hit circle a few times.

Found the issue - the test only passed on fast hardware due to a race condition where the worker would be removed from the onboarding pool before the onboarding pool expiration message was sent.