### PR TITLE
[MTurk] Using a tmp dir for scratch work. 

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -279,6 +279,10 @@ class ParlaiParser(argparse.ArgumentParser):
             '--heroku-team', dest='heroku_team', default=None,
             help='Specify Heroku team name to use for launching Dynos.'
         )
+        mturk.add_argument(
+            '--tmp-dir', dest='tmp_dir', default=None,
+            help='Specify location to use for scratch builds and such.'
+        )
 
         mturk.set_defaults(is_sandbox=True)
         mturk.set_defaults(is_debug=False)

--- a/parlai/mturk/core/dev/mturk_data_handler.py
+++ b/parlai/mturk/core/dev/mturk_data_handler.py
@@ -21,9 +21,7 @@ def force_dir(path):
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
 
-core_dir = os.path.dirname(os.path.abspath(__file__))
-mturk_dir = os.path.dirname(core_dir)
-data_dir = os.path.join(mturk_dir, 'run_data')
+data_dir = os.path.join(shared_utils.get_mturk_dir(), 'run_data')
 os.makedirs(data_dir, exist_ok=True)
 
 # Run data table:

--- a/parlai/mturk/core/dev/mturk_manager.py
+++ b/parlai/mturk/core/dev/mturk_manager.py
@@ -154,6 +154,9 @@ class MTurkManager():
         self.db_logger = None
         self.logging_permitted = False  # Enables logging to parl.ai
         self.task_state = self.STATE_CREATED
+        if opt.get('tmp_dir') is None:
+            opt['tmp_dir'] = shared_utils.get_tmp_dir()
+        self.tmp_dir = opt['tmp_dir']
         self._init_logging_config()
         self._assert_opts()
 
@@ -1046,12 +1049,14 @@ class MTurkManager():
             self.populate_legacy_task_files(task_directory_path)
             self.server_url = server_utils.setup_legacy_server(
                 self.server_task_name, self.task_files_to_copy,
-                self.opt['local'], heroku_team, self.opt['hobby'])
+                self.opt['local'], heroku_team, self.opt['hobby'],
+                tmp_dir=self.opt['tmp_dir'])
         else:
             self.populate_task_files(task_directory_path)
             self.server_url = server_utils.setup_server(
                 self.server_task_name, self.task_files_to_copy,
-                self.opt['local'], heroku_team, self.opt['hobby'])
+                self.opt['local'], heroku_team, self.opt['hobby'],
+                tmp_dir=self.opt['tmp_dir'])
 
         shared_utils.print_and_log(logging.INFO, self.server_url)
 

--- a/parlai/mturk/core/dev/mturk_manager.py
+++ b/parlai/mturk/core/dev/mturk_manager.py
@@ -1300,7 +1300,8 @@ class MTurkManager():
         finally:
             if self.server_task_name is not None:
                 server_utils.delete_server(self.server_task_name,
-                                           self.opt['local'])
+                                           self.opt['local'],
+                                           tmp_dir=self.opt['tmp_dir'])
             if self.topic_arn is not None:
                 mturk_utils.delete_sns_topic(self.topic_arn)
             if self.opt['unique_worker'] and not self.opt['unique_qual_name']:

--- a/parlai/mturk/core/dev/mturk_utils.py
+++ b/parlai/mturk/core/dev/mturk_utils.py
@@ -150,7 +150,7 @@ def create_hit_config(opt, task_description, unique_worker, is_sandbox):
         'chat_title': opt.get('chat_title', opt.get('hit_title', 'Live Chat')),
         'template_type': opt.get('frontend_template_type', 'default'),
     }
-    hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
+    hit_config_file_path = os.path.join(opt['tmp_dir'], 'hit_config.json')
     if os.path.exists(hit_config_file_path):
         os.remove(hit_config_file_path)
     with open(hit_config_file_path, 'w') as hit_config_file:

--- a/parlai/mturk/core/dev/server_utils.py
+++ b/parlai/mturk/core/dev/server_utils.py
@@ -15,11 +15,12 @@ import shlex
 import shutil
 import subprocess
 import time
+import parlai.mturk.core.shared_utils as shared_utils
 
 region_name = 'us-east-1'
 user_name = getpass.getuser()
 
-parent_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = shared_utils.get_core_dir()
 legacy_server_source_directory_name = 'server_legacy'
 server_source_directory_name = 'react_server'
 heroku_server_directory_name = 'heroku_server'
@@ -33,7 +34,8 @@ heroku_url = \
 
 
 def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
-                               heroku_team=None, use_hobby=False):
+                               heroku_team=None, use_hobby=False,
+                               tmp_dir=parent_dir):
     print("Heroku: Collecting files...")
     # Install Heroku CLI
     os_name = None
@@ -57,13 +59,13 @@ def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
 
     # Remove existing heroku client files
     existing_heroku_directory_names = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))
     if len(existing_heroku_directory_names) == 0:
