### PR TITLE
[MemNN] Time feature bug fix 

### DIFF
--- a/parlai/agents/memnn/memnn.py
+++ b/parlai/agents/memnn/memnn.py
@@ -63,22 +63,20 @@ class MemnnAgent(TorchRankerAgent):
         return 2
 
     def __init__(self, opt, shared=None):
-        # all instances may need some params
-        super().__init__(opt, shared)
-
         self.id = 'MemNN'
         self.memsize = opt['memsize']
         if self.memsize < 0:
             self.memsize = 0
         self.use_time_features = opt['time_features']
-
-        if not shared:
-            if opt['time_features']:
-                for i in range(self.memsize):
-                    self.dict[self._time_feature(i)] = 100000000 + i
+        super().__init__(opt, shared)
 
     def build_model(self):
         """Build MemNN model."""
+        if self.use_time_features:
+            # add time features to dictionary before building the model
+            for i in range(self.memsize):
+                self.dict[self._time_feature(i)] = 100000000 + i
+
         kwargs = opt_to_kwargs(self.opt)
         self.model = MemNN(len(self.dict), self.opt['embedding_size'],
                            padding_idx=self.NULL_IDX, **kwargs)

--- a/parlai/agents/memnn/modules.py
+++ b/parlai/agents/memnn/modules.py
@@ -36,23 +36,10 @@ class MemNN(nn.Module):
         # prepare features
         self.hops = hops
 
-        # time features: we learn an embedding for each memory slot
-        self.extra_features = 0
-        if time_features:
-            self.extra_features += memsize
-            self.time_features = torch.LongTensor(
-                range(num_features, num_features + memsize))
-
         def embedding(use_extra_feats=True):
-            if use_extra_feats:
-                return Embed(num_features + self.extra_features,
-                             embedding_size,
-                             position_encoding=position_encoding,
-                             padding_idx=padding_idx)
-            else:
-                return Embed(num_features, embedding_size,
-                             position_encoding=position_encoding,
-                             padding_idx=padding_idx)
+            return Embed(num_features, embedding_size,
+                         position_encoding=position_encoding,
+                         padding_idx=padding_idx)
 
         # TODO: add token dropout?
         # TODO: add dropout


### PR DESCRIPTION
Fixes #1639.

Time features were added to the dictionary after the model was built, resulting in a size mismatch when re-loading the model. To fix, we add the time features *before* building the model. (Note that in Torch Ranker Agent, build_model() is called if `not shared`, so we are indeed only doing this once.)