### PR TITLE
[BERT Classifier] CLS + SEP tokens, plus segments

### DIFF
--- a/parlai/agents/bert_classifier/bert_classifier.py
+++ b/parlai/agents/bert_classifier/bert_classifier.py
@@ -99,14 +99,14 @@ class BertClassifierAgent(TorchClassifierAgent):
 
     def _set_text_vec(self, *args, **kwargs):
         obs = super()._set_text_vec(*args, **kwargs)
-        if self.add_cls_token:
+        if 'text_vec' in obs and self.add_cls_token:
             # insert [CLS] token
-            start_tensor = obs['text_vec'].new_tensor([self.dict.start_idx])
+            start_tensor = torch.LongTensor([self.dict.start_idx])
             obs['text_vec'] = torch.cat([start_tensor, obs['text_vec']], 0)
         return obs
 
     def score(self, batch):
-        segment_idx = batch.text_vec * 0
+        segment_idx = (batch.text_vec * 0).long()
         if self.sep_last_utt:
             batch_len = batch.text_vec.size(1)
             # find where [SEP] token is
@@ -118,8 +118,7 @@ class BertClassifierAgent(TorchClassifierAgent):
             else:
                 # only one utterance: everything after [CLS] token
                 # should be segment 1
-                segment_idx = (batch.text_vec != self.dict.start_idx)
-
+                segment_idx = (batch.text_vec != self.dict.start_idx).long()
         mask = (batch.text_vec != self.NULL_IDX).long()
         token_idx = batch.text_vec * mask
         return self.model(token_idx, segment_idx, mask)

--- a/parlai/agents/bert_classifier/bert_classifier.py
+++ b/parlai/agents/bert_classifier/bert_classifier.py
@@ -54,7 +54,6 @@ class BertClassifierAgent(TorchClassifierAgent):
                                             'bert_models', MODEL_PATH)
         opt['pretrained_path'] = self.pretrained_path
         super().__init__(opt, shared)
-        self.delimiter = opt['delimiter']
 
     @classmethod
     def history_class(cls):

--- a/parlai/agents/bert_classifier/bert_classifier.py
+++ b/parlai/agents/bert_classifier/bert_classifier.py
@@ -7,18 +7,40 @@ from parlai.agents.bert_ranker.bert_dictionary import BertDictionaryAgent
 from parlai.agents.bert_ranker.helpers import (
     BertWrapper,
     get_bert_optimizer,
-    MODEL_PATH,
-    surround
+    MODEL_PATH
 )
+from parlai.core.torch_agent import History
 from parlai.core.torch_classifier_agent import TorchClassifierAgent
 from parlai.zoo.bert.build import download
 
+from collections import deque
 import os
+import torch
 try:
     from pytorch_pretrained_bert import BertModel
 except ImportError:
     raise Exception(("BERT rankers needs pytorch-pretrained-BERT installed. \n "
                      "pip install pytorch-pretrained-bert"))
+
+
+class BertClassifierHistory(History):
+    def __init__(self, opt, **kwargs):
+        self.sep_last_utt = opt.get('sep_last_utt', False)
+        super().__init__(opt, **kwargs)
+
+    def get_history_vec(self):
+        """Override from parent class to possibly add [SEP] token."""
+        if not self.sep_last_utt or len(self.history_vecs) <= 1:
+            return super().get_history_vec()
+
+        history = deque(maxlen=self.max_len)
+        for vec in self.history_vecs[:-1]:
+            history.extend(vec)
+            history.extend(self.delimiter_tok)
+        history.extend([self.dict.end_idx])  # add [SEP] token
+        history.extend(self.history_vecs[-1])
+
+        return history
 
 
 class BertClassifierAgent(TorchClassifierAgent):
@@ -31,8 +53,12 @@ class BertClassifierAgent(TorchClassifierAgent):
         self.pretrained_path = os.path.join(opt['datapath'], 'models',
                                             'bert_models', MODEL_PATH)
         opt['pretrained_path'] = self.pretrained_path
