### PR TITLE
New circleCI config which would've caught bug.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,14 +35,13 @@ setup: &setup
       echo ". ~/venv/bin/activate" >> $BASH_ENV
       . ~/venv/bin/activate
       pip3 install --upgrade --progress-bar off pip
-      pip3 install --progress-bar off flake8 gitpython
-      python setup.py develop --no-deps
+
 
 installdeps: &installdeps
   run:
     name: Installs basic dependencies
     command: |
-      pip3 install --progress-bar off -r requirements.txt
+      python setup.py develop
 
 installtorchgpu: &installtorchgpu
   run:
@@ -125,7 +124,9 @@ jobs:
       - run:
           name: Lint
           working_directory: ~/ParlAI
-          command: bash ./tests/lint_changed.sh
+          command: |
+            pip install flake8 gitpython flake8-bugbear  # only what's needd to lint
+            bash ./tests/lint_changed.sh
 
   nightly_gpu_tests:
     <<: *gpu
@@ -215,6 +216,8 @@ jobs:
           name: "Conditionally launching long tests..."
           working_directory: ~/ParlAI/
           command: |
+            pip install gitpython
+            python setup.py develop --no-deps
             python .circleci/triggers.py | while read job; do
               curl -s \
                 --data "build_parameters[CIRCLE_JOB]=${job}" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 Pillow
 boto3
 botocore
-flake8
 flake8-bugbear
+flake8
 gitpython
 h5py
 joblib


### PR DESCRIPTION
**Patch description**
#1732 shows that our CircleCI missed a basic error with setup.py failing. This was due to some "hacks" in the CircleCI to ensure the lint was fast as possible. This patch updates the circleci setup to be as close to the issue as possible

**Testing steps**
This PR should show a failure on the initial commit, and pass on the second commit. The first identifies that we would've identified #1732, and the second shows that this fixes #1732.

The error logs for the first commit should say

**Logs**
```
Installed /private/home/roller/.conda/envs/test/lib/python3.6/site-packages/flake8_bugbear-19.3.0-py3.6.egg
error: The 'flake8' distribution was not found and is required by parlai
```