### PR TITLE
minor fix for aggregate_task_reports

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -14,6 +14,7 @@ from parlai.core.thread_utils import SharedTable
 from parlai.core.utils import round_sigfigs, no_lock
 from collections import Counter
 from parlai.core.utils import warn_once
+from numbers import Number
 
 import re
 
@@ -82,14 +83,17 @@ def aggregate_task_reports(reports, tasks, micro=True):
     total_exs = sum(exs.values())
     total_report['exs'] = total_exs
     for metric, task_vals in metrics.items():
-        if micro:
-            # average over the number of examples
-            vals = [task_vals[task] * exs[task] for task in tasks]
-            total_report[metric] = round_sigfigs(sum(vals) / total_exs, 4)
-        else:  # macro
-            # average over tasks
-            vals = task_vals.values()
-            total_report[metric] = round_sigfigs(sum(vals) / len(vals), 4)
+        if all([isinstance(v, Number) for v in task_vals.values()]):
+            if micro:
+                # average over the number of examples
+                vals = [task_vals[task] * exs[task] for task in tasks]
+                total_report[metric] = round_sigfigs(sum(vals) / total_exs, 4)
+            else:  # macro
+                # average over tasks
+                vals = task_vals.values()
+                total_report[metric] = round_sigfigs(sum(vals) / len(vals), 4)
+        else:
+            total_report[metric] = task_vals
     # add a warning describing how metrics were averaged across tasks.
     total_report['warning'] = 'metrics are averaged across tasks'
     if micro:

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -92,8 +92,6 @@ def aggregate_task_reports(reports, tasks, micro=True):
                 # average over tasks
                 vals = task_vals.values()
                 total_report[metric] = round_sigfigs(sum(vals) / len(vals), 4)
-        else:
-            total_report[metric] = task_vals
     # add a warning describing how metrics were averaged across tasks.
     total_report['warning'] = 'metrics are averaged across tasks'
     if micro:


### PR DESCRIPTION
**Patch description**
The current aggregate_task_reports breaks the old imagechat agent where it will generate a metrics of style imagechat{{first_round:hit@1, second_round:}} etc

**Testing steps**
Test with comment_battle agent
**Logs**
```
{'exs': 15000, 'accuracy': 0.0102, 'f1': 0.0736, 'hits@1': 0.0102, 'hits@5': 0.0519, 'hits@10': 0.101, 'hits@100': 1.0, 'bleu': 0.009928, 'rouge-1': 0.08521, 'rouge-2': 0.01487, 'rouge-L': 0.07907, 'first_rou
nd': {'hitsAt1KC100': 0.01, 'loss': -0.5, 'med_rank': 50.0}, 'second_round': {'hitsAt1KC100': 0.0118, 'loss': -0.5, 'med_rank': 49.0}, 'third_round': {'hitsAt1KC100': 0.0088, 'loss': -0.5, 'med_rank': 50.5}}
{'exs': 5000, 'accuracy': 0.0412, 'f1': 0.1728, 'hits@1': 0.0412, 'hits@5': 0.178, 'hits@10': 0.321, 'hits@100': 1.0, 'bleu': 0.04148, 'rouge-1': 0.1809, 'rouge-2': 0.05158, 'rouge-L': 0.1728, 'first_round':
{'hitsAt1KC100': 0.0412, 'loss': -0.5, 'med_rank': 20.0}, 'second_round': {}, 'third_round': {}}
{'exs': 1014, 'accuracy': 0.03649, 'f1': 0.191, 'hits@1': 0.0365, 'hits@5': 0.179, 'hits@10': 0.323, 'hits@100': 1.0, 'bleu': 0.03649, 'rouge-1': 0.2062, 'rouge-2': 0.05138, 'rouge-L': 0.1928, 'first_round':
{'hitsAt1KC100': 0.03649, 'loss': -0.5, 'med_rank': 18.0}, 'second_round': {}, 'third_round': {}}
valid:{'tasks': {'comment_battle:imageDialog': {'exs': 15000, 'accuracy': 0.0102, 'f1': 0.0736, 'hits@1': 0.0102, 'hits@5': 0.0519, 'hits@10': 0.101, 'hits@100': 1.0, 'bleu': 0.009928, 'rouge-1': 0.08521, 'ro
uge-2': 0.01487, 'rouge-L': 0.07907, 'first_round': {'hitsAt1KC100': 0.01, 'loss': -0.5, 'med_rank': 50.0}, 'second_round': {'hitsAt1KC100': 0.0118, 'loss': -0.5, 'med_rank': 49.0}, 'third_round': {'hitsAt1KC
100': 0.0088, 'loss': -0.5, 'med_rank': 50.5}}, 'internal:coco_caption:PersonalityTeacher': {'exs': 5000, 'accuracy': 0.0412, 'f1': 0.1728, 'hits@1': 0.0412, 'hits@5': 0.178, 'hits@10': 0.321, 'hits@100': 1.0
, 'bleu': 0.04148, 'rouge-1': 0.1809, 'rouge-2': 0.05158, 'rouge-L': 0.1728, 'first_round': {'hitsAt1KC100': 0.0412, 'loss': -0.5, 'med_rank': 20.0}, 'second_round': {}, 'third_round': {}}, 'internal:flickr30
k:PersonalityTeacher': {'exs': 1014, 'accuracy': 0.03649, 'f1': 0.191, 'hits@1': 0.0365, 'hits@5': 0.179, 'hits@10': 0.323, 'hits@100': 1.0, 'bleu': 0.03649, 'rouge-1': 0.2062, 'rouge-2': 0.05138, 'rouge-L':
0.1928, 'first_round': {'hitsAt1KC100': 0.03649, 'loss': -0.5, 'med_rank': 18.0}, 'second_round': {}, 'third_round': {}}}, 'exs': 21014, 'accuracy': 0.01884, 'f1': 0.1029, 'hits@1': 0.01885, 'hits@5': 0.08804
, 'hits@10': 0.1641, 'hits@100': 1.0, 'bleu': 0.01872, 'rouge-1': 0.1138, 'rouge-2': 0.02537, 'rouge-L': 0.1069, 'first_round': {'comment_battle:imageDialog': {'hitsAt1KC100': 0.01, 'loss': -0.5, 'med_rank':
50.0}, 'internal:coco_caption:PersonalityTeacher': {'hitsAt1KC100': 0.0412, 'loss': -0.5, 'med_rank': 20.0}, 'internal:flickr30k:PersonalityTeacher': {'hitsAt1KC100': 0.03649, 'loss': -0.5, 'med_rank': 18.0}}
, 'second_round': {'comment_battle:imageDialog': {'hitsAt1KC100': 0.0118, 'loss': -0.5, 'med_rank': 49.0}, 'internal:coco_caption:PersonalityTeacher': {}, 'internal:flickr30k:PersonalityTeacher': {}}, 'third_
round': {'comment_battle:imageDialog': {'hitsAt1KC100': 0.0088, 'loss': -0.5, 'med_rank': 50.5}, 'internal:coco_caption:PersonalityTeacher': {}, 'internal:flickr30k:PersonalityTeacher': {}}, 'warning': 'metri
cs are averaged across tasks and weighted by the number of examples per task'}
```

