### PR TITLE
HotpotQA task added

### DIFF
--- a/parlai/tasks/hotpotqa/__init__.py
+++ b/parlai/tasks/hotpotqa/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/parlai/tasks/hotpotqa/agents.py
+++ b/parlai/tasks/hotpotqa/agents.py
@@ -11,9 +11,7 @@ from .build import build
 import copy
 import os
 
-'''All teachers have a version with and without label candidates. Each teacher
-defaults to using a dataset with label candidates. To use a dataset without
-label candidates, specify this using the task flag:
+'''Usage:
 
 --task hotspotqa:{TEACHER_NAME}
 

--- a/parlai/tasks/hotpotqa/agents.py
+++ b/parlai/tasks/hotpotqa/agents.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from parlai.core.teachers import ParlAIDialogTeacher
+from parlai.core.utils import warn_once
+from .build import build
+
+import copy
+import os
+
+
+def _path(opt):
+    # Build the data if it doesn't exist.
+    build(opt)
+    dt = opt['datatype'].split(':')[0]
+    if dt == 'test_distractor':
+        warn_once('WARNING: Test set not included. Setting datatype to valid.')
+        dt = 'valid_distractor'
+    if dt == 'test_fullwiki':
+        warn_once('WARNING: Test set not included. Setting datatype to valid.')
+        dt = 'valid_fullwiki'
+    return os.path.join(opt['datapath'], 'HotpotQA', dt + '.txt')
+
+
+class DefaultTeacher(ParlAIDialogTeacher):
+    def __init__(self, opt, shared=None):
+        opt = copy.deepcopy(opt)
+        opt['parlaidialogteacher_datafile'] = _path(opt)
+        super().__init__(opt, shared)

--- a/parlai/tasks/hotpotqa/agents.py
+++ b/parlai/tasks/hotpotqa/agents.py
@@ -11,22 +11,41 @@ from .build import build
 import copy
 import os
 
+'''All teachers have a version with and without label candidates. Each teacher
+defaults to using a dataset with label candidates. To use a dataset without
+label candidates, specify this using the task flag:
 
-def _path(opt):
+--task hotspotqa:{TEACHER_NAME}
+
+where TEACHER_NAME is distractor or fullwiki (default).
+'''
+
+
+def _path(opt, teacher_name):
     # Build the data if it doesn't exist.
     build(opt)
     dt = opt['datatype'].split(':')[0]
-    if dt == 'test_distractor':
+    if dt == 'test':
         warn_once('WARNING: Test set not included. Setting datatype to valid.')
-        dt = 'valid_distractor'
-    if dt == 'test_fullwiki':
-        warn_once('WARNING: Test set not included. Setting datatype to valid.')
-        dt = 'valid_fullwiki'
+        dt = 'valid'
+    if dt == 'valid':
+        dt = dt + '_' + teacher_name
     return os.path.join(opt['datapath'], 'HotpotQA', dt + '.txt')
 
 
-class DefaultTeacher(ParlAIDialogTeacher):
+class DistractorTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
-        opt['parlaidialogteacher_datafile'] = _path(opt)
+        opt['parlaidialogteacher_datafile'] = _path(opt, "distractor")
         super().__init__(opt, shared)
+
+
+class FullwikiTeacher(ParlAIDialogTeacher):
+    def __init__(self, opt, shared=None):
+        opt = copy.deepcopy(opt)
+        opt['parlaidialogteacher_datafile'] = _path(opt, "fullwiki")
+        super().__init__(opt, shared)
+
+
+class DefaultTeacher(FullwikiTeacher):
+    pass

--- a/parlai/tasks/hotpotqa/build.py
+++ b/parlai/tasks/hotpotqa/build.py
@@ -27,7 +27,7 @@ def _handle_data_point(data_point):
     context_question_txt = ""
     for [title, sentences_list] in data_point['context']:
         sentences = '\\n'.join(sentences_list)
-        context_question_txt += '{}\\n{}\\n\\n'.format(title,sentences)
+        context_question_txt += '{}\\n{}\\n\\n'.format(title, sentences)
 
     context_question_txt += data_point['question']
 

--- a/parlai/tasks/hotpotqa/build.py
+++ b/parlai/tasks/hotpotqa/build.py
@@ -10,9 +10,9 @@ import os
 import json
 
 VERSION = '1'
-TRAIN_FILENAME = f'hotpot_train_v{VERSION}.1.json'
-DEV_DISTRACTOR_FILENAME = f'hotpot_dev_distractor_v{VERSION}.json'
-DEV_FULLWIKI_FILENAME = f'hotpot_dev_fullwiki_v{VERSION}.json'
+TRAIN_FILENAME = 'hotpot_train_v{}.1.json'.format(VERSION)
+DEV_DISTRACTOR_FILENAME = 'hotpot_dev_distractor_v{}.json'.format(VERSION)
+DEV_FULLWIKI_FILENAME = 'hotpot_dev_fullwiki_v{}.json'.format(VERSION)
 
 URL = 'http://curtis.ml.cmu.edu/datasets/hotpot/'
 
