### PR TITLE
[Tests] Fix Flaky PytorchDataTeacher Integration Test

### DIFF
--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -13,6 +13,7 @@ The corpora are all randomly, but deterministically generated
 """
 
 from parlai.core.teachers import DialogTeacher
+from torch.utils.data import Dataset
 import copy
 import random
 import itertools
@@ -105,6 +106,107 @@ class CandidateTeacher(DialogTeacher):
                 offset = (i + j) % len(self.corpus)
                 cands.append(self.corpus[offset])
             yield (text, [text], 0, cands), True
+
+
+class CandidateTeacherDataset(Dataset):
+    """Candidate Teacher, in Pytorch Dataset form"""
+    def __init__(self, opt, shared=None,
+                 vocab_size=VOCAB_SIZE,
+                 example_size=EXAMPLE_SIZE,
+                 num_candidates=NUM_CANDIDATES,
+                 num_train=NUM_TRAIN,
+                 num_test=NUM_TEST):
+        """
+        :param int vocab_size: size of the vocabulary
+        :param int example_size: length of each example
+        :param int num_candidates: number of label_candidates generated
+        :param int num_train: size of the training set
+        :param int num_test: size of the valid/test sets
+        """
+        self.opt = opt
+        opt['datafile'] = opt['datatype'].split(':')[0]
+        self.datafile = opt['datafile']
+
+        self.vocab_size = vocab_size
+        self.example_size = example_size
+        self.num_candidates = num_candidates
+        self.num_train = num_train
+        self.num_test = num_test
+
+        # set up the vocabulary
+        self.words = list(map(str, range(self.vocab_size)))
+        self.data = self.setup_data(opt['datatype'].split(':')[0])
+
+    def __getitem__(self, index):
+        return (index, self.data[index])
+
+    def __len__(self):
+        return self.num_examples()
+
+    def num_episodes(self):
+        return len(self.data)
+
+    def num_examples(self):
+        return self.num_episodes()
+
+    def setup_data(self, fold):
+        data = []
+        # N words appearing in a random order
+        self.rng = random.Random(42)
+        full_corpus = [
+            list(x) for x in itertools.permutations(self.words, self.example_size)
+        ]
+        self.rng.shuffle(full_corpus)
+
+        it = iter(full_corpus)
+        self.train = list(itertools.islice(it, self.num_train))
+        self.val = list(itertools.islice(it, self.num_test))
+        self.test = list(itertools.islice(it, self.num_test))
+
+        # check we have enough data
+        assert (len(self.train) == self.num_train), len(self.train)
+        assert (len(self.val) == self.num_test), len(self.val)
+        assert (len(self.test) == self.num_test), len(self.test)
+
+        # check every word appear in the training set
+        assert len(set(itertools.chain(*self.train)) - set(self.words)) == 0
+
+        # select which set we're using
+        if fold == "train":
+            self.corpus = self.train
+        elif fold == "valid":
+            self.corpus = self.val
+        elif fold == "test":
+            self.corpus = self.test
+
+        # make sure the corpus is actually text strings
+        self.corpus = [' '.join(x) for x in self.corpus]
+
+        for i, text in enumerate(self.corpus):
+            cands = []
+            for j in range(NUM_CANDIDATES):
+                offset = (i + j) % len(self.corpus)
+                cands.append(self.corpus[offset])
+            ex = {
+                'text': text,
+                'labels': tuple([text]),
+                'label_candidates': tuple(cands),
+                'episode_done': True
+            }
+            data.append(ex)
+        return data
+
+
+class NoCandidateTeacherDataset(CandidateTeacherDataset):
+    def setup_data(self, fold):
+        data = super().setup_data(fold)
+        for d in data:
+            del d['label_candidates']
+        return data
+
+
+class DefaultDataset(CandidateTeacherDataset):
+    pass
 
 
 class MultipassTeacher(CandidateTeacher):

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -109,20 +109,18 @@ class CandidateTeacher(DialogTeacher):
 
 
 class CandidateTeacherDataset(Dataset):
-    """Candidate Teacher, in Pytorch Dataset form"""
+    """
+    Candidate Teacher, in Pytorch Dataset form
+
+    Identical setup. Only difference is a `self.data` object, which contains
+    all the episodes in the task.
+    """
     def __init__(self, opt, shared=None,
                  vocab_size=VOCAB_SIZE,
                  example_size=EXAMPLE_SIZE,
                  num_candidates=NUM_CANDIDATES,
                  num_train=NUM_TRAIN,
                  num_test=NUM_TEST):
-        """
-        :param int vocab_size: size of the vocabulary
-        :param int example_size: length of each example
-        :param int num_candidates: number of label_candidates generated
-        :param int num_train: size of the training set
-        :param int num_test: size of the valid/test sets
-        """
         self.opt = opt
         opt['datafile'] = opt['datatype'].split(':')[0]
         self.datafile = opt['datafile']

--- a/tests/nightly/cpu/test_pytorch_data_teacher_integration.py
+++ b/tests/nightly/cpu/test_pytorch_data_teacher_integration.py
@@ -49,7 +49,6 @@ class TestPytorchDataTeacher(unittest.TestCase):
         The Seq2Seq model can solve the babi:task10k:1 task with the normal
         ParlAI setup, and thus should be able to with a PytorchDataTeacher
         """
