### PR TITLE
Fix coqa

### DIFF
--- a/parlai/tasks/coqa/build.py
+++ b/parlai/tasks/coqa/build.py
@@ -16,25 +16,25 @@ URL = 'https://nlp.stanford.edu/data/coqa/'
 
 def make_parlai_format(outpath, dtype, data):
     print('building parlai:' + dtype)
-    for each in data:
-        output = []
-        story = each['story'].replace('\n', '\\n')
-        for question, ans in zip(each['questions'], each['answers']):
-            question_txt = ''
-            if question['turn_id'] == 1:
-                # include the context in the very first turn
-                question_txt = story + '\\n' + question['input_text']
-            else:
-                question_txt = question['input_text']
-            output.append('text:{question}\tlabels:{labels}'.format(
-                question=question_txt,
-                labels=ans['input_text'].replace('|', ' __PIPE__ ')
-            ))
-            if question['turn_id'] < len(each['questions']):
-                output.append('\n')
-        output.append('\t\tepisode_done:True\n')
     with open(os.path.join(outpath, dtype + '.txt'), 'w') as fout:
-        fout.write(''.join(output))
+        for each in data:
+            output = []
+            story = each['story'].replace('\n', '\\n')
+            for question, ans in zip(each['questions'], each['answers']):
+                question_txt = ''
+                if question['turn_id'] == 1:
+                    # include the context in the very first turn
+                    question_txt = story + '\\n' + question['input_text']
+                else:
+                    question_txt = question['input_text']
+                output.append('text:{question}\tlabels:{labels}'.format(
+                    question=question_txt,
+                    labels=ans['input_text'].replace('|', ' __PIPE__ ')
+                ))
+                if question['turn_id'] < len(each['questions']):
+                    output.append('\n')
+            output.append('\t\tepisode_done:True\n')
+            fout.write(''.join(output))
 
 
 def build(opt):

--- a/parlai/tasks/coqa/build.py
+++ b/parlai/tasks/coqa/build.py
@@ -11,6 +11,7 @@ import json
 
 TRAIN_FILENAME = 'coqa-train-v1.0.json'
 VALID_FILENAME = 'coqa-dev-v1.0.json'
+VERSION = '1.0'
 URL = 'https://nlp.stanford.edu/data/coqa/'
 
 
@@ -39,7 +40,7 @@ def make_parlai_format(outpath, dtype, data):
 
 def build(opt):
     dpath = os.path.join(opt['datapath'], 'CoQA')
-    version = None
+    version = VERSION
 
     if not build_data.built(dpath, version_string=version):
         print('[building data: ' + dpath + ']')


### PR DESCRIPTION
**Patch description**
The previous PR mistakenly put 
```
with open(os.path.join(outpath, dtype + '.txt'), 'w') as fout:
        fout.write(''.join(output))
```
at the end of the file, so the only the last sample get printed out.
We also add version `1.0` to force an update for the user.

**Logs**

```
python examples/display_data.py -t coqa
```
```
 rm -rf /tmp/tg*  &&  python examples/train_model.py -m transformer/generator  -t coqa -bs 32 -mf /tmp/tg00  --truncate 1024
```

