### PR TITLE
Bug in the qualification_flow_example.py

### DIFF
--- a/parlai/mturk/tasks/qualification_flow_example/worlds.py
+++ b/parlai/mturk/tasks/qualification_flow_example/worlds.py
@@ -94,7 +94,7 @@ class QualificationFlowSoloWorld(MTurkTaskWorld):
             }
             self.mturk_agent.observe(validate(ad))
             answer = self.mturk_agent.act()
-            if answer == self.questions[self.curr_question][1]:
+            if answer['text'] == self.questions[self.curr_question][1]:
                 self.correct += 1
             self.curr_question += 1
 


### PR DESCRIPTION
It seems that we need to compare the answer['text'] and the actual answer rather than the answer dictionary.