-        print('Testing pyt_train with datatype {}'.format(datatype))
         defaults = parser_defaults.copy()
         defaults['datatype'] = datatype
         defaults['shuffle'] = True  # for train:stream
@@ -77,7 +76,6 @@ class TestPytorchDataTeacher(unittest.TestCase):
         This tests whether an agent can train to completion with
         these preprocessed examples
         """
-        print('Testing pyt_preprocess_train')
         defaults = parser_defaults.copy()
         defaults['datatype'] = 'train'
         defaults['pytorch_preprocess'] = True
@@ -97,9 +95,6 @@ class TestPytorchDataTeacher(unittest.TestCase):
         :param preprocess:
             (bool) whether to preprocess the data
         """
-        print('Testing pyt_batchsort_train with datatype {} and preprocess {}'.format(
-            datatype, preprocess
-        ))
         defaults = parser_defaults.copy()
         defaults['datatype'] = datatype
         defaults['pytorch_preprocess'] = preprocess
@@ -129,7 +124,6 @@ class TestPytorchDataTeacher(unittest.TestCase):
         Test that the pytorch teacher works with given Pytorch Datasets
         as well
         """
-        print('Testing ptyd teacher')
         defaults = parser_defaults.copy()
         defaults['datatype'] = 'train:stream'
         defaults['image_mode'] = 'ascii'

--- a/tests/nightly/cpu/test_pytorch_data_teacher_integration.py
+++ b/tests/nightly/cpu/test_pytorch_data_teacher_integration.py
@@ -41,34 +41,33 @@ def solved_task(str_output, valid, test):
 class TestPytorchDataTeacher(unittest.TestCase):
     """Various Integration tests for PytorchDataTeacher"""
 
-    def test_pyt_train(self):
+    def _pyt_train(self, datatype):
         """
         Integration test: ensure that pytorch data teacher can successfully
         teach Seq2Seq model to fully solve the babi:task10k:1 task.
 
         The Seq2Seq model can solve the babi:task10k:1 task with the normal
         ParlAI setup, and thus should be able to with a PytorchDataTeacher
-
-        This tests the following setups:
-            1. -dt train
-            2. -dt train:stream
-            3. -dt train:stream:ordered
         """
-        dts = [
-            'train',
-            'train:stream',
-            'train:stream:ordered'
-        ]
-        for dt in dts:
-            defaults = parser_defaults.copy()
-            defaults['datatype'] = dt
-            defaults['shuffle'] = True  # for train:stream
-            str_output, valid, test = testing_utils.train_model(defaults)
-            self.assertTrue(
-                solved_task(str_output, valid, test),
-                'Teacher could not teach seq2seq with args: {}; here is str_output: {}'
-                .format(defaults, str_output)
-            )
+        print('Testing pyt_train with datatype {}'.format(datatype))
+        defaults = parser_defaults.copy()
+        defaults['datatype'] = datatype
+        defaults['shuffle'] = True  # for train:stream
+        str_output, valid, test = testing_utils.train_model(defaults)
+        self.assertTrue(
+            solved_task(str_output, valid, test),
+            'Teacher could not teach seq2seq with args: {}; here is str_output: {}'
+            .format(defaults, str_output)
+        )
+
+    def test_pyt_train(self):
+        self._pyt_train('train')
+
+    def test_pyt_train_stream(self):
+        self._pyt_train('train:stream')
+
+    def test_pyt_train_stream_ordered(self):
+        self._pyt_train('train:stream:ordered')
 
     def test_pyt_preprocess_train(self):
         """
@@ -78,7 +77,7 @@ class TestPytorchDataTeacher(unittest.TestCase):
         This tests whether an agent can train to completion with
         these preprocessed examples
         """
-        # Second, check that the model will train
+        print('Testing pyt_preprocess_train')
         defaults = parser_defaults.copy()
         defaults['datatype'] = 'train'
         defaults['pytorch_preprocess'] = True
@@ -89,45 +88,48 @@ class TestPytorchDataTeacher(unittest.TestCase):
             .format(str_output)
         )
 
-    def test_pyt_batchsort_train(self):
+    def _pyt_batchsort_train(self, datatype, preprocess):
         """
         Tests the functionality of training with batchsort
-        under the following conditions:
 
