### PR TITLE
Suggestion to check ssl on connection refused

### DIFF
--- a/parlai/mturk/core/dev/socket_manager.py
+++ b/parlai/mturk/core/dev/socket_manager.py
@@ -429,6 +429,7 @@ class SocketManager():
                 self.server_death_callback()
                 raise ConnectionRefusedError(  # noqa F821 we only support py3
                     'Was not able to establish a connection with the server, '
+                    'please try to run again. If that fails,'
                     'please ensure that your local device has the correct SSL '
                     'certs installed.'
                 )

--- a/parlai/mturk/core/dev/socket_manager.py
+++ b/parlai/mturk/core/dev/socket_manager.py
@@ -428,7 +428,10 @@ class SocketManager():
             if time.time() - start_time > self.DEF_DEAD_TIME:
                 self.server_death_callback()
                 raise ConnectionRefusedError(  # noqa F821 we only support py3
-                    'Was not able to establish a connection with the server')
+                    'Was not able to establish a connection with the server, '
+                    'please ensure that your local device has the correct SSL '
+                    'certs installed.'
+                )
             try:
                 self._send_world_alive()
             except Exception:

--- a/parlai/mturk/core/legacy_2018/socket_manager.py
+++ b/parlai/mturk/core/legacy_2018/socket_manager.py
@@ -518,6 +518,7 @@ class SocketManager():
                 self.server_death_callback()
                 raise ConnectionRefusedError(  # noqa F821 we only support py3
                     'Was not able to establish a connection with the server, '
+                    'please try to run again. If that fails,'
                     'please ensure that your local device has the correct SSL '
                     'certs installed.'
                 )

--- a/parlai/mturk/core/legacy_2018/socket_manager.py
+++ b/parlai/mturk/core/legacy_2018/socket_manager.py
@@ -517,7 +517,10 @@ class SocketManager():
             if time.time() - start_time > self.DEF_DEAD_TIME:
                 self.server_death_callback()
                 raise ConnectionRefusedError(  # noqa F821 we only support py3
-                    'Was not able to establish a connection with the server')
+                    'Was not able to establish a connection with the server, '
+                    'please ensure that your local device has the correct SSL '
+                    'certs installed.'
+                )
             try:
                 self._send_world_alive()
             except Exception:

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -518,6 +518,7 @@ class SocketManager():
                 self.server_death_callback()
                 raise ConnectionRefusedError(  # noqa F821 we only support py3
                     'Was not able to establish a connection with the server, '
+                    'please try to run again. If that fails,'
                     'please ensure that your local device has the correct SSL '
                     'certs installed.'
                 )

--- a/parlai/mturk/core/socket_manager.py
+++ b/parlai/mturk/core/socket_manager.py
@@ -517,7 +517,10 @@ class SocketManager():
             if time.time() - start_time > self.DEF_DEAD_TIME:
                 self.server_death_callback()
                 raise ConnectionRefusedError(  # noqa F821 we only support py3
-                    'Was not able to establish a connection with the server')
+                    'Was not able to establish a connection with the server, '
+                    'please ensure that your local device has the correct SSL '
+                    'certs installed.'
+                )
             try:
                 self._send_world_alive()
             except Exception:


### PR DESCRIPTION
**Patch description**
As noted in #1739, `ConnectionRefusedError` can be caused by not having the proper SSL certificates installed on a local machine. In fact, this has been the primary cause of `ConnectionRefusedError`, and everything else so far has proven to be transient. This adds a bit more context to the error message to hopefully let debugging be easier for the end-user.