### PR TITLE
[MTurk] Treat abandons as a special case of returns

### DIFF
--- a/parlai/mturk/core/dev/mturk_manager.py
+++ b/parlai/mturk/core/dev/mturk_manager.py
@@ -692,6 +692,7 @@ class MTurkManager():
             self._on_socket_dead(agent.worker_id, assignment_id)
         elif mturk_event_type == SNS_ASSIGN_ABANDONDED:
             agent.set_hit_is_abandoned()
+            agent.hit_is_returned = True
             # Treat as a socket_dead event
             self._on_socket_dead(agent.worker_id, assignment_id)
         elif mturk_event_type == SNS_ASSIGN_SUBMITTED:

--- a/parlai/mturk/core/legacy_2018/mturk_manager.py
+++ b/parlai/mturk/core/legacy_2018/mturk_manager.py
@@ -692,6 +692,7 @@ class MTurkManager():
             self._on_socket_dead(agent.worker_id, assignment_id)
         elif mturk_event_type == SNS_ASSIGN_ABANDONDED:
             agent.set_hit_is_abandoned()
+            agent.hit_is_returned = True
             # Treat as a socket_dead event
             self._on_socket_dead(agent.worker_id, assignment_id)
         elif mturk_event_type == SNS_ASSIGN_SUBMITTED:

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -701,6 +701,7 @@ class MTurkManager():
             self._on_socket_dead(agent.worker_id, assignment_id)
         elif mturk_event_type == SNS_ASSIGN_ABANDONDED:
             agent.set_hit_is_abandoned()
+            agent.hit_is_returned = True
             # Treat as a socket_dead event
             self._on_socket_dead(agent.worker_id, assignment_id)
         elif mturk_event_type == SNS_ASSIGN_SUBMITTED:


### PR DESCRIPTION
This only particularly affects static tasks. As of now on certain SNS messages we would update the state of an agent to reflect the amazon event. Abandon events wouldn't really occur with any frequency on dialogue/connected tasks, and even if a worker didn't finish in the allotted time, by leaving the page they'd be considered a disconnect. As the `MTurkAgent.act()` method uses a task being returned as an exit condition, this PR makes abandons equivalent to returns, but retains the abandoned flag as it can be an important signal for a task that has too short of a duration set.