### PR TITLE
Lengthen timeout for nightly tests. [long]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
       - <<: *installtorchgpu
       - run:
           name: Nightly GPU tests
-          no_output_timeout: 30m
+          no_output_timeout: 60m
           command: python setup.py test -s tests.suites.nightly_gpu -v
 
   nightly_cpu_tests:
@@ -152,7 +152,7 @@ jobs:
       - <<: *installtorchcpu
       - run:
           name: All nightly CPU tests
-          no_output_timeout: 30m
+          no_output_timeout: 60m
           command: python setup.py test -s tests.suites.nightly_cpu -v
 
   mturk_tests:


### PR DESCRIPTION
Just lengthen the timeout before a test is marked as nonresponsive. Hoping this cleans up the cpu nightly test.