-        if os.path.exists(os.path.join(parent_dir, 'heroku.tar.gz')):
-            os.remove(os.path.join(parent_dir, 'heroku.tar.gz'))
+        if os.path.exists(os.path.join(tmp_dir, 'heroku.tar.gz')):
+            os.remove(os.path.join(tmp_dir, 'heroku.tar.gz'))
 
         # Get the heroku client and unzip
-        os.chdir(parent_dir)
+        os.chdir(tmp_dir)
         sh.wget(shlex.split('{}-{}-{}.tar.gz -O heroku.tar.gz'.format(
             heroku_url,
             os_name,
@@ -72,14 +74,14 @@ def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
         sh.tar(shlex.split('-xvzf heroku.tar.gz'))
 
     heroku_directory_name = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))[0]
-    heroku_directory_path = os.path.join(parent_dir, heroku_directory_name)
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))[0]
+    heroku_directory_path = os.path.join(tmp_dir, heroku_directory_name)
     heroku_executable_path = \
         os.path.join(heroku_directory_path, 'bin', 'heroku')
 
     server_source_directory_path = \
         os.path.join(parent_dir, legacy_server_source_directory_name)
-    heroku_server_directory_path = os.path.join(parent_dir, '{}_{}'.format(
+    heroku_server_directory_path = os.path.join(tmp_dir, '{}_{}'.format(
         heroku_server_directory_name,
         task_name
     ))
@@ -98,7 +100,7 @@ def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
         task_directory_path
     )
 
-    hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
+    hit_config_file_path = os.path.join(tmp_dir, 'hit_config.json')
     sh.mv(hit_config_file_path, task_directory_path)
 
     for file_path in task_files_to_copy:
@@ -212,8 +214,9 @@ def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
 
 
 def setup_heroku_server(task_name, task_files_to_copy=None,
-                        heroku_team=None, use_hobby=False):
-    print("Heroku: Collecting files...")
+                        heroku_team=None, use_hobby=False, tmp_dir=parent_dir):
+
+    print("Heroku: Collecting files... for ", tmp_dir)
     # Install Heroku CLI
     os_name = None
     bit_architecture = None
@@ -236,13 +239,13 @@ def setup_heroku_server(task_name, task_files_to_copy=None,
 
     # Remove existing heroku client files
     existing_heroku_directory_names = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))
     if len(existing_heroku_directory_names) == 0:
-        if os.path.exists(os.path.join(parent_dir, 'heroku.tar.gz')):
-            os.remove(os.path.join(parent_dir, 'heroku.tar.gz'))
+        if os.path.exists(os.path.join(tmp_dir, 'heroku.tar.gz')):
+            os.remove(os.path.join(tmp_dir, 'heroku.tar.gz'))
 
         # Get the heroku client and unzip
-        os.chdir(parent_dir)
+        os.chdir(tmp_dir)
         sh.wget(shlex.split('{}-{}-{}.tar.gz -O heroku.tar.gz'.format(
             heroku_url,
             os_name,
@@ -251,14 +254,14 @@ def setup_heroku_server(task_name, task_files_to_copy=None,
         sh.tar(shlex.split('-xvzf heroku.tar.gz'))
 
     heroku_directory_name = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))[0]
-    heroku_directory_path = os.path.join(parent_dir, heroku_directory_name)
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))[0]
+    heroku_directory_path = os.path.join(tmp_dir, heroku_directory_name)
     heroku_executable_path = \
         os.path.join(heroku_directory_path, 'bin', 'heroku')
 
     server_source_directory_path = \
         os.path.join(parent_dir, server_source_directory_name)
-    heroku_server_development_path = os.path.join(parent_dir, '{}_{}'.format(
+    heroku_server_development_path = os.path.join(tmp_dir, '{}_{}'.format(
         heroku_server_directory_name,
         task_name
     ))
@@ -350,7 +353,7 @@ def setup_heroku_server(task_name, task_files_to_copy=None,
         except FileNotFoundError:  # noqa: F821 we don't support python2
             pass
 
-    hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
+    hit_config_file_path = os.path.join(tmp_dir, 'hit_config.json')
     sh.mv(hit_config_file_path, target_resource_dir)
 
     print("Heroku: Starting server...")
@@ -447,18 +450,18 @@ def setup_heroku_server(task_name, task_files_to_copy=None,
     os.chdir(parent_dir)
 
     # Clean up heroku files
-    if os.path.exists(os.path.join(parent_dir, 'heroku.tar.gz')):
-        os.remove(os.path.join(parent_dir, 'heroku.tar.gz'))
+    if os.path.exists(os.path.join(tmp_dir, 'heroku.tar.gz')):
+        os.remove(os.path.join(tmp_dir, 'heroku.tar.gz'))
 
     sh.rm(shlex.split('-rf {}'.format(heroku_server_development_path)))
 
     return 'https://{}.herokuapp.com'.format(heroku_app_name)
 
 
-def delete_heroku_server(task_name):
+def delete_heroku_server(task_name, tmp_dir=parent_dir):
     heroku_directory_name = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))[0]
-    heroku_directory_path = os.path.join(parent_dir, heroku_directory_name)
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))[0]
+    heroku_directory_path = os.path.join(tmp_dir, heroku_directory_name)
     heroku_executable_path = \
         os.path.join(heroku_directory_path, 'bin', 'heroku')
 
