### PR TITLE
Arg provenance: trace your opt history

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -42,7 +42,7 @@ This module also provides a utility method:
 """
 
 from parlai.core.build_data import modelzoo_path
-from parlai.core.utils import warn_once
+from parlai.core.utils import Opt, warn_once
 from .metrics import Metrics, aggregate_metrics
 import copy
 import importlib
@@ -417,7 +417,7 @@ def _load_opt_file(optfile):
         # oops it's pickled
         with open(optfile, 'rb') as handle:
             opt = pickle.load(handle)
-    return opt
+    return Opt(opt)
 
 
 def load_agent_module(opt):

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -13,8 +13,9 @@ import json
 import sys as _sys
 import datetime
 from parlai.core.agents import get_agent_module, get_task_module
-from parlai.tasks.tasks import ids_to_tasks
 from parlai.core.build_data import modelzoo_path
+from parlai.tasks.tasks import ids_to_tasks
+from parlai.core.utils import Opt
 
 
 def print_announcements(opt):
@@ -671,7 +672,7 @@ class ParlaiParser(argparse.ArgumentParser):
         """
         self.add_extra_args(args)
         self.args = super().parse_args(args=args)
-        self.opt = vars(self.args)
+        self.opt = Opt(vars(self.args))
 
         # custom post-parsing
         self.opt['parlai_home'] = self.parlai_home

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -11,6 +11,7 @@ import math
 import os
 import random
 import time
+import traceback
 import warnings
 import heapq
 
@@ -153,6 +154,33 @@ def load_cands(path, lines_have_ids=False, cands_are_replies=False):
                 else:
                     cands.append(line)
     return cands
+
+
+class Opt(dict):
+    """
+    Class for tracking options.
+
+    Functions like a dict, but allows us to track the history of arguments
+    as they are set.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.history = {}
+
+    def __setitem__(self, key, val):
+        loc = traceback.format_stack()[-2]
+        self.history.setdefault(key, []).append((loc, val))
+        super().__setitem__(key, val)
+
+    def display_history(self, key):
+        """Display the history for an item in the dict."""
+        if key not in self.history:
+            print('No history for key {}'.format(key))
+            return
+        item_hist = self.history[key]
+        for i, change in enumerate(item_hist):
+            print('{}. {} was set to {} at:\n{}\n'.format(i, key, change[1],
+                                                          change[0]))
 
 
 class Predictor(object):

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -6,6 +6,7 @@
 """File for miscellaneous utility functions and constants."""
 
 from collections import deque
+from copy import deepcopy
 from functools import lru_cache
 import math
 import os
@@ -172,14 +173,24 @@ class Opt(dict):
         self.history.setdefault(key, []).append((loc, val))
         super().__setitem__(key, val)
 
+    def __deepcopy__(self, memo):
+        """Override deepcopy so that history is copied over to new object."""
+        # deepcopy the dict
+        memo = deepcopy(dict(self))
+        # make into Opt object
+        memo = Opt(memo)
+        # deepcopy the history
+        memo.history = deepcopy(self.history)
+        return memo
+
     def display_history(self, key):
         """Display the history for an item in the dict."""
         if key not in self.history:
-            print('No history for key {}'.format(key))
+            print('No history for key {}.'.format(key))
             return
         item_hist = self.history[key]
         for i, change in enumerate(item_hist):
-            print('{}. {} was set to {} at:\n{}\n'.format(i, key, change[1],
+            print('{}. {} was set to {} at:\n{}\n'.format(i + 1, key, change[1],
                                                           change[0]))
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,8 @@ from parlai.core.utils import round_sigfigs
 from parlai.core.utils import set_namedtuple_defaults
 from parlai.core.utils import padded_tensor
 from parlai.core.utils import argsort
+from parlai.core.utils import Opt
+from copy import deepcopy
 import time
 import unittest
 import torch
@@ -117,6 +119,20 @@ class TestUtils(unittest.TestCase):
         assert argsort(keys, items, items2, descending=True) == [items, items2]
 
         assert np.all(argsort(torch_keys, torch_keys)[0].numpy() == np.arange(1, 6))
+
+    def test_opt(self):
+        opt = {'x': 0}
+        opt = Opt(opt)
+        opt['x'] += 1
+        opt['x'] = 10
+        history = opt.history['x']
+        self.assertEqual(history[0][1], 1, 'History not set properly')
+        self.assertEqual(history[1][1], 10, 'History not set properly')
+
+        opt_copy = deepcopy(opt)
+        history = opt_copy.history['x']
+        self.assertEqual(history[0][1], 1, 'Deepcopy history not set properly')
+        self.assertEqual(history[1][1], 10, 'Deepcopy history not set properly')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Patch description**
Ever find your self chasing through ParlAI to find out where that arg got set? Have we got a solution for you!

Now Opt is a subclass of dict. This new object traces the history of args being set. Simply call `opt.display_history(arg)` for some arg to see the file/line numbers in which this arg was changed. 

For instance, if we run `python examples/train_model.py -t convai2 -m transformer/ranker -mf /tmp/test_opt --learningrate 0.5` and then inside the TransformerRankerAgent call `self.opt.display_history('learningrate')` the output is as follows:

```
1. learningrate was set to 0.5 at:
  File "/private/home/edinan/ParlAI/parlai/core/agents.py", line 451, in load_agent_module
    new_opt[k] = v
```

Diff also includes a unittest to test this functionality.