### PR TITLE
Internal Zoo shortcuts

### DIFF
--- a/docs/source/tutorial_basic.rst
+++ b/docs/source/tutorial_basic.rst
@@ -338,7 +338,7 @@ Here are some examples:
    python examples/train_model.py -m drqa -t squad -bs 32 -mf /tmp/model_drqa
 
    #Tests an existing attentive LSTM model (DrQA reader) on the SQuAD dataset from our model zoo:
-   python examples/eval_model.py -t squad -mf "models:drqa/squad/model"
+   python examples/eval_model.py -t squad -mf "zoo:drqa/squad/model"
 
 
 The main flags are:

--- a/docs/source/tutorial_messenger.rst
+++ b/docs/source/tutorial_messenger.rst
@@ -15,7 +15,7 @@ Facebook agents communicate in observation/action dict format, the same as all o
 
 .. figure:: _static/img/personachat_example.png
    :align: center
-   
+
    *Sample chat with a PersonaChat model over messenger*
 
 Each messenger task has at least one messenger agent that connects to ParlAI using the Facebook messenger Send/Receive API, encapsulated as a ``MessengerAgent`` object.
@@ -44,7 +44,7 @@ For instance, after downloading the personachat models you can run:
 
 .. code-block:: bash
 
-    python run.py --model projects.personachat.kvmemnn.kvmemnn:Kvmemnn --model_file models:personachat/kvmemnn/kvmemnn/persona-self_rephraseTrn-True_rephraseTst-False_lr-0.1_esz-500_margin-0.1_tfidf-False_shareEmb-True_hops1_lins0_model
+    python run.py --model projects.personachat.kvmemnn.kvmemnn:Kvmemnn --model_file zoo:personachat/kvmemnn/kvmemnn/persona-self_rephraseTrn-True_rephraseTst-False_lr-0.1_esz-500_margin-0.1_tfidf-False_shareEmb-True_hops1_lins0_model
 
 This code will allow users to talk with a bot in conversations like the one displayed above.
 

--- a/parlai/agents/drqa/drqa.py
+++ b/parlai/agents/drqa/drqa.py
@@ -15,7 +15,7 @@ Note:
 To use pretrained word embeddings, set the --embedding_file path argument.
 GloVe is recommended, see http://nlp.stanford.edu/data/glove.840B.300d.zip.
 To automatically download glove, use:
---embedding_file models:glove_vectors/glove.840B.300d.txt
+--embedding_file zoo:glove_vectors/glove.840B.300d.txt
 """
 
 try:

--- a/parlai/agents/tfidf_retriever/README.md
+++ b/parlai/agents/tfidf_retriever/README.md
@@ -16,5 +16,5 @@ python examples/eval_model.py -t personachat -mf /tmp/personachat_tfidf -dt test
 
  Alternatively, interact with a Wikipedia-based TFIDF model from the model zoo
  ```bash
- python examples/interactive.py -mf models:wikipedia_full/tfidf_retriever/model
+ python examples/interactive.py -mf zoo:wikipedia_full/tfidf_retriever/model
  ```

--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -16,6 +16,8 @@ import requests
 import shutil
 import tqdm
 
+from parlai.core.utils import warn_once
+
 
 def built(path, version_string=None):
     """
