### PR TITLE
allow to add a start and end token to the text vec if needed

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1040,7 +1040,8 @@ class TorchAgent(ABC, Agent):
         else:
             return vec[:truncate]
 
-    def _set_text_vec(self, obs, history, truncate):
+    def _set_text_vec(self, obs, history, truncate, add_start=False,
+                      add_end=False):
         """
         Set the 'text_vec' field in the observation.
 
@@ -1053,7 +1054,9 @@ class TorchAgent(ABC, Agent):
             # text vec is not precomputed, so we set it using the history
             obs['text'] = history.get_history_str()
             if obs['text'] is not None:
-                obs['text_vec'] = history.get_history_vec()
+                vec = history.get_history_vec()
+                vec = self._add_start_end_tokens(vec, add_start, add_end)
+                obs['text_vec'] = vec
 
         # check truncation
         if 'text_vec' in obs:


### PR DESCRIPTION
**Patch description**
Since the history class has been put in place, I think we can no longer add a start and end token and that all classes that need it (the bert_ranker classes for instance) are doing so a bit artisanally. This allows to override _set_text_vec to add start and end token.

**Testing steps**
Create an agent that overrides _set_text_vec, for instance:
```
    def _set_text_vec(self, *args, **kwargs):
        kwargs['add_start'] = True
        kwargs['add_end'] = True
        return super()._set_text_vec(*args, **kwargs)
```
Observe that start and end tokens are added.
