### PR TITLE
[TorchAgent] Safer getattr calls

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -780,7 +780,8 @@ class TorchAgent(Agent):
             self._number_training_updates = states['number_training_updates']
         if self.scheduler and 'lr_scheduler' in states:
             self.scheduler.load_state_dict(states['lr_scheduler'])
-        if states.get('warmup_scheduler') and getattr(self, 'warmup_scheduler'):
+        if states.get('warmup_scheduler') and getattr(self, 'warmup_scheduler',
+                                                      None):
             self.warmup_scheduler.load_state_dict(states['warmup_scheduler'])
 
     def report(self):
@@ -1373,10 +1374,10 @@ class TorchAgent(Agent):
             )
         else:
             states['number_training_updates'] = self._number_training_updates
-            if getattr(self, 'scheduler'):
+            if getattr(self, 'scheduler', None):
                 states['lr_scheduler'] = self.scheduler.state_dict()
                 states['lr_scheduler_type'] = self.opt['lr_scheduler']
-            if getattr(self, 'warmup_scheduler'):
+            if getattr(self, 'warmup_scheduler', None):
                 states['warmup_scheduler'] = self.warmup_scheduler.state_dict()
 
         return states


### PR DESCRIPTION
**Patch description**
Fixes #1646. Safer calls to `getattr` so errors don't throw when `self.scheduler` and `self.warmup_scheduler` don't exist.

**Testing steps**
Edited code such that `self.scheduler` and `self.warmup_scheduler` were not set and trained a model. It's not clear to me what triggered this in the first place, as our code always sets `self.scheduler = None` if we don't want a scheduler, etc. However, this should prevent errors when subclassing TorchAgent and overriding these functions.
