### PR TITLE
Adding survey to MTurkManager Shutdown

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -1324,6 +1324,16 @@ class MTurkManager():
                 self._upload_worker_data()
             if self.worker_manager is not None:
                 self.worker_manager.shutdown()
+            print("\n".join([
+                "",
+                "*" * 80,
+                "Thank you for using ParlAI! We are conducting a user survey.",
+                "Please consider filling it out at "
+                "https://forms.gle/uEFbYGP7w6hiuGQT9",
+                "*" * 80,
+                ""
+            ]))
+
 
     # MTurk Agent Interaction Functions #
 

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -1334,7 +1334,6 @@ class MTurkManager():
                 ""
             ]))
 
-
     # MTurk Agent Interaction Functions #
 
     def force_expire_hit(self, worker_id, assign_id, text=None, ack_func=None):


### PR DESCRIPTION
**Patch description**
The survey link is likely drowned out by all of the other content, so I'm adding it to the end of execution for MTurkManager as well.

**Testing steps**
Ran `qa_data_collection`.

**Expected behavior**
```
Heroku: Deleting server: jju-62f6509e-qadatacollection
Destroying jju-62f6509e-qadatacollection (including all add-ons)... done

********************************************************************************
Thank you for using ParlAI! We are conducting a user survey.
Please consider filling it out at https://forms.gle/uEFbYGP7w6hiuGQT9
********************************************************************************
```