@@ -556,7 +559,8 @@ def delete_local_server(task_name):
 
 
 def setup_legacy_server(task_name, task_files_to_copy, local=False,
-                        heroku_team=None, use_hobby=False, legacy=True):
+                        heroku_team=None, use_hobby=False, legacy=True,
+                        tmp_dir=parent_dir):
     if local:
         return setup_local_server(
             task_name,
@@ -566,22 +570,24 @@ def setup_legacy_server(task_name, task_files_to_copy, local=False,
         task_name,
         task_files_to_copy=task_files_to_copy,
         heroku_team=heroku_team, use_hobby=use_hobby,
+        tmp_dir=tmp_dir,
     )
 
 
 def setup_server(task_name, task_files_to_copy, local=False, heroku_team=None,
-                 use_hobby=False, legacy=True):
+                 use_hobby=False, legacy=True, tmp_dir=parent_dir):
     if local:
         raise Exception('Local server not yet supported for non-legacy tasks')
     return setup_heroku_server(
         task_name,
         task_files_to_copy=task_files_to_copy,
         heroku_team=heroku_team, use_hobby=use_hobby,
+        tmp_dir=tmp_dir,
     )
 
 
-def delete_server(task_name, local=False):
+def delete_server(task_name, local=False, tmp_dir=parent_dir):
     if local:
         delete_local_server(task_name)
     else:
-        delete_heroku_server(task_name)
+        delete_heroku_server(task_name, tmp_dir)

--- a/parlai/mturk/core/dev/shared_utils.py
+++ b/parlai/mturk/core/dev/shared_utils.py
@@ -7,6 +7,7 @@
 import logging
 import time
 import uuid
+import os
 
 # Sleep constants
 THREAD_SHORT_SLEEP = 0.1
@@ -55,3 +56,15 @@ def print_and_log(level, message, should_print=False):
 def generate_event_id(worker_id):
     """Return a unique id to use for identifying a packet for a worker"""
     return '{}_{}'.format(worker_id, uuid.uuid4())
+
+
+def get_mturk_dir():
+    import parlai.mturk
+    return os.path.dirname(os.path.abspath(parlai.mturk.__file__))
+
+
+def get_tmp_dir():
+    """Return the location of the temporary directory in which we store
+    things related to a run but that can be safely deleted
+    """
+    return os.path.join(get_mturk_dir(), 'tmp')

--- a/parlai/mturk/core/dev/shared_utils.py
+++ b/parlai/mturk/core/dev/shared_utils.py
@@ -63,8 +63,16 @@ def get_mturk_dir():
     return os.path.dirname(os.path.abspath(parlai.mturk.__file__))
 
 
+def get_core_dir():
+    import parlai.mturk.core
+    return os.path.dirname(os.path.abspath(parlai.mturk.core.__file__))
+
+
 def get_tmp_dir():
     """Return the location of the temporary directory in which we store
     things related to a run but that can be safely deleted
     """
-    return os.path.join(get_mturk_dir(), 'tmp')
+    tmp_dir = os.path.join(get_mturk_dir(), 'tmp')
+    if not os.path.exists(tmp_dir):
+        os.mkdir(tmp_dir)
+    return tmp_dir

--- a/parlai/mturk/core/legacy_2018/mturk_data_handler.py
+++ b/parlai/mturk/core/legacy_2018/mturk_data_handler.py
@@ -21,9 +21,7 @@ def force_dir(path):
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
 
-core_dir = os.path.dirname(os.path.abspath(__file__))
-mturk_dir = os.path.dirname(core_dir)
-data_dir = os.path.join(mturk_dir, 'run_data')
+data_dir = os.path.join(shared_utils.get_mturk_dir(), 'run_data')
 os.makedirs(data_dir, exist_ok=True)
 
 # Run data table:

--- a/parlai/mturk/core/legacy_2018/mturk_manager.py
+++ b/parlai/mturk/core/legacy_2018/mturk_manager.py
@@ -154,6 +154,9 @@ class MTurkManager():
         self.db_logger = None
         self.logging_permitted = False  # Enables logging to parl.ai
         self.task_state = self.STATE_CREATED
+        if opt.get('tmp_dir') is None:
+            opt['tmp_dir'] = shared_utils.get_tmp_dir()
+        self.tmp_dir = opt['tmp_dir']
         self._init_logging_config()
         self._assert_opts()
 