@@ -244,9 +246,9 @@ def modelzoo_path(datapath, path):
     """
     if path is None:
         return None
-    if not path.startswith('models:'):
+    if not path.startswith('models:') and not path.startswith('internal:'):
         return path
-    else:
+    elif path.startswith('models:'):
         # Check if we need to download the model
         animal = path[7:path.rfind('/')].replace('/', '.')
         if '.' not in animal:
@@ -259,3 +261,17 @@ def modelzoo_path(datapath, path):
             pass
 
         return os.path.join(datapath, 'models', path[7:])
+    else:
+        # Internal path --  useful for non-public projects.
+        # Save the path to your internal model zoo in
+        # parlai_internal/.internal_zoo_path
+        zoo_path = 'parlai_internal/zoo/.internal_zoo_path'
+        if not os.path.isfile('parlai_internal/zoo/.internal_zoo_path'):
+            warn_once('Please specify the path to your internal zoo in the '
+                      'file parlai_internal/zoo/.internal_zoo_path in your '
+                      'internal repository.')
+            return None
+        else:
+            with open(zoo_path, 'r') as f:
+                zoo = f.read().split('\n')[0]
+            return os.path.join(zoo, path[9:])

--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -266,6 +266,7 @@ def modelzoo_path(datapath, path):
         # Internal path (starts with "izoo:") -- useful for non-public
         # projects.  Save the path to your internal model zoo in
         # parlai_internal/.internal_zoo_path
+        # TODO: test the internal zoo.
         zoo_path = 'parlai_internal/zoo/.internal_zoo_path'
         if not os.path.isfile('parlai_internal/zoo/.internal_zoo_path'):
             raise RuntimeError(

--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -263,8 +263,8 @@ def modelzoo_path(datapath, path):
 
         return os.path.join(datapath, 'models', path[zoo_len:])
     else:
-        # Internal path (starts with "izoo:")--useful for non-public projects.
-        # Save the path to your internal model zoo in
+        # Internal path (starts with "izoo:") -- useful for non-public
+        # projects.  Save the path to your internal model zoo in
         # parlai_internal/.internal_zoo_path
         zoo_path = 'parlai_internal/zoo/.internal_zoo_path'
         if not os.path.isfile('parlai_internal/zoo/.internal_zoo_path'):

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -697,7 +697,7 @@ class ParlaiParser(argparse.ArgumentParser):
                     self.overridable[key] = self.opt[key]
         self.opt['override'] = self.overridable
 
-        # map filenames that start with 'models:' to point to the model zoo dir
+        # map filenames that start with 'zoo:' to point to the model zoo dir
         if self.opt.get('model_file') is not None:
             self.opt['model_file'] = modelzoo_path(self.opt.get('datapath'),
                                                    self.opt['model_file'])

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -858,7 +858,7 @@ class TorchAgent(Agent):
             embs = vocab.GloVe(
                 name=name, dim=pretrained_dim,
                 cache=modelzoo_path(self.opt.get('datapath'),
-                                    'models:glove_vectors'))
+                                    'zoo:glove_vectors'))
         elif emb_type.startswith('fasttext_cc'):
             init = 'fasttext_cc'
             from parlai.zoo.fasttext_cc_vectors.build import download

--- a/tests/nightly/gpu/test_controllable.py
+++ b/tests/nightly/gpu/test_controllable.py
@@ -69,7 +69,7 @@ class TestControllableDialogue(unittest.TestCase):
         Check the greedy model produces correct results.
         """
         _, valid, _ = testing_utils.eval_model({
-            'model_file': 'models:controllable_dialogue/convai2_finetuned_baseline',
+            'model_file': 'zoo:controllable_dialogue/convai2_finetuned_baseline',
             'task': 'projects.controllable_dialogue.tasks.agents',
             'beam_size': 1,
             'batchsize': 64,
@@ -83,7 +83,7 @@ class TestControllableDialogue(unittest.TestCase):
         Check the beamsearch baseline produces correct results.
         """
         _, valid, _ = testing_utils.eval_model({
-            'model_file': 'models:controllable_dialogue/convai2_finetuned_baseline',
+            'model_file': 'zoo:controllable_dialogue/convai2_finetuned_baseline',
             'task': 'projects.controllable_dialogue.tasks.agents',
             'beam_size': 20,
             'beam_min_n_best': 10,
@@ -103,7 +103,7 @@ class TestControllableDialogue(unittest.TestCase):
         Checks the finetuned model with repetition blocking produces correct results.
         """
         _, valid, _ = testing_utils.eval_model({
-            'model_file': 'models:controllable_dialogue/convai2_finetuned_baseline',
+            'model_file': 'zoo:controllable_dialogue/convai2_finetuned_baseline',
             'task': 'projects.controllable_dialogue.tasks.agents',
             'beam_size': 20,
             'beam_min_n_best': 10,
@@ -126,7 +126,7 @@ class TestControllableDialogue(unittest.TestCase):
         """
         _, valid, _ = testing_utils.eval_model({
             # b11e10 stands for 11 buckets, embedding size 10
-            'model_file': 'models:controllable_dialogue/control_questionb11e10',
+            'model_file': 'zoo:controllable_dialogue/control_questionb11e10',
             'task': 'projects.controllable_dialogue.tasks.agents',
             'beam_size': 20,
             'beam_min_n_best': 10,
@@ -149,7 +149,7 @@ class TestControllableDialogue(unittest.TestCase):
         Checks the question-controlled model (z=10 boost) produces correct results.
         """
         _, valid, _ = testing_utils.eval_model({
-            'model_file': 'models:controllable_dialogue/control_questionb11e10',
+            'model_file': 'zoo:controllable_dialogue/control_questionb11e10',
             'task': 'projects.controllable_dialogue.tasks.agents',
             'beam_size': 20,
             'beam_min_n_best': 10,
@@ -173,7 +173,7 @@ class TestControllableDialogue(unittest.TestCase):
         Checks the specificity-CT model (z=7) produces correct results.
         """
         _, valid, _ = testing_utils.eval_model({
-            'model_file': 'models:controllable_dialogue/control_avgnidf10b10e',
+            'model_file': 'zoo:controllable_dialogue/control_avgnidf10b10e',
             'task': 'projects.controllable_dialogue.tasks.agents',
             'beam_size': 20,
             'beam_min_n_best': 10,
@@ -196,7 +196,7 @@ class TestControllableDialogue(unittest.TestCase):
         Checks the specificity-weighted decoding model produces correct results.
         """
         _, valid, _ = testing_utils.eval_model({
-            'model_file': 'models:controllable_dialogue/convai2_finetuned_baseline',
+            'model_file': 'zoo:controllable_dialogue/convai2_finetuned_baseline',
             'task': 'projects.controllable_dialogue.tasks.agents',
             'beam_size': 20,
             'beam_min_n_best': 10,
@@ -218,7 +218,7 @@ class TestControllableDialogue(unittest.TestCase):
         Checks the responsiveness-weighted decoding model produces correct results.
         """
         _, valid, _ = testing_utils.eval_model({
-            'model_file': 'models:controllable_dialogue/convai2_finetuned_baseline',
+            'model_file': 'zoo:controllable_dialogue/convai2_finetuned_baseline',
             'task': 'projects.controllable_dialogue.tasks.agents',
             'beam_size': 20,
             'beam_min_n_best': 10,

--- a/tests/nightly/gpu/test_drqa.py
+++ b/tests/nightly/gpu/test_drqa.py
@@ -14,7 +14,7 @@ class TestDrQAModel(unittest.TestCase):
     def test_pretrained(self):
         stdout, _, test = testing_utils.eval_model(dict(
             task='squad:index',
-            model_file='models:drqa/squad/model',
+            model_file='zoo:drqa/squad/model',
         ))
         self.assertGreaterEqual(
             test['accuracy'], 0.68,

--- a/tests/nightly/gpu/test_wizard.py
+++ b/tests/nightly/gpu/test_wizard.py
@@ -11,7 +11,7 @@ import parlai.core.testing_utils as testing_utils
 
 END2END_OPTIONS = {
     'task': 'wizard_of_wikipedia:generator:random_split',
-    'model_file': 'models:wizard_of_wikipedia/end2end_generator/model',
+    'model_file': 'zoo:wizard_of_wikipedia/end2end_generator/model',
     'batchsize': 32,
     'log_every_n_secs': 30,
     'embedding_type': 'random',
@@ -21,7 +21,7 @@ END2END_OPTIONS = {
 RETRIEVAL_OPTIONS = {
     'task': 'wizard_of_wikipedia',
     'model': 'projects:wizard_of_wikipedia:wizard_transformer_ranker',
-    'model_file': 'models:wizard_of_wikipedia/full_dialogue_retrieval_model/model',
+    'model_file': 'zoo:wizard_of_wikipedia/full_dialogue_retrieval_model/model',
     'datatype': 'test',
     'n_heads': 6,
     'ffn_size': 1200,

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -77,7 +77,7 @@ class TestDictionary(unittest.TestCase):
             pass
         testing_utils.download_unittest_models()
 
-        zoo_path = 'models:unittest/seq2seq/model'
+        zoo_path = 'zoo:unittest/seq2seq/model'
         model_path = modelzoo_path(datapath, zoo_path)
         os.remove(model_path + '.dict')
         # Test that eval model fails

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -165,8 +165,8 @@ class TestBackwardsCompatibility(unittest.TestCase):
         stdout, valid, test = testing_utils.eval_model(dict(
             task='integration_tests:multipass',
             model='seq2seq',
-            model_file='models:unittest/seq2seq/model',
-            dict_file='models:unittest/seq2seq/model.dict',
+            model_file='zoo:unittest/seq2seq/model',
+            dict_file='zoo:unittest/seq2seq/model.dict',
             no_cuda=True,
         ))
 

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -90,8 +90,8 @@ class TestTransformerRanker(unittest.TestCase):
         stdout, valid, test = testing_utils.eval_model(dict(
             task='integration_tests:multipass',
             model='transformer/ranker',
-            model_file='models:unittest/transformer_ranker/model',
-            dict_file='models:unittest/transformer_ranker/model.dict',
+            model_file='zoo:unittest/transformer_ranker/model',
+            dict_file='zoo:unittest/transformer_ranker/model.dict',
             batch_size=64,
         ))
 
@@ -272,8 +272,8 @@ class TestTransformerGenerator(unittest.TestCase):
         stdout, valid, test = testing_utils.eval_model(dict(
             task='integration_tests:multipass',
             model='transformer/generator',
-            model_file='models:unittest/transformer_generator2/model',
-            dict_file='models:unittest/transformer_generator2/model.dict',
+            model_file='zoo:unittest/transformer_generator2/model',
+            dict_file='zoo:unittest/transformer_generator2/model.dict',
             rank_candidates=True,
             batch_size=64,
         ))


### PR DESCRIPTION
**Patch description**
Shortcut for models contained in an internal zoo. Useful for non-public repositories. Specify the path to your internal model zoo in your parlai_internal repository at `parlai_internal/zoo/.internal_zoo_path`. Then, when you specify your model with `-mf internal:<rest of model file path>` it automatically checks the specified repository. 

Also changed shortcut for public zoo from `models:` to `zoo:`. Note that `models:` will still work to preserve backwards compatibility.

**Testing steps**
Test by adding models to internal repository and running.
