### PR TITLE
Add support for Resnext101 WSL features

### DIFF
--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -87,9 +87,6 @@ class ImageLoader:
         else:
             raise RuntimeError('Image mode {} not supported'.format(self.image_mode))
 
-        # cut off the additional layer.
-        self.netCNN = nn.Sequential(*list(CNN(pretrained=True).children())[:layer_num])
-
         # initialize the transform function using torch vision.
         self.transform = transforms.Compose(
             [

--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -25,79 +25,93 @@ class ImageLoader:
         self.netCNN = None
         self.im = opt.get('image_mode', 'none')
         if self.im not in ['none', 'raw', 'ascii']:
-            self.init_cnn(self.opt)
+            if 'image_mode' not in opt or 'image_size' not in opt:
+                raise RuntimeError(
+                    'Need to add image arguments to opt. See '
+                    'parlai.core.params.ParlaiParser.add_image_args'
+                )
+            self.image_mode = opt['image_mode']
+            self.image_size = opt['image_size']
+            self.crop_size = opt['image_cropsize']
+            self._lazy_import_torch()
+            self._init_transform()
+            if 'resnet' in self.image_mode:
+                self._init_resnet_cnn()
+            elif 'resnext' in self.image_mode:
+                self._init_resnext_cnn()
+            else:
+                raise RuntimeError('Image mode {} not supported'.format(self.image_mode))
 
-    def init_cnn(self, opt):
-        """
-        Lazy initialization of preprocessor model.
-
-        In case we don't need any image preprocessing.
-        """
+    def _lazy_import_torch(self):
         try:
             import torch
-
-            self.use_cuda = not opt.get('no_cuda', False) and torch.cuda.is_available()
-            self.torch = torch
         except ImportError:
             raise ImportError('Need to install Pytorch: go to pytorch.org')
         import torchvision
         import torchvision.transforms as transforms
         import torch.nn as nn
 
-        if 'image_mode' not in opt or 'image_size' not in opt:
-            raise RuntimeError(
-                'Need to add image arguments to opt. See '
-                'parlai.core.params.ParlaiParser.add_image_args'
-            )
-        self.image_mode = opt['image_mode']
-        self.image_size = opt['image_size']
-        self.crop_size = opt['image_cropsize']
-
+        self.use_cuda = not self.opt.get('no_cuda', False) and torch.cuda.is_available()
         if self.use_cuda:
             print('[ Using CUDA ]')
-            torch.cuda.set_device(opt.get('gpu', -1))
+            torch.cuda.set_device(self.opt.get('gpu', -1))
+        self.torch = torch
+        self.torchvision = torchvision
+        self.transforms = transforms
+        self.nn = nn
 
-        if 'resnet' in self.image_mode:
-            cnn_type, layer_num = self._image_mode_switcher()
-            # initialize the pretrained CNN using pytorch.
-            CNN = getattr(torchvision.models, cnn_type)
-
-            # cut off the additional layer.
-            self.netCNN = nn.Sequential(
-                *list(CNN(pretrained=True).children())[:layer_num])
-        elif 'resnext' in self.image_mode:
-            try:
-                model = torch.hub.load('facebookresearch/WSL-Images', self.image_mode)
-                self.netCNN = nn.Sequential(
-                    *list(model.children())[:-1])
-            except RuntimeError as e:
-                # Perhaps specified one of the wrong model names
-                print('If you have specified one of the resnext101 wsl models, '
-                      'please make sure it is one of the following: \n'
-                      'resnext101_32x8d_wsl, resnext101_32x16d_wsl, '
-                      'resnext101_32x32d_wsl, resnext101_32x48d_wsl')
-                raise e
-            except AttributeError:
-                # E.g. "module 'torch' has no attribute 'hub'"
-                raise RuntimeError(
-                    'Please install the latest pytorch distribution to have access '
-                    'to the resnext101 wsl models')
-            except Exception as e:
-                raise e
-        else:
-            raise RuntimeError('Image mode {} not supported'.format(self.image_mode))
-
+    def _init_transform(self):
         # initialize the transform function using torch vision.
-        self.transform = transforms.Compose(
+        self.transform = self.transforms.Compose(
             [
-                transforms.Scale(self.image_size),
-                transforms.CenterCrop(self.crop_size),
-                transforms.ToTensor(),
-                transforms.Normalize(
+                self.transforms.Scale(self.image_size),
+                self.transforms.CenterCrop(self.crop_size),
+                self.transforms.ToTensor(),
+                self.transforms.Normalize(
                     mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
                 ),
             ]
         )
+
+    def _init_resnet_cnn(self):
+        """Lazily initialize preprocessor model.
+
+        When image_mode is one of the ``resnet`` varieties
+        """
+        cnn_type, layer_num = self._image_mode_switcher()
+        # initialize the pretrained CNN using pytorch.
+        CNN = getattr(self.torchvision.models, cnn_type)
+
+        # cut off the additional layer.
+        self.netCNN = self.nn.Sequential(
+            *list(CNN(pretrained=True).children())[:layer_num])
+
+        if self.use_cuda:
+            self.netCNN.cuda()
+
+    def _init_resnext_cnn(self):
+        """Lazily initialize preprocessor model
+
+        When image_mode is one of the ``resnext101_..._wsl`` varieties
+        """
+        try:
+            model = self.torch.hub.load('facebookresearch/WSL-Images', self.image_mode)
+            # cut off layer for ImageNet classification
+            self.netCNN = self.nn.Sequential(
+                *list(model.children())[:-1])
+        except RuntimeError as e:
+            # Perhaps specified one of the wrong model names
+            print('If you have specified one of the resnext101 wsl models, '
+                  'please make sure it is one of the following: \n'
+                  'resnext101_32x8d_wsl, resnext101_32x16d_wsl, '
+                  'resnext101_32x32d_wsl, resnext101_32x48d_wsl')
+            raise e
+        except AttributeError:
+            # E.g. "module 'torch' has no attribute 'hub'"
+            raise RuntimeError(
+                'Please install the latest pytorch distribution to have access '
+                'to the resnext101 wsl models (pytorch 1.1.0, torchvision 0.3.0)')
+
         if self.use_cuda:
             self.netCNN.cuda()
 

--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -40,7 +40,9 @@ class ImageLoader:
             elif 'resnext' in self.image_mode:
                 self._init_resnext_cnn()
             else:
-                raise RuntimeError('Image mode {} not supported'.format(self.image_mode))
+                raise RuntimeError(
+                    'Image mode {} not supported'.format(self.image_mode)
+                )
 
     def _lazy_import_torch(self):
         try:
@@ -84,7 +86,8 @@ class ImageLoader:
 
         # cut off the additional layer.
         self.netCNN = self.nn.Sequential(
-            *list(CNN(pretrained=True).children())[:layer_num])
+            *list(CNN(pretrained=True).children())[:layer_num]
+        )
 
         if self.use_cuda:
             self.netCNN.cuda()
@@ -97,20 +100,22 @@ class ImageLoader:
         try:
             model = self.torch.hub.load('facebookresearch/WSL-Images', self.image_mode)
             # cut off layer for ImageNet classification
-            self.netCNN = self.nn.Sequential(
-                *list(model.children())[:-1])
+            self.netCNN = self.nn.Sequential(*list(model.children())[:-1])
         except RuntimeError as e:
             # Perhaps specified one of the wrong model names
-            print('If you have specified one of the resnext101 wsl models, '
-                  'please make sure it is one of the following: \n'
-                  'resnext101_32x8d_wsl, resnext101_32x16d_wsl, '
-                  'resnext101_32x32d_wsl, resnext101_32x48d_wsl')
+            print(
+                'If you have specified one of the resnext101 wsl models, '
+                'please make sure it is one of the following: \n'
+                'resnext101_32x8d_wsl, resnext101_32x16d_wsl, '
+                'resnext101_32x32d_wsl, resnext101_32x48d_wsl'
+            )
             raise e
         except AttributeError:
             # E.g. "module 'torch' has no attribute 'hub'"
             raise RuntimeError(
                 'Please install the latest pytorch distribution to have access '
-                'to the resnext101 wsl models (pytorch 1.1.0, torchvision 0.3.0)')
+                'to the resnext101 wsl models (pytorch 1.1.0, torchvision 0.3.0)'
+            )
 
         if self.use_cuda:
             self.netCNN.cuda()

--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -65,19 +65,27 @@ class ImageLoader:
             # cut off the additional layer.
             self.netCNN = nn.Sequential(
                 *list(CNN(pretrained=True).children())[:layer_num])
-        else:
+        elif 'resnext' in self.image_mode:
             try:
                 model = torch.hub.load('facebookresearch/WSL-Images', self.image_mode)
                 self.netCNN = nn.Sequential(
                     *list(model.children())[:-1])
             except RuntimeError as e:
+                # Perhaps specified one of the wrong model names
                 print('If you have specified one of the resnext101 wsl models, '
-                      'please make sure it is one of the following: '
-                      '\n["resnext101_32x8d_wsl", "resnext101_32x16d_wsl", '
-                      '"resnext101_32x32d_wsl", "resnext101_32x48d_wsl"]')
+                      'please make sure it is one of the following: \n'
+                      'resnext101_32x8d_wsl, resnext101_32x16d_wsl, '
+                      'resnext101_32x32d_wsl, resnext101_32x48d_wsl')
                 raise e
+            except AttributeError:
+                # E.g. "module 'torch' has no attribute 'hub'"
+                raise RuntimeError(
+                    'Please install the latest pytorch distribution to have access '
+                    'to the resnext101 wsl models')
             except Exception as e:
-                raise RuntimeError('Please install the latest pytorch distribution')
+                raise e
+        else:
+            raise RuntimeError('Image mode {} not supported'.format(self.image_mode))
 
         # cut off the additional layer.
         self.netCNN = nn.Sequential(*list(CNN(pretrained=True).children())[:layer_num])

--- a/parlai/scripts/extract_image_feature.py
+++ b/parlai/scripts/extract_image_feature.py
@@ -109,6 +109,7 @@ def extract_feats(opt):
             pbar.update()
         pbar.close()
     elif opt.get('use_hdf5_extraction', False):
+        # TODO Deprecate
         '''One can specify a Pytorch Dataset for custom image loading'''
         nw = opt.get('numworkers', 1)
         im = opt.get('image_mode', 'raw')

--- a/parlai/scripts/extract_image_feature.py
+++ b/parlai/scripts/extract_image_feature.py
@@ -103,9 +103,11 @@ def extract_feats(opt):
         world = create_task(opt, agent)
 
         total_exs = world.num_examples()
-        # TODO: wrap in a tqdm
+        pbar = tqdm.tqdm(unit='ex', total=total_exs)
         while not world.epoch_done():
             world.parley()
+            pbar.update()
+        pbar.close()
     elif opt.get('use_hdf5_extraction', False):
         '''One can specify a Pytorch Dataset for custom image loading'''
         nw = opt.get('numworkers', 1)


### PR DESCRIPTION
**Patch description**
Add support for extracting/loading [Resnext WSL features](https://pytorch.org/hub/facebookresearch_WSL-Images_resnext/) (from PyTorch)

Access via specifying one of the following `--image-mode`s:
- resnext101_32x8d_wsl
- resnext101_32x16d_wsl
- resnext101_32x32d_wsl
- resnext101_32x48d_wsl

**Testing steps**
1. install latest pytorch and torchvision distributions
2. `python examples/display_data -t flickr30k --image-mode resnext101_32x8d_wsl -dt valid`

**Logs**
```
$ python examples/extract_image_feature.py -t flickr30k -dt valid --image-mode resnext101_32x8d_wsl
...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1014/1014 [00:01<00:00, 560.29ex/s]
[ Finished extracting images ]
```
