### PR TITLE
[MTurk] Adding test debug message for a test that is flaky on circle

### DIFF
--- a/parlai/mturk/core/test/test_socket_manager.py
+++ b/parlai/mturk/core/test/test_socket_manager.py
@@ -1175,7 +1175,12 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         msg_id = self.agent1.send_message(test_message_text_1)
         self.assertEqualBy(lambda: self.message_packet is None, False, 8)
         self.assertEqualBy(lambda: acked_packet is None, False, 8)
-        self.assertEqual(self.message_packet.id, acked_packet.id)
+        self.assertEqual(
+            self.message_packet.id,
+            acked_packet.id,
+            'Packet {} was not the expected acked packet {}'
+                .format(self.message_packet, acked_packet)
+        )
         self.assertEqual(self.message_packet.id, msg_id)
         self.assertEqual(self.message_packet.data['text'], test_message_text_1)
 


### PR DESCRIPTION
**Patch description**
This test occasionally fails on circle and I'm not sure why, so I've added some logging to it to make things a little bit more clear. This test is going to be deprecated soon but in the meantime it would be nice to figure it out.
