### PR TITLE
(WIP) FbDialogTeacher deprecation

### DIFF
--- a/parlai/scripts/convert_fbdialog_to_parlai.py
+++ b/parlai/scripts/convert_fbdialog_to_parlai.py
@@ -18,7 +18,7 @@ from parlai.core.utils import msg_to_str
 import random
 
 
-def setup_data(path, cloze=False):
+def setup_data(path, cloze=False, double=False):
     r"""
     Read data in the fbdialog format.
 
@@ -46,6 +46,9 @@ def setup_data(path, cloze=False):
         r: '1'
         c: ['hallway', 'kitchen', 'bathroom']
         new_episode = False (this is the second example in the episode)
+
+    :param cloze:
+        if cloze, add special question to the end
     """
     print("[loading fbdialog data:" + path + "]")
     with open(path) as read:
@@ -239,7 +242,10 @@ def dump_data(opt):
     print('[ starting to convert.. ]')
     print('[ saving output to {} ]'.format(outfile))
     with open(outfile, 'w') as fw:
-        for ep in _read_episode(setup_data(opt.get('infile'), cloze=opt.get('cloze'))):
+        data_loader = setup_data(opt.get('infile'), cloze=opt.get('cloze'))
+        if opt.get('additional_data_loader'):
+            data_loader = opt.get('additional_data_loader')((data_loader))
+        for ep in _read_episode(data_loader):
             for i, ex in enumerate(ep):
                 ex = build_table(ex)
                 ex['episode_done'] = i == len(ep) - 1
@@ -262,6 +268,8 @@ def main():
     parser.add_argument('-if', '--ignore-fields', default='id', type=str,
                         help='Ignore these fields from the message (returned\
                                 with .act() )')
+    parser.add_argument('--cloze', default=False, type='bool',
+                        help='whether dataset is cloze')
     opt = parser.parse_args()
     dump_data(opt)
 

