### PR TITLE
Another test typo.

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -321,7 +321,7 @@ class TestTransformerGenerator(unittest.TestCase):
             num_epochs=1,
             numthreads=1,
             no_cuda=True,
-            embeddingsize=16,
+            embedding_size=16,
             hiddensize=16,
         ))
         self.assertIn('valid:{', stdout)


### PR DESCRIPTION
**Patch description**
Small typo in a unit test was doing something *slightly* different than expected. Basically similar fix to #1671.

**Testing steps**
Just run the unit test.

**Expected behavior**
Unit test passes, probably a marginal bit faster.

**Logs**
If applicable, please paste the command line from your testing:

```
$ python tests/test_transformers.py
...........
----------------------------------------------------------------------
Ran 11 tests in 96.572s

OK
```