### PR TITLE
Add warning when positions exceeds embedding matrix size

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -358,11 +358,11 @@ class TransformerEncoder(nn.Module):
         if self.embeddings_scale:
             tensor = tensor * np.sqrt(self.dim)
 
-        if positions.shape[1] > self.n_positions:
+        if positions.max().item() > self.n_positions:
             warn_once(
                 'You are inputting a sequence of {x} length, but only have'
                 '--n-positions {y}. Set --truncate or increase --n-positions'.format(
-                    x=positions.shape[1],
+                    x=positions.max().item(),
                     y=self.n_positions)
             )
         tensor = tensor + self.position_embeddings(positions).expand_as(tensor)
@@ -537,11 +537,11 @@ class TransformerDecoder(nn.Module):
             tensor = tensor * np.sqrt(self.dim)
         if self.variant == 'xlm':
             tensor = _normalize(tensor, self.norm_embeddings)
-        if positions.shape[1] > self.n_positions:
+        if positions.max().item() > self.n_positions:
             warn_once(
                 'You are inputting a sequence of {x} length, but only have'
                 '--n-positions {y}. Set --truncate or increase --n-positions'.format(
-                    x=positions.shape[1],
+                    x=positions.max().item(),
                     y=self.n_positions)
             )
         tensor = tensor + self.position_embeddings(positions).expand_as(tensor)

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -360,7 +360,7 @@ class TransformerEncoder(nn.Module):
 
         if positions.max().item() > self.n_positions:
             warn_once(
-                'You are inputting a sequence of {x} length, but only have'
+                'You are inputting a sequence of {x} length, but only have '
                 '--n-positions {y}. Set --truncate or increase --n-positions'.format(
                     x=positions.max().item(),
                     y=self.n_positions)
@@ -539,7 +539,7 @@ class TransformerDecoder(nn.Module):
             tensor = _normalize(tensor, self.norm_embeddings)
         if positions.max().item() > self.n_positions:
             warn_once(
-                'You are inputting a sequence of {x} length, but only have'
+                'You are inputting a sequence of {x} length, but only have '
                 '--n-positions {y}. Set --truncate or increase --n-positions'.format(
                     x=positions.max().item(),
                     y=self.n_positions)

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -10,6 +10,7 @@ import math
 import numpy as np
 
 from parlai.core.torch_generator_agent import TorchGeneratorModel
+from parlai.core.utils import warn_once
 from parlai.core.utils import neginf
 
 LAYER_NORM_EPS = 1e-12  # Epsilon for layer norm.
@@ -291,6 +292,7 @@ class TransformerEncoder(nn.Module):
         self.variant = variant
         self.n_segments = n_segments
 
+        self.n_positions = n_positions
         self.out_dim = embedding_size
         assert embedding_size % n_heads == 0, \
             'Transformer embedding size must be a multiple of n_heads'
@@ -356,6 +358,13 @@ class TransformerEncoder(nn.Module):
         if self.embeddings_scale:
             tensor = tensor * np.sqrt(self.dim)
 
+        if positions.shape[1] > self.n_positions:
+            warn_once(
+                'You are inputting a sequence of {x} length, but only have'
+                '--n-positions {y}. Set --truncate or increase --n-positions'.format(
+                    x=positions.shape[1],
+                    y=self.n_positions)
+            )
         tensor = tensor + self.position_embeddings(positions).expand_as(tensor)
 
         if self.n_segments >= 1:
@@ -482,6 +491,7 @@ class TransformerDecoder(nn.Module):
         self.embeddings_scale = embeddings_scale
         self.dropout = nn.Dropout(p=dropout)  # --dropout
 
+        self.n_positions = n_positions
         self.out_dim = embedding_size
         assert embedding_size % n_heads == 0, \
             'Transformer embedding size must be a multiple of n_heads'
@@ -527,7 +537,13 @@ class TransformerDecoder(nn.Module):
             tensor = tensor * np.sqrt(self.dim)
         if self.variant == 'xlm':
             tensor = _normalize(tensor, self.norm_embeddings)
-
+        if positions.shape[1] > self.n_positions:
+            warn_once(
+                'You are inputting a sequence of {x} length, but only have'
+                '--n-positions {y}. Set --truncate or increase --n-positions'.format(
+                    x=positions.shape[1],
+                    y=self.n_positions)
+            )
         tensor = tensor + self.position_embeddings(positions).expand_as(tensor)
         tensor = self.dropout(tensor)  # --dropout
 


### PR DESCRIPTION
**Patch description**
We give an warning of the sentence length goes beyond the n-position (1024 by default) 

**Logs**
```
 rm -rf /tmp/tg*  &&   python examples/train_model.py -m transformer/generator  -t coqa   -bs 32 -mf /tmp/tg01
```
```
[loading parlAI text data:/private/home/daju/ParlAI/data/CoQA/train.txt]
[ training... ]
[ time:2.0s total_exs:608 epochs:0.01 ] {'exs': 608, 'lr': 1, 'num_updates': 19, 'loss': 171.9, 'token_acc': 0.2386, 'nll_loss': 9.098, 'ppl': 8938.0}
[ time:4.0s total_exs:1216 epochs:0.01 ] {'exs': 608, 'lr': 1, 'num_updates': 38, 'loss': 156.3, 'token_acc': 0.2707, 'nll_loss': 8.269, 'ppl': 3901.0}
[ time:6.0s total_exs:1792 epochs:0.02 ] {'exs': 576, 'lr': 1, 'num_updates': 56, 'loss': 145.0, 'token_acc': 0.2477, 'nll_loss': 8.094, 'ppl': 3274.0}
[ time:8.0s total_exs:2304 epochs:0.02 ] {'exs': 512, 'lr': 1, 'num_updates': 72, 'loss': 124.0, 'token_acc': 0.2549, 'nll_loss': 7.82, 'ppl': 2489.0}
[ time:10.0s total_exs:2912 epochs:0.03 ] {'exs': 608, 'lr': 1, 'num_updates': 91, 'loss': 148.4, 'token_acc': 0.239, 'nll_loss': 7.844, 'ppl': 2552.0}
/private/home/daju/ParlAI/parlai/agents/transformer/modules.py:366: UserWarning: You are inputting a sequence of 1042 length, but only have--n-positions 1024. Set --truncate or increase --n-positions
  y=self.n_positions)
```