--- a/parlai/scripts/convert_fbdialog_to_parlai.py
+++ b/parlai/scripts/convert_fbdialog_to_parlai.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Convert FB Dialog format into the ParlAI text format.
+
+Examples
+--------
+
+.. code-block:: shell
+
+  python convert_fbdialog_to_parlai.py --infile infile --outfile /tmp/dump
+"""
+
+from parlai.core.params import ParlaiParser
+from parlai.core.utils import msg_to_str
+import random
+
+
+def setup_data(path, cloze=False):
+    r"""
+    Read data in the fbdialog format.
+
+    Returns ``((x,y,r,c), new_episode?)`` tuples.
+
+    ``x`` represents a query, ``y`` represents the labels, ``r`` represents
+    any reward, and ``c`` represents any label_candidates.
+
+    The example above will be translated into the following tuples:
+
+    ::
+
+        x: 'Sam went to the kitchen\nPat gave Sam the milk\nWhere is the milk?'
+        y: ['kitchen']
+        r: '1'
+        c: ['hallway', 'kitchen', 'bathroom']
+        new_episode = True (this is the first example in the episode)
+
+
+    ::
+
+        x: 'Sam went to the hallway\\nPat went to the bathroom\\nWhere is the
+            milk?'
+        y: ['hallway']
+        r: '1'
+        c: ['hallway', 'kitchen', 'bathroom']
+        new_episode = False (this is the second example in the episode)
+    """
+    print("[loading fbdialog data:" + path + "]")
+    with open(path) as read:
+        start = True
+        x = ''
+        reward = 0
+        last_conv_id = None
+        for line in read:
+            line = line.strip().replace('\\n', '\n')
+            if len(line) == 0:
+                # empty response
+                continue
+
+            # first, get conversation index -- '1' means start of episode
+            space_idx = line.find(' ')
+            if space_idx == -1:
+                # empty line, both individuals are saying whitespace
+                conv_id = int(line)
+            else:
+                conv_id = int(line[:space_idx])
+
+            # split line into constituent parts, if available:
+            # x<tab>y<tab>reward<tab>label_candidates
+            # where y, reward, and label_candidates are optional
+            split = line[space_idx + 1:].split('\t')
+
+            # remove empty items and strip each one
+            for i in range(len(split)):
+                word = split[i].strip()
+                if len(word) == 0:
+                    split[i] = ''
+                else:
+                    split[i] = word
+            # Empty reward string same as None
+            if len(split) > 2 and split[2] == '':
+                split[2] = None
+
+            # now check if we're at a new episode
+            if last_conv_id is None or conv_id <= last_conv_id:
+                x = x.strip()
+                if x:
+                    yield [x, None, reward], start
+                start = True
+                reward = 0
+                # start a new episode
+                if cloze:
+                    x = 'Fill in the blank in the last sentence.\n{x}'.format(
+                        x=split[0]
+                    )
+                else:
+                    x = split[0]
+            else:
+                if x:
+                    # otherwise add current x to what we have so far
+                    x = '{x}\n{next_x}'.format(x=x, next_x=split[0])
+                else:
+                    x = split[0]
+            last_conv_id = conv_id
+            if len(split) > 2 and split[2]:
+                reward += float(split[2])
+
+            if len(split) > 1 and split[1]:
+                # only generate an example if we have a y
+                split[0] = x
+                # split labels
+                split[1] = split[1].split('|')
+                if len(split) > 3:
+                    # split label_candidates
+                    split[3] = split[3].split('|')
+                if len(split) > 2:
+                    split[2] = reward
+                else:
+                    split.append(reward)
+                if start:
+                    yield split, True
+                    start = False
+                else:
+                    yield split, False
+                # reset x in case there is unlabeled data still left
+                x = ''
+                reward = 0
+        if x:
+            yield [x, None, reward], start
+
+
+def _read_episode(data_loader):
+    """
+    Read one episode at a time from the provided iterable over entries.
+
+    :param data_loader:
+        an iterable which returns tuples in the format described in the
+        class docstring.
+    """
+    episode = []
+    last_cands = None
+    for entry, new in data_loader:
+        if new and len(episode) > 0:
+            yield tuple(episode)
+            episode = []
+            last_cands = None
+
+        # intern all strings so we don't store them more than once
+        # TODO: clean up the if .. sys.intern else None by refactoring
+        new_entry = []
+        if len(entry) > 0:
+            # process text if available
+            if entry[0] is not None:
+                new_entry.append(entry[0])
+            else:
+                new_entry.append(None)
+            # TODO: unindent all of these one level.
+            if len(entry) > 1:
+                # process labels if available
+                if entry[1] is None:
+                    new_entry.append(None)
+                elif hasattr(entry[1], '__iter__') and type(entry[1]) is not str:
+                    # TODO: this could use the abc collections
+                    # make sure iterable over labels, not single string
+                    new_entry.append(tuple(e for e in entry[1]))
+                else:
+                    raise TypeError(
+                        'Must provide iterable over labels, not a single string.'
+                    )
+            if len(entry) > 2:
+                # process reward if available
+                if entry[2] is not None:
+                    new_entry.append(entry[2])
+                else:
+                    new_entry.append(None)
+            if len(entry) > 3:
+                # process label candidates if available
+                if entry[3] is None:
+                    new_entry.append(None)
+                elif last_cands and entry[3] is last_cands:
+                    # if cands are shared, say "same" so we
+                    # don't store them again
+                    # TODO: This is bad, and it's not actually used anywhere
+                    # DEPRECATIONDAY: make this more rational
+                    new_entry.append('same as last time')
+                elif hasattr(entry[3], '__iter__') and type(entry[3]) is not str:
+                    # make sure iterable over candidates, not single string
+                    last_cands = entry[3]
+                    new_entry.append(tuple(e for e in entry[3]))
+                else:
+                    raise TypeError(
+                        'Must provide iterable over label candidates, '
+                        'not a single string.'
+                    )
+            if len(entry) > 4 and entry[4] is not None:
+                new_entry.append(entry[4])
+
+        episode.append(tuple(new_entry))
+
+    if len(episode) > 0:
+        yield tuple(episode)
+
+def build_table(entry):
+    """
+    Packs an entry into an action-observation dictionary.
+
+    :param entry: a tuple in the form described in the class docstring.
+    """
+    table = {}
+    if entry[0] is not None:
+        table['text'] = entry[0]
+    if len(entry) > 1:
+        if entry[1] is not None:
+            table['labels'] = entry[1]
+    if len(entry) > 2:
+        if entry[2] is not None:
+            table['reward'] = entry[2]
+    if len(entry) > 3:
+        if entry[3] is not None:
+            table['label_candidates'] = entry[3]
+    if len(entry) > 4 and entry[4] is not None:
+        table['image'] = entry[4]
+
+    if 'labels' in table and 'label_candidates' in table:
+        if table['labels'][0] not in table['label_candidates']:
+            raise RuntimeError('true label missing from candidate labels')
+    return table
+
+
+def dump_data(opt):
+    ignorefields = opt.get('ignore_fields', '')
+    if opt.get('outfile') is None:
+        raise RuntimeError('Please specify outfile when converting to ParlAI format')
+    if opt.get('infile') is None:
+        raise RuntimeError('Please specify infile when converting to ParlAI format')
+    outfile = opt['outfile']
+    print('[ starting to convert.. ]')
+    print('[ saving output to {} ]'.format(outfile))
+    with open(outfile, 'w') as fw:
+        for ep in _read_episode(setup_data(opt.get('infile'), cloze=opt.get('cloze'))):
+            for i, ex in enumerate(ep):
+                ex = build_table(ex)
+                ex['episode_done'] = i == len(ep) - 1
+                ex['labels'] = ex.get('labels', ex.pop('eval_labels', None))
+                txt = msg_to_str(ex, ignore_fields=ignorefields)
+                fw.write(txt + '\n')
+                if ex.get('episode_done', False):
+                    fw.write('\n')
+
+
+def main():
+    random.seed(42)
+    # Get command line arguments
+    parser = ParlaiParser()
+    parser.add_argument('-of', '--outfile', default=None, type=str,
+                        help='Output file where to save, by default will be \
+                                created in /tmp')
+    parser.add_argument('-inf', '--infile', default=None, type=str,
+                        help='Input file to load in fbdialog format')
+    parser.add_argument('-if', '--ignore-fields', default='id', type=str,
+                        help='Ignore these fields from the message (returned\
+                                with .act() )')
+    opt = parser.parse_args()
+    dump_data(opt)
+
+
+if __name__ == '__main__':
+    main()

--- a/parlai/tasks/babi/agents.py
+++ b/parlai/tasks/babi/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 import parlai.core.agents as core_agents
 from .build import build
 
@@ -40,39 +40,46 @@ def mod_labels(ys, task):
 
 
 # Single bAbI task (1k training).
-class Task1kTeacher(FbDialogTeacher):
+class Task1kTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         task = opt.get('task', 'babi:Task1k:1')
         self.task_num = task.split(':')[2]
         opt['datafile'] = _path('', self.task_num, opt)
         opt['cands_datafile'] = _path('', task.split(':')[2], opt, 'train')
+        opt['parlaidialogteacher_datafile'] = self._convert_from_fbdialog(opt['datafile'])
+        opt['parlaidialogteacher_cands_datafile'] = self._convert_from_fbdialog(opt['cands_datafile'])
         super().__init__(opt, shared)
 
-    def setup_data(self, path):
-        for entry, new in super().setup_data(path):
-            entry[1] = mod_labels(entry[1], self.task_num)
-            yield entry, new
+    def get(self, episode_idx, entry_idx=None):
+        """Override to modify labels."""
+        ex = super().get(episode_idx, entry_idx)
+        ex['labels'] = mod_labels(ex['labels'], self.task_num)
+        return ex
 
-    def load_cands(self, path):
-        return mod_labels(super().load_cands(path), self.task_num)
-
+    def _load_cands(self, path):
+        super()._load_cands(path)
+        self.cands = mod_labels(self.cands, self.task_num)
 
 # Single bAbI task (10k training).
-class Task10kTeacher(FbDialogTeacher):
+class Task10kTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         task = opt.get('task', 'babi:Task10k:1')
         self.task_num = task.split(':')[2]
         opt['datafile'] = _path('-10k', self.task_num, opt)
         opt['cands_datafile'] = _path('-10k', task.split(':')[2], opt, 'train')
+        opt['parlaidialogteacher_datafile'] = self._convert_from_fbdialog(opt['datafile'])
+        opt['parlaidialogteacher_cands_datafile'] = self._convert_from_fbdialog(opt['cands_datafile'])
         super().__init__(opt, shared)
 
-    def setup_data(self, path):
-        for entry, new in super().setup_data(path):
-            entry[1] = mod_labels(entry[1], self.task_num)
-            yield entry, new
+    def get(self, episode_idx, entry_idx=None):
+        """Override to modify labels."""
+        ex = super().get(episode_idx, entry_idx)
+        ex['labels'] = mod_labels(ex['labels'], self.task_num)
+        return ex
 
-    def load_cands(self, path):
-        return mod_labels(super().load_cands(path), self.task_num)
+    def _load_cands(self, path):
+        super()._load_cands(path)
+        self.cands = mod_labels(self.cands, self.task_num)
 
 
 # By default train on all tasks at once.

--- a/parlai/tasks/babi/agents.py
+++ b/parlai/tasks/babi/agents.py
@@ -46,8 +46,12 @@ class Task1kTeacher(ParlAIDialogTeacher):
         self.task_num = task.split(':')[2]
         opt['datafile'] = _path('', self.task_num, opt)
         opt['cands_datafile'] = _path('', task.split(':')[2], opt, 'train')
-        opt['parlaidialogteacher_datafile'] = self._convert_from_fbdialog(opt['datafile'])
-        opt['parlaidialogteacher_cands_datafile'] = self._convert_from_fbdialog(opt['cands_datafile'])
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['cands_datafile']
+        )
         super().__init__(opt, shared)
 
     def get(self, episode_idx, entry_idx=None):
@@ -67,8 +71,12 @@ class Task10kTeacher(ParlAIDialogTeacher):
         self.task_num = task.split(':')[2]
         opt['datafile'] = _path('-10k', self.task_num, opt)
         opt['cands_datafile'] = _path('-10k', task.split(':')[2], opt, 'train')
-        opt['parlaidialogteacher_datafile'] = self._convert_from_fbdialog(opt['datafile'])
-        opt['parlaidialogteacher_cands_datafile'] = self._convert_from_fbdialog(opt['cands_datafile'])
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['cands_datafile']
+        )
         super().__init__(opt, shared)
 
     def get(self, episode_idx, entry_idx=None):

--- a/parlai/tasks/booktest/agents.py
+++ b/parlai/tasks/booktest/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -23,10 +23,13 @@ def _path(opt):
     return os.path.join(opt['datapath'], 'BookTest', 'booktest-gut', suffix)
 
 
-class DefaultTeacher(FbDialogTeacher):
+class DefaultTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         if 'stream' not in opt['datatype']:
             print(
                 'Dataset might not fit in memory. If this is the case, use' +

--- a/parlai/tasks/cbt/agents.py
+++ b/parlai/tasks/cbt/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 import parlai.core.agents as core_agents
 from .build import build
 
@@ -28,31 +28,39 @@ def _path(task, opt):
         opt['datapath'], 'CBT', 'CBTest', 'data', task + '_' + suffix + '.txt')
 
 
-class NETeacher(FbDialogTeacher):
+class NETeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt['datafile'] = _path('cbtest_NE', opt)
-        opt['cloze'] = True
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile'], cloze=True
+        )
         super().__init__(opt, shared)
 
 
-class CNTeacher(FbDialogTeacher):
+class CNTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt['datafile'] = _path('cbtest_CN', opt)
-        opt['cloze'] = True
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile'], cloze=True
+        )
         super().__init__(opt, shared)
 
 
-class VTeacher(FbDialogTeacher):
+class VTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt['datafile'] = _path('cbtest_V', opt)
-        opt['cloze'] = True
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile'], cloze=True
+        )
         super().__init__(opt, shared)
 
 
-class PTeacher(FbDialogTeacher):
+class PTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt['datafile'] = _path('cbtest_P', opt)
-        opt['cloze'] = True
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile'], cloze=True
+        )
         super().__init__(opt, shared)
 
 

--- a/parlai/tasks/convai2/agents.py
+++ b/parlai/tasks/convai2/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from parlai.core.utils import warn_once
 from .build import build
 
@@ -33,7 +33,7 @@ def _path(opt, persona, use_cands):
     return os.path.join(opt['datapath'], 'ConvAI2', dt + cands + '.txt')
 
 
-class BothTeacher(FbDialogTeacher):
+class BothTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         try:
@@ -42,10 +42,13 @@ class BothTeacher(FbDialogTeacher):
         except Exception:
             use_cands = True
         opt['datafile'] = _path(opt, 'both_original', use_cands)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
-class NoneTeacher(FbDialogTeacher):
+class NoneTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         try:
@@ -54,10 +57,13 @@ class NoneTeacher(FbDialogTeacher):
         except Exception:
             use_cands = True
         opt['datafile'] = _path(opt, 'none_original', use_cands)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
-class SelfOriginalTeacher(FbDialogTeacher):
+class SelfOriginalTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         try:
@@ -66,6 +72,9 @@ class SelfOriginalTeacher(FbDialogTeacher):
         except Exception:
             use_cands = True
         opt['datafile'] = _path(opt, 'self_original', use_cands)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
@@ -73,7 +82,7 @@ class SelfTeacher(SelfOriginalTeacher):
     pass
 
 
-class SelfRevisedTeacher(FbDialogTeacher):
+class SelfRevisedTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         try:
@@ -82,6 +91,9 @@ class SelfRevisedTeacher(FbDialogTeacher):
         except Exception:
             use_cands = True
         opt['datafile'] = _path(opt, 'self_revised', use_cands)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 

--- a/parlai/tasks/dbll_babi/agents.py
+++ b/parlai/tasks/dbll_babi/agents.py
@@ -11,7 +11,7 @@
 # which specifies task 2, and policy with 0.5 answers correct, see the paper
 # for more details: https://arxiv.org/abs/1604.06045
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -48,22 +48,30 @@ def _path(subdir, task, opt, dt=''):
                             suffix=_suffixes[dt]))
 
 
-class TaskTeacher(FbDialogTeacher):
+class TaskTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         params = opt['task'].split(':')[2]
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(os.path.join('babi', 'babi1'), params, opt)
         opt['cands_datafile'] = _path(os.path.join('babi', 'babi1'), params,
                                       opt, 'train')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['cands_datafile']
+        )
         super().__init__(opt, shared)
 
 
 # Defaults to task 2 with p=0.5.
-class DefaultTeacher(FbDialogTeacher):
+class DefaultTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         task = '2_p0.5'
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(os.path.join('babi', 'babi1'), task, opt)
         opt['cands_datafile'] = _path(os.path.join('babi', 'babi1'), task,
                                       opt, 'train')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(opt['datafile'])
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(opt['cands_datafile'])
         super().__init__(opt, shared)

--- a/parlai/tasks/dbll_movie/agents.py
+++ b/parlai/tasks/dbll_movie/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -41,16 +41,17 @@ def _path(subdir, task, opt):
 
 
 # The knowledge base of facts that can be used to answer questions.
-class KBTeacher(FbDialogTeacher):
+class KBTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         build(opt)
         opt['datafile'] = os.path.join(
             opt['datapath'], 'DBLL', 'dbll', 'movieqa-dbll', 'movie_kb.txt')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(opt['datafile'])
         super().__init__(opt, shared)
 
 
 # Each individual task.
-class TaskTeacher(FbDialogTeacher):
+class TaskTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         params = opt['task'].split(':')[2]
         opt = copy.deepcopy(opt)
@@ -59,11 +60,17 @@ class TaskTeacher(FbDialogTeacher):
         opt['cands_datafile'] = os.path.join(opt['datapath'], 'WikiMovies',
                                              'movieqa', 'knowledge_source',
                                              'entities.txt')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['cands_datafile']
+        )
         super().__init__(opt, shared)
 
 
 # Defaults to task 2 with p=0.5.
-class DefaultTeacher(FbDialogTeacher):
+class DefaultTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         task = "2_p0.5"
         opt = copy.deepcopy(opt)
@@ -72,5 +79,11 @@ class DefaultTeacher(FbDialogTeacher):
         opt['cands_datafile'] = os.path.join(opt['datapath'], 'WikiMovies',
                                              'movieqa', 'knowledge_source',
                                              'entities.txt')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['cands_datafile']
+        )
         super().__init__(opt, shared)
         self.defaultPosReward = 1

--- a/parlai/tasks/dialog_babi/agents.py
+++ b/parlai/tasks/dialog_babi/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 import parlai.core.agents as core_agents
 from .build import build
 
@@ -49,20 +49,25 @@ def _path(task, opt):
 
 
 # The knowledge base of facts that can be used to answer questions.
-class KBTeacher(FbDialogTeacher):
+class KBTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         build(opt)
         opt['datafile'] = os.path.join(opt['datapath'], 'dialog-bAbI',
                                        'dialog-bAbI-tasks',
                                        'dialog-babi-kb-all.txt')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(opt['datafile'])
         super().__init__(opt, shared)
 
 
 # Single task.
-class TaskTeacher(FbDialogTeacher):
+class TaskTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         paths = _path(opt['task'].split(':')[2], opt)
         opt['datafile'], opt['cands_datafile'] = paths
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(opt['datafile'])
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['cands_datafile']
+        )
         super().__init__(opt, shared)
 
 

--- a/parlai/tasks/dialog_babi_plus/agents.py
+++ b/parlai/tasks/dialog_babi_plus/agents.py
@@ -6,7 +6,7 @@
 
 import os
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from parlai.tasks.dialog_babi_plus.build import build
 
 tasks = {}
@@ -36,19 +36,22 @@ def _path(task, opt):
 
 
 # The knowledge base of facts that can be used to answer questions.
-class KBTeacher(FbDialogTeacher):
+class KBTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         build(opt)
         opt['datafile'] = os.path.join(opt['datapath'], 'dialog-bAbI-plus',
                                        'dialog-bAbI-plus-tasks',
                                        'dialog-babi-kb-all.txt')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(opt['datafile'])
         super().__init__(opt, shared)
 
 
 # Single task.
-class DefaultTeacher(FbDialogTeacher):
+class DefaultTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         default_task_id = 1
         paths = _path(default_task_id, opt)
         opt['datafile'], opt['cands_datafile'] = paths
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(opt['datafile'])
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(opt['cands_datafile'])
         super().__init__(opt, shared)

--- a/parlai/tasks/fromfile/agents.py
+++ b/parlai/tasks/fromfile/agents.py
@@ -7,47 +7,9 @@
 # This task simply loads the specified file: useful for quick tests without
 # setting up a new task.
 
-from parlai.core.teachers import FbDialogTeacher, ParlAIDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 
 import copy
-
-
-class FbformatTeacher(FbDialogTeacher):
-    """This task simply loads the specified file: useful for quick tests without
-    setting up a new task.
-    """
-
-    @staticmethod
-    def add_cmdline_args(argparser):
-        agent = argparser.add_argument_group('FromFile Task Arguments')
-        agent.add_argument('-dp', '--fromfile-datapath', type=str,
-                           help="Data file")
-
-    def __init__(self, opt, shared=None):
-        opt = copy.deepcopy(opt)
-        if not opt.get('fromfile_datapath'):
-            raise RuntimeError('fromfile_datapath not specified')
-        opt['datafile'] = opt['fromfile_datapath']
-        super().__init__(opt, shared)
-
-
-class Fbformat2Teacher(FbDialogTeacher):
-    """This task simply loads the specified file: useful for quick tests without
-    setting up a new task. Used to set up a second task.
-    """
-
-    @staticmethod
-    def add_cmdline_args(argparser):
-        agent = argparser.add_argument_group('FromFile Task Arguments')
-        agent.add_argument('-dp', '--fromfile-datapath2', type=str,
-                           help="Data file")
-
-    def __init__(self, opt, shared=None):
-        opt = copy.deepcopy(opt)
-        if not opt.get('fromfile_datapath2'):
-            raise RuntimeError('-dp', 'fromfile_datapath2 not specified')
-        opt['datafile'] = opt['fromfile_datapath2']
-        super().__init__(opt, shared)
 
 
 class ParlaiformatTeacher(ParlAIDialogTeacher):

--- a/parlai/tasks/insuranceqa/agents.py
+++ b/parlai/tasks/insuranceqa/agents.py
@@ -6,7 +6,7 @@
 import copy
 import os
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 
@@ -22,15 +22,18 @@ def _path(version, opt, exsz=''):
 
 
 # V1 InsuranceQA task
-class V1Teacher(FbDialogTeacher):
+class V1Teacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path('V1', opt)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
 # V2 InsuranceQA task
-class V2Teacher(FbDialogTeacher):
+class V2Teacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         task = opt.get('task', None)
@@ -39,6 +42,9 @@ class V2Teacher(FbDialogTeacher):
             task = 'insuranceqa:V2:100'
         split = task.split(':')
         opt['datafile'] = _path('V2', opt, split[2])
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 

--- a/parlai/tasks/mctest/agents.py
+++ b/parlai/tasks/mctest/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -18,17 +18,23 @@ def _path(opt, filtered):
     return os.path.join(opt['datapath'], 'MCTest', dt + filtered + '.txt')
 
 
-class Task160Teacher(FbDialogTeacher):
+class Task160Teacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, '160')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
-class Task500Teacher(FbDialogTeacher):
+class Task500Teacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, '500')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 

--- a/parlai/tasks/moviedialog/agents.py
+++ b/parlai/tasks/moviedialog/agents.py
@@ -17,7 +17,7 @@ Task 3: Dialogs discussing questions about movies as well as recommendations.
 Task 4: Dialogs discussing Movies from Reddit (the /r/movies SubReddit).
 """
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 import parlai.core.agents as core_agents
 from .build import build
 
