### PR TITLE
No need for yaml titles in PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,3 @@
----
-name: "[Pull Request]"
-about: Submitting a pull request
-
----
-
 **Patch description**
 Please enter a clear and concise description of what your pull request does, and why
 it is necessary. If your patch fixes an issue, please reference that issue here.


### PR DESCRIPTION
**Patch description**
Current pull request template has the yaml information at the top. This is used for issues, but not PRs for some reason. This patch deletes those lines so they won't be inserted at the top of the PR.

**Testing steps**
Tested with current version, observed these extra lines.

**Expected behavior**
Only stuff from "Patch description" and below will be inserted.