@@ -1046,12 +1049,14 @@ class MTurkManager():
             self.populate_legacy_task_files(task_directory_path)
             self.server_url = server_utils.setup_legacy_server(
                 self.server_task_name, self.task_files_to_copy,
-                self.opt['local'], heroku_team, self.opt['hobby'])
+                self.opt['local'], heroku_team, self.opt['hobby'],
+                tmp_dir=self.opt['tmp_dir'])
         else:
             self.populate_task_files(task_directory_path)
             self.server_url = server_utils.setup_server(
                 self.server_task_name, self.task_files_to_copy,
-                self.opt['local'], heroku_team, self.opt['hobby'])
+                self.opt['local'], heroku_team, self.opt['hobby'],
+                tmp_dir=self.opt['tmp_dir'])
 
         shared_utils.print_and_log(logging.INFO, self.server_url)
 

--- a/parlai/mturk/core/legacy_2018/mturk_manager.py
+++ b/parlai/mturk/core/legacy_2018/mturk_manager.py
@@ -1300,7 +1300,8 @@ class MTurkManager():
         finally:
             if self.server_task_name is not None:
                 server_utils.delete_server(self.server_task_name,
-                                           self.opt['local'])
+                                           self.opt['local'],
+                                           tmp_dir=self.opt['tmp_dir'])
             if self.topic_arn is not None:
                 mturk_utils.delete_sns_topic(self.topic_arn)
             if self.opt['unique_worker'] and not self.opt['unique_qual_name']:

--- a/parlai/mturk/core/legacy_2018/mturk_utils.py
+++ b/parlai/mturk/core/legacy_2018/mturk_utils.py
@@ -150,7 +150,7 @@ def create_hit_config(opt, task_description, unique_worker, is_sandbox):
         'chat_title': opt.get('chat_title', opt.get('hit_title', 'Live Chat')),
         'template_type': opt.get('frontend_template_type', 'default'),
     }
-    hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
+    hit_config_file_path = os.path.join(opt['tmp_dir'], 'hit_config.json')
     if os.path.exists(hit_config_file_path):
         os.remove(hit_config_file_path)
     with open(hit_config_file_path, 'w') as hit_config_file:

--- a/parlai/mturk/core/legacy_2018/server_utils.py
+++ b/parlai/mturk/core/legacy_2018/server_utils.py
@@ -15,11 +15,12 @@ import shlex
 import shutil
 import subprocess
 import time
+import parlai.mturk.core.shared_utils as shared_utils
 
 region_name = 'us-east-1'
 user_name = getpass.getuser()
 
-parent_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = shared_utils.get_core_dir()
 legacy_server_source_directory_name = 'server_legacy'
 server_source_directory_name = 'react_server'
 heroku_server_directory_name = 'heroku_server'
@@ -33,7 +34,8 @@ heroku_url = \
 
 
 def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
-                               heroku_team=None, use_hobby=False):
+                               heroku_team=None, use_hobby=False,
+                               tmp_dir=parent_dir):
     print("Heroku: Collecting files...")
     # Install Heroku CLI
     os_name = None
@@ -57,13 +59,13 @@ def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
 
     # Remove existing heroku client files
     existing_heroku_directory_names = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))
     if len(existing_heroku_directory_names) == 0:
-        if os.path.exists(os.path.join(parent_dir, 'heroku.tar.gz')):
-            os.remove(os.path.join(parent_dir, 'heroku.tar.gz'))
+        if os.path.exists(os.path.join(tmp_dir, 'heroku.tar.gz')):
+            os.remove(os.path.join(tmp_dir, 'heroku.tar.gz'))
 
         # Get the heroku client and unzip
-        os.chdir(parent_dir)
+        os.chdir(tmp_dir)
         sh.wget(shlex.split('{}-{}-{}.tar.gz -O heroku.tar.gz'.format(
             heroku_url,
             os_name,
@@ -72,14 +74,14 @@ def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
         sh.tar(shlex.split('-xvzf heroku.tar.gz'))
 
     heroku_directory_name = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))[0]
-    heroku_directory_path = os.path.join(parent_dir, heroku_directory_name)
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))[0]
+    heroku_directory_path = os.path.join(tmp_dir, heroku_directory_name)
     heroku_executable_path = \
         os.path.join(heroku_directory_path, 'bin', 'heroku')
 
     server_source_directory_path = \
         os.path.join(parent_dir, legacy_server_source_directory_name)
-    heroku_server_directory_path = os.path.join(parent_dir, '{}_{}'.format(
+    heroku_server_directory_path = os.path.join(tmp_dir, '{}_{}'.format(
         heroku_server_directory_name,
         task_name
     ))
@@ -98,7 +100,7 @@ def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
         task_directory_path
     )
 
-    hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
+    hit_config_file_path = os.path.join(tmp_dir, 'hit_config.json')
     sh.mv(hit_config_file_path, task_directory_path)
 
     for file_path in task_files_to_copy:
@@ -212,8 +214,9 @@ def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
 
 
 def setup_heroku_server(task_name, task_files_to_copy=None,
-                        heroku_team=None, use_hobby=False):
-    print("Heroku: Collecting files...")
+                        heroku_team=None, use_hobby=False, tmp_dir=parent_dir):
+
+    print("Heroku: Collecting files... for ", tmp_dir)
     # Install Heroku CLI
     os_name = None
     bit_architecture = None
