### PR TITLE
Support using APEX layernorm.

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -2,6 +2,19 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+"""
+Implements NN code for transformers.
+
+Original paper: https://arxiv.org/abs/1706.03762. (Vaswani, 2017). The
+`Annotated Transformer` (Rush, 2018) is an excellent reading guide which explains
+much of the mechanics of the Transformer model
+(http://nlp.seas.harvard.edu/2018/04/03/attention.html).
+
+This module also supports special segments (ala BERT;
+https://arxiv.org/abs/1810.04805), and a few different variations seen in the
+literature (BERT and XLM; https://arxiv.org/abs/1901.07291).
+"""
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -13,11 +26,19 @@ from parlai.core.torch_generator_agent import TorchGeneratorModel
 from parlai.core.utils import warn_once
 from parlai.core.utils import neginf
 
+try:
+    from apex.normalization.fused_layer_norm import FusedLayerNorm as LayerNorm
+except ImportError:
+    warn_once(
+        "Installing APEX can give a significant speed boost."
+    )
+    from torch.nn import LayerNorm
+
 LAYER_NORM_EPS = 1e-12  # Epsilon for layer norm.
 
 
 def _normalize(tensor, norm_layer):
-    """Broadcast layer norm"""
+    """Broadcast layer norm."""
     size = tensor.size()
     return norm_layer(tensor.view(-1, size[-1])).view(size)
 