```
[ loaded 7199 episodes with a total of 108647 examples ]
```
```
[ training... ]
[ time:2.0s total_exs:448 epochs:0.0 ] {'exs': 448, 'lr': 1, 'num_updates': 14, 'loss': 132.2, 'token_acc': 0.1986, 'nll_loss': 9.428, 'ppl': 12440.0}
[ time:4.0s total_exs:928 epochs:0.01 ] {'exs': 480, 'lr': 1, 'num_updates': 29, 'loss': 122.7, 'token_acc': 0.2738, 'nll_loss': 8.222, 'ppl': 3723.0}
[ time:6.0s total_exs:1376 epochs:0.01 ] {'exs': 448, 'lr': 1, 'num_updates': 43, 'loss': 114.1, 'token_acc': 0.2506, 'nll_loss': 8.182, 'ppl': 3576.0}
[ time:8.0s total_exs:1760 epochs:0.02 ] {'exs': 384, 'lr': 1, 'num_updates': 55, 'loss': 98.06, 'token_acc': 0.2238, 'nll_loss': 8.221, 'ppl': 3718.0}
[ time:10.0s total_exs:2240 epochs:0.02 ] {'exs': 480, 'lr': 1, 'num_updates': 70, 'loss': 116.7, 'token_acc': 0.2522, 'nll_loss': 7.817, 'ppl': 2481.0}
[ time:12.0s total_exs:2752 epochs:0.03 ] {'exs': 512, 'lr': 1, 'num_updates': 86, 'loss': 123.5, 'token_acc': 0.2348, 'nll_loss': 7.763, 'ppl': 2351.0}
[ time:14.0s total_exs:3264 epochs:0.03 ] {'exs': 512, 'lr': 1, 'num_updates': 102, 'loss': 117.9, 'token_acc': 0.2699, 'nll_loss': 7.39, 'ppl': 1620.0}
[ time:16.0s total_exs:3776 epochs:0.03 ] {'exs': 512, 'lr': 1, 'num_updates': 118, 'loss': 120.1, 'token_acc': 0.258, 'nll_loss': 7.534, 'ppl': 1871.0}
[ time:18.0s total_exs:4224 epochs:0.04 ] {'exs': 448, 'lr': 1, 'num_updates': 132, 'loss': 105.4, 'token_acc': 0.247, 'nll_loss': 7.548, 'ppl': 1898.0}
[ time:20.0s total_exs:4544 epochs:0.04 ] {'exs': 320, 'lr': 1, 'num_updates': 142, 'loss': 75.72, 'token_acc': 0.2534, 'nll_loss': 7.632, 'ppl': 2063.0}
[ time:22.0s total_exs:4992 epochs:0.05 ] {'exs': 448, 'lr': 1, 'num_updates': 156, 'loss': 102.7, 'token_acc': 0.2618, 'nll_loss': 7.381, 'ppl': 1605.0}
[ time:24.0s total_exs:5472 epochs:0.05 ] {'exs': 480, 'lr': 1, 'num_updates': 171, 'loss': 109.1, 'token_acc': 0.2677, 'nll_loss': 7.307, 'ppl': 1490.0}
[ time:26.0s total_exs:5984 epochs:0.06 ] {'exs': 512, 'lr': 1, 'num_updates': 187, 'loss': 116.6, 'token_acc': 0.281, 'nll_loss': 7.335, 'ppl': 1533.0}
[ time:29.0s total_exs:6464 epochs:0.06 ] {'exs': 480, 'lr': 1, 'num_updates': 202, 'loss': 111.9, 'token_acc': 0.2549, 'nll_loss': 7.476, 'ppl': 1766.0}
[ time:31.0s total_exs:6848 epochs:0.06 ] {'exs': 384, 'lr': 1, 'num_updates': 214, 'loss': 88.39, 'token_acc': 0.246, 'nll_loss': 7.384, 'ppl': 1609.0}
[ time:33.0s total_exs:7264 epochs:0.07 ] {'exs': 416, 'lr': 1, 'num_updates': 227, 'loss': 91.73, 'token_acc': 0.274, 'nll_loss': 7.092, 'ppl': 1202.0}
[ time:35.0s total_exs:7776 epochs:0.07 ] {'exs': 512, 'lr': 1, 'num_updates': 243, 'loss': 115.1, 'token_acc': 0.2588, 'nll_loss': 7.223, 'ppl': 1370.0}
[ time:37.0s total_exs:8288 epochs:0.08 ] {'exs': 512, 'lr': 1, 'num_updates': 259, 'loss': 115.1, 'token_acc': 0.2549, 'nll_loss': 7.217, 'ppl': 1362.0}
[ time:39.0s total_exs:8832 epochs:0.08 ] {'exs': 544, 'lr': 1, 'num_updates': 276, 'loss': 119.8, 'token_acc': 0.2768, 'nll_loss': 7.067, 'ppl': 1173.0}
[ time:41.0s total_exs:9280 epochs:0.09 ] {'exs': 448, 'lr': 1, 'num_updates': 290, 'loss': 98.48, 'token_acc': 0.2508, 'nll_loss': 7.071, 'ppl': 1178.0}
[ time:43.0s total_exs:9632 epochs:0.09 ] {'exs': 352, 'lr': 1, 'num_updates': 301, 'loss': 76.85, 'token_acc': 0.2575, 'nll_loss': 7.016, 'ppl': 1114.0}
[ time:45.0s total_exs:10016 epochs:0.09 ] {'exs': 384, 'lr': 1, 'num_updates': 313, 'loss': 79.84, 'token_acc': 0.293, 'nll_loss': 6.723, 'ppl': 831.6}
[ time:47.0s total_exs:10496 epochs:0.1 ] {'exs': 480, 'lr': 1, 'num_updates': 328, 'loss': 101.7, 'token_acc': 0.2927, 'nll_loss': 6.798, 'ppl': 895.8}
[ time:49.0s total_exs:10880 epochs:0.1 ] {'exs': 384, 'lr': 1, 'num_updates': 340, 'loss': 82.71, 'token_acc': 0.2663, 'nll_loss': 6.938, 'ppl': 1031.0}
[ time:51.0s total_exs:11264 epochs:0.1 ] {'exs': 384, 'lr': 1, 'num_updates': 352, 'loss': 84.66, 'token_acc': 0.2574, 'nll_loss': 7.06, 'ppl': 1165.0}
[ time:53.0s total_exs:11744 epochs:0.11 ] {'exs': 480, 'lr': 1, 'num_updates': 367, 'loss': 104.0, 'token_acc': 0.2808, 'nll_loss': 6.972, 'ppl': 1066.0}
[ time:56.0s total_exs:12256 epochs:0.11 ] {'exs': 512, 'lr': 1, 'num_updates': 383, 'loss': 111.3, 'token_acc': 0.2877, 'nll_loss': 6.966, 'ppl': 1060.0}
[ time:58.0s total_exs:12768 epochs:0.12 ] {'exs': 512, 'lr': 1, 'num_updates': 399, 'loss': 109.0, 'token_acc': 0.2848, 'nll_loss': 6.832, 'ppl': 926.9}
[ time:60.0s total_exs:13248 epochs:0.12 ] {'exs': 480, 'lr': 1, 'num_updates': 414, 'loss': 104.3, 'token_acc': 0.2422, 'nll_loss': 6.989, 'ppl': 1084.0}
[ time:62.0s total_exs:13664 epochs:0.13 ] {'exs': 416, 'lr': 1, 'num_updates': 427, 'loss': 91.05, 'token_acc': 0.266, 'nll_loss': 7.04, 'ppl': 1141.0}
[ time:64.0s total_exs:14048 epochs:0.13 ] {'exs': 384, 'lr': 1, 'num_updates': 439, 'loss': 82.73, 'token_acc': 0.2946, 'nll_loss': 6.904, 'ppl': 996.2}
[ time:66.0s total_exs:14496 epochs:0.13 ] {'exs': 448, 'lr': 1, 'num_updates': 453, 'loss': 94.46, 'token_acc': 0.2591, 'nll_loss': 6.81, 'ppl': 906.5}
[ time:68.0s total_exs:14976 epochs:0.14 ] {'exs': 480, 'lr': 1, 'num_updates': 468, 'loss': 101.0, 'token_acc': 0.2685, 'nll_loss': 6.755, 'ppl': 858.1}
[ time:70.0s total_exs:15488 epochs:0.14 ] {'exs': 512, 'lr': 1, 'num_updates': 484, 'loss': 107.0, 'token_acc': 0.2815, 'nll_loss': 6.72, 'ppl': 829.1}
[ time:72.0s total_exs:16032 epochs:0.15 ] {'exs': 544, 'lr': 1, 'num_updates': 501, 'loss': 119.9, 'token_acc': 0.2372, 'nll_loss': 7.074, 'ppl': 1181.0}
[ time:74.0s total_exs:16544 epochs:0.15 ] {'exs': 512, 'lr': 1, 'num_updates': 517, 'loss': 108.2, 'token_acc': 0.2733, 'nll_loss': 6.779, 'ppl': 879.1}
[ time:76.0s total_exs:17056 epochs:0.16 ] {'exs': 512, 'lr': 1, 'num_updates': 533, 'loss': 108.0, 'token_acc': 0.2774, 'nll_loss': 6.781, 'ppl': 880.7}
[ time:78.0s total_exs:17408 epochs:0.16 ] {'exs': 352, 'lr': 1, 'num_updates': 544, 'loss': 73.98, 'token_acc': 0.2824, 'nll_loss': 6.78, 'ppl': 880.3}
[ time:80.0s total_exs:17760 epochs:0.16 ] {'exs': 352, 'lr': 1, 'num_updates': 555, 'loss': 74.06, 'token_acc': 0.2745, 'nll_loss': 6.8, 'ppl': 898.0}
[ time:82.0s total_exs:18176 epochs:0.17 ] {'exs': 416, 'lr': 1, 'num_updates': 568, 'loss': 88.5, 'token_acc': 0.2724, 'nll_loss': 6.85, 'ppl': 943.7}
[ time:84.0s total_exs:18688 epochs:0.17 ] {'exs': 512, 'lr': 1, 'num_updates': 584, 'loss': 108.1, 'token_acc': 0.2778, 'nll_loss': 6.799, 'ppl': 896.8}
[ time:87.0s total_exs:19136 epochs:0.18 ] {'exs': 448, 'lr': 1, 'num_updates': 598, 'loss': 92.43, 'token_acc': 0.2939, 'nll_loss': 6.63, 'ppl': 757.7}
[ time:89.0s total_exs:19520 epochs:0.18 ] {'exs': 384, 'lr': 1, 'num_updates': 610, 'loss': 80.5, 'token_acc': 0.2547, 'nll_loss': 6.755, 'ppl': 858.7}
[ time:91.0s total_exs:19872 epochs:0.18 ] {'exs': 352, 'lr': 1, 'num_updates': 621, 'loss': 72.04, 'token_acc': 0.2675, 'nll_loss': 6.61, 'ppl': 742.2}
[ time:93.0s total_exs:20352 epochs:0.19 ] {'exs': 480, 'lr': 1, 'num_updates': 636, 'loss': 97.52, 'token_acc': 0.2916, 'nll_loss': 6.517, 'ppl': 676.6}
[ time:95.0s total_exs:20896 epochs:0.19 ] {'exs': 544, 'lr': 1, 'num_updates': 653, 'loss': 112.0, 'token_acc': 0.2881, 'nll_loss': 6.627, 'ppl': 755.3}
[ time:97.0s total_exs:21440 epochs:0.2 ] {'exs': 544, 'lr': 1, 'num_updates': 670, 'loss': 112.6, 'token_acc': 0.2815, 'nll_loss': 6.665, 'ppl': 784.8}
[ time:99.0s total_exs:21952 epochs:0.2 ] {'exs': 512, 'lr': 1, 'num_updates': 686, 'loss': 104.1, 'token_acc': 0.3017, 'nll_loss': 6.514, 'ppl': 674.4}
[ time:101.0s total_exs:22464 epochs:0.21 ] {'exs': 512, 'lr': 1, 'num_updates': 702, 'loss': 107.6, 'token_acc': 0.2643, 'nll_loss': 6.757, 'ppl': 859.8}
[ time:103.0s total_exs:22976 epochs:0.21 ] {'exs': 512, 'lr': 1, 'num_updates': 718, 'loss': 106.7, 'token_acc': 0.2791, 'nll_loss': 6.67, 'ppl': 788.2}
[ time:105.0s total_exs:23392 epochs:0.22 ] {'exs': 416, 'lr': 1, 'num_updates': 731, 'loss': 86.64, 'token_acc': 0.2546, 'nll_loss': 6.708, 'ppl': 818.6}
[ time:107.0s total_exs:23808 epochs:0.22 ] {'exs': 416, 'lr': 1, 'num_updates': 744, 'loss': 83.6, 'token_acc': 0.2915, 'nll_loss': 6.461, 'ppl': 639.8}
[ time:109.0s total_exs:24320 epochs:0.22 ] {'exs': 512, 'lr': 1, 'num_updates': 760, 'loss': 106.9, 'token_acc': 0.26, 'nll_loss': 6.691, 'ppl': 805.1}
[ time:111.0s total_exs:24800 epochs:0.23 ] {'exs': 480, 'lr': 1, 'num_updates': 775, 'loss': 98.92, 'token_acc': 0.2779, 'nll_loss': 6.63, 'ppl': 757.2}
[ time:113.0s total_exs:25216 epochs:0.23 ] {'exs': 416, 'lr': 1, 'num_updates': 788, 'loss': 84.02, 'token_acc': 0.2915, 'nll_loss': 6.534, 'ppl': 688.1}
[ time:115.0s total_exs:25696 epochs:0.24 ] {'exs': 480, 'lr': 1, 'num_updates': 803, 'loss': 98.75, 'token_acc': 0.2708, 'nll_loss': 6.61, 'ppl': 742.3}
[ time:118.0s total_exs:26240 epochs:0.24 ] {'exs': 544, 'lr': 1, 'num_updates': 820, 'loss': 106.2, 'token_acc': 0.2853, 'nll_loss': 6.315, 'ppl': 552.6}
[ time:120.0s total_exs:26720 epochs:0.25 ] {'exs': 480, 'lr': 1, 'num_updates': 835, 'loss': 98.71, 'token_acc': 0.2809, 'nll_loss': 6.597, 'ppl': 732.5}
[ time:122.0s total_exs:27104 epochs:0.25 ] {'exs': 384, 'lr': 1, 'num_updates': 847, 'loss': 78.08, 'token_acc': 0.2836, 'nll_loss': 6.535, 'ppl': 689.2}
[ time:124.0s total_exs:27552 epochs:0.25 ] {'exs': 448, 'lr': 1, 'num_updates': 861, 'loss': 91.76, 'token_acc': 0.2731, 'nll_loss': 6.577, 'ppl': 718.3}
[ time:126.0s total_exs:27936 epochs:0.26 ] {'exs': 384, 'lr': 1, 'num_updates': 873, 'loss': 77.64, 'token_acc': 0.2791, 'nll_loss': 6.511, 'ppl': 672.5}
[ time:128.0s total_exs:28320 epochs:0.26 ] {'exs': 384, 'lr': 1, 'num_updates': 885, 'loss': 76.16, 'token_acc': 0.2708, 'nll_loss': 6.375, 'ppl': 587.0}
[ time:130.0s total_exs:28864 epochs:0.27 ] {'exs': 544, 'lr': 1, 'num_updates': 902, 'loss': 108.1, 'token_acc': 0.2861, 'nll_loss': 6.391, 'ppl': 596.7}
[ time:132.0s total_exs:29408 epochs:0.27 ] {'exs': 544, 'lr': 1, 'num_updates': 919, 'loss': 110.5, 'token_acc': 0.2796, 'nll_loss': 6.525, 'ppl': 682.2}
[ time:134.0s total_exs:29888 epochs:0.28 ] {'exs': 480, 'lr': 1, 'num_updates': 934, 'loss': 95.87, 'token_acc': 0.2616, 'nll_loss': 6.448, 'ppl': 631.6}
[ time:137.0s total_exs:30400 epochs:0.28 ] {'exs': 512, 'lr': 1, 'num_updates': 950, 'loss': 105.3, 'token_acc': 0.2827, 'nll_loss': 6.585, 'ppl': 724.2}
[ time:139.0s total_exs:30912 epochs:0.28 ] {'exs': 512, 'lr': 1, 'num_updates': 966, 'loss': 104.9, 'token_acc': 0.2667, 'nll_loss': 6.586, 'ppl': 725.0}
[ time:141.0s total_exs:31296 epochs:0.29 ] {'exs': 384, 'lr': 1, 'num_updates': 978, 'loss': 79.59, 'token_acc': 0.2487, 'nll_loss': 6.744, 'ppl': 849.2}
```

**Data tests (if applicable)**
`python setup.py test -s tests.suites.datatests`
```
running test
running egg_info
writing parlai.egg-info/PKG-INFO
writing dependency_links to parlai.egg-info/dependency_links.txt
writing requirements to parlai.egg-info/requires.txt
writing top-level names to parlai.egg-info/top_level.txt
reading manifest file 'parlai.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'parlai.egg-info/SOURCES.txt'
running build_ext
test_verify_data (test_new_tasks.TestNewTasks) ... ok

----------------------------------------------------------------------
Ran 1 test in 13.334s

OK
```
