### PR TITLE
allowing to fix the size of the context

### DIFF
--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -13,7 +13,6 @@ from .helpers import (BertWrapper, BertModel, get_bert_optimizer,
 
 import os
 import torch
-import pdb
 
 
 class CrossEncoderRankerAgent(TorchRankerAgent):

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -13,6 +13,7 @@ from .helpers import (BertWrapper, BertModel, get_bert_optimizer,
 
 import os
 import torch
+import pdb
 
 
 class CrossEncoderRankerAgent(TorchRankerAgent):
@@ -67,6 +68,16 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
         nb_cands = cand_vecs.size()[1]
         size_batch = cand_vecs.size()[0]
         text_vec = batch.text_vec
+
+        if self.opt['fix_size'] != -1:
+            if text_vec.size(1) < self.opt['fix_size']:
+                new_text_vec = text_vec.new_zeros((text_vec.size(0), self.opt['fix_size']))
+                new_text_vec[:, 0:text_vec.size(1)] = text_vec
+                text_vec = new_text_vec
+            else:
+                text_vec = text_vec[:, 0:self.opt['fix_size']]
+
+
         tokens_context = text_vec.unsqueeze(
             1).expand(-1, nb_cands, -1).contiguous().view(nb_cands * size_batch, -1)
         segments_context = tokens_context * 0

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -76,7 +76,6 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
             else:
                 text_vec = text_vec[:, 0:self.opt['fix_size']]
 
-
         tokens_context = text_vec.unsqueeze(
             1).expand(-1, nb_cands, -1).contiguous().view(nb_cands * size_batch, -1)
         segments_context = tokens_context * 0

--- a/parlai/agents/bert_ranker/helpers.py
+++ b/parlai/agents/bert_ranker/helpers.py
@@ -35,6 +35,9 @@ def add_common_args(parser):
                         help='Which layer of Bert do we use? Default=-1=last one.')
     parser.add_argument('--out-dim', type=int, default=768,
                         help='For biencoder, output dimension')
+    parser.add_argument('--fix-size', type=int, default=-1,
+                        help='For crossencoder, fix the context to a given size'
+                             'including PAD')
     parser.add_argument('--topn', type=int, default=10,
                         help='For the biencoder: select how many elements to return')
     parser.add_argument('--data-parallel', type='bool', default=False,


### PR DESCRIPTION
Related to issue #1794, this is a fix that we used for this paper https://arxiv.org/pdf/1905.01969.pdf but did not make his way to public ParlAI yet. 

For the crossencoder in bert_ranker, the context is concatenated with the candidates. However, in case of batching, some padding are inserted between the context and the candidate. This does not change the performance, but leads to results that slightly vary during eval depending on the batch size.

This provides a fix by setting the context width to be constant.