### PR TITLE
TorchAgent models have better display names by default.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -540,8 +540,10 @@ class TorchAgent(Agent):
         # indicate whether using fp16
         self.fp16 = self.opt.get('fp16', False)
 
+        # Default to the class name, sans "Agent". child can override
+        self.id = type(self).__name__.replace("Agent", "")
+
         # now set up any fields that all instances may need
-        self.id = 'TorchAgent'  # child can override
         self.EMPTY = torch.LongTensor([])
         self.NULL_IDX = self.dict[self.dict.null_token]
         self.START_IDX = self.dict[self.dict.start_token]


### PR DESCRIPTION
**Patch description**
Use class names as the default `id` for TorchAgent models, instead of `TorchAgent`. Fixes #1653.

**Expected behavior**
Places that display the agent name will have a nicer default name.

**Logs**
```
$ python examples/display_model.py -t integration_tests -mf models:unittest/transformer_ranker/model

[eval_labels_choice]: 5 4 2 0
[integration_tests]: 5 4 2 0
[label_candidates: 5 4 2 0|3 1 2 0|3 6 4 5|6 1 3 2|5 0 2 6|...and 5 more]
[eval_labels: 5 4 2 0]
   [TransformerRanker]: 5 4 2 0
   [text_candidates: 5 4 2 0|5 0 2 6|2 5 3 4|2 6 0 5|1 5 0 4|...and 5 more]
- - - - - - - - - - - - - - - - - - - - -
~~
[eval_labels_choice]: 3 1 2 0
[integration_tests]: 3 1 2 0
[label_candidates: 3 1 2 0|3 6 4 5|6 1 3 2|5 0 2 6|1 2 5 3|...and 5 more]
[eval_labels: 3 1 2 0]
   [TransformerRanker]: 1 2 5 3
   [text_candidates: 1 2 5 3|3 1 2 0|1 5 0 4|2 6 0 5|2 5 3 4|...and 5 more]
- - - - - - - - - - - - - - - - - - - - -
~~
[eval_labels_choice]: 3 6 4 5
[integration_tests]: 3 6 4 5
[label_candidates: 3 6 4 5|6 1 3 2|5 0 2 6|1 2 5 3|2 5 3 4|...and 5 more]
[eval_labels: 3 6 4 5]
   [TransformerRanker]: 4 6 5 0
   [text_candidates: 4 6 5 0|3 6 4 5|6 1 3 2|6 0 2 4|5 0 2 6|...and 5 more]
- - - - - - - - - - - - - - - - - - - - -
~~
[eval_labels_choice]: 6 1 3 2
[integration_tests]: 6 1 3 2
[label_candidates: 6 1 3 2|5 0 2 6|1 2 5 3|2 5 3 4|2 6 0 5|...and 5 more]
[eval_labels: 6 1 3 2]
   [TransformerRanker]: 6 1 3 2
   [text_candidates: 6 1 3 2|1 2 5 3|2 6 0 5|2 0 3 1|6 0 2 4|...and 5 more]
- - - - - - - - - - - - - - - - - - - - -
~~
[eval_labels_choice]: 5 0 2 6
[integration_tests]: 5 0 2 6
[label_candidates: 5 0 2 6|1 2 5 3|2 5 3 4|2 6 0 5|6 0 2 4|...and 5 more]
[eval_labels: 5 0 2 6]
   [TransformerRanker]: 5 0 2 6
   [text_candidates: 5 0 2 6|2 6 0 5|6 0 2 4|4 6 5 0|2 5 3 4|...and 5 more]
- - - - - - - - - - - - - - - - - - - - -
~~
[eval_labels_choice]: 1 2 5 3
[integration_tests]: 1 2 5 3
[label_candidates: 1 2 5 3|2 5 3 4|2 6 0 5|6 0 2 4|1 5 0 4|...and 5 more]
[eval_labels: 1 2 5 3]
   [TransformerRanker]: 1 5 3 2
   [text_candidates: 1 5 3 2|1 2 5 3|2 1 3 6|2 5 3 4|1 5 0 4|...and 5 more]
- - - - - - - - - - - - - - - - - - - - -
~~
[eval_labels_choice]: 2 5 3 4
[integration_tests]: 2 5 3 4
[label_candidates: 2 5 3 4|2 6 0 5|6 0 2 4|1 5 0 4|4 6 5 0|...and 5 more]
[eval_labels: 2 5 3 4]
   [TransformerRanker]: 4 2 5 3
   [text_candidates: 4 2 5 3|2 5 3 4|4 6 5 0|2 1 3 6|2 6 0 5|...and 5 more]
- - - - - - - - - - - - - - - - - - - - -
~~
[eval_labels_choice]: 2 6 0 5
[integration_tests]: 2 6 0 5
[label_candidates: 2 6 0 5|6 0 2 4|1 5 0 4|4 6 5 0|2 0 3 1|...and 5 more]
[eval_labels: 2 6 0 5]
   [TransformerRanker]: 2 6 0 5
   [text_candidates: 2 6 0 5|6 0 2 4|6 0 3 2|4 6 5 0|2 0 3 1|...and 5 more]
- - - - - - - - - - - - - - - - - - - - -
~~
[eval_labels_choice]: 6 0 2 4
[integration_tests]: 6 0 2 4
[label_candidates: 6 0 2 4|1 5 0 4|4 6 5 0|2 0 3 1|4 2 5 3|...and 5 more]
[eval_labels: 6 0 2 4]
   [TransformerRanker]: 6 4 2 1
   [text_candidates: 6 4 2 1|4 6 5 0|6 0 2 4|4 2 5 3|6 0 3 2|...and 5 more]
- - - - - - - - - - - - - - - - - - - - -
~~
[eval_labels_choice]: 1 5 0 4
[integration_tests]: 1 5 0 4
[label_candidates: 1 5 0 4|4 6 5 0|2 0 3 1|4 2 5 3|1 5 3 2|...and 5 more]
[eval_labels: 1 5 0 4]
   [TransformerRanker]: 1 5 0 4
   [text_candidates: 1 5 0 4|0 5 1 6|4 6 5 0|1 5 3 2|4 2 5 3|...and 5 more]
- - - - - - - - - - - - - - - - - - - - -
~~
```