### PR TITLE
[MTurk] Moving run_data

### DIFF
--- a/parlai/mturk/.gitignore
+++ b/parlai/mturk/.gitignore
@@ -1,1 +1,2 @@
 run_data/
+tmp/

--- a/parlai/mturk/README.md
+++ b/parlai/mturk/README.md
@@ -4,3 +4,4 @@
 - **tasks**: contains a number of tasks that have been launched on MTurk to collect various datasets (shared for reproducibility), as well as a few tasks that exist as examples of possible MTurk functionality
 - **scripts/**: contains various helpful review and cleanup scripts to manage tasks from the command line (especially after mistakes or major failures).
 - **webapp**: contains server and build files for the [Beta] ParlAI-MTurk frontend, which is currently under heavy development and may undergo many changes
+- **run_data/**: contains all of the cross-run state in sqlite databases (default `pmt_data.db` and `pmt_sbdata.db`), as well as any world data saved by the default behavior of `MTurkDataWorld` (in `live` and `sandbox` folders, following the behavior specified in `MTurkDataHandler`).

--- a/parlai/mturk/core/.gitignore
+++ b/parlai/mturk/core/.gitignore
@@ -1,1 +1,0 @@
-run_data/

--- a/parlai/mturk/core/README.md
+++ b/parlai/mturk/core/README.md
@@ -29,7 +29,6 @@ parlai/mturk/core on your local machine may also create a few folders and files 
 
 - **heroku_server_.../**: contains the build files for a server that was started using ParlAI. If this remains after no servers are running, it exists because a server failed to cleanup the local files, and the folder can be deleted freely.
 - **heroku-cli-v.../**: contains the bin files required to run heroku. These are stored here where we know where they are so that the server setup scripts don't need to search for existing heroku installations elsewhere.
-- **run_data/**: contains all of the cross-run state in sqlite databases (default `pmt_data.db` and `pmt_sbdata.db`), as well as any world data saved by the default behavior of `MTurkDataWorld` (in `live` and `sandbox` folders, following the behavior specified in `MTurkDataHandler`).
 
 ### Files
 

--- a/parlai/mturk/core/dev/README.md
+++ b/parlai/mturk/core/dev/README.md
@@ -30,7 +30,6 @@ parlai/mturk/core on your local machine may also create a few folders and files 
 
 - **heroku_server_.../**: contains the build files for a server that was started using ParlAI. If this remains after no servers are running, it exists because a server failed to cleanup the local files, and the folder can be deleted freely.
 - **heroku-cli-v.../**: contains the bin files required to run heroku. These are stored here where we know where they are so that the server setup scripts don't need to search for existing heroku installations elsewhere.
-- **run_data/**: contains all of the cross-run state in sqlite databases (default `pmt_data.db` and `pmt_sbdata.db`), as well as any world data saved by the default behavior of `MTurkDataWorld` (in `live` and `sandbox` folders, following the behavior specified in `MTurkDataHandler`).
 
 ### Files
 

--- a/parlai/mturk/core/dev/mturk_data_handler.py
+++ b/parlai/mturk/core/dev/mturk_data_handler.py
@@ -21,7 +21,9 @@ def force_dir(path):
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
 
-data_dir = os.path.dirname(os.path.abspath(__file__)) + '/run_data'
+core_dir = os.path.dirname(os.path.abspath(__file__))
+mturk_dir = os.path.dirname(core_dir)
+data_dir = os.path.join(mturk_dir, 'run_data')
 os.makedirs(data_dir, exist_ok=True)
 
 # Run data table:

--- a/parlai/mturk/core/legacy_2018/.gitignore
+++ b/parlai/mturk/core/legacy_2018/.gitignore
@@ -1,1 +1,0 @@
-run_data/

--- a/parlai/mturk/core/legacy_2018/README.md
+++ b/parlai/mturk/core/legacy_2018/README.md
@@ -30,7 +30,6 @@ parlai/mturk/core on your local machine may also create a few folders and files 
 
 - **heroku_server_.../**: contains the build files for a server that was started using ParlAI. If this remains after no servers are running, it exists because a server failed to cleanup the local files, and the folder can be deleted freely.
 - **heroku-cli-v.../**: contains the bin files required to run heroku. These are stored here where we know where they are so that the server setup scripts don't need to search for existing heroku installations elsewhere.
-- **run_data/**: contains all of the cross-run state in sqlite databases (default `pmt_data.db` and `pmt_sbdata.db`), as well as any world data saved by the default behavior of `MTurkDataWorld` (in `live` and `sandbox` folders, following the behavior specified in `MTurkDataHandler`).
 
 ### Files
 

--- a/parlai/mturk/core/legacy_2018/mturk_data_handler.py
+++ b/parlai/mturk/core/legacy_2018/mturk_data_handler.py
@@ -21,7 +21,9 @@ def force_dir(path):
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
 
-data_dir = os.path.dirname(os.path.abspath(__file__)) + '/run_data'
+core_dir = os.path.dirname(os.path.abspath(__file__))
+mturk_dir = os.path.dirname(core_dir)
+data_dir = os.path.join(mturk_dir, 'run_data')
 os.makedirs(data_dir, exist_ok=True)
 
 # Run data table:

--- a/parlai/mturk/core/mturk_data_handler.py
+++ b/parlai/mturk/core/mturk_data_handler.py
@@ -21,8 +21,28 @@ def force_dir(path):
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
 
-data_dir = os.path.dirname(os.path.abspath(__file__)) + '/run_data'
-os.makedirs(data_dir, exist_ok=True)
+data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'run_data')
+core_dir = os.path.dirname(os.path.abspath(__file__))
+mturk_dir = os.path.dirname(core_dir)
+new_data_dir = os.path.join(mturk_dir, 'run_data')
+
+if os.path.exists(data_dir) and not os.path.exists(new_data_dir):
+    import shutil
+    acknowledge = input(
+        'run_data is being permanently moved from `parlai/mturk/core/run_data`'
+        ' to `parlai/mturk/run_data`. Enter anything to let this script copy '
+        'run_data over. It will leave the old data in case you want to double '
+        'check, though you should be able to safely remove '
+        '`parlai/mturk/core/run_data`.'
+    )
+    shutil.copytree(data_dir, new_data_dir)
+    print('Copied. `parlai/mturk/core/run_data` can now be safely deleted.')
+else:
+    new_data_dir = os.path.join(mturk_dir, 'run_data')
+    os.makedirs(new_data_dir, exist_ok=True)
+
+data_dir = new_data_dir
+
 
 # Run data table:
 CREATE_RUN_DATA_SQL_TABLE = (

--- a/parlai/mturk/core/mturk_data_handler.py
+++ b/parlai/mturk/core/mturk_data_handler.py
@@ -29,14 +29,14 @@ new_data_dir = os.path.join(mturk_dir, 'run_data')
 if os.path.exists(data_dir) and not os.path.exists(new_data_dir):
     import shutil
     acknowledge = input(
-        'run_data is being permanently moved from `parlai/mturk/core/run_data`'
-        ' to `parlai/mturk/run_data`. Enter anything to let this script copy '
+        'run_data is being permanently moved from `{}`'
+        ' to `{}`. Enter anything to let this script copy '
         'run_data over. It will leave the old data in case you want to double '
         'check, though you should be able to safely remove '
-        '`parlai/mturk/core/run_data`.'
+        '`{}`.'.format(data_dir, new_data_dir, data_dir)
     )
     shutil.copytree(data_dir, new_data_dir)
-    print('Copied. `parlai/mturk/core/run_data` can now be safely deleted.')
+    print('Copied. `{}` can now be safely deleted.'.format(data_dir))
 else:
     new_data_dir = os.path.join(mturk_dir, 'run_data')
     os.makedirs(new_data_dir, exist_ok=True)


### PR DESCRIPTION
Moves the location that `run_data` refers to to `parlai/mturk/run_data` rather than sitting it in `core`, which wasn't really ever the right place to put it. Also includes a check to the `core.MTurkManager` to handle the migration automatically via copy. People can remove their old directory following this migration. Updates the branched copies to just refer to the correct data directory.

Updates `.gitignore`s and `README.md`s to reflect the changing situation.

As all references to `run_data` leverage the MTurkDataHandler, updating this callsite is sufficient for migration.