@@ -60,7 +60,7 @@ def _path(task, opt):
 
 
 # The knowledge base of facts that can be used to answer questions.
-class KBTeacher(FbDialogTeacher):
+class KBTeacher(ParlAIDialogTeacher):
     """Simple text entry with each movie's facts in the knowledge base."""
 
     def __init__(self, opt, shared=None):
@@ -68,11 +68,14 @@ class KBTeacher(FbDialogTeacher):
         build(opt)
         opt['datafile'] = os.path.join(opt['datapath'], 'MovieDialog',
                                        'movie_dialog_dataset', 'movie_kb.txt')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
 # Single task.
-class TaskTeacher(FbDialogTeacher):
+class TaskTeacher(ParlAIDialogTeacher):
     """Teacher with single task, specified by moviedialog:task:N."""
 
     def __init__(self, opt, shared=None):
@@ -83,6 +86,9 @@ class TaskTeacher(FbDialogTeacher):
         except IndexError:
             self.task = '1'  # default task
         opt['datafile'], opt['cands_datafile'] = _path(self.task, opt)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 

--- a/parlai/tasks/ms_marco/agents.py
+++ b/parlai/tasks/ms_marco/agents.py
@@ -7,7 +7,7 @@ import copy
 import json
 import os
 
-from parlai.core.teachers import DialogTeacher, FbDialogTeacher
+from parlai.core.teachers import DialogTeacher, ParlAIDialogTeacher
 from .build import build
 
 
