### PR TITLE
[Torch Agent] break if 'episode_done' key doesn't exist

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -18,7 +18,6 @@ See below for documentation on each specific tool.
 """
 
 from collections import deque
-from copy import deepcopy
 import json
 import random
 import numpy as np
@@ -1351,7 +1350,7 @@ class TorchAgent(Agent):
         reply = self.last_reply(use_reply=self.opt.get('use_reply', 'label'))
         # update the history using the observation
         self.history.update_history(observation, add_next=reply)
-        self.observation = deepcopy(observation)
+        self.observation = observation
         return self.vectorize(self.observation, self.history,
                               text_truncate=self.text_truncate,
                               label_truncate=self.label_truncate)
@@ -1485,7 +1484,7 @@ class TorchAgent(Agent):
         self.replies['batch_reply'] = batch_reply
         self._save_history(observations, batch_reply)  # save model predictions
 
-        return deepcopy(batch_reply)
+        return batch_reply
 
     def train_step(self, batch):
         """[Abstract] Process one batch with training labels."""

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1482,10 +1482,10 @@ class TorchAgent(Agent):
             return batch_reply
 
         self.match_batch(batch_reply, batch.valid_indices, output)
-        self.replies['batch_reply'] = deepcopy(batch_reply)
+        self.replies['batch_reply'] = batch_reply
         self._save_history(observations, batch_reply)  # save model predictions
 
-        return batch_reply
+        return deepcopy(batch_reply)
 
     def train_step(self, batch):
         """[Abstract] Process one batch with training labels."""

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1335,43 +1335,6 @@ class TorchAgent(ABC, Agent):
             return batch_reply[self.batch_idx].get('text')
         return None
 
-<<<<<<< HEAD
-    def _save_history(self, observations, replies):
-        """Save the model replies to the history."""
-        # make sure data structure is set up
-        if 'predictions' not in self.replies:
-            self.replies['predictions'] = {}
-        if 'episode_ends' not in self.replies:
-            self.replies['episode_ends'] = {}
-        # shorthand
-        preds = self.replies['predictions']
-        ends = self.replies['episode_ends']
-        for i, obs in enumerate(observations):
-            # iterate through batch, saving replies
-            if i not in preds:
-                preds[i] = []
-            if ends.get(i):
-                # check whether *last* example was the end of an episode
-                preds[i].clear()
-            ends[i] = obs['episode_done']
-            preds[i].append(replies[i].get('text'))
-
-    def reply_history(self):
-        """
-        Get the model's predicted reply history within this episode.
-
-        :param batch:
-            (default False) return the reply history for every row in the
-            batch, otherwise will return just for this example.
-
-        :return:
-            list of lists of strings, each of the past model replies in in the
-            current episode. will be None wherever model did not reply.
-        """
-        # make sure in batch order
-        preds = sorted((b, p) for b, p in self.replies['predictions'].items())
-        return [p for b, p in preds]
-
     def observe(self, observation):
         """
         Process incoming message in preparation for producing a response.

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -17,12 +17,13 @@ Contains the following main utilities:
 See below for documentation on each specific tool.
 """
 
-from torch import optim
 from collections import deque
+from copy import deepcopy
 import json
 import random
 import numpy as np
 import os
+from torch import optim
 
 from parlai.core.agents import Agent
 from parlai.core.build_data import modelzoo_path
@@ -236,7 +237,7 @@ class History(object):
                 # update history vecs
                 self._update_vecs(text)
 
-        if obs.get('episode_done', True):
+        if obs['episode_done']:
             # end of this episode, clear the history when we see a new example
             self.reset_on_next_update = True
 
@@ -1285,7 +1286,7 @@ class TorchAgent(Agent):
         # if the last observation was the end of an episode,
         # then we shouldn't use it as history
         if (use_reply == 'none' or not self.observation or
-                self.observation.get('episode_done', True)):
+                self.observation['episode_done']):
             return None
 
         if use_reply == 'label':
@@ -1322,7 +1323,7 @@ class TorchAgent(Agent):
             if ends.get(i):
                 # check whether *last* example was the end of an episode
                 preds[i].clear()
-            ends[i] = obs.get('episode_done', True)
+            ends[i] = obs['episode_done']
             preds[i].append(replies[i].get('text'))
 
     def reply_history(self):
@@ -1350,7 +1351,7 @@ class TorchAgent(Agent):
         reply = self.last_reply(use_reply=self.opt.get('use_reply', 'label'))
         # update the history using the observation
         self.history.update_history(observation, add_next=reply)
-        self.observation = observation
+        self.observation = deepcopy(observation)
         return self.vectorize(self.observation, self.history,
                               text_truncate=self.text_truncate,
                               label_truncate=self.label_truncate)
@@ -1481,7 +1482,7 @@ class TorchAgent(Agent):
             return batch_reply
 
         self.match_batch(batch_reply, batch.valid_indices, output)
-        self.replies['batch_reply'] = batch_reply
+        self.replies['batch_reply'] = deepcopy(batch_reply)
         self._save_history(observations, batch_reply)  # save model predictions
 
         return batch_reply

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -222,8 +222,10 @@ class TestTorchAgent(unittest.TestCase):
         param options.
         """
         agent = get_agent()