@@ -236,13 +239,13 @@ def setup_heroku_server(task_name, task_files_to_copy=None,
 
     # Remove existing heroku client files
     existing_heroku_directory_names = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))
     if len(existing_heroku_directory_names) == 0:
-        if os.path.exists(os.path.join(parent_dir, 'heroku.tar.gz')):
-            os.remove(os.path.join(parent_dir, 'heroku.tar.gz'))
+        if os.path.exists(os.path.join(tmp_dir, 'heroku.tar.gz')):
+            os.remove(os.path.join(tmp_dir, 'heroku.tar.gz'))
 
         # Get the heroku client and unzip
-        os.chdir(parent_dir)
+        os.chdir(tmp_dir)
         sh.wget(shlex.split('{}-{}-{}.tar.gz -O heroku.tar.gz'.format(
             heroku_url,
             os_name,
@@ -251,14 +254,14 @@ def setup_heroku_server(task_name, task_files_to_copy=None,
         sh.tar(shlex.split('-xvzf heroku.tar.gz'))
 
     heroku_directory_name = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))[0]
-    heroku_directory_path = os.path.join(parent_dir, heroku_directory_name)
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))[0]
+    heroku_directory_path = os.path.join(tmp_dir, heroku_directory_name)
     heroku_executable_path = \
         os.path.join(heroku_directory_path, 'bin', 'heroku')
 
     server_source_directory_path = \
         os.path.join(parent_dir, server_source_directory_name)
-    heroku_server_development_path = os.path.join(parent_dir, '{}_{}'.format(
+    heroku_server_development_path = os.path.join(tmp_dir, '{}_{}'.format(
         heroku_server_directory_name,
         task_name
     ))
@@ -350,7 +353,7 @@ def setup_heroku_server(task_name, task_files_to_copy=None,
         except FileNotFoundError:  # noqa: F821 we don't support python2
             pass
 
-    hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
+    hit_config_file_path = os.path.join(tmp_dir, 'hit_config.json')
     sh.mv(hit_config_file_path, target_resource_dir)
 
     print("Heroku: Starting server...")
@@ -447,18 +450,18 @@ def setup_heroku_server(task_name, task_files_to_copy=None,
     os.chdir(parent_dir)
 
     # Clean up heroku files
-    if os.path.exists(os.path.join(parent_dir, 'heroku.tar.gz')):
-        os.remove(os.path.join(parent_dir, 'heroku.tar.gz'))
+    if os.path.exists(os.path.join(tmp_dir, 'heroku.tar.gz')):
+        os.remove(os.path.join(tmp_dir, 'heroku.tar.gz'))
 
     sh.rm(shlex.split('-rf {}'.format(heroku_server_development_path)))
 
     return 'https://{}.herokuapp.com'.format(heroku_app_name)
 
 
-def delete_heroku_server(task_name):
+def delete_heroku_server(task_name, tmp_dir=parent_dir):
     heroku_directory_name = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))[0]
-    heroku_directory_path = os.path.join(parent_dir, heroku_directory_name)
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))[0]
+    heroku_directory_path = os.path.join(tmp_dir, heroku_directory_name)
     heroku_executable_path = \
         os.path.join(heroku_directory_path, 'bin', 'heroku')
 
@@ -556,7 +559,8 @@ def delete_local_server(task_name):
 
 
 def setup_legacy_server(task_name, task_files_to_copy, local=False,
-                        heroku_team=None, use_hobby=False, legacy=True):
+                        heroku_team=None, use_hobby=False, legacy=True,
+                        tmp_dir=parent_dir):
     if local:
         return setup_local_server(
             task_name,
@@ -566,22 +570,24 @@ def setup_legacy_server(task_name, task_files_to_copy, local=False,
         task_name,
         task_files_to_copy=task_files_to_copy,
         heroku_team=heroku_team, use_hobby=use_hobby,
+        tmp_dir=tmp_dir,
     )
 
 
 def setup_server(task_name, task_files_to_copy, local=False, heroku_team=None,
-                 use_hobby=False, legacy=True):
+                 use_hobby=False, legacy=True, tmp_dir=parent_dir):
     if local:
         raise Exception('Local server not yet supported for non-legacy tasks')
     return setup_heroku_server(
         task_name,
         task_files_to_copy=task_files_to_copy,
         heroku_team=heroku_team, use_hobby=use_hobby,
+        tmp_dir=tmp_dir,
     )
 
 
-def delete_server(task_name, local=False):
+def delete_server(task_name, local=False, tmp_dir=parent_dir):
     if local:
         delete_local_server(task_name)
     else:
