### PR TITLE
Fix a bug in resuming LR with warmup and reduceonplateau

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -842,12 +842,17 @@ class TorchAgent(ABC, Agent):
         :param bool hard_reset: If true, the LR scheduler should ignore the
             state dictionary.
         """
+        # first make sure there are no null pointers
+        if states is None:
+            states = {}
         optimizer = self.optimizer
         if self.fp16:
             # lr schedulers don't work with apex, they expect the "real" optimizer
             optimizer = optimizer.optimizer
 
-        if self.opt.get('warmup_updates', -1) > 0:
+        warmup_updates = self.opt.get('warmup_updates', -1)
+        updates_so_far = states.get('number_training_updates', 0)
+        if warmup_updates > 0 and updates_so_far < warmup_updates:
 
             def _warmup_lr(step):
                 start = self.opt['warmup_rate']
@@ -898,10 +903,6 @@ class TorchAgent(ABC, Agent):
             )
 
         # time to load LR state from the checkpoint, if possible.
-        if states is None:
-            # first make sure there are no null pointers
-            states = {}
-
         if (
             # there is already an old LR scheduler saved on disk
             states

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -852,7 +852,7 @@ class TorchAgent(ABC, Agent):
 
         warmup_updates = self.opt.get('warmup_updates', -1)
         updates_so_far = states.get('number_training_updates', 0)
-        if warmup_updates > 0 and updates_so_far < warmup_updates:
+        if warmup_updates > 0 and (updates_so_far < warmup_updates or hard_reset):
 
             def _warmup_lr(step):
                 start = self.opt['warmup_rate']

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -121,9 +121,7 @@ class TestTransformerRanker(unittest.TestCase):
             )
             # make sure the learning rate is decreasing
             self.assertGreater(
-                valid2['lr'],
-                1e-5,
-                'Learning rate should not be that low when resuming',
+                valid2['lr'], 1e-5, 'Learning rate should not be that low when resuming'
             )
 
     def test_backcomp(self):

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -85,6 +85,47 @@ class TestTransformerRanker(unittest.TestCase):
                 valid2['lr'], valid1['lr'], 'Learning rate is not decreasing'
             )
 
+    def test_resuming_reduce_on_plateau(self):
+        """ Reduce on Plateau can be tricky when combined
+            with warmup. See:
+            https://github.com/facebookresearch/ParlAI/pull/1812
+        """
+        with testing_utils.tempdir() as tmpdir:
+            model_file = os.path.join(tmpdir, 'model')
+            stdout1, valid1, test1 = testing_utils.train_model(
+                dict(
+                    model_file=model_file,
+                    task='integration_tests:candidate',
+                    model='transformer/ranker',
+                    optimizer='adamax',
+                    learningrate=7e-3,
+                    batchsize=32,
+                    num_epochs=1,
+                    n_layers=1,
+                    n_heads=1,
+                    ffn_size=32,
+                    embedding_size=32,
+                    warmup_updates=1,
+                    lr_scheduler='reduceonplateau',
+                )
+            )
+
+            stdout2, valid2, test2 = testing_utils.train_model(
+                dict(
+                    model_file=model_file,
+                    task='integration_tests:candidate',
+                    model='transformer/ranker',
+                    num_epochs=1,
+                    lr_scheduler='reduceonplateau',
+                )
+            )
+            # make sure the learning rate is decreasing
+            self.assertGreater(
+                valid2['lr'],
+                1e-5,
+                'Learning rate should not be that low when resuming',
+            )
+
     def test_backcomp(self):
         """
         Tests that the transformer ranker model files continue to work over time.


### PR DESCRIPTION
**Patch description**
In some conditions, restarting a training from checkpoint would multiply the learning rate by 1e-4 due to a weird behavior of the warmup scheduler.
Those conditions were: 
- ReduceOnPlateau is used
- warmup_updates is used
- TransformerRankerAgent is used

