### PR TITLE
Officially remove py35 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,6 @@ standard_cpu36: &standard_cpu36
   docker:
     - image: circleci/python:3.6.5-node
 
-standard_cpu35: &standard_cpu35
-  docker:
-    - image: circleci/python:3.5.7
-
 gpu: &gpu
   environment:
     CUDA_VERSION: "10.0"
@@ -60,12 +56,6 @@ installtorchgpu: &installtorchgpu
       pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off torchtext
-
-installtorchcpu35: &installtorchcpu35
-  run:
-    name: Install torch CPU and dependencies
-    command: |
-      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp35-cp35m-linux_x86_64.whl
 
 installtorchcpu36: &installtorchcpu36
   run:
@@ -115,19 +105,6 @@ jobs:
       - run:
           name: Data tests
           command: python setup.py test -s tests.suites.datatests -v
-
-  unittests_35:
-    <<: *standard_cpu35
-    working_directory: ~/ParlAI
-    steps:
-      - checkout
-      - <<: *fixgit
-      - <<: *setup
-      - <<: *installdeps
-      - <<: *installtorchcpu35
-      - run:
-          name: Unit tests (py35)
-          command: python setup.py test -s tests.suites.unittests -v
 
   unittests_36:
     <<: *standard_cpu36
@@ -287,7 +264,6 @@ workflows:
       - lint
       - unittests_37
       - unittests_36
-      - unittests_35
       - mturk_tests:
           filters:
             branches:
@@ -316,7 +292,6 @@ workflows:
               only:
                 - master
     jobs:
-      - unittests_35
       - unittests_36
       - unittests_37
       - mturk_tests

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ python projects/convai2/interactive.py -mf models:convai2/kvmemnn/model
 
 ## Requirements
 
-ParlAI currently requires Python3.
+ParlAI currently requires Python3.6 or higher.
 
 Dependencies of the core modules are listed in requirement.txt.
 

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@
 from setuptools import setup, find_packages
 import sys
 
-if sys.version_info < (3,):
-    sys.exit('Sorry, Python 3 is required for ParlAI.')
+if sys.version_info < (3, 6):
+    sys.exit('Sorry, Python >=3.6 is required for ParlAI.')
 
 with open('README.md', encoding="utf8") as f:
     readme = f.read()
@@ -27,6 +27,7 @@ setup(
     long_description=readme,
     url='http://parl.ai/',
     license=license,
+    python_requires='>=3.6',
     packages=find_packages(exclude=(
         'data', 'docs', 'downloads', 'examples', 'logs', 'tests')),
     install_requires=reqs.strip().split('\n'),


### PR DESCRIPTION
**Patch description**
Bumps up our version requirements to Python 3.6.

**Testing steps**
1) CircleCI should initially fail when it tries to spin up a py35 environment and setup ParlAI.
2) CircleCI should later pass once I remove the py35 environment.

**Logs**
```
#!/bin/bash -eo pipefail
python setup.py develop
python -c "import nltk; nltk.download('punkt')"
Sorry, Python >=3.6 is required for ParlAI.
Exited with code 1
```