-        delete_heroku_server(task_name)
+        delete_heroku_server(task_name, tmp_dir)

--- a/parlai/mturk/core/legacy_2018/shared_utils.py
+++ b/parlai/mturk/core/legacy_2018/shared_utils.py
@@ -7,6 +7,7 @@
 import logging
 import time
 import uuid
+import os
 
 # Sleep constants
 THREAD_SHORT_SLEEP = 0.1
@@ -55,3 +56,15 @@ def print_and_log(level, message, should_print=False):
 def generate_event_id(worker_id):
     """Return a unique id to use for identifying a packet for a worker"""
     return '{}_{}'.format(worker_id, uuid.uuid4())
+
+
+def get_mturk_dir():
+    import parlai.mturk
+    return os.path.dirname(os.path.abspath(parlai.mturk.__file__))
+
+
+def get_tmp_dir():
+    """Return the location of the temporary directory in which we store
+    things related to a run but that can be safely deleted
+    """
+    return os.path.join(get_mturk_dir(), 'tmp')

--- a/parlai/mturk/core/legacy_2018/shared_utils.py
+++ b/parlai/mturk/core/legacy_2018/shared_utils.py
@@ -63,8 +63,16 @@ def get_mturk_dir():
     return os.path.dirname(os.path.abspath(parlai.mturk.__file__))
 
 
+def get_core_dir():
+    import parlai.mturk.core
+    return os.path.dirname(os.path.abspath(parlai.mturk.core.__file__))
+
+
 def get_tmp_dir():
     """Return the location of the temporary directory in which we store
     things related to a run but that can be safely deleted
     """
-    return os.path.join(get_mturk_dir(), 'tmp')
+    tmp_dir = os.path.join(get_mturk_dir(), 'tmp')
+    if not os.path.exists(tmp_dir):
+        os.mkdir(tmp_dir)
+    return tmp_dir

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -163,6 +163,9 @@ class MTurkManager():
         self.db_logger = None
         self.logging_permitted = False  # Enables logging to parl.ai
         self.task_state = self.STATE_CREATED
+        if opt.get('tmp_dir') is None:
+            opt['tmp_dir'] = shared_utils.get_tmp_dir()
+        self.tmp_dir = opt['tmp_dir']
         self._init_logging_config()
         self._assert_opts()
 
@@ -1055,12 +1058,14 @@ class MTurkManager():
             self.populate_legacy_task_files(task_directory_path)
             self.server_url = server_utils.setup_legacy_server(
                 self.server_task_name, self.task_files_to_copy,
-                self.opt['local'], heroku_team, self.opt['hobby'])
+                self.opt['local'], heroku_team, self.opt['hobby'],
+                tmp_dir=self.opt['tmp_dir'])
         else:
             self.populate_task_files(task_directory_path)
             self.server_url = server_utils.setup_server(
                 self.server_task_name, self.task_files_to_copy,
-                self.opt['local'], heroku_team, self.opt['hobby'])
+                self.opt['local'], heroku_team, self.opt['hobby'],
+                tmp_dir=self.opt['tmp_dir'])
 
         shared_utils.print_and_log(logging.INFO, self.server_url)
 
@@ -1304,7 +1309,8 @@ class MTurkManager():
         finally:
             if self.server_task_name is not None:
                 server_utils.delete_server(self.server_task_name,
-                                           self.opt['local'])
+                                           self.opt['local'],
+                                           tmp_dir=self.opt['tmp_dir'])
             if self.topic_arn is not None:
                 mturk_utils.delete_sns_topic(self.topic_arn)
             if self.opt['unique_worker'] and not self.opt['unique_qual_name']:

--- a/parlai/mturk/core/mturk_utils.py
+++ b/parlai/mturk/core/mturk_utils.py
@@ -150,7 +150,7 @@ def create_hit_config(opt, task_description, unique_worker, is_sandbox):
         'chat_title': opt.get('chat_title', opt.get('hit_title', 'Live Chat')),
         'template_type': opt.get('frontend_template_type', 'default'),
     }
-    hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
+    hit_config_file_path = os.path.join(opt['tmp_dir'], 'hit_config.json')
     if os.path.exists(hit_config_file_path):
         os.remove(hit_config_file_path)
     with open(hit_config_file_path, 'w') as hit_config_file:

--- a/parlai/mturk/core/server_utils.py
+++ b/parlai/mturk/core/server_utils.py
@@ -15,11 +15,12 @@ import shlex
 import shutil
 import subprocess
 import time
+import parlai.mturk.core.shared_utils as shared_utils
 
 region_name = 'us-east-1'
 user_name = getpass.getuser()
 
-parent_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = shared_utils.get_core_dir()
 legacy_server_source_directory_name = 'server_legacy'
 server_source_directory_name = 'react_server'
 heroku_server_directory_name = 'heroku_server'
@@ -33,7 +34,8 @@ heroku_url = \
 
 
 def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
