### PR TITLE
changes to work with CI in parlai internal

### DIFF
--- a/tests/lint_changed.sh
+++ b/tests/lint_changed.sh
@@ -12,6 +12,17 @@ flake8 --version | grep '^3\.[6-9]\.' >/dev/null || \
     ( echo "Please install flake8 >=3.6.0." && false )
 
 CHANGED_FILES="$(git diff --name-only master... | grep '\.py$' | tr '\n' ' ')"
+
+while getopts i opt; do
+  case $opt in
+    i)
+      CHANGED_FILES="$(git -C ./parlai_internal/ diff --name-only master... |
+      xargs -I '{}' realpath --relative-to=. $(git -C ./parlai_internal/ rev-parse --show-toplevel)/'{}' |
+      grep '\.py$' | tr '\n' ' ')"
+      ;;
+    esac
+  done
+
 if [ "$CHANGED_FILES" != "" ]
 then
     # soft complaint on too-long-lines

--- a/tests/suites.py
+++ b/tests/suites.py
@@ -52,6 +52,7 @@ def mturk():
     test_suite = test_loader.discover("parlai/mturk/core/test/")
     return test_suite
 
+
 @_clear_cmdline_args
 def internal_tests():
     """Internal Tests"""

--- a/tests/suites.py
+++ b/tests/suites.py
@@ -52,6 +52,13 @@ def mturk():
     test_suite = test_loader.discover("parlai/mturk/core/test/")
     return test_suite
 
+@_clear_cmdline_args
+def internal_tests():
+    """Internal Tests"""
+    test_loader = unittest.TestLoader()
+    test_suite = test_loader.discover("parlai_internal/tests")
+    return test_suite
+
 
 if __name__ == '__main__':
     unittest.run(unittests())


### PR DESCRIPTION
**Patch description**
This allows us to invoke internal tests and lint from public repo.
eg 
```
tests/lint_changed - i
 python setup.py test -s tests.suites.internal_tests
```

**Testing steps**
Do `tests/lint_changed - i` and `python setup.py test -s tests.suites.internal_tests`

**Logs**
When echo `$CHANGED_FILES` it gives 
```
parlai_internal/tests/__init__.py parlai_internal/tests/test_import.py
```
When running ` python setup.py test -s tests.suites.internal_tests`
it gives:
```
Installed /private/home/daju/ParlAI/.eggs/restructuredtext_lint-1.3.0-py3.6.egg
running egg_info
writing parlai.egg-info/PKG-INFO
writing dependency_links to parlai.egg-info/dependency_links.txt
writing requirements to parlai.egg-info/requires.txt
writing top-level names to parlai.egg-info/top_level.txt
reading manifest file 'parlai.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'parlai.egg-info/SOURCES.txt'
running build_ext
test_import_agent (test_import.TestImport) ... /private/home/daju/.conda/envs/ladder/lib/python3.6/importlib/_bootstrap.py:219: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  return f(*args, **kwds)
/private/home/daju/.conda/envs/ladder/lib/python3.6/importlib/_bootstrap.py:219: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  return f(*args, **kwds)
/private/home/daju/.conda/envs/ladder/lib/python3.6/importlib/_bootstrap.py:219: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  return f(*args, **kwds)
ok
test_import_dialog (test_import.TestImport) ... ok
test_import_fbdialog (test_import.TestImport) ... ok
test_import_teacher (test_import.TestImport) ... ok
test_import_threadutils (test_import.TestImport) ... ok
test_import_world (test_import.TestImport) ... ok

----------------------------------------------------------------------
Ran 6 tests in 1.461s

OK
```