@@ -27,7 +27,7 @@ def _handle_data_point(data_point):
     context_question_txt = ""
     for [title, sentences_list] in data_point['context']:
         sentences = '\\n'.join(sentences_list)
-        context_question_txt += f'{title}\\n{sentences}\\n\\n'
+        context_question_txt += '{}\\n{}\\n\\n'.format(title,sentences)
 
     context_question_txt += data_point['question']
 

--- a/parlai/tasks/hotpotqa/build.py
+++ b/parlai/tasks/hotpotqa/build.py
@@ -20,6 +20,7 @@ OUTPUT_FORMAT = (
     'labels:{answer}'
 )
 
+
 def _handle_data_point(data_point):
     output = []
     context_question_txt = ""

--- a/parlai/tasks/hotpotqa/build.py
+++ b/parlai/tasks/hotpotqa/build.py
@@ -9,9 +9,10 @@ import parlai.core.build_data as build_data
 import os
 import json
 
-TRAIN_FILENAME = 'hotpot_train_v1.1.json'
-DEV_DISTRACTOR_FILENAME = 'hotpot_dev_distractor_v1.json'
-DEV_FULLWIKI_FILENAME = 'hotpot_dev_fullwiki_v1.json'
+VERSION = '1'
+TRAIN_FILENAME = f'hotpot_train_v{VERSION}.1.json'
+DEV_DISTRACTOR_FILENAME = f'hotpot_dev_distractor_v{VERSION}.json'
+DEV_FULLWIKI_FILENAME = f'hotpot_dev_fullwiki_v{VERSION}.json'
 
 URL = 'http://curtis.ml.cmu.edu/datasets/hotpot/'
 
@@ -48,7 +49,7 @@ def make_parlai_format(outpath, dtype, data):
 def build(opt):
     dpath = os.path.join(opt['datapath'], 'HotpotQA')
 
-    if not build_data.built(dpath):
+    if not build_data.built(dpath, version_string=VERSION):
         print('[building data: ' + dpath + ']')
         if build_data.built(dpath):
             # An older version exists, so remove these outdated files.
@@ -73,4 +74,4 @@ def build(opt):
             make_parlai_format(dpath, 'valid_fullwiki', data)
 
         # Mark the data as built.
-        build_data.mark_done(dpath)
+        build_data.mark_done(dpath, version_string=VERSION)

