### PR TITLE
Fix locally broken unit test.

### DIFF
--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 from parlai.core.build_data import modelzoo_path
 from parlai.core.dict import find_ngrams
+from parlai.core.params import ParlaiParser
 import parlai.core.testing_utils as testing_utils
 import os
 import shutil
@@ -68,11 +69,7 @@ class TestDictionary(unittest.TestCase):
         appropriate error.
         """
         # Download model, move to a new location
-        datapath = os.path.join(
-            (os.path.dirname(os.path.dirname(os.path.dirname(
-             os.path.realpath(__file__))))),
-            'ParlAI/data',
-        )
+        datapath = ParlaiParser().parse_args(print_args=False)['datapath']
         try:
             # remove unittest models if there before
             shutil.rmtree(os.path.join(datapath, 'models/unittest'))


### PR DESCRIPTION
**Patch description**
I complained about a unittest being broken on devfairs in #1705, but not CircleCI. This turned out to be broken on master.

Looks like this bug was another casualty of #1668 or similar.

**Testing steps**
```
$ python setup.py test -s tests.suites.unittests -q
running test
Searching for websocket-client
Best match: websocket-client 0.56.0
Processing websocket_client-0.56.0-py3.6.egg

Using /private/home/roller/working/parlai/.eggs/websocket_client-0.56.0-py3.6.egg
running egg_info
writing parlai.egg-info/PKG-INFO
writing dependency_links to parlai.egg-info/dependency_links.txt
writing requirements to parlai.egg-info/requires.txt
writing top-level names to parlai.egg-info/top_level.txt
reading manifest file 'parlai.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'parlai.egg-info/SOURCES.txt'
running build_ext
...........ss......s...............s....../private/home/roller/.conda/envs/fairseq-fp16-20190211/lib/python3.6/site-packages/numpy/matrixlib/defmatrix.py:68: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
  return matrix(data, dtype=dtype, copy=False)
.......................................
----------------------------------------------------------------------
Ran 81 tests in 404.562s

OK (skipped=4)
```