-        1. -dt train --pytorch_preprocess False
-        2. -dt train:stream --pytorch_preprocess False
-        3. -dt train --pytorch_preprocess True --batch_sort_field text_vec
+        :param datatype:
+            (string) datatype to train with
+        :param preprocess:
+            (bool) whether to preprocess the data
         """
-        # Next, check that training works
-        dt_and_preprocess = [
-            ('train', False),
-            ('train:stream', False),
-            ('train', True)
-        ]
-        for dt, preprocess in dt_and_preprocess:
-            defaults = parser_defaults.copy()
-            defaults['datatype'] = dt
-            defaults['pytorch_preprocess'] = preprocess
-            defaults['pytorch_teacher_batch_sort'] = True
-            defaults['batchsize'] = 32
-            if preprocess:
-                defaults['batch_sort_field'] = 'text_vec'
-            str_output, valid, test = testing_utils.train_model(defaults)
-            self.assertTrue(
-                solved_task(str_output, valid, test),
-                'Teacher could not teach seq2seq with batch sort '
-                'and args {} and output {}'
-                .format((dt, preprocess), str_output)
-            )
+        print('Testing pyt_batchsort_train with datatype {} and preprocess {}'.format(
+            datatype, preprocess
+        ))
+        defaults = parser_defaults.copy()
+        defaults['datatype'] = datatype
+        defaults['pytorch_preprocess'] = preprocess
+        defaults['pytorch_teacher_batch_sort'] = True
+        defaults['batchsize'] = 32
+        if preprocess:
+            defaults['batch_sort_field'] = 'text_vec'
+        str_output, valid, test = testing_utils.train_model(defaults)
+        self.assertTrue(
+            solved_task(str_output, valid, test),
+            'Teacher could not teach seq2seq with batch sort '
+            'and args {} and output {}'
+            .format((datatype, preprocess), str_output)
+        )
+
+    def test_pyt_batchsort_train(self):
+        self._pyt_batchsort_train('train', False)
+
+    def test_pyt_batchsort_train_stream(self):
+        self._pyt_batchsort_train('train:stream', False)
+
+    def test_pyt_batchsort_train_preprocess(self):
+        self._pyt_batchsort_train('train', True)
 
     def test_pytd_teacher(self):
         """
         Test that the pytorch teacher works with given Pytorch Datasets
         as well
-
-        I'll be using the Flickr30k dataset to ensure that the observations
-        are the same.
         """
+        print('Testing ptyd teacher')
         defaults = parser_defaults.copy()
         defaults['datatype'] = 'train:stream'
         defaults['image_mode'] = 'ascii'
@@ -135,7 +137,7 @@ class TestPytorchDataTeacher(unittest.TestCase):
         with testing_utils.capture_output():
             # Get processed act from agent
             parser = display_setup_args()
-            defaults['pytorch_teacher_dataset'] = 'flickr30k'
+            defaults['pytorch_teacher_dataset'] = 'integration_tests'
             del defaults['pytorch_teacher_task']
             parser.set_defaults(**defaults)
             opt = parser.parse_args()
@@ -143,7 +145,7 @@ class TestPytorchDataTeacher(unittest.TestCase):
             pytorch_teacher_act = teacher.act()
 
             parser = display_setup_args()
-            defaults['task'] = 'flickr30k'
+            defaults['task'] = 'integration_tests'
             del defaults['pytorch_teacher_dataset']
             parser.set_defaults(**defaults)
             opt = parser.parse_args()
@@ -156,9 +158,11 @@ class TestPytorchDataTeacher(unittest.TestCase):
         for key in keys:
             self.assertTrue(pytorch_teacher_act[key] == regular_teacher_act[key],
                             'PytorchDataTeacher does not have the same value '
-                            'as regular teacher for act key: {}'.format(key))
+                            'as regular teacher for act key: {}. '
+                            'Values: {}; {}'.format(
+                                key, pytorch_teacher_act[key], regular_teacher_act[key])
+                            )
 
-    @unittest.skip("This test needs to be updated to something smaller.")
     def test_pyt_multitask(self):
         """
             Unit test for ensuring that PytorchDataTeacher correctly handles
@@ -188,18 +192,19 @@ class TestPytorchDataTeacher(unittest.TestCase):
                 'following args: {}'.format(opt)
             )
 
-        task1 = 'babi:task1k:1'
-        task2 = 'babi:task1k:2'
-        dataset1 = 'flickr30k'
-        dataset2 = 'vqa_v1'
+        # task; num eps; num exs
+        task1 = 'babi:task1k:1'  # 180, 900
+        task2 = 'babi:task1k:2'  # 180, 900
+        dataset1 = 'integration_tests'  # 500, 500
+        dataset2 = 'integration_tests:NoCandidateTeacherDataset'  # 500, 500
 
         # Expected example and episode counts
         eps_and_exs_counts = [
             (1800, 1800),
             (1080, 1800),
-            (29900, 29900),
-            (29180, 29900),
-            (277349, 277349)
+            (1400, 1400),
+            (680, 1400),
+            (1000, 1000)
         ]
         defaults = parser_defaults.copy()
 


### PR DESCRIPTION
**Patch description**
Fixes the flakiness of the pytorch data teacher integration tests. Specifically, adds a couple pytorch dataset teachers to the `integration_tests` task, and uses 

Note that this test now takes roughly 60 seconds to run; perhaps we can consider moving this to unit tests?

**Testing steps**
`python tests/nightly/cpu/test_pytorch_data_teacher_integration.py`

**Expected behavior**
Tests pass

**Logs**

```
$ python tests/nightly/cpu/test_pytorch_data_teacher_integration.py
.........
----------------------------------------------------------------------
Ran 9 tests in 54.974s

OK
```
