### PR TITLE
Nightly GPU stability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
       - <<: *installtorchgpu
       - run:
           name: Nightly GPU tests
-          no_output_timeout: 30m
+          no_output_timeout: 60m
           command: python setup.py test -s tests.suites.nightly_gpu -v
 
   mturk_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,9 +137,19 @@ jobs:
       - <<: *installdeps
       - <<: *installtorchgpu
       - run:
+          name: Generate model file checksum
+          command: bash .circleci/zoochecksum.sh > zoochecksum
+      - restore_cache:
+          keys:
+            - nightlydata-v0-{{ checksum "zoochecksum" }}
+      - run:
           name: Nightly GPU tests
           no_output_timeout: 60m
           command: python setup.py test -s tests.suites.nightly_gpu -v
+      - restore_cache:
+          key: nightlydata-v0-{{ checksum "zoochecksum" }}
+          paths:
+            - data
 
   mturk_tests:
     <<: *standard_cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
           name: Nightly GPU tests
           no_output_timeout: 60m
           command: python setup.py test -s tests.suites.nightly_gpu -v
-      - restore_cache:
+      - save_cache:
           key: nightlydata-v0-{{ checksum "zoochecksum" }}
           paths:
             - data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,19 +137,9 @@ jobs:
       - <<: *installdeps
       - <<: *installtorchgpu
       - run:
-          name: Generate model file checksum
-          command: bash .circleci/zoochecksum.sh > zoochecksum
-      - restore_cache:
-          keys:
-            - nightlydata-v0-{{ checksum "zoochecksum" }}
-      - run:
           name: Nightly GPU tests
           no_output_timeout: 60m
           command: python setup.py test -s tests.suites.nightly_gpu -v
-      - save_cache:
-          key: nightlydata-v0-{{ checksum "zoochecksum" }}
-          paths:
-            - data
 
   mturk_tests:
     <<: *standard_cpu

--- a/.circleci/zoochecksum.sh
+++ b/.circleci/zoochecksum.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+git ls-files parlai/zoo/ tests/nightly/gpu | sort | xargs md5sum

--- a/.circleci/zoochecksum.sh
+++ b/.circleci/zoochecksum.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-git ls-files parlai/zoo/ tests/nightly/gpu | sort | xargs md5sum
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+git ls-files '**/build.py' 'parlai/zoo/' 'tests/nightly/gpu' | sort | xargs md5sum

--- a/.circleci/zoochecksum.sh
+++ b/.circleci/zoochecksum.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Copyright (c) Facebook, Inc. and its affiliates.
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
-git ls-files '**/build.py' 'parlai/zoo/' 'tests/nightly/gpu' | sort | xargs md5sum

--- a/parlai/core/testing_utils.py
+++ b/parlai/core/testing_utils.py
@@ -88,8 +88,6 @@ class retry(object):
                 try:
                     return testfn(testself, *args, **kwargs)
                 except testself.failureException:
-                    # Output to help with timeouts.
-                    print('Retry')
                     pass
             # last time, actually throw any errors there may be
             return testfn(testself, *args, **kwargs)

--- a/parlai/core/testing_utils.py
+++ b/parlai/core/testing_utils.py
@@ -88,6 +88,8 @@ class retry(object):
                 try:
                     return testfn(testself, *args, **kwargs)
                 except testself.failureException:
+                    # Output to help with timeouts.
+                    print('Retry')
                     pass
             # last time, actually throw any errors there may be
             return testfn(testself, *args, **kwargs)
@@ -202,8 +204,8 @@ def train_model(opt):
     If model_file is not in opt, then this helper will create a temporary
     directory to store the model, dict, etc.
 
-    :return: (stdout, stderr, valid_results, test_results)
-    :rtype: (str, str, dict, dict)
+    :return: (stdout, valid_results, test_results)
+    :rtype: (str, dict, dict)
     """
     import parlai.scripts.train_model as tms
 
@@ -216,6 +218,7 @@ def train_model(opt):
             parser = tms.setup_args()
             # needed at the very least to set the overrides.
             parser.set_params(**opt)
+            parser.set_params(log_every_n_secs=10)
             popt = parser.parse_args(print_args=False)
             # in some rare cases, like for instance if the model class also
             # overrides its default params, the params override will not
@@ -232,12 +235,17 @@ def train_model(opt):
     )
 
 
-def eval_model(opt):
+def eval_model(opt, skip_test=False):
     """
     Runs through an evaluation loop.
 
-    :return: (stdout, stderr, valid_results, test_results)
-    :rtype: (str, str, dict, dict)
+    :param opt:
+        Any non-default options you wish to set.
+    :param bool skip_test:
+        If true skips the test evaluation, and the third return value will be None.
+
+    :return: (stdout, valid_results, test_results)
+    :rtype: (str, dict, dict)
 
     If model_file is not in opt, then this helper will create a temporary directory
     to store the model files, and clean up afterwards. You can keep the directory
@@ -247,6 +255,7 @@ def eval_model(opt):
     import parlai.scripts.eval_model as ems
     parser = ems.setup_args()
     parser.set_params(**opt)
+    parser.set_params(log_every_n_secs=10)
     popt = parser.parse_args(print_args=False)
 
     if popt.get('model_file') and not popt.get('dict_file'):
@@ -256,7 +265,7 @@ def eval_model(opt):
         popt['datatype'] = 'valid'
         valid = ems.eval_model(popt)
         popt['datatype'] = 'test'
-        test = ems.eval_model(popt)
+        test = None if skip_test else ems.eval_model(popt)
 
     return (
         output.getvalue(),

--- a/tests/nightly/gpu/test_bert.py
+++ b/tests/nightly/gpu/test_bert.py
@@ -29,12 +29,8 @@ class TestBertModel(unittest.TestCase):
             short_final_eval=True,
         ))
         # can't conclude much from the biencoder after that little iterations.
-        # accuracy should be present and somewhere between 0.01 and 0.2
-        # basically it's still a random classifier
-        self.assertGreaterEqual(
-            test['accuracy'], 0.01,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout)
-        )
+        # this test will just make sure it hasn't crashed and the accuracy isn't
+        # too high
         self.assertLessEqual(
             test['accuracy'], 0.5,
             'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout)
@@ -44,7 +40,7 @@ class TestBertModel(unittest.TestCase):
         stdout, valid, test = testing_utils.train_model(dict(
             task='convai2',
             model='bert_ranker/cross_encoder_ranker',
-            num_epochs=0.001,
+            num_epochs=0.002,
             batchsize=1,
             candidates="inline",
             type_optimization="all_encoder_layers",
@@ -58,7 +54,7 @@ class TestBertModel(unittest.TestCase):
         # accuracy should be present and somewhere between 0.2 and 0.8
         # (large interval so that it doesn't flake.)
         self.assertGreaterEqual(
-            test['accuracy'], 0.15,
+            test['accuracy'], 0.03,
             'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout)
         )
         self.assertLessEqual(


### PR DESCRIPTION
**Patch description**
This patch attempts to generally improve the stability, speed, and readability of the nightly GPU tests.

*Mechanisms:*
- Increase the timeout of the test without output (simple)
- Decrease the logging verbosity of tests (make 10s instead of default 2s)
- Widen the threshold for BERT tests. They often misfire.
- Add `skip_test` option to `testing_utils.eval_model` to avoid unnecessary runs.

**Testing steps**
Run CircleCI nightly gpu tests multiple times.

**Expected behavior**
Tests pass consistently with many reruns.