-        self.use_segment_idx = opt.get('use_segment_idx', False)
         super().__init__(opt, shared)
+        self.delimiter = opt['delimiter']
+
+    @classmethod
+    def history_class(cls):
+        return BertClassifierHistory
 
     @staticmethod
     def add_cmdline_args(parser):
@@ -46,7 +72,10 @@ class BertClassifierAgent(TorchClassifierAgent):
                             help='which part of the encoders do we optimize '
                                  '(defaults to all layers)')
         parser.add_argument('--add-cls-token', type='bool', default=True,
-                            help='add [CLS] and [SEP] tokens to text vec')
+                            help='add [CLS] token to text vec')
+        parser.add_argument('--sep-last-utt', type='bool', default=False,
+                            help='separate the last utterance into a different'
+                                 'segment with [SEP] token in between')
         parser.set_defaults(
             dict_maxexs=0,  # skip building dictionary
         )
@@ -70,14 +99,21 @@ class BertClassifierAgent(TorchClassifierAgent):
     def _set_text_vec(self, *args, **kwargs):
         obs = super()._set_text_vec(*args, **kwargs)
         if self.opt.get('add_cls_token', True):
-            # concatenate the [CLS] and [SEP] tokens
-            if obs is not None and 'text_vec' in obs:
-                obs['text_vec'] = surround(obs['text_vec'], self.START_IDX,
-                                           self.END_IDX)
+            # insert [CLS] token
+            start_tensor = obs['text_vec'].new_tensor([self.dict.start_idx])
+            obs['text_vec'] = torch.cat([start_tensor, obs['text_vec']], 0)
         return obs
 
     def score(self, batch):
         segment_idx = batch.text_vec * 0
+        if self.opt.get('sep_last_utt', False):
+            batch_len = batch.text_vec.size(1)
+            # find where [SEP] token is
+            seps = (batch.text_vec == self.dict.end_idx).nonzero()
+            for row in seps:
+                # set last utterance to segment 1
+                segment_idx[row[0], list(range(row[1], batch_len))] = 1
+
         mask = (batch.text_vec != self.NULL_IDX).long()
         token_idx = batch.text_vec * mask
         return self.model(token_idx, segment_idx, mask)

--- a/parlai/agents/bert_ranker/bert_dictionary.py
+++ b/parlai/agents/bert_ranker/bert_dictionary.py
@@ -14,6 +14,7 @@ except ImportError:
 from .helpers import VOCAB_PATH
 
 import os
+import torch
 
 
 class BertDictionaryAgent(DictionaryAgent):
@@ -49,8 +50,12 @@ class BertDictionaryAgent(DictionaryAgent):
         tokens_id = self.tokenizer.convert_tokens_to_ids(tokens)
         return tokens_id
 
-    def vec2txt(self, tensor):
-        idxs = [idx.item() for idx in tensor.cpu()]
+    def vec2txt(self, vec):
+        if not isinstance(vec, list):
+            # assume tensor
+            idxs = [idx.item() for idx in vec.cpu()]
+        else:
+            idxs = vec
         toks = self.tokenizer.convert_ids_to_tokens(idxs)
         return ' '.join(toks)
 

--- a/parlai/agents/bert_ranker/bert_dictionary.py
+++ b/parlai/agents/bert_ranker/bert_dictionary.py
@@ -14,7 +14,6 @@ except ImportError:
 from .helpers import VOCAB_PATH
 
 import os
-import torch
 
 
 class BertDictionaryAgent(DictionaryAgent):


### PR DESCRIPTION
**Patch description**
- Add option to add CLS token to the front of the text_vec. This defaults to True. We keep it as an option for backwards compatibility as some models were not doing this before. (Note: old models will still break unless we set the flag correctly, which is a tradeoff.)
- Add option to separate the last utterance in the history: adds a separator token and uses a different segment index for these tokens.
- Also add option to pass in a list to BERT's dictionary `vec2txt` function.

**Testing steps**
Train models.