-        obs_labs = {'text': 'No. Try not.', 'labels': ['Do.', 'Do not.']}
-        obs_elabs = {'text': 'No. Try not.', 'eval_labels': ['Do.', 'Do not.']}
+        obs_labs = {'text': 'No. Try not.', 'labels': ['Do.', 'Do not.'],
+                    'episode_done': True}
+        obs_elabs = {'text': 'No. Try not.', 'eval_labels': ['Do.', 'Do not.'],
+                     'episode_done': True}
 
         for obs in (obs_labs, obs_elabs):
             lab_key = 'labels' if 'labels' in obs else 'eval_labels'
@@ -290,6 +292,7 @@ class TestTorchAgent(unittest.TestCase):
         obs = {
             'text': 'Hello.\nMy name is Inogo Montoya.\n'
                     'You killed my father.\nPrepare to die.',
+            'episode_done': True,
         }
         agent.history.update_history(obs)
         vecs = agent.history.get_history_vec_list()
@@ -308,19 +311,25 @@ class TestTorchAgent(unittest.TestCase):
         agent = get_agent(rank_candidates=True)
         obs_labs = [
             {'text': 'It\'s only a flesh wound.',
-             'labels': ['Yield!']},
+             'labels': ['Yield!'],
+             'episode_done': True},
             {'text': 'The needs of the many outweigh...',
-             'labels': ['The needs of the few.']},
+             'labels': ['The needs of the few.'],
+             'episode_done': True},
             {'text': 'Hello there.',
-             'labels': ['General Kenobi.']},
+             'labels': ['General Kenobi.'],
+             'episode_done': True},
         ]
         obs_elabs = [
             {'text': 'It\'s only a flesh wound.',
-             'eval_labels': ['Yield!']},
+             'eval_labels': ['Yield!'],
+             'episode_done': True},
             {'text': 'The needs of the many outweigh...',
-             'eval_labels': ['The needs of the few.']},
+             'eval_labels': ['The needs of the few.'],
+             'episode_done': True},
             {'text': 'Hello there.',
-             'eval_labels': ['General Kenobi.']},
+             'eval_labels': ['General Kenobi.'],
+             'episode_done': True},
         ]
         for obs_batch in (obs_labs, obs_elabs):
             lab_key = 'labels' if 'labels' in obs_batch[0] else 'eval_labels'
@@ -782,11 +791,14 @@ class TestTorchAgent(unittest.TestCase):
 
         obs_labs = [
             {'text': 'It\'s only a flesh wound.',
-             'labels': ['Yield!']},
+             'labels': ['Yield!'],
+             'episode_done': True},
             {'text': 'The needs of the many outweigh...',
-             'labels': ['The needs of the few.']},
+             'labels': ['The needs of the few.'],
+             'episode_done': True},
             {'text': 'Hello there.',
-             'labels': ['General Kenobi.']},
+             'labels': ['General Kenobi.'],
+             'episode_done': True},
         ]
         obs_labs_vecs = []
         for o in obs_labs:
@@ -799,11 +811,14 @@ class TestTorchAgent(unittest.TestCase):
 
         obs_elabs = [
             {'text': 'It\'s only a flesh wound.',
-             'eval_labels': ['Yield!']},
+             'eval_labels': ['Yield!'],
+             'episode_done': True},
             {'text': 'The needs of the many outweigh...',
-             'eval_labels': ['The needs of the few.']},
+             'eval_labels': ['The needs of the few.'],
+             'episode_done': True},
             {'text': 'Hello there.',
-             'eval_labels': ['General Kenobi.']},
+             'eval_labels': ['General Kenobi.'],
+             'episode_done': True},
         ]
         obs_elabs_vecs = []
         for o in obs_elabs:


### PR DESCRIPTION
**Patch description**
-  EDIT: removed copies. After discussion with @stephenroller I'm inclined to believe that any scripts that use acts/observations should do the proper copying themselves. cc @jaseweston. 
- Break if 'episode_done' key doesn't exist in an observation. By default we were setting it to True, which can mask issues and cause bugs. 

**Testing steps**
Test by editing acts and inspecting the history.