@@ -78,11 +99,17 @@ def _build_decoder(opt, dictionary, embedding=None, padding_idx=None,
 
 
 def gelu(tensor):
+    """
+    Compute gelu function.
+
+    c.f. https://arxiv.org/abs/1606.08415
+    """
     return 0.5 * tensor * (1.0 + torch.erf(tensor / math.sqrt(2.0)))
 
 
 class TransformerMemNetModel(nn.Module):
-    """Model which takes context, memories, candidates and encodes them"""
+    """Model which takes context, memories, candidates and encodes them."""
+
     def __init__(self, opt, dictionary):
         super().__init__()
         self.opt = opt
@@ -145,6 +172,7 @@ class TransformerMemNetModel(nn.Module):
         self.attender = BasicAttention(dim=2, attn=opt['memory_attention'])
 
     def encode_cand(self, words):
+        """Encode the candidates."""
         if words is None:
             return None
 
@@ -163,6 +191,7 @@ class TransformerMemNetModel(nn.Module):
         return encoded
 
     def encode_context_memory(self, context_w, memories_w):
+        """Encode the memories."""
         # [batch, d]
         if context_w is None:
             # it's possible that only candidates were passed into the
@@ -185,6 +214,7 @@ class TransformerMemNetModel(nn.Module):
         return weights, context_h
 
     def forward(self, xs, mems, cands):
+        """Forward pass."""
         weights, context_h = self.encode_context_memory(xs, mems)
         cands_h = self.encode_cand(cands)
 
@@ -196,6 +226,7 @@ class TransformerMemNetModel(nn.Module):
 
 
 def create_position_codes(n_pos, dim, out):
+    """Create positional codes and store them in ``out``."""
     position_enc = np.array([
         [pos / np.power(10000, 2 * j / dim) for j in range(dim // 2)]
         for pos in range(n_pos)
@@ -208,7 +239,12 @@ def create_position_codes(n_pos, dim, out):
 
 
 class TransformerResponseWrapper(nn.Module):
-    """Transformer response rapper. Pushes input through transformer and MLP"""
+    """
+    Wrap transformer response.
+
+    Pushes input through transformer and MLP.
+    """
+
     def __init__(self, transformer, hdim):
         super(TransformerResponseWrapper, self).__init__()
         dim = transformer.out_dim
@@ -220,6 +256,7 @@ class TransformerResponseWrapper(nn.Module):
         )
 
     def forward(self, *args):
+        """Forward pass."""
         return self.mlp(self.transformer(*args))
 
 
@@ -257,6 +294,7 @@ class TransformerEncoder(nn.Module):
         Which transformer architecture to use. Could be AIAYN or XLM.
         Future versions may support things like GPT-2, ...
     """
+
     def __init__(
         self,
         n_heads,
@@ -326,7 +364,7 @@ class TransformerEncoder(nn.Module):
 
         # embedding normalization
         if self.variant == 'xlm':
-            self.norm_embeddings = nn.LayerNorm(self.dim, eps=LAYER_NORM_EPS)
+            self.norm_embeddings = LayerNorm(self.dim, eps=LAYER_NORM_EPS)
         elif self.variant == 'aiayn':
             pass
         else:
@@ -349,9 +387,14 @@ class TransformerEncoder(nn.Module):
 
     def forward(self, input, positions=None, segments=None):
         """
-            input data is a FloatTensor of shape [batch, seq_len, dim]
-            mask is a ByteTensor of shape [batch, seq_len], filled with 1 when
-            inside the sequence and 0 outside.
+        Forward pass.
+
+        :param LongTensor[batch,seqlen] input:
+            The input IDs
+        :param BoolTensor[batch,seqlen] mask:
+            The attention mask; 1 means attend, 0 means ignore.
+        :param LongTensor[batch,seqlen]:
+            If provided, additionally adds ``segments`` as extra embedding features.
         """
         mask = input != self.padding_idx
         if positions is None:
@@ -402,6 +445,8 @@ class TransformerEncoder(nn.Module):
 
 
 class TransformerEncoderLayer(nn.Module):
+    """Implements a single Transformer encoder layer."""
+
     def __init__(
         self,
         n_heads,
@@ -422,14 +467,15 @@ class TransformerEncoderLayer(nn.Module):
             n_heads, embedding_size,
             dropout=attention_dropout,  # --attention-dropout
         )
-        self.norm1 = nn.LayerNorm(embedding_size, eps=LAYER_NORM_EPS)
+        self.norm1 = LayerNorm(embedding_size, eps=LAYER_NORM_EPS)
         self.ffn = TransformerFFN(embedding_size, ffn_size,
                                   relu_dropout=relu_dropout,
                                   activation=self.activation)
-        self.norm2 = nn.LayerNorm(embedding_size, eps=LAYER_NORM_EPS)
+        self.norm2 = LayerNorm(embedding_size, eps=LAYER_NORM_EPS)
         self.dropout = nn.Dropout(p=dropout)
 
     def forward(self, tensor, mask):
+        """Forward pass."""
         tensor = tensor + self.dropout(self.attention(tensor, mask=mask))
         tensor = _normalize(tensor, self.norm1)
         tensor = tensor + self.dropout(self.ffn(tensor))
@@ -501,7 +547,7 @@ class TransformerDecoder(nn.Module):
         self.embeddings = embedding
 
         if self.variant == 'xlm':
-            self.norm_embeddings = nn.LayerNorm(self.dim, eps=LAYER_NORM_EPS)
+            self.norm_embeddings = LayerNorm(self.dim, eps=LAYER_NORM_EPS)
         elif self.variant == 'aiayn':
             pass
         else:
@@ -529,6 +575,16 @@ class TransformerDecoder(nn.Module):
             ))
 
     def forward(self, input, encoder_state, incr_state=None):
+        """
+        Forward pass.
+
+        :param LongTensor[batch,seqlen] input:
+            The decoder inputs (partial or full decoded token IDs).
+        :param encoder_state:
+            Output from the encoder module forward pass.
+        :param incr_state:
+            Ignored. Should always be ``None`` in this version.
+        """
         encoder_output, encoder_mask = encoder_state
 
         seq_len = input.size(1)
@@ -556,6 +612,15 @@ class TransformerDecoder(nn.Module):
 
 
 class TransformerDecoderLayer(nn.Module):
+    """
+    Implements a single Transformer decoder layer.
+
+    Decoder layers are similar to encoder layers but:
+
+    1. Self-attention is limited in a casaul (auto-regressive) manner.
+    2. Attend over all of the encoder states.
+    """
+
     def __init__(
         self,
         n_heads,
@@ -577,19 +642,20 @@ class TransformerDecoderLayer(nn.Module):
         self.self_attention = MultiHeadAttention(
             n_heads, embedding_size, dropout=attention_dropout
         )
-        self.norm1 = nn.LayerNorm(embedding_size, eps=LAYER_NORM_EPS)
+        self.norm1 = LayerNorm(embedding_size, eps=LAYER_NORM_EPS)
 
         self.encoder_attention = MultiHeadAttention(
             n_heads, embedding_size, dropout=attention_dropout
         )
-        self.norm2 = nn.LayerNorm(embedding_size, eps=LAYER_NORM_EPS)
+        self.norm2 = LayerNorm(embedding_size, eps=LAYER_NORM_EPS)
 
         self.ffn = TransformerFFN(
             embedding_size, ffn_size, relu_dropout=relu_dropout, activation=activation
         )
-        self.norm3 = nn.LayerNorm(embedding_size, eps=LAYER_NORM_EPS)
+        self.norm3 = LayerNorm(embedding_size, eps=LAYER_NORM_EPS)
 
     def forward(self, x, encoder_output, encoder_mask):
+        """Forward pass."""
         decoder_mask = self._create_selfattn_mask(x)
         # first self attn
         residual = x
@@ -631,6 +697,8 @@ class TransformerDecoderLayer(nn.Module):
 
 
 class TransformerGeneratorModel(TorchGeneratorModel):
+    """Implements a full generator model, with one encoder and one decoder."""
+
     def __init__(self, opt, dictionary):
         self.pad_idx = dictionary[dictionary.null_token]
         self.start_idx = dictionary[dictionary.start_token]
@@ -668,6 +736,11 @@ class TransformerGeneratorModel(TorchGeneratorModel):
         )
 
     def reorder_encoder_states(self, encoder_states, indices):
+        """
+        Reorder the encoder states.
+
+        See ``TorchGeneratorModel.reorder_encoder_states`` for a description.
+        """
         enc, mask = encoder_states
         if not torch.is_tensor(indices):
             indices = torch.LongTensor(indices).to(enc.device)
@@ -676,16 +749,24 @@ class TransformerGeneratorModel(TorchGeneratorModel):
         return enc, mask
 
     def reorder_decoder_incremental_state(self, incremental_state, inds):
+        """
+        Reorder the decoder incremental state.
+
+        Not implemented in Transformers, since ``incremental_state`` is always None.
+        """
         # no support for incremental decoding at this time
         return None
 
     def output(self, tensor):
+        """Compute output logits."""
         # project back to vocabulary
         output = F.linear(tensor, self.embeddings.weight)
         return output
 
 
 class BasicAttention(nn.Module):
+    """Implements simple/classical attention."""
+
     def __init__(self, dim=1, attn='cosine'):
         super().__init__()
         self.softmax = nn.Softmax(dim=dim)
@@ -695,6 +776,7 @@ class BasicAttention(nn.Module):
         self.dim = dim
 
     def forward(self, xs, ys):
+        """Forward pass."""
         if self.attn == 'cosine':
             l1 = self.cosine(xs, ys).unsqueeze(self.dim - 1)
         else:
@@ -711,6 +793,12 @@ class BasicAttention(nn.Module):
 
 
 class MultiHeadAttention(nn.Module):
+    """
+    Implements MultiHeadAttention; this is the core workhorse of the Transformer.
+
+    See Vaswani (2017) for an extensive description.
+    """
+
     def __init__(self, n_heads, dim, dropout=0):
         super(MultiHeadAttention, self).__init__()
         self.n_heads = n_heads
@@ -730,6 +818,9 @@ class MultiHeadAttention(nn.Module):
         nn.init.xavier_normal_(self.out_lin.weight)
 
     def forward(self, query, key=None, value=None, mask=None):
+        """Forward pass."""
+        # TODO: there are a lot of parameters to document here.
+
         # Input is [B, query_len, dim]
         # Mask is [B, key_len] (selfattn) or [B, key_len, key_len] (enc attn)
         batch_size, query_len, dim = query.size()
@@ -795,6 +886,8 @@ class MultiHeadAttention(nn.Module):
 
 
 class TransformerFFN(nn.Module):
+    """Implements the FFN part of the transformer."""
+
     def __init__(self, dim, dim_hidden, relu_dropout=0, activation='relu'):
         super(TransformerFFN, self).__init__()
         self.relu_dropout = nn.Dropout(p=relu_dropout)
@@ -813,6 +906,7 @@ class TransformerFFN(nn.Module):
         # TODO: initialize biases to 0
 
     def forward(self, x):
+        """Forward pass."""
         x = self.nonlinear(self.lin1(x))
         x = self.relu_dropout(x)  # --relu-dropout
         x = self.lin2(x)


### PR DESCRIPTION
**Patch description**
This patch uses APEX's FusedLayerNorm in transformer when it's available. A long time ago, I noticed that this enabled like a ~8% training speedup in the right setting, but it broke CPU models.

Recently, NVIDIA fixed this bug with nvidia/apex#239, making it CPU compatible. That makes it safe for us to use.

**Testing steps**
Unit tests pass. Should test locally; will add this to this PR before merging.

**Logs**
Command:
`python examples/train_model.py -m transformer/generator -t convai2 -tr 128 -mf /tmp/foo -bs 128 --fp16 false -eps 2 -opt adam -lr 1e-4 --fp16 true`

With the patch:
`[ num_epochs completed:2.0 time elapsed:159.66534757614136s ]`

Without the patch:
`[ num_epochs completed:2.0 time elapsed:160.46017456054688s ]`

Doesn't seem like a lot here, but this is very small model. The benefits are more substantial with much larger models (and more time).