### PR TITLE
More TRA fixes

### DIFF
--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -552,7 +552,6 @@ class TorchRankerAgent(TorchAgent):
                             'set `--ignore-bad-candidates True`.'
                         )
 
-                    
         elif source == 'fixed':
             warn_once(
                 "[ Executing {} mode with a common set of fixed candidates "

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -550,7 +550,7 @@ class TorchRankerAgent(TorchAgent):
                             'At least one of your examples has a set of label candidates '
                             'that does not contain the label. To ignore this error '
                             'set `--ignore-bad-candidates True`.'
-        )
+                        )
 
                     
         elif source == 'fixed':
@@ -588,6 +588,7 @@ class TorchRankerAgent(TorchAgent):
                             'At least one of your examples has a set of label candidates '
                             'that does not contain the label. To ignore this error '
                             'set `--ignore-bad-candidates True`.'
+                        )
 
         elif source == 'vocab':
             warn_once(

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -543,7 +543,7 @@ class TorchRankerAgent(TorchAgent):
                     if label_inds[i] == -1:
                         bad_batch = True
                 if bad_batch:
-                    if self.opt.get('ignore_bad_candidates'):
+                    if self.opt.get('ignore_bad_candidates') and not self.is_training:
                         label_inds = None
                     else:
                         raise RuntimeError(
@@ -581,7 +581,7 @@ class TorchRankerAgent(TorchAgent):
                     if label_inds[i] == -1:
                         bad_batch = True
                 if bad_batch:
-                    if self.opt.get('ignore_bad_candidates'):
+                    if self.opt.get('ignore_bad_candidates') and not self.is_training:
                         label_inds = None
                     else:
                         raise RuntimeError(


### PR DESCRIPTION
Two TRA fixes:

(1) when no label was present, we still want it to be fast (e.g. in self-play) but it wasn't doing that.

(2) it didn't respect 'ignore_bad_candidates' despite the message, so if there was a label, it would just bug out with a fixed candidate set