### PR TITLE
Fix download issues with new datapath logic.

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -617,7 +617,7 @@ class ParlaiParser(argparse.ArgumentParser):
         # custom post-parsing
         self.opt['parlai_home'] = self.parlai_home
 
-        self._infer_datapath(self.opt)
+        self.opt = self._infer_datapath(self.opt)
 
         # set all arguments specified in commandline as overridable
         option_strings_dict = {}

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -531,6 +531,7 @@ class ParlaiParser(argparse.ArgumentParser):
     def add_extra_args(self, args=None):
         """Add more args depending on how known args are set."""
         parsed = vars(self.parse_known_args(args, nohelp=True)[0])
+        parsed = self._infer_datapath(parsed)
 
         # find which image mode specified if any, and add additional arguments
         image_mode = parsed.get('image_mode', None)
@@ -579,6 +580,28 @@ class ParlaiParser(argparse.ArgumentParser):
             args = [a for a in args if a != '-h' and a != '--help']
         return super().parse_known_args(args, namespace)
 
+    def _infer_datapath(self, opt):
+        """
+        Sets the value for opt['datapath'] and opt['download_path'], correctly
+        respecting environmental variables and the default.
+        """
+        # set environment variables
+        # Priority for setting the datapath (same applies for download_path):
+        # --datapath -> os.environ['PARLAI_DATAPATH'] -> <self.parlai_home>/data
+        if opt.get('download_path'):
+            os.environ['PARLAI_DOWNPATH'] = opt['download_path']
+        elif os.environ.get('PARLAI_DOWNPATH') is None:
+            os.environ['PARLAI_DOWNPATH'] = os.path.join(self.parlai_home, 'downloads')
+        if opt.get('datapath'):
+            os.environ['PARLAI_DATAPATH'] = opt['datapath']
+        elif os.environ.get('PARLAI_DATAPATH') is None:
+            os.environ['PARLAI_DATAPATH'] = os.path.join(self.parlai_home, 'data')
+
+        opt['download_path'] = os.environ['PARLAI_DOWNPATH']
+        opt['datapath'] = os.environ['PARLAI_DATAPATH']
+
+        return opt
+
     def parse_args(self, args=None, namespace=None, print_args=True):
         """
         Parses the provided arguments and returns a dictionary of the ``args``.
@@ -594,20 +617,7 @@ class ParlaiParser(argparse.ArgumentParser):
         # custom post-parsing
         self.opt['parlai_home'] = self.parlai_home
 
-        # set environment variables
-        # Priority for setting the datapath (same applies for download_path):
-        # --datapath -> os.environ['PARLAI_DATAPATH'] -> <self.parlai_home>/data
-        if self.opt.get('download_path'):
-            os.environ['PARLAI_DOWNPATH'] = self.opt['download_path']
-        elif os.environ.get('PARLAI_DOWNPATH') is None:
-            os.environ['PARLAI_DOWNPATH'] = os.path.join(self.parlai_home, 'downloads')
-        if self.opt.get('datapath'):
-            os.environ['PARLAI_DATAPATH'] = self.opt['datapath']
-        elif os.environ.get('PARLAI_DATAPATH') is None:
-            os.environ['PARLAI_DATAPATH'] = os.path.join(self.parlai_home, 'data')
-
-        self.opt['download_path'] = os.environ['PARLAI_DOWNPATH']
-        self.opt['datapath'] = os.environ['PARLAI_DATAPATH']
+        self._infer_datapath(self.opt)
 
         # set all arguments specified in commandline as overridable
         option_strings_dict = {}


### PR DESCRIPTION
**Patch description**
CircleCI has been failing all the GPU tests since the last patches: https://circleci.com/gh/facebookresearch/ParlAI/2385.

The issue is that calling with --model-file "models:foo" tries to use `parse_known_args`, which did not have the extra logic for handling inferred datapaths. Previously this was okay because CircleCI lets you write anywhere, so handling something like making `/private/home/roller` was totally okay on Docker.

Curiously, the backwards compatibility tests have NOT been failing, though this is probably because they do NOT use the "-mf models:" syntax. We may need to introduce this as another test; I don't recall why I had a special download for testing_utils:

https://github.com/facebookresearch/ParlAI/blob/38f8ff497b75165325a18ad4c3c508a92a0265e5/parlai/core/testing_utils.py#L268-L278

**Testing steps**
Manually deleted the wizard models folder on my devfair and then ran the test manually. The CircleCI tests will run on this commit


**Expected behavior**
Tests pass

**Logs**
```
devfair0237 parlai master » python tests/nightly/gpu/test_wizard.py
.[building data: /private/home/roller/working/parlai/data/models/wizard_of_wikipedia/full_dialogue_retrieval_model/wizard_retrieval_2.tgz]
[ downloading: http://parl.ai/downloads/_models/wizard_of_wikipedia/wizard_retrieval_2.tgz to /private/home/roller/working/parlai/data/models/wizard_of_wikipedia/full_dialogue_retrieval_model/wizard_retrieval
_2.tgz ]
Downloading wizard_retrieval_2.tgz: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5.54G/5.54G [01:11<00:00, 76.9MB/s]
unpacking wizard_retrieval_2.tgz
.
----------------------------------------------------------------------
Ran 2 tests in 746.297s

OK
```