### PR TITLE
Report correct agent-reported metrics during evaluation when multi-tasking

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -59,7 +59,7 @@ def aggregate_task_reports(reports, tasks, micro=True):
 
     :param reports: list of report dicts from separate tasks
     :param tasks: list of tasks
-    :param mico: average per example if True, else average over t
+    :param micro: average per example if True, else average over t
 
     :return: aggregated report dicts
     """

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -53,6 +53,46 @@ def normalize_answer(s):
     return white_space_fix(remove_articles(remove_punc(lower(s))))
 
 
+def aggregate_task_reports(reports, tasks, micro=True):
+    """
+    Aggregate separate task reports into a single report.
+
+    :param reports: list of report dicts from separate tasks
+    :param tasks: list of tasks
+    :param mico: average per example if True, else average over t
+
+    :return: aggregated report dicts
+    """
+    if len(reports) == 1:
+        # singular task
+        return reports[0]
+    # multiple tasks, aggregate metrics
+    metrics = {}
+    exs = {}
+    total_report = {'tasks': {}}
+    # collect metrics from all reports
+    for i, report in enumerate(reports):
+        total_report['tasks'][tasks[i]] = report
+        for metric, val in report.items():
+            if metric == 'exs':
+                exs[tasks[i]] = val
+            else:
+                metrics.setdefault(metric, {})[tasks[i]] = val
+    # now aggregate
+    total_exs = sum(exs.values())
+    total_report['exs'] = total_exs
+    for metric, task_vals in metrics.items():
+        if micro:
+            # average over the number of examples
+            vals = [task_vals[task] * exs[task] for task in tasks]
+            total_report[metric] = round_sigfigs(sum(vals) / total_exs, 4)
+        else:  # macro
+            # average over tasks
+            vals = task_vals.values()
+            total_report[metric] = round_sigfigs(sum(vals) / len(vals), 4)
+    return total_report
+
+
 def _exact_match(guess, answers):
     """Check if guess is a (normalized) exact match with any answer."""
     if guess is None or answers is None:

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -169,11 +169,6 @@ def aggregate_metrics(reporters):
     if num_tasks > 0:
         for k in sums.keys():
             m[k] = round_sigfigs(sums[k] / num_tasks, 4)
-    m['exs'] = total
-    m['accuracy'] = 0
-    if num_tasks > 0:
-        for k in sums.keys():
-            m[k] = round_sigfigs(sums[k] / num_tasks, 4)
     return m
 
 

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -90,6 +90,11 @@ def aggregate_task_reports(reports, tasks, micro=True):
             # average over tasks
             vals = task_vals.values()
             total_report[metric] = round_sigfigs(sum(vals) / len(vals), 4)
+    # add a warning describing how metrics were averaged across tasks.
+    total_report['warning'] = 'metrics are averaged across tasks'
+    if micro:
+        total_report['warning'] += (' and weighted by the number of examples '
+                                    'per task')
     return total_report
 
 

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -149,14 +149,11 @@ def aggregate_metrics(reporters):
         sums['rouge-L'] = 0.0
     num_tasks = 0
     total = 0
-    agent_metrics = {}
     for i in range(len(reporters)):
         task_id = reporters[i].getID()
         task_report = reporters[i].report()
-        for metric, val in task_report.items():
-            agent_metrics.setdefault(metric, []).append(val)
         while task_id in m['tasks']:
-            # prevent name cloberring if using multiple tasks with same ID
+            # prevent name clobbering if using multiple tasks with same ID
             task_id += '_'
         m['tasks'][task_id] = task_report
         total += task_report['exs']
@@ -167,11 +164,11 @@ def aggregate_metrics(reporters):
                 found_any = True
         if found_any:
             num_tasks += 1
-    # aggregate agent reported metrics across tasks (average)
-    if len(reporters) > 0:
-        m['tasks']['all'] = {}
-        for metric, vals in agent_metrics.items():
-            m['tasks']['all'][metric] = round_sigfigs(sum(vals) / len(vals), 4)
+    m['exs'] = total
+    m['accuracy'] = 0
+    if num_tasks > 0:
+        for k in sums.keys():
+            m[k] = round_sigfigs(sums[k] / num_tasks, 4)
     m['exs'] = total
     m['accuracy'] = 0
     if num_tasks > 0:

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -49,7 +49,7 @@ def setup_args(parser=None):
 
 
 def _eval_single_world(opt, agent, task):
-    print('[ Evaluating task {} on using datatype {}. ] '.format(
+    print('[ Evaluating task {} using datatype {}. ] '.format(
         task, opt.get('datatype', 'N/A')))
     task_opt = opt.copy()  # copy opt since we're editing the task
     task_opt['task'] = task

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -49,13 +49,13 @@ def _eval_single_world(opt, agent, task):
     task_opt['task'] = task
     world = create_task(task_opt, agent)  # create worlds for tasks
 
-    # logging
+    # set up logging
     log_every_n_secs = opt.get('log_every_n_secs', -1)
     if log_every_n_secs <= 0:
         log_every_n_secs = float('inf')
     log_time = TimeLogger()
 
-    # Show some example dialogs:
+    # max number of examples to evaluate
     max_cnt = opt['num_examples'] if opt['num_examples'] > 0 else float('inf')
     cnt = 0
 
@@ -63,6 +63,7 @@ def _eval_single_world(opt, agent, task):
         cnt += opt.get('batchsize', 1)
         world.parley()
         if opt['display_examples']:
+            # display examples
             print(world.display() + '\n~~')
         if log_time.time() > log_every_n_secs:
             report = world.report()

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -22,7 +22,6 @@ from parlai.core.logs import TensorboardLogger
 from parlai.core.worlds import create_task
 from parlai.core.utils import TimeLogger, round_sigfigs
 
-from copy import deepcopy
 import random
 
 
@@ -66,13 +65,12 @@ def eval_model(opt, printargs=None, print_parser=None):
     random.seed(42)
 
     reports = []
+    agent = create_agent(opt, requireModelExists=True)  # create model
     tasks = opt['task'].split(',')
     for task in tasks:
-        # Create model and assign it to the specified task
-        task_opt = deepcopy(opt)  # copy opt since we're editing the task
+        task_opt = opt.copy()  # copy opt since we're editing the task
         task_opt['task'] = task
-        agent = create_agent(task_opt, requireModelExists=True)
-        world = create_task(task_opt, agent)
+        world = create_task(task_opt, agent)  # create worlds for tasks
 
         if print_parser:
             # Show arguments after loading model

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -77,8 +77,8 @@ def _eval_single_world(opt, agent, task):
                                         report)
             print(text)
 
-    world.reset()
     report = world.report()
+    world.reset()
     return report
 
 

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -77,6 +77,7 @@ def _eval_single_world(opt, agent, task):
                                         report)
             print(text)
 
+    world.reset()
     report = world.report()
     return report
 

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -26,7 +26,6 @@ Examples
 # TODO List:
 # * More logging (e.g. to files), make things prettier.
 
-from copy import deepcopy
 import numpy as np
 import os
 import signal
@@ -232,7 +231,7 @@ def load_eval_worlds(agent, opt, datatype):
     tasks = opt['task'].split(',')
     worlds = []
     for task in tasks:
-        task_opt = deepcopy(opt)
+        task_opt = opt.copy()  # copy opt since we edit the task
         task_opt['task'] = task
         if opt.get('validation_share_agent', False):
             valid_agent = create_agent_from_shared(agent.share())

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -508,16 +508,12 @@ class TrainLoop():
             self.agent.receive_metrics(valid_report)
 
         # check which metric to look at
-        if 'tasks' in valid_report:
-            if '/' in opt['validation_metric']:
-                # if you are multitasking and want your validation metric to be
-                # a metric specific to a subtask, specify your validation metric
-                # as -vmt subtask/metric
-                subtask = opt['validation_metric'].split('/')[0]
-                validation_metric = opt['validation_metric'].split('/')[1]
-            else:
-                subtask = 'all'
-                validation_metric = opt['validation_metric']
+        if 'tasks' in valid_report and '/' in opt['validation_metric']:
+            # if you are multitasking and want your validation metric to be
+            # a metric specific to a subtask, specify your validation metric
+            # as -vmt subtask/metric
+            subtask = opt['validation_metric'].split('/')[0]
+            validation_metric = opt['validation_metric'].split('/')[1]
             new_valid = valid_report['tasks'][subtask][validation_metric]
         else:
             new_valid = valid_report[opt['validation_metric']]

--- a/projects/convai2/baselines/kvmemnn/eval_f1.py
+++ b/projects/convai2/baselines/kvmemnn/eval_f1.py
@@ -23,7 +23,7 @@ def main():
     fnames = ['kvmemnn.tgz']
     opt['model_type'] = 'kvmemnn'  # for builder
     download_models(opt, fnames, 'convai2')
-    return eval_f1(parser, print_parser=parser)
+    return eval_f1(opt, print_parser=parser)
 
 
 if __name__ == '__main__':

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -42,6 +42,36 @@ class TestEvalModel(unittest.TestCase):
                 self.assertEqual(score['rouge-2'], 1, 'rouge-2 != 1')
                 self.assertEqual(score['rouge-L'], 1, 'rouge-L != 1')
 
+    def test_multitasking_metrics(self):
+        stdout, valid, test = testing_utils.eval_model({
+            'task': 'integration_tests:candidate,'
+                    'integration_tests:multiturnCandidate',
+            'model': 'random_candidate',
+            'num_epochs': 0.5,
+            'aggregate_micro': True,
+        })
+
+        task1_acc = valid['tasks']['integration_tests:candidate']['accuracy']
+        task2_acc = valid['tasks']['integration_tests:multiturnCandidate']['accuracy']
+        total_acc = valid['accuracy']
+        # task 2 is 4 times the size of task 1
+        self.assertAlmostEqual(total_acc, (task1_acc + 4 * task2_acc) / 5, 4,
+                               'Task accuracy is averaged incorrectly')
+
+        stdout, valid, test = testing_utils.eval_model({
+            'task': 'integration_tests:candidate,'
+                    'integration_tests:multiturnCandidate',
+            'model': 'random_candidate',
+            'num_epochs': 0.5,
+            'aggregate_micro': False,
+        })
+        task1_acc = valid['tasks']['integration_tests:candidate']['accuracy']
+        task2_acc = valid['tasks']['integration_tests:multiturnCandidate']['accuracy']
+        total_acc = valid['accuracy']
+        # metrics should be averaged equally across tasks
+        self.assertAlmostEqual(total_acc, (task1_acc + task2_acc) / 2, 4,
+                               'Task accuracy is averaged incorrectly')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -24,6 +24,36 @@ class TestTrainModel(unittest.TestCase):
         self.assertEqual(valid['exs'], 10, 'Validation exs is wrong')
         self.assertEqual(test['exs'], 10, 'Test exs is wrong')
 
+    def test_multitasking_metrics(self):
+        stdout, valid, test = testing_utils.train_model({
+            'task': 'integration_tests:candidate,'
+                    'integration_tests:multiturnCandidate',
+            'model': 'random_candidate',
+            'num_epochs': 0.5,
+            'aggregate_micro': True,
+        })
+
+        task1_acc = valid['tasks']['integration_tests:candidate']['accuracy']
+        task2_acc = valid['tasks']['integration_tests:multiturnCandidate']['accuracy']
+        total_acc = valid['accuracy']
+        # task 2 is 4 times the size of task 1
+        self.assertAlmostEqual(total_acc, (task1_acc + 4 * task2_acc) / 5, 4,
+                               'Task accuracy is averaged incorrectly')
+
+        stdout, valid, test = testing_utils.train_model({
+            'task': 'integration_tests:candidate,'
+                    'integration_tests:multiturnCandidate',
+            'model': 'random_candidate',
+            'num_epochs': 0.5,
+            'aggregate_micro': False,
+        })
+        task1_acc = valid['tasks']['integration_tests:candidate']['accuracy']
+        task2_acc = valid['tasks']['integration_tests:multiturnCandidate']['accuracy']
+        total_acc = valid['accuracy']
+        # metrics should be averaged equally across tasks
+        self.assertAlmostEqual(total_acc, (task1_acc + task2_acc) / 2, 4,
+                               'Task accuracy is averaged incorrectly')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Patch description**
Currently during multitasking, agent reported metrics aren't reported correctly. This changes makes sure that the metrics are reported correctly during evaluation by creating multiple worlds and iterating through them sequentially, collecting separate metrics for each world and then finally aggregating them. 

Note that in this case, if we specify `validation_max_exes`, it splits the number of examples equally across tasks. In the future, this could change to be different proportions.

**Testing steps**
Train and evaluate models, check that metrics are reported correctly. [Edit: should probably write unit tests but will wait until feedback from initial review...]
