### PR TITLE
Add Black support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,12 +140,6 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - run:
-          name: JS Lint
-          working_directory: ~/ParlAI/parlai/mturk
-          command: |
-            npm install
-            npm run lint
-      - run:
           name: black
           working_directory: ~/ParlAI
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,10 +140,14 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - run:
+          name: minimum black dependencies
+          working_directory: ~/ParlAI
+          command: |
+            pip install -q gitpython black  # only what's needd to lint
+      - run:
           name: black
           working_directory: ~/ParlAI
           command: |
-            pip install gitpython black  # only what's needd to lint
             bash ./tests/lint_changed.sh -b
 
   lint:
@@ -160,10 +164,14 @@ jobs:
             npm install
             npm run lint
       - run:
+          name: minimum lint dependencies
+          working_directory: ~/ParlAI
+          command: |
+            pip install -q flake8 gitpython flake8-bugbear  # only what's needd to lint
+      - run:
           name: Lint
           working_directory: ~/ParlAI
           command: |
-            pip install flake8 gitpython flake8-bugbear  # only what's needd to lint
             bash ./tests/lint_changed.sh
 
   nightly_gpu_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,26 @@ jobs:
           name: Unit tests (py37)
           command: python setup.py test -s tests.suites.unittests -v
 
+  black:
+    <<: *standard_cpu36
+    working_directory: ~/ParlAI
+    steps:
+      - checkout
+      - <<: *fixgit
+      - <<: *setup
+      - run:
+          name: JS Lint
+          working_directory: ~/ParlAI/parlai/mturk
+          command: |
+            npm install
+            npm run lint
+      - run:
+          name: black
+          working_directory: ~/ParlAI
+          command: |
+            pip install gitpython black  # only what's needd to lint
+            bash ./tests/lint_changed.sh -b
+
   lint:
     <<: *standard_cpu36
     working_directory: ~/ParlAI
@@ -261,6 +281,7 @@ workflows:
   version: 2
   commit:
     jobs:
+      - black
       - lint
       - unittests_37
       - unittests_36

--- a/.flake8
+++ b/.flake8
@@ -10,6 +10,7 @@ extend-ignore =
     W503
     F403
     F401
+    D202
 select = C,E,F,W,B,B950,D,RST
 
 max-line-length=80

--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,10 @@ extend-ignore =
     D107
     D105
     E203
+    E266
+    W503
+    F403
+    F401
 select = C,E,F,W,B,B950,D,RST
 
 max-line-length=80

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ desired to increase the pool of tasks, models, and baselines.
 We actively welcome your pull requests.
 
 1. Fork the repo and create your branch from `master`. Set up your environment
