### PR TITLE
[MTurk] Fixing socket manager test

### DIFF
--- a/parlai/mturk/core/test/test_socket_manager.py
+++ b/parlai/mturk/core/test/test_socket_manager.py
@@ -1171,6 +1171,7 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         # Run rest of tests
 
         # Test message send from agent
+        acked_packet = None
         test_message_text_1 = 'test_message_text_1'
         msg_id = self.agent1.send_message(test_message_text_1)
         self.assertEqualBy(lambda: self.message_packet is None, False, 8)


### PR DESCRIPTION
**Patch description**
Occasionally this test wouldn't reset the value for the `acked_packet`, meaning if at this point in time the new ack hadn't been processed, the packed checked against the message packet would be wrong. This clears the issue by resetting `acked_packet` entirely before sending a new message.

**Testing steps**
Tests began failing consistently if I added a delay before updating `acked_packet`. With this change tests pass even with the delay.

**Logs**
Run failure noted here: https://circleci.com/gh/facebookresearch/ParlAI/3678