-                               heroku_team=None, use_hobby=False):
+                               heroku_team=None, use_hobby=False,
+                               tmp_dir=parent_dir):
     print("Heroku: Collecting files...")
     # Install Heroku CLI
     os_name = None
@@ -57,13 +59,13 @@ def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
 
     # Remove existing heroku client files
     existing_heroku_directory_names = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))
     if len(existing_heroku_directory_names) == 0:
-        if os.path.exists(os.path.join(parent_dir, 'heroku.tar.gz')):
-            os.remove(os.path.join(parent_dir, 'heroku.tar.gz'))
+        if os.path.exists(os.path.join(tmp_dir, 'heroku.tar.gz')):
+            os.remove(os.path.join(tmp_dir, 'heroku.tar.gz'))
 
         # Get the heroku client and unzip
-        os.chdir(parent_dir)
+        os.chdir(tmp_dir)
         sh.wget(shlex.split('{}-{}-{}.tar.gz -O heroku.tar.gz'.format(
             heroku_url,
             os_name,
@@ -72,14 +74,14 @@ def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
         sh.tar(shlex.split('-xvzf heroku.tar.gz'))
 
     heroku_directory_name = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))[0]
-    heroku_directory_path = os.path.join(parent_dir, heroku_directory_name)
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))[0]
+    heroku_directory_path = os.path.join(tmp_dir, heroku_directory_name)
     heroku_executable_path = \
         os.path.join(heroku_directory_path, 'bin', 'heroku')
 
     server_source_directory_path = \
         os.path.join(parent_dir, legacy_server_source_directory_name)
-    heroku_server_directory_path = os.path.join(parent_dir, '{}_{}'.format(
+    heroku_server_directory_path = os.path.join(tmp_dir, '{}_{}'.format(
         heroku_server_directory_name,
         task_name
     ))
@@ -98,7 +100,7 @@ def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
         task_directory_path
     )
 
-    hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
+    hit_config_file_path = os.path.join(tmp_dir, 'hit_config.json')
     sh.mv(hit_config_file_path, task_directory_path)
 
     for file_path in task_files_to_copy:
@@ -212,8 +214,9 @@ def setup_legacy_heroku_server(task_name, task_files_to_copy=None,
 
 
 def setup_heroku_server(task_name, task_files_to_copy=None,
-                        heroku_team=None, use_hobby=False):
-    print("Heroku: Collecting files...")
+                        heroku_team=None, use_hobby=False, tmp_dir=parent_dir):
+
+    print("Heroku: Collecting files... for ", tmp_dir)
     # Install Heroku CLI
     os_name = None
     bit_architecture = None
@@ -236,13 +239,13 @@ def setup_heroku_server(task_name, task_files_to_copy=None,
 
     # Remove existing heroku client files
     existing_heroku_directory_names = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))
     if len(existing_heroku_directory_names) == 0:
-        if os.path.exists(os.path.join(parent_dir, 'heroku.tar.gz')):
-            os.remove(os.path.join(parent_dir, 'heroku.tar.gz'))
+        if os.path.exists(os.path.join(tmp_dir, 'heroku.tar.gz')):
+            os.remove(os.path.join(tmp_dir, 'heroku.tar.gz'))
 
         # Get the heroku client and unzip
-        os.chdir(parent_dir)
+        os.chdir(tmp_dir)
         sh.wget(shlex.split('{}-{}-{}.tar.gz -O heroku.tar.gz'.format(
             heroku_url,
             os_name,
@@ -251,14 +254,14 @@ def setup_heroku_server(task_name, task_files_to_copy=None,
         sh.tar(shlex.split('-xvzf heroku.tar.gz'))
 
     heroku_directory_name = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))[0]
-    heroku_directory_path = os.path.join(parent_dir, heroku_directory_name)
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))[0]
+    heroku_directory_path = os.path.join(tmp_dir, heroku_directory_name)
     heroku_executable_path = \
         os.path.join(heroku_directory_path, 'bin', 'heroku')
 
     server_source_directory_path = \
         os.path.join(parent_dir, server_source_directory_name)
