### PR TITLE
Update tutorial_quick.rst

### DIFF
--- a/docs/source/tutorial_quick.rst
+++ b/docs/source/tutorial_quick.rst
@@ -57,7 +57,7 @@ Let's try asking the model a question ourselves.
 .. code-block:: bash
 
   # interact with saved model
-  python examples/interactive.py -mf /tmp/babi_memnn
+  python examples/interactive.py -mf /tmp/babi_memnn --eval-candidates vocab
   ...
   Enter your message: John went to the hallway.\n Where is John?
 


### PR DESCRIPTION
add eval-candidates arg to interactive command in quick start tutorial

**Testing steps**
ran `python examples/interactive.py -mf /tmp/babi_memnn --eval-candidates vocab`

**Logs**
```
Enter Your Message: John is in the hallway.\n Where is John?
/Users/ahm/ParlAI/parlai/core/torch_ranker_agent.py:463: UserWarning: [ Executing eval mode with tokens from vocabulary as candidates. ]
  ''.format(mode)
[TorchAgent]: hallway
```