@@ -24,10 +24,13 @@ def _path(opt, is_passage=False):
     return os.path.join(opt['datapath'], 'MS_MARCO', fname)
 
 
-class PassageTeacher(FbDialogTeacher):
+class PassageTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, is_passage=True)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 

--- a/parlai/tasks/mturkwikimovies/agents.py
+++ b/parlai/tasks/mturkwikimovies/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -21,11 +21,17 @@ def _path(opt, filtered):
                         'qa-{type}.txt'.format(type=dt))
 
 
-class DefaultTeacher(FbDialogTeacher):
+class DefaultTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, '')
         opt['cands_datafile'] = os.path.join(opt['datapath'], 'WikiMovies',
                                              'movieqa', 'knowledge_source',
                                              'entities.txt')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['cands_datafile']
+        )
         super().__init__(opt, shared)

--- a/parlai/tasks/personachat/agents.py
+++ b/parlai/tasks/personachat/agents.py
@@ -21,7 +21,7 @@ This is specified in the following way:
 """
 
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -35,17 +35,23 @@ def _path(opt, persona):
     return os.path.join(opt['datapath'], 'Persona-Chat', 'personachat', dt + '.txt')
 
 
-class NoneTeacher(FbDialogTeacher):
+class NoneTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, 'none_original')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
-class SelfOriginalTeacher(FbDialogTeacher):
+class SelfOriginalTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, 'self_original')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
@@ -53,17 +59,23 @@ class SelfTeacher(SelfOriginalTeacher):
     pass
 
 
-class SelfRevisedTeacher(FbDialogTeacher):
+class SelfRevisedTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, 'self_revised')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
-class OtherOriginalTeacher(FbDialogTeacher):
+class OtherOriginalTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, 'other_original')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
@@ -71,17 +83,23 @@ class OtherTeacher(OtherOriginalTeacher):
     pass
 
 
-class OtherRevisedTeacher(FbDialogTeacher):
+class OtherRevisedTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, 'other_revised')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
-class BothOriginalTeacher(FbDialogTeacher):
+class BothOriginalTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, 'both_original')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
@@ -89,10 +107,13 @@ class BothTeacher(BothOriginalTeacher):
     pass
 
 
-class BothRevisedTeacher(FbDialogTeacher):
+class BothRevisedTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, 'both_revised')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 

--- a/parlai/tasks/personalized_dialog/agents.py
+++ b/parlai/tasks/personalized_dialog/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 import parlai.core.agents as core_agents
 from .build import build
 
@@ -38,36 +38,51 @@ def _path(exsz, task, opt):
 
 
 # The knowledge base of facts that can be used to answer questions.
-class KBTeacher(FbDialogTeacher):
+class KBTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         build(opt)
         opt['datafile'] = os.path.join(
             opt['datapath'], 'personalized-dialog', 'personalized-dialog-dataset',
             'personalized-dialog-kb-all.txt'
         )
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
 # python <script.py> -t personalized_dialog:FullTask:<task_id>
 # Single full task.
-class FullTaskTeacher(FbDialogTeacher):
+class FullTaskTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt['datafile'] = _path('full', opt['task'].split(':')[2], opt)
         opt['cands_datafile'] = os.path.join(
             opt['datapath'], 'personalized-dialog', 'personalized-dialog-dataset',
             'personalized-dialog-candidates.txt'
         )
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['cands_datafile']
+        )
         super().__init__(opt, shared)
 
 
 # python <script.py> -t personalized_dialog:SmallTask:<task_id>
 # Single small task.
-class SmallTaskTeacher(FbDialogTeacher):
+class SmallTaskTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt['datafile'] = _path('small', opt['task'].split(':')[2], opt)
         opt['cands_datafile'] = os.path.join(
             opt['datapath'], 'personalized-dialog', 'personalized-dialog-dataset',
             'personalized-dialog-candidates.txt'
+        )
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['cands_datafile']
         )
         super().__init__(opt, shared)
 
@@ -83,6 +98,9 @@ class AllFullTeacher(core_agents.MultiTaskTeacher):
             opt['datapath'], 'personalized-dialog', 'personalized-dialog-dataset',
             'personalized-dialog-candidates.txt'
         )
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['cands_datafile']
+        )
         super().__init__(opt, shared)
 
 
@@ -96,6 +114,9 @@ class AllSmallTeacher(core_agents.MultiTaskTeacher):
         opt['cands_datafile'] = os.path.join(
             opt['datapath'], 'personalized-dialog', 'personalized-dialog-dataset',
             'personalized-dialog-candidates.txt'
+        )
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['cands_datafile']
         )
         super().__init__(opt, shared)
 

--- a/parlai/tasks/qacnn/agents.py
+++ b/parlai/tasks/qacnn/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -18,8 +18,11 @@ def _path(opt):
     return os.path.join(opt['datapath'], 'QACNN', dt + '.txt')
 
 
-class DefaultTeacher(FbDialogTeacher):
+class DefaultTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)

--- a/parlai/tasks/qadailymail/agents.py
+++ b/parlai/tasks/qadailymail/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -18,8 +18,11 @@ def _path(opt):
     return os.path.join(opt['datapath'], 'QADailyMail', dt + '.txt')
 
 
-class DefaultTeacher(FbDialogTeacher):
+class DefaultTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)

--- a/parlai/tasks/scan/agents.py
+++ b/parlai/tasks/scan/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -18,8 +18,11 @@ def _path(opt):
     return os.path.join(opt['datapath'], 'SCAN', dt + '.txt')
 
 
-class DefaultTeacher(FbDialogTeacher):
+class DefaultTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)

--- a/parlai/tasks/simplequestions/agents.py
+++ b/parlai/tasks/simplequestions/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -18,8 +18,11 @@ def _path(opt, filtered):
     return os.path.join(opt['datapath'], 'SimpleQuestions', 'sq', dt + '.txt')
 
 
-class DefaultTeacher(FbDialogTeacher):
+class DefaultTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, '')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)

--- a/parlai/tasks/webquestions/agents.py
+++ b/parlai/tasks/webquestions/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -18,8 +18,11 @@ def _path(opt):
     return os.path.join(opt['datapath'], 'WebQuestions', dt + '.txt')
 
 
-class DefaultTeacher(FbDialogTeacher):
+class DefaultTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)

--- a/parlai/tasks/wikimovies/agents.py
+++ b/parlai/tasks/wikimovies/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -27,7 +27,7 @@ def _path(opt):
 
 
 # The knowledge base of facts that can be used to answer questions.
-class KBTeacher(FbDialogTeacher):
+class KBTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         build(opt)
         task = opt.get('task')
@@ -45,10 +45,13 @@ class KBTeacher(FbDialogTeacher):
         kbs['ie'] = 'wiki_ie.txt'
         opt['datafile'] = os.path.join(opt['datapath'], 'WikiMovies', 'movieqa',
                                        'knowledge_source', kbs[kb])
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
-class DefaultTeacher(FbDialogTeacher):
+class DefaultTeacher(ParlAIDialogTeacher):
 
     def __init__(self, opt, shared=None):
         build(opt)
@@ -57,4 +60,10 @@ class DefaultTeacher(FbDialogTeacher):
         opt['cands_datafile'] = os.path.join(opt['datapath'], 'WikiMovies',
                                              'movieqa', 'knowledge_source',
                                              'entities.txt')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
+        opt['parlaidialogteacher_cands_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['cands_datafile']
+        )
         super().__init__(opt, shared)

--- a/parlai/tasks/wikiqa/agents.py
+++ b/parlai/tasks/wikiqa/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -18,17 +18,23 @@ def _path(opt, filtered):
     return os.path.join(opt['datapath'], 'WikiQA', dt + filtered + '.txt')
 
 
-class FilteredTeacher(FbDialogTeacher):
+class FilteredTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, '-filtered')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 
-class UnfilteredTeacher(FbDialogTeacher):
+class UnfilteredTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['datafile'] = _path(opt, '')
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 

--- a/parlai/tasks/wmt/agents.py
+++ b/parlai/tasks/wmt/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FbDialogTeacher
+from parlai.core.teachers import ParlAIDialogTeacher
 from .build import build
 
 import copy
@@ -18,12 +18,15 @@ def _path(task, opt, dt):
                         '{task}_{type}.txt'.format(task=task, type=dt))
 
 
-class EnDeTeacher(FbDialogTeacher):
+class EnDeTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         self.task_name = 'en_de'
         dt = opt['datatype'].split(':')[0]
         opt['datafile'] = _path(self.task_name, opt, dt)
+        opt['parlaidialogteacher_datafile'] = ParlAIDialogTeacher._convert_from_fbdialog(
+            opt['datafile']
+        )
         super().__init__(opt, shared)
 
 


### PR DESCRIPTION
**Patch description**
1. Deprecate FbDialogTeacher. Force convert all existing tasks that use FbDialogFormat to ParlAIDialogFormat.
2. Add streaming to ParlAIDialogTeacher

**Testing steps**
Ensure that the following tasks output the exact same data when running `python examples/display_data.py` with the new format as with the old format:

- [ ] babi
- [ ] booktest
- [ ] cbt
- [ ] convai2
- [ ] cornell_movie
- [ ] dbll_babi
- [ ] dbll_movie
- [ ] dialog_babi
- [ ] dialog_babi_plus
- [ ] insuranceqa
- [ ] moviedialog
- [ ] ms_marco
- [ ] mturkwikimovies
- [ ] opensubtitles
- [ ] personachat
- [ ] personalized_dialog
- [ ] qacnn
- [ ] qadailymail
- [ ] scan
- [ ] simplequestions
- [ ] webquestions
- [ ] wikimovies
- [ ] wikiqa
- [ ] wmt
- [ ] 

**Logs**

_Will update when available_

**Other information**
Any other information or context you would like to provide.

**Data tests (if applicable)**
I will run these for all teachers...
`python setup.py test -s tests.suites.datatests`. Please paste this log here.
