### PR TITLE
Report number of parameters in TorchAgent.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1572,3 +1572,21 @@ class TorchAgent(Agent):
             return
 
         self.optimizer.zero_grad()
+
+    def _total_parameters(self):
+        """
+        Compute the total number of parameters in the model.
+
+        :return:
+            total number of parameters in the model.
+        """
+        return sum(p.numel() for p in self.model.parameters())
+
+    def _trainable_parameters(self):
+        """
+        Compute the total number of trainable parameters in the model.
+
+        :return:
+            total number of trainable parameters in the model.
+        """
+        return sum(p.numel() for p in self.model.parameters() if p.requires_grad)

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -358,7 +358,7 @@ class TorchGeneratorAgent(TorchAgent):
             self.build_criterion()
             self.build_model()
             print("Total parameters: {}".format(self._total_parameters()))
-            print("Total trainable:  {}".format(self._trainable_parameters()))
+            print("Trainable parameters:  {}".format(self._trainable_parameters()))
 
             if self.fp16:
                 self.model = self.model.half()

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -357,6 +357,9 @@ class TorchGeneratorAgent(TorchAgent):
 
             self.build_criterion()
             self.build_model()
+            print("Total parameters: {}".format(self._total_parameters()))
+            print("Total trainable:  {}".format(self._trainable_parameters()))
+
             if self.fp16:
                 self.model = self.model.half()
 


### PR DESCRIPTION
**Patch description**
Using a TorchAgent will now output the total number of parameters and trainable parameters in the initialization step.

**Testing steps**
```
python examples/train_model.py -t integration_tests -m transformer/generator \
    -esz 16 -hid 32 -nl 2 -mf /tmp/itest  \
    --learn-positional-embeddings false

...
[ dictionary built with 11 tokens in 0s ]
[ no model with opt yet at: /tmp/itest(.opt) ]
Dictionary: loading dictionary from /tmp/itest.dict
[ num words =  11 ]
[ Using CUDA ]
Total parameters: 44080
Total trainable:  11312
[creating task(s): integration_tests]
[ training... ]
[ time:2.0s total_exs:95 epochs:0.19 ] {'exs': 95, 'lr': 1, 'num_updates': 95, 'loss': 197.7, 'token_acc': 0.1929, 'nll_loss': 2.084, 'ppl': 8.033}
[ time:4.0s total_exs:192 epochs:0.38 ] {'exs': 97, 'lr': 1, 'num_updates': 192, 'loss': 172.6, 'token_acc': 0.3361, 'nll_loss': 1.779, 'ppl': 5.924}
...
```

**Other information**
Any other information or context you would like to provide.

**Data tests (if applicable)**
If you added a new teacher, you will be asked to run
`python setup.py test -s tests.suites.datatests`. Please paste this log here.
