### PR TITLE
Update train_end2end.py

### DIFF
--- a/projects/wizard_of_wikipedia/generator/train_end2end.py
+++ b/projects/wizard_of_wikipedia/generator/train_end2end.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
         n_heads=2,
         dropout=0.20,
         ffn_size=512,
-        embeddingsize=256,
+        embedding_size=256,
         log_every_n_secs=10,
         validation_patience=12,
         validation_metric='ppl',


### PR DESCRIPTION
**Patch description**
There was a typo in the supplied arguments for a pretraining script. Fixes #1670.

**Testing steps**
Checked the arguments carefully again.