### PR TITLE
Fix fp16 candidate encodings.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -538,7 +538,7 @@ class TorchAgent(Agent):
             if not shared and opt['gpu'] != -1:
                 torch.cuda.set_device(opt['gpu'])
         # indicate whether using fp16
-        self.fp16 = self.opt.get('fp16', False)
+        self.fp16 = self.use_cuda and self.opt.get('fp16', False)
 
         # Default to the class name, sans "Agent". child can override
         self.id = type(self).__name__.replace("Agent", "")

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -626,6 +626,10 @@ class TorchRankerAgent(TorchAgent):
                     self.fixed_candidate_encs = encs
                     if self.use_cuda:
                         self.fixed_candidate_encs = self.fixed_candidate_encs.cuda()
+                    if self.fp16:
+                        self.fixed_candidate_encs = self.fixed_candidate_encs.half()
+                    else:
+                        self.fixed_candidate_encs = self.fixed_candidate_encs.float()
                 else:
                     self.fixed_candidate_encs = None
 
@@ -635,8 +639,7 @@ class TorchRankerAgent(TorchAgent):
                 self.fixed_candidate_encs = None
 
     def load_candidates(self, path, cand_type='vectors'):
-        print("[ Loading fixed candidate set {} from {} ]".format(cand_type,
-                                                                  path))
+        print("[ Loading fixed candidate set {} from {} ]".format(cand_type, path))
         return torch.load(path, map_location=lambda cpu, _: cpu)
 
     def make_candidate_vecs(self, cands):


### PR DESCRIPTION
**Patch description**
If a model was trained in fp16, and then candidates were encoded using the GPU, they will be stored to disk in fp16 mode. This is fine, but we also need to potentially convert them back to fp32 in case we're using CPU model

**Testing steps**
Ran Jason's command and tested interactive mode on CPU.

**Logs**
```
$ python projects/convai2/interactive.py -mf removed --fixed-candidates-path removed  --encode-candidate-vecs True -ecands fixed --fp16 False --no-cuda
Enter [DONE] if you want a new partner at any time.
Enter Your Message: hi
/private/home/roller/working/parlai/parlai/core/torch_ranker_agent.py:440: UserWarning: [ Executing eval mode with a common set of fixed candidates (n = 126027). ]
  "(n = {}). ]".format(mode, len(self.fixed_candidates))
[removed]: hello . i am joan and i love to cook . how about you ?
```