-   and run `pre-commit` once.
+   and run `pre-commit install` once.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Black your code (`black`), and make sure your code lints (`bash tests/lint_changed.sh`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,11 @@ desired to increase the pool of tasks, models, and baselines.
 ## Pull Requests
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `master`. Set up your environment
+   and run `pre-commit` once.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
-4. Make sure your code lints (`bash tests/lint_changed.sh`)
+4. Black your code (`black`), and make sure your code lints (`bash tests/lint_changed.sh`).
 5. Ensure the test suite passes. Run `python setup.py test`.
 6. If you've added a new dataset, you should also run
    `python setup.py test -s tests.suites.datatests`. Copy-paste the output into a

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -786,14 +786,12 @@ class TorchAgent(ABC, Agent):
             print('WARNING: not loading optim state since optim class changed.')
         elif optim_states:
             # check for any fp16/fp32 conversions we need to do
-            optimstate_fp16 = ('loss_scaler' in optim_states)
+            optimstate_fp16 = 'loss_scaler' in optim_states
             if self.fp16 and optimstate_fp16:
                 # previously trained in fp16, now we're training in fp16.
                 # ideally no action needed, but APEX broke backwards
                 # compatibility and this is the hack around it.
-                optim_states['loss_scaler'] = (
-                    self.optimizer.state_dict()['loss_scaler']
-                )
+                optim_states['loss_scaler'] = self.optimizer.state_dict()['loss_scaler']
             elif optimstate_fp16 and not self.fp16:
                 # old optimizer was fp16 but now we're doing fp32,
                 # drop the fp16 wrapper from the state_dict and just load
@@ -890,9 +888,11 @@ class TorchAgent(ABC, Agent):
 
         if (
             # there is already an old LR scheduler saved on disk
-            states and
+            states
+            and
             # and the old LR scheduler is different
-            states.get('lr_scheduler_type') != self.opt['lr_scheduler'] and
+            states.get('lr_scheduler_type') != self.opt['lr_scheduler']
+            and
             # and we're not already using a fresh scheduler
             not hard_reset
         ):
@@ -1434,8 +1434,11 @@ class TorchAgent(ABC, Agent):
         """
         # if the last observation was the end of an episode,
         # then we shouldn't use it as history
-        if (use_reply == 'none' or not self.observation or
-                self.observation['episode_done']):
+        if (
+            use_reply == 'none'
+            or not self.observation
+            or self.observation['episode_done']
+        ):
             return None
 
         if use_reply == 'label':

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -103,7 +103,7 @@ class Batch(AttrDict):
         candidate_vecs=None,
         image=None,
         observations=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             text_vec=text_vec,
@@ -116,7 +116,7 @@ class Batch(AttrDict):
             candidate_vecs=candidate_vecs,
             image=image,
             observations=observations,
-            **kwargs
+            **kwargs,
         )
 
 

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -169,6 +169,7 @@ def load_cands(path, lines_have_ids=False, cands_are_replies=False):
 
 
 def load_opt_file(optfile):
+    """Load an Opt from disk."""
     try:
         # try json first
         with open(optfile, 'r') as handle:
@@ -224,6 +225,7 @@ class Opt(dict):
         return memo
 
     def display_deepcopies(self):
+        """Display all deepcopies."""
         if len(self.deepcopies) == 0:
             print('No deepcopies performed on this opt.')
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.black]
+line-length = 88
+skip-string-normalization = true
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+)/
+'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ tqdm
 websocket-client
 websocket-server
 py-rouge
+pre-commit

--- a/tests/lint_changed.sh
+++ b/tests/lint_changed.sh
@@ -30,7 +30,8 @@ then
     then
         command -v black >/dev/null || \
             ( echo "Please install black." && false )
-        exec black -q --check $CHANGED_FILES
+        # only output if something needs to change
+        black --check $CHANGED_FILES
     else
         flake8 --version | grep '^3\.[6-9]\.' >/dev/null || \
             ( echo "Please install flake8 >=3.6.0." && false )

--- a/tests/lint_changed.sh
+++ b/tests/lint_changed.sh
@@ -11,22 +11,34 @@ set -e
 flake8 --version | grep '^3\.[6-9]\.' >/dev/null || \
     ( echo "Please install flake8 >=3.6.0." && false )
 
+command -v black >/dev/null || \
+    ( echo "Please install black." && false )
+
+
 CHANGED_FILES="$(git diff --name-only master... | grep '\.py$' | tr '\n' ' ')"
 
-while getopts i opt; do
+while getopts bi opt; do
   case $opt in
     i)
       CHANGED_FILES="$(git -C ./parlai_internal/ diff --name-only master... |
       xargs -I '{}' realpath --relative-to=. $(git -C ./parlai_internal/ rev-parse --show-toplevel)/'{}' |
       grep '\.py$' | tr '\n' ' ')"
       ;;
-    esac
+    b)
+      CMD="black"
+  esac
+
   done
 
 if [ "$CHANGED_FILES" != "" ]
 then
-    # soft complaint on too-long-lines
-    flake8 --select=E501 --show-source $CHANGED_FILES
-    # hard complaint on really long lines
-    exec flake8 --max-line-length=127 --show-source $CHANGED_FILES
+    if [[ "$CMD" == "black" ]]
+    then
+        exec black -q --check $CHANGED_FILES
+    else
+        # soft complaint on too-long-lines
+        flake8 --select=E501 --show-source $CHANGED_FILES
+        # hard complaint on really long lines
+        exec flake8 --max-line-length=127 --show-source $CHANGED_FILES
+    fi
 fi

--- a/tests/lint_changed.sh
+++ b/tests/lint_changed.sh
@@ -8,15 +8,9 @@
 # It's much more strict than our check for lint across the entire code base.
 
 set -e
-flake8 --version | grep '^3\.[6-9]\.' >/dev/null || \
-    ( echo "Please install flake8 >=3.6.0." && false )
 
-command -v black >/dev/null || \
-    ( echo "Please install black." && false )
-
-
+CMD="flake8"
 CHANGED_FILES="$(git diff --name-only master... | grep '\.py$' | tr '\n' ' ')"
-
 while getopts bi opt; do
   case $opt in
     i)
@@ -34,8 +28,13 @@ if [ "$CHANGED_FILES" != "" ]
 then
     if [[ "$CMD" == "black" ]]
     then
+        command -v black >/dev/null || \
+            ( echo "Please install black." && false )
         exec black -q --check $CHANGED_FILES
     else
+        flake8 --version | grep '^3\.[6-9]\.' >/dev/null || \
+            ( echo "Please install flake8 >=3.6.0." && false )
+
         # soft complaint on too-long-lines
         flake8 --select=E501 --show-source $CHANGED_FILES
         # hard complaint on really long lines


### PR DESCRIPTION
**Patch description**
This PR sets up our environment for black. If you want the optional pre-commit hooks to autorun black on your code, you can run once `pip install pre-commit; pre-commit install`.

Similar to lint, this test will check that you blacked your code before it's allowed to run. It's recommend you just hook it into your editor.

A separate PR will actually *black* the codebase.

We'll get lots and lots and lots of merge conflicts on any partial changes we have now. That will be a little bit of pain, but the easiest way to reduce them is to additionally black any PRs you're working on, which should bring both branches to a consistent format.

**Testing steps**
The CI tests in this repo here.