### PR TITLE
Fix Arg Failure/Error Message

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -798,3 +798,9 @@ class ParlaiParser(argparse.ArgumentParser):
 
         arg_group.add_argument = ag_add_argument  # override _ => -
         return arg_group
+
+    def error(self, message):
+        """Override to print custom error message."""
+        self.print_help()
+        _sys.stderr.write('\nParse Error: %s\n' % message)
+        _sys.exit(2)


### PR DESCRIPTION
**Patch description**
Previously, if you specified an incorrect argument on the command line, the error message would print _before_ the arg help, which led to having to scroll all the way up past the help message to find your error.

This patch switches the order.

**Testing steps**
1. Pass an incorrect arg to any script in ParlAI
2. Observe that the error message is printed out at the bottom, not at the top.

**Logs**
```
$ python examples/train_model.py -bad-arg badarg
usage: train_model.py [-h] [-v] [-t TASK]
                      [-dt {train,train:stream,train:ordered,train:ordered:stream,train:stream:ordered,train:evalmode,train:evalmode:stream,train:evalmode:ordered,train:evalmode:ordered:stream,train:evalmode:stream:ordered,valid,valid:stream,test,test:stream}]
                      [-nt NUMTHREADS] [-bs BATCHSIZE] [-dp DATAPATH] [-m MODEL] [-mf MODEL_FILE] [-im INIT_MODEL] [-et EVALTASK]
                      [-eps NUM_EPOCHS] [-ttim MAX_TRAIN_TIME] [-vtim VALIDATION_EVERY_N_SECS] [-stim SAVE_EVERY_N_SECS]
                      [-sval SAVE_AFTER_VALID] [-veps VALIDATION_EVERY_N_EPOCHS] [-vp VALIDATION_PATIENCE]
                      [-vmt VALIDATION_METRIC] [-vmm {max,min}] [-pyt PYTORCH_TEACHER_TASK] [-pytd PYTORCH_TEACHER_DATASET]

Train a model

optional arguments:
  -h, --help
        show this help message and exit

Main ParlAI Arguments:
  -v, --show-advanced-args
        Show hidden command line options (advanced users only) (default: False)
  -t, --task TASK
        ParlAI task(s), e.g. "babi:Task1" or "babi,cbt" (default: None)
  -dt, --datatype {train,train:stream,train:ordered,train:ordered:stream,train:stream:ordered,train:evalmode,train:evalmode:stream,train:evalmode:ordered,train:evalmode:ordered:stream,train:evalmode:stream:ordered,valid,valid:stream,test,test:stream}
        choose from: train, train:ordered, valid, test. to stream data add ":stream" to any option (e.g., train:stream). by
        default: train is random with replacement, valid is ordered, test is ordered. (default: train)
  -nt, --numthreads NUMTHREADS
        number of threads. Used for hogwild if batchsize is 1, else for number of threads in threadpool loading, (default: 1)
  -bs, --batchsize BATCHSIZE
        batch size for minibatch training schemes (default: 1)
  -dp, --datapath DATAPATH
        path to datasets, defaults to {parlai_dir}/data (default: None)

ParlAI Model Arguments:
  -m, --model MODEL
        the model class name. can match parlai/agents/<model> for agents in that directory, or can provide a fully specified
        module for `from X import Y` via `-m X:Y` (e.g. `-m parlai.agents.seq2seq.seq2seq:Seq2SeqAgent`) (default: None)
  -mf, --model-file MODEL_FILE
        model file name for loading and saving models (default: None)
  -im, --init-model INIT_MODEL
        load model weights and dict from this file (default: None)

Training Loop Arguments:
  -et, --evaltask EVALTASK
        task to use for valid/test (defaults to the one used for training if not set) (default: None)
  -eps, --num-epochs NUM_EPOCHS
  -ttim, --max-train-time MAX_TRAIN_TIME
  -vtim, --validation-every-n-secs VALIDATION_EVERY_N_SECS
        Validate every n seconds. Saves model to model_file (if set) whenever best val metric is found (default: -1)
  -stim, --save-every-n-secs SAVE_EVERY_N_SECS
        Saves the model to model_file.checkpoint after every n seconds (default -1, never). (default: -1)
  -sval, --save-after-valid SAVE_AFTER_VALID
        Saves the model to model_file.checkpoint after every validation (default False).
  -veps, --validation-every-n-epochs VALIDATION_EVERY_N_EPOCHS
        Validate every n epochs. Saves model to model_file (if set) whenever best val metric is found (default: -1)
  -vp, --validation-patience VALIDATION_PATIENCE
        number of iterations of validation where result does not improve before we stop training (default: 10)
  -vmt, --validation-metric VALIDATION_METRIC
        key into report table for selecting best validation (default: accuracy)
  -vmm, --validation-metric-mode {max,min}
        how to optimize validation metric (max or min) (default: None)

PytorchData Arguments:
  -pyt, --pytorch-teacher-task PYTORCH_TEACHER_TASK
        Use the PytorchDataTeacher for multiprocessed data loading with a standard ParlAI task, e.g. "babi:Task1k" (default: None)
  -pytd, --pytorch-teacher-dataset PYTORCH_TEACHER_DATASET
        Use the PytorchDataTeacher for multiprocessed data loading with a pytorch Dataset, e.g. "vqa_1" or "flickr30k" (default:
        None)

Parse Error: unrecognized arguments: -bad-arg badarg
```
