### PR TITLE
Change quickstart tutorial to use `-bs 1` instead

### DIFF
--- a/docs/source/tutorial_quick.rst
+++ b/docs/source/tutorial_quick.rst
@@ -42,8 +42,8 @@ Now let's try to train a model on it (even on your laptop, this should train fas
 
 .. code-block:: bash
 
-  # train MemNN using batch size 8 and 4 threads for 5 epochs
-  python examples/train_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -bs 8 -nt 4 -eps 5 -m memnn --no-cuda
+  # train MemNN using batch size 1 and 4 threads for 5 epochs
+  python examples/train_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -bs 1 -nt 4 -eps 5 -m memnn --no-cuda
 
 Let's print some of its predictions to make sure it's working.
 


### PR DESCRIPTION
**Patch description**
This is a temporary mitigation for #1805 to update the quickstart docs to suggest users use `--batchsize 1` instead of `--batchsize 8` when training the hogwild memnn.

There's something broken about hogwild with a batchsize on OSX (but not on Linux). I can't begin to fathom why (perhaps @alexholdenmiller has an idea?).

**Testing steps**
Just a doc update.