### PR TITLE
Block directories in circleci. [long]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,11 @@ setup: &setup
   run:
     name: Sets up the virtual environment
     command: |
+      # make sure everything works outside our dev machines by ensuring there
+      # will be permissions errors if our directories are used
+      mkdir -p /checkpoint /private/home /scratch
+      sudo chmod 000 /checkpoint /private /private/home /scratch
+      # actually set up the environment
       mkdir -p ~/venv
       virtualenv --python=python3.6 ~/venv
       echo ". ~/venv/bin/activate" >> $BASH_ENV


### PR DESCRIPTION
**Patch description**
By default, CircleCI docker images have read/write/etc access to every directory. This means that if our system creates one of our own personal home directories (e.g. `/private/home/roller`), it can read and write from that directory no problem.

This can prevent early detection of bugs like #1622 and #1673, where the files were being downloaded happily in the integration tests, but not working for actual users.

**Testing steps**
CircleCI should pass.