### PR TITLE
Don't output the LR warning when finetuning.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -769,7 +769,14 @@ class TorchAgent(ABC, Agent):
             # first make sure there are no null pointers
             states = {}
 
-        if states and states.get('lr_scheduler_type') != self.opt['lr_scheduler']:
+        if (
+            # there is already an old LR scheduler saved on disk
+            states and
+            # and the old LR scheduler is different
+            states.get('lr_scheduler_type') != self.opt['lr_scheduler'] and
+            # and we're not already using a fresh scheduler
+            not hard_reset
+        ):
             # the LR scheduler changed, start things fresh
             warn_once("LR scheduler is different from saved. Starting fresh!")
             hard_reset = True


### PR DESCRIPTION
**Patch description**
Previously, when you started fine tuning a model, the LR scheduler would reset. But it would also show a weird cryptic message when it reset.

Now, this cryptic message only shows when the LR scheduler actually changed; not when the user explicitly knows they're fine tuning.