### PR TITLE
New numpy changed default api.

### DIFF
--- a/parlai/agents/tfidf_retriever/utils.py
+++ b/parlai/agents/tfidf_retriever/utils.py
@@ -13,7 +13,7 @@ import scipy.sparse as sp
 from sklearn.utils import murmurhash3_32
 try:
     import torch
-except ImportError as e:
+except ImportError:
     raise ImportError('Need to install Pytorch: go to pytorch.org')
 
 

--- a/parlai/agents/tfidf_retriever/utils.py
+++ b/parlai/agents/tfidf_retriever/utils.py
@@ -44,7 +44,7 @@ def save_sparse_tensor(filename, matrix, metadata=None):
 
 
 def load_sparse_csr(filename):
-    loader = np.load(filename + '.npz')
+    loader = np.load(filename + '.npz', allow_pickle=True)
     matrix = sp.csr_matrix((loader['data'], loader['indices'],
                             loader['indptr']), shape=loader['shape'])
     return matrix, loader['metadata'].item(0) if 'metadata' in loader else None


### PR DESCRIPTION
**Description**
A new version of numpy was released last night, which changes the default parameter of `np.load` to `allow_pickle=False`.
https://github.com/numpy/numpy/releases. This broke our TF-IDF model and our unit tests. This patch explicitly adds in this keyword arg.

**Testing**
Unit tests should pass now.