### PR TITLE
Explicitly use utf-8 encoding in many places.

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -553,14 +553,15 @@ class DictionaryAgent(Agent):
         print('Dictionary: saving dictionary to {}'.format(filename))
 
         make_dir(os.path.dirname(filename))
-        with open(filename, 'a' if append else 'w') as write:
+        mode = 'a' if append else 'w'
+        with open(filename, mode, encoding='utf-8') as write:
             for i in self.ind2tok.keys():
                 tok = self.ind2tok[i]
                 cnt = self.freq[tok]
                 write.write('{tok}\t{cnt}\n'.format(tok=escape(tok), cnt=cnt))
 
         # save opt file
-        with open(filename + '.opt', 'w') as handle:
+        with open(filename + '.opt', 'w', encoding='utf-8') as handle:
             json.dump(self.opt, handle)
 
     def sort(self, trim=True):
@@ -707,7 +708,7 @@ class _BPEHelper(object):
             self._load_from_codecs()
 
     def _load_from_codecs(self):
-        with open(self.codecs, 'r') as codecs_file:
+        with open(self.codecs, 'r', encoding='utf-8') as codecs_file:
             self.bpe = apply_bpe.BPE(codecs_file)
 
     def tokenize(self, text):
@@ -752,7 +753,7 @@ class _BPEHelper(object):
             num_symbols = 30000
         if minfreq <= 0:
             minfreq = 2
-        with open(self.codecs, 'w') as outstream:
+        with open(self.codecs, 'w', encoding='utf-8') as outstream:
             learn_bpe.learn_bpe(
                 dictionary,
                 outstream,
@@ -768,6 +769,7 @@ class _BPEHelper(object):
         """
         Copy the codecs file to a new location.
         """
-        with open(target_file, 'w') as wfile, open(self.codecs) as rfile:
-            for line in rfile:
-                wfile.write(line)
+        with open(target_file, 'w', encoding='utf-8') as wfile:
+            with open(self.codecs, encoding='utf-8') as rfile:
+                for line in rfile:
+                    wfile.write(line)

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -31,7 +31,7 @@ def get_model_name(opt):
             if os.path.isfile(optfile):
                 try:
                     # try json first
-                    with open(optfile, 'r') as handle:
+                    with open(optfile, 'r', encoding='utf-8') as handle:
                         new_opt = json.load(handle)
                         model = new_opt.get('model', None)
                 except UnicodeDecodeError:

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1400,7 +1400,7 @@ class TorchAgent(Agent):
                     torch.save(states, write)
 
                 # save opt file
-                with open(path + '.opt', 'w') as handle:
+                with open(path + '.opt', 'w', encoding='utf-8') as handle:
                     if hasattr(self, 'model_version'):
                         self.opt['model_version'] = self.model_version()
                     json.dump(self.opt, handle)

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -587,7 +587,7 @@ class TorchRankerAgent(TorchAgent):
 
                 # Load candidates
                 print("[ Loading fixed candidate set from {} ]".format(cand_path))
-                with open(cand_path, 'r') as f:
+                with open(cand_path, 'r', encoding='utf-8') as f:
                     cands = [line.strip() for line in f.readlines()]
 
                 # Load or create candidate vectors


### PR DESCRIPTION
**Patch description**
We use UTF-8 encoding in most places in ParlAI, especially all our files. This is fine on our machines (and many OSes) which have default UTF-8 encodings. Users on less friendly OSes might have their system encoding set differently, but our strings are still utf-8. Fixes #1702.

**Testing steps**
```
$ PYTHONIOENCODING=ascii python tests/nightly/gpu/test_wizard.py
----------------------------------------------------------------------
Ran 2 tests in 636.505s

OK

$ CUDA_VISIBLE_DEVICES='' PYTHONIOENCODING=ascii python setup.py test -s tests.suites.unittests -q
running test
Searching for websocket-client
Best match: websocket-client 0.56.0
Processing websocket_client-0.56.0-py3.6.egg

Using /private/home/roller/working/parlai/.eggs/websocket_client-0.56.0-py3.6.egg
running egg_info
writing parlai.egg-info/PKG-INFO
writing dependency_links to parlai.egg-info/dependency_links.txt
writing requirements to parlai.egg-info/requires.txt
writing top-level names to parlai.egg-info/top_level.txt
reading manifest file 'parlai.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'parlai.egg-info/SOURCES.txt'
running build_ext
....E....ss.............................../private/home/roller/.conda/envs/fairseq-fp16-20190211/lib/python3.6/site-packages/numpy/matrixlib/defmatrix.py:68: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
  return matrix(data, dtype=dtype, copy=False)
.......................................
======================================================================
ERROR: test_set_model_file_without_dict_file (test_dict.TestDictionary)
Check that moving a model without moving the dictionary raises the
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/private/home/roller/working/parlai/tests/test_dict.py", line 85, in test_set_model_file_without_dict_file
    os.remove(model_path + '.dict')
FileNotFoundError: [Errno 2] No such file or directory: '/private/home/roller/working/ParlAI/data/models/unittest/seq2seq/model.dict'

----------------------------------------------------------------------
Ran 81 tests in 240.807s
```
Strangely, this seems to have broken something else. Very sad. Pushing anyway.

Also CircleCI with GPU.