-    heroku_server_development_path = os.path.join(parent_dir, '{}_{}'.format(
+    heroku_server_development_path = os.path.join(tmp_dir, '{}_{}'.format(
         heroku_server_directory_name,
         task_name
     ))
@@ -350,7 +353,7 @@ def setup_heroku_server(task_name, task_files_to_copy=None,
         except FileNotFoundError:  # noqa: F821 we don't support python2
             pass
 
-    hit_config_file_path = os.path.join(parent_dir, 'hit_config.json')
+    hit_config_file_path = os.path.join(tmp_dir, 'hit_config.json')
     sh.mv(hit_config_file_path, target_resource_dir)
 
     print("Heroku: Starting server...")
@@ -447,18 +450,18 @@ def setup_heroku_server(task_name, task_files_to_copy=None,
     os.chdir(parent_dir)
 
     # Clean up heroku files
-    if os.path.exists(os.path.join(parent_dir, 'heroku.tar.gz')):
-        os.remove(os.path.join(parent_dir, 'heroku.tar.gz'))
+    if os.path.exists(os.path.join(tmp_dir, 'heroku.tar.gz')):
+        os.remove(os.path.join(tmp_dir, 'heroku.tar.gz'))
 
     sh.rm(shlex.split('-rf {}'.format(heroku_server_development_path)))
 
     return 'https://{}.herokuapp.com'.format(heroku_app_name)
 
 
-def delete_heroku_server(task_name):
+def delete_heroku_server(task_name, tmp_dir=parent_dir):
     heroku_directory_name = \
-        glob.glob(os.path.join(parent_dir, 'heroku-cli-*'))[0]
-    heroku_directory_path = os.path.join(parent_dir, heroku_directory_name)
+        glob.glob(os.path.join(tmp_dir, 'heroku-cli-*'))[0]
+    heroku_directory_path = os.path.join(tmp_dir, heroku_directory_name)
     heroku_executable_path = \
         os.path.join(heroku_directory_path, 'bin', 'heroku')
 
@@ -556,7 +559,8 @@ def delete_local_server(task_name):
 
 
 def setup_legacy_server(task_name, task_files_to_copy, local=False,
-                        heroku_team=None, use_hobby=False, legacy=True):
+                        heroku_team=None, use_hobby=False, legacy=True,
+                        tmp_dir=parent_dir):
     if local:
         return setup_local_server(
             task_name,
@@ -566,22 +570,24 @@ def setup_legacy_server(task_name, task_files_to_copy, local=False,
         task_name,
         task_files_to_copy=task_files_to_copy,
         heroku_team=heroku_team, use_hobby=use_hobby,
+        tmp_dir=tmp_dir,
     )
 
 
 def setup_server(task_name, task_files_to_copy, local=False, heroku_team=None,
-                 use_hobby=False, legacy=True):
+                 use_hobby=False, legacy=True, tmp_dir=parent_dir):
     if local:
         raise Exception('Local server not yet supported for non-legacy tasks')
     return setup_heroku_server(
         task_name,
         task_files_to_copy=task_files_to_copy,
         heroku_team=heroku_team, use_hobby=use_hobby,
+        tmp_dir=tmp_dir,
     )
 
 
-def delete_server(task_name, local=False):
+def delete_server(task_name, local=False, tmp_dir=parent_dir):
     if local:
         delete_local_server(task_name)
     else:
-        delete_heroku_server(task_name)
+        delete_heroku_server(task_name, tmp_dir)

--- a/parlai/mturk/core/shared_utils.py
+++ b/parlai/mturk/core/shared_utils.py
@@ -7,6 +7,7 @@
 import logging
 import time
 import uuid
+import os
 
 # Sleep constants
 THREAD_SHORT_SLEEP = 0.1
@@ -55,3 +56,15 @@ def print_and_log(level, message, should_print=False):
 def generate_event_id(worker_id):
     """Return a unique id to use for identifying a packet for a worker"""
     return '{}_{}'.format(worker_id, uuid.uuid4())
+
+
+def get_mturk_dir():
+    import parlai.mturk
+    return os.path.dirname(os.path.abspath(parlai.mturk.__file__))
+
+
+def get_tmp_dir():
+    """Return the location of the temporary directory in which we store
+    things related to a run but that can be safely deleted
+    """
+    return os.path.join(get_mturk_dir(), 'tmp')

--- a/parlai/mturk/core/shared_utils.py
+++ b/parlai/mturk/core/shared_utils.py
@@ -63,8 +63,16 @@ def get_mturk_dir():
     return os.path.dirname(os.path.abspath(parlai.mturk.__file__))
 
 
+def get_core_dir():
+    import parlai.mturk.core
+    return os.path.dirname(os.path.abspath(parlai.mturk.core.__file__))
+
+
 def get_tmp_dir():
     """Return the location of the temporary directory in which we store
     things related to a run but that can be safely deleted
     """
-    return os.path.join(get_mturk_dir(), 'tmp')
+    tmp_dir = os.path.join(get_mturk_dir(), 'tmp')
+    if not os.path.exists(tmp_dir):
+        os.mkdir(tmp_dir)
+    return tmp_dir


### PR DESCRIPTION
Rather than arbitrarily dumping things in core, like in #1634 and #1637 I'm moving things out to the `mturk` directory. This provides an `mturk/tmp` directory to put temporary heroku files related to launching a server, along with other build artifacts. I'll update the webapp to use this on the next webapp pass I take.

This also adds a command line argument that lets us specify the temporary scratch directory, `--tmp-dir`. Should save us time building on distributed filesystems if we have a local scratch directory and use that instead.

Note you only need to check the 4 files once between dev, legacy_2018, and core. I probably should've made this change before the split!

