### PR TITLE
Parallelize tests on CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,6 @@ jobs:
 
   unittests_36:
     <<: *standard_cpu36
-    parallelism: 4
     working_directory: ~/ParlAI
     steps:
       - checkout
@@ -122,7 +121,6 @@ jobs:
 
   unittests_37:
     <<: *standard_cpu37
-    parallelism: 4
     working_directory: ~/ParlAI
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
   nightly_gpu_tests:
     <<: *gpu
     working_directory: ~/ParlAI
-    parallelism: 4
+    parallelism: 8
     steps:
       - checkout
       - <<: *fixgit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,7 @@ jobs:
 
   unittests_36:
     <<: *standard_cpu36
+    parallelism: 4
     working_directory: ~/ParlAI
     steps:
       - checkout
@@ -121,6 +122,7 @@ jobs:
 
   unittests_37:
     <<: *standard_cpu37
+    parallelism: 4
     working_directory: ~/ParlAI
     steps:
       - checkout
@@ -177,6 +179,7 @@ jobs:
   nightly_gpu_tests:
     <<: *gpu
     working_directory: ~/ParlAI
+    parallelism: 4
     steps:
       - checkout
       - <<: *fixgit

--- a/tests/suites.py
+++ b/tests/suites.py
@@ -8,6 +8,8 @@
 
 import os
 import unittest
+import random
+from itertools import chain
 
 
 def _circleci_parallelism(suite):
@@ -19,7 +21,13 @@ def _circleci_parallelism(suite):
     # on all hosts.
     total = int(os.environ['CIRCLE_NODE_TOTAL'])
     index = int(os.environ['CIRCLE_NODE_INDEX'])
-    tests = [t for i, t in enumerate(suite._tests) if i % total == index]
+
+    # right now each test is corresponds to a /file/. Certain files are slower than
+    # others, so we want to flatten it
+    tests = [testfile._tests for testfile in suite._tests]
+    tests = list(chain.from_iterable(tests))
+    random.Random(42).shuffle(tests)
+    tests = [t for i, t in enumerate(tests) if i % total == index]
     return unittest.TestSuite(tests)
 
 

--- a/tests/suites.py
+++ b/tests/suites.py
@@ -4,14 +4,27 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+"""Various test loaders."""
+
+import os
 import unittest
 
 
+def _circleci_parallelism(suite):
+    """Allow for parallelism in CircleCI for speedier tests.."""
+    if int(os.environ.get('CIRCLE_NODE_TOTAL', 0)) <= 1:
+        # either not running on circleci, or we're not using parallelism.
+        return suite
+    # tests are automatically sorted by discover, so we will get the same ordering
+    # on all hosts.
+    total = int(os.environ['CIRCLE_NODE_TOTAL'])
+    index = int(os.environ['CIRCLE_NODE_INDEX'])
+    tests = [t for i, t in enumerate(suite._tests) if i % total == index]
+    return unittest.TestSuite(tests)
+
+
 def _clear_cmdline_args(fn):
-    """
-    Helper decorator to make sure 'python setup.py test' doesn't look like
-    a parlai call.
-    """
+    """Decorate to make sure 'python setup.py test' doesn't look like a parlai call."""
     import sys
 
     sys.argv = sys.argv[:1]
@@ -21,9 +34,9 @@ def _clear_cmdline_args(fn):
 @_clear_cmdline_args
 def datatests():
     """
-    Tests for data integrity. Runs on CircleCI.
+    Test for data integrity.
 
-    Separate to help distinguish failure reasons.
+    Runs on CircleCI. Separate to help distinguish failure reasons.
     """
     test_loader = unittest.TestLoader()
     test_suite = test_loader.discover('tests/datatests')
@@ -32,17 +45,27 @@ def datatests():
 
 @_clear_cmdline_args
 def nightly_gpu():
-    """Nightly GPU tests. Runs on internal infra."""
+    """
+    Nightly GPU tests.
+
+    Runs on CircleCI nightly, and when [gpu] or [long] appears in a commit string.
+    """
     test_loader = unittest.TestLoader()
     test_suite = test_loader.discover('tests/nightly/gpu')
+    test_suite = _circleci_parallelism(test_suite)
     return test_suite
 
 
 @_clear_cmdline_args
 def unittests():
-    """Short tests, found in tests root directory."""
+    """
+    Short tests.
+
+    Runs on CircleCI on every commit. Returns everything in the tests root directory.
+    """
     test_loader = unittest.TestLoader()
     test_suite = test_loader.discover('tests')
+    test_suite = _circleci_parallelism(test_suite)
     return test_suite
 
 


### PR DESCRIPTION
**Patch description**
Adds parallelism to CircleCI, so unittests run on multiple machines (hopefully much faster)

**Testing steps**
CircleCI.