### PR TITLE
[Pretrained transformers] small fix; only save once

### DIFF
--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -166,7 +166,7 @@ class TransformerRankerAgent(TorchRankerAgent):
             '--reduction-type',
             type=str,
             default='mean',
-            choices=['first', 'max', 'mean', 'none'],
+            choices=['first', 'max', 'mean'],
             help='Type of reduction at the end of transformer',
         )
 

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -166,7 +166,7 @@ class TransformerRankerAgent(TorchRankerAgent):
             '--reduction-type',
             type=str,
             default='mean',
-            choices=['first', 'max', 'mean'],
+            choices=['first', 'max', 'mean', 'none'],
             help='Type of reduction at the end of transformer',
         )
 

--- a/parlai/zoo/pretrained_transformers/build.py
+++ b/parlai/zoo/pretrained_transformers/build.py
@@ -7,7 +7,7 @@
 Pretrained model allowing to get the same performances as in
 https://arxiv.org/abs/1905.01969
 """
-from parlai.core.build_data import download_models, get_model_dir
+from parlai.core.build_data import built, download_models, get_model_dir
 import os
 import os.path
 import torch
@@ -16,16 +16,19 @@ import torch
 def download(datapath):
     model_name = 'pretrained_transformers'
     mdir = os.path.join(get_model_dir(datapath), model_name)
-    opt = {'datapath': datapath}
-    fnames = ['pretrained_transformers_v1.tar.gz']
-    download_models(opt, fnames, model_name, version='v1.0', use_model_type=False)
-    print('Creating base models for bi and polyencoders')
-    for pretrained_type in ['reddit', 'wikito']:
-        path_cross = os.path.join(mdir, 'cross_model_huge_%s.mdl' % pretrained_type)
-        path_bi = os.path.join(mdir, 'bi_model_huge_%s.mdl' % pretrained_type)
-        path_poly = os.path.join(mdir, 'poly_model_huge_%s.mdl' % pretrained_type)
-        create_bi_model(path_cross, path_bi)
-        create_poly_model(path_cross, path_poly)
+    version = 'v1.0'
+    models_built = built(mdir, version)
+    if not models_built:
+        opt = {'datapath': datapath}
+        fnames = ['pretrained_transformers_v1.tar.gz']
+        download_models(opt, fnames, model_name, version=version, use_model_type=False)
+        print('Creating base models for bi and polyencoders')
+        for pretrained_type in ['reddit', 'wikito']:
+            path_cross = os.path.join(mdir, 'cross_model_huge_%s.mdl' % pretrained_type)
+            path_bi = os.path.join(mdir, 'bi_model_huge_%s.mdl' % pretrained_type)
+            path_poly = os.path.join(mdir, 'poly_model_huge_%s.mdl' % pretrained_type)
+            create_bi_model(path_cross, path_bi)
+            create_poly_model(path_cross, path_poly)
 
 
 def create_bi_model(path_to_crossmodel, path_output):


### PR DESCRIPTION
**Patch description**
Every time we used pretrained transformers from the zoo, a call to `torch.save` was being made. This led to a race condition when many processes were trying to load these models at once. Edited to only make this call once.

Eventually will edit the files uploaded to the zoo so that these calls do not have to be made at all.

**Testing steps**
Load up these models using a call to the zoo. Delete folder and try again.