--- a/parlai/tasks/hotpotqa/build.py
+++ b/parlai/tasks/hotpotqa/build.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# Download and build the data if it does not exist.
+
+import parlai.core.build_data as build_data
+import os
+import json
+
+TRAIN_FILENAME = 'hotpot_train_v1.1.json'
+DEV_DISTRACTOR_FILENAME = 'hotpot_dev_distractor_v1.json'
+DEV_FULLWIKI_FILENAME = 'hotpot_dev_fullwiki_v1.json'
+
+URL = 'http://curtis.ml.cmu.edu/datasets/hotpot/'
+
+OUTPUT_FORMAT = (
+    'text:{context_question}\t'
+    'labels:{answer}'
+)
+
+def _handle_data_point(data_point):
+    output = []
+    context_question_txt = ""
+    for [title, sentences_list] in data_point['context']:
+        sentences = '\\n'.join(sentences_list)
+        context_question_txt += f'{title}\\n{sentences}\\n\\n'
+
+    context_question_txt += data_point['question']
+
+    output = OUTPUT_FORMAT.format(
+        context_question=context_question_txt,
+        answer=data_point['answer']
+    )
+    output += '\t\tepisode_done:True\n'
+    return output
+
+
+def make_parlai_format(outpath, dtype, data):
+    print('building parlai:' + dtype)
+    with open(os.path.join(outpath, dtype + '.txt'), 'w') as fout:
+        for data_point in data:
+            fout.write(_handle_data_point(data_point))
+
+
+def build(opt):
+    dpath = os.path.join(opt['datapath'], 'HotpotQA')
+
+    if not build_data.built(dpath):
+        print('[building data: ' + dpath + ']')
+        if build_data.built(dpath):
+            # An older version exists, so remove these outdated files.
+            build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # Download the data.
+        build_data.download(URL + TRAIN_FILENAME, dpath, TRAIN_FILENAME)
+        build_data.download(URL + DEV_DISTRACTOR_FILENAME, dpath, DEV_DISTRACTOR_FILENAME)
+        build_data.download(URL + DEV_FULLWIKI_FILENAME, dpath, DEV_FULLWIKI_FILENAME)
+
+        with open(os.path.join(dpath, TRAIN_FILENAME)) as f:
+            data = json.load(f)
+            make_parlai_format(dpath, 'train', data)
+
+        with open(os.path.join(dpath, DEV_DISTRACTOR_FILENAME)) as f:
+            data = json.load(f)
+            make_parlai_format(dpath, 'valid_distractor', data)
+
+        with open(os.path.join(dpath, DEV_FULLWIKI_FILENAME)) as f:
+            data = json.load(f)
+            make_parlai_format(dpath, 'valid_fullwiki', data)
+
+        # Mark the data as built.
+        build_data.mark_done(dpath)

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -195,6 +195,21 @@ task_list = [
         ),
     },
     {
+        "id": "HotpotQA",
+        "display_name": "HotpotQA",
+        "task": "hotpotqa",
+        "tags": ["All", "QA"],
+        "description": (
+            "HotpotQA is a dataset for multi-hop question answering."
+            "The overall setting is that given some context paragraphs"
+            "(e.g., a few paragraphs, or the entire Web) and a question,"
+            "a QA system answers the question by extracting a span of text"
+            "from the context. It is necessary to perform multi-hop reasoning"
+            "to correctly answer the question."
+            "Link: https://arxiv.org/pdf/1809.09600.pdf"
+        ),
+    },
+    {
         "id": "LIGHT-Dialogue",
         "display_name": "LIGHT-Dialogue",
         "task": "light_dialog",


### PR DESCRIPTION
**Patch description**
Add the HotpotQA dataset. Please see https://arxiv.org/pdf/1809.09600.pdf

**Testing steps**
1. Run `python examples/display_data.py -t hotpotqa`

```
~~
[/private/home/fabiopetroni/ParlAI/data/HotpotQA/train.txt]: Mount Panorama Circuit
Mount Panorama Circuit is a motor racing track located in Bathurst, New South Wales, Australia.
 It is situated on a hill with the dual official names of Mount Panorama and Wahluu and is best known as the home of the Bathurst 1000 motor race held each October, and the Bathurst 12 Hour event held each February.
 The 6.213 km long track is technically a street circuit, and is a public road, with normal speed restrictions, when no racing events are being run, and there are many residences which can only be accessed from the circuit.

2016 Intercontinental GT Challenge
The 2016 Intercontinental GT Challenge was the first season of the Intercontinental GT Challenge.
 The season featured three rounds — after the cancellation of the 6 Hours of the Americas - starting with ...
Bathurst, in New South Wales, Australia on 9 February 2014, was the twelfth running of the Bathurst 12 Hour.

What is the length of the track where the 2013 Liqui Moly Bathurst 12 Hour was staged?
[labels: 6.213 km long]
```

**Other information**
Any other information or context you would like to provide.

**Data tests (if applicable)**
If you added a new teacher, you will be asked to run
`python setup.py -s tests.suites.datatests`. Please paste this log here.

```
running test
Searching for flake8-docstrings
Best match: flake8-docstrings 1.3.0
Processing flake8_docstrings-1.3.0-py3.7.egg

Using /private/home/fabiopetroni/ParlAI/.eggs/flake8_docstrings-1.3.0-py3.7.egg
Searching for flake8-rst-docstrings
Best match: flake8-rst-docstrings 0.0.9
Processing flake8_rst_docstrings-0.0.9-py3.7.egg

Using /private/home/fabiopetroni/ParlAI/.eggs/flake8_rst_docstrings-0.0.9-py3.7.egg
Searching for pydocstyle>=2.1
Best match: pydocstyle 3.0.0
Processing pydocstyle-3.0.0-py3.7.egg

Using /private/home/fabiopetroni/ParlAI/.eggs/pydocstyle-3.0.0-py3.7.egg
Searching for flake8-polyfill
Best match: flake8-polyfill 1.0.2
Processing flake8_polyfill-1.0.2-py3.7.egg

Using /private/home/fabiopetroni/ParlAI/.eggs/flake8_polyfill-1.0.2-py3.7.egg
Searching for restructuredtext_lint
Best match: restructuredtext-lint 1.3.0
Processing restructuredtext_lint-1.3.0-py3.7.egg

Using /private/home/fabiopetroni/ParlAI/.eggs/restructuredtext_lint-1.3.0-py3.7.egg
running egg_info
writing parlai.egg-info/PKG-INFO
writing dependency_links to parlai.egg-info/dependency_links.txt
writing requirements to parlai.egg-info/requires.txt
writing top-level names to parlai.egg-info/top_level.txt
reading manifest file 'parlai.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'parlai.egg-info/SOURCES.txt'
running build_ext
test_verify_data (test_new_tasks.TestNewTasks) ... ok

----------------------------------------------------------------------
Ran 1 test in 50.066s

OK
```