### PR TITLE
Allow zoo: paths in --init-model.

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -361,6 +361,7 @@ def compare_init_model_opts(opt, curr_opt):
     """Print loud warning when `init_model` opts differ from previous configuration."""
     if opt.get('init_model') is None:
         return
+    opt['init_model'] = modelzoo_path(opt['datapath'], opt['init_model'])
     optfile = opt['init_model'] + '.opt'
     if not os.path.isfile(optfile):
         return


### PR DESCRIPTION
**Patch description**
Allow the use of `--init-model zoo:whatever` or `--init-model izoo:whatever`

**Testing steps**
Ask to see internal example.