### PR TITLE
[MTurk] Disconnects raise instead of silently text failing

### DIFF
--- a/parlai/mturk/core/dev/agents.py
+++ b/parlai/mturk/core/dev/agents.py
@@ -13,6 +13,7 @@ from parlai.core.agents import Agent
 import parlai.mturk.core.dev.data_model as data_model
 import parlai.mturk.core.dev.shared_utils as shared_utils
 
+
 # types of exceptions thrown when an agent exits the chat. These are thrown
 # on a failed MTurkAgent.act call. If one of these is thrown and not handled,
 # the world will die and enter cleanup. If you would like your task to be able

--- a/parlai/mturk/core/dev/agents.py
+++ b/parlai/mturk/core/dev/agents.py
@@ -13,11 +13,38 @@ from parlai.core.agents import Agent
 import parlai.mturk.core.dev.data_model as data_model
 import parlai.mturk.core.dev.shared_utils as shared_utils
 
-# Special act messages for failure states
-# TODO replace with raised errors
-MTURK_DISCONNECT_MESSAGE = '[DISCONNECT]'  # Turker disconnected from conv
-TIMEOUT_MESSAGE = '[TIMEOUT]'  # the Turker did not respond but didn't return
-RETURN_MESSAGE = '[RETURNED]'  # the Turker returned the HIT
+# types of exceptions thrown when an agent exits the chat. These are thrown
+# on a failed MTurkAgent.act call. If one of these is thrown and not handled,
+# the world will die and enter cleanup. If you would like your task to be able
+# to continue working when an agent leaves, you'll need to catch these errors.
+class AbsentAgentError(Exception):
+    """Exceptions for when an agent leaves a task"""
+
+    def __init__(self, message, worker_id, assignment_id):
+        self.message = message
+        self.worker_id = worker_id
+        self.assignment_id = assignment_id
+
+
+class AgentDisconnectedError(AbsentAgentError):
+    """Exception for a real disconnect event (no signal)"""
+
+    def __init__(self, worker_id, assignment_id):
+        super().__init__(f'Agent disconnected', worker_id, assignment_id)
+
+
+class AgentTimeoutError(AbsentAgentError):
+    """Exception for when a worker doesn't respond in time"""
+
+    def __init__(self, timeout, worker_id, assignment_id):
+        super().__init__(f'Agent exceeded {timeout}', worker_id, assignment_id)
+
+
+class AgentReturnedError(AbsentAgentError):
+    """Exception for an explicit return event (worker returns task)"""
+
+    def __init__(self, worker_id, assignment_id):
+        super().__init__(f'Agent returned HIT', worker_id, assignment_id)
 
 
 class AssignState:
@@ -33,6 +60,7 @@ class AssignState:
     STATUS_DONE = 'done'
     STATUS_DISCONNECT = 'disconnect'
     STATUS_PARTNER_DISCONNECT = 'partner disconnect'
+    # TODO remove this
     STATUS_PARTNER_DISCONNECT_EARLY = 'partner disconnect early'
     STATUS_EXPIRED = 'expired'
     STATUS_RETURNED = 'returned'
@@ -97,23 +125,19 @@ class MTurkAgent(Agent):
     ASSIGNMENT_APPROVED = 'Approved'
     ASSIGNMENT_REJECTED = 'Rejected'
 
-    MTURK_DISCONNECT_MESSAGE = MTURK_DISCONNECT_MESSAGE
-    TIMEOUT_MESSAGE = TIMEOUT_MESSAGE
-    RETURN_MESSAGE = RETURN_MESSAGE
-
     def __init__(self, opt, mturk_manager, hit_id, assignment_id, worker_id):
         super().__init__(opt)
 
         # all MTurkManager functions explicitly used by agents extracted here
         self.m_send_state_change = mturk_manager.send_state_change
         self.m_send_message = mturk_manager.send_message
-        self.m_handle_turker_timeout = mturk_manager.handle_turker_timeout
         self.m_send_command = mturk_manager.send_command
         # TODO update or remove this function
         self.m_get_agent_work_status = mturk_manager.get_agent_work_status
         self.m_approve_work = mturk_manager.approve_work
         self.m_reject_work = mturk_manager.reject_work
         self.m_block_worker = mturk_manager.block_worker
+        self.m_soft_block_worker = mturk_manager.soft_block_worker
         self.m_pay_bonus = mturk_manager.pay_bonus
         self.m_email_worker = mturk_manager.email_worker
         self.m_free_workers = mturk_manager.free_workers
@@ -146,9 +170,6 @@ class MTurkAgent(Agent):
         self.feedback = None
         self.msg_queue = Queue()
 
-    def _get_episode_done_msg(self, text):
-        return {'id': self.id, 'text': text, 'episode_done': True}
-
     def set_status(self, status, conversation_id=None, agent_id=None):
         """
         Set the status of this agent on the task, update db, push update
@@ -164,7 +185,6 @@ class MTurkAgent(Agent):
             self.id = agent_id
             update_packet['agent_id'] = agent_id
         self.m_send_state_change(self.worker_id, self.assignment_id, update_packet)
-        # TODO handle cleanup for changing into a final state?
         if self.db_logger is not None:
             if status == AssignState.STATUS_ONBOARDING:
                 self.db_logger.log_start_onboard(
@@ -277,16 +297,15 @@ class MTurkAgent(Agent):
         self.msg_queue = None
         self.recieved_packets = None
 
-    # TODO replace episode dones with disconnect messages
     def get_new_act_message(self):
         """Get a new act message if one exists, return None otherwise"""
         # See if any agent has disconnected
         if self.disconnected or self.some_agent_disconnected:
-            return self._get_episode_done_msg(MTURK_DISCONNECT_MESSAGE)
+            raise AgentDisconnectedError(self.worker_id, self.assignment_id)
 
         # Check if the current turker already returned the HIT
         if self.hit_is_returned:
-            return self._get_episode_done_msg(RETURN_MESSAGE)
+            raise AgentReturnedError(self.worker_id, self.assignment_id)
 
         if self.msg_queue is not None:
             # Check if Turker sends a message
@@ -297,18 +316,6 @@ class MTurkAgent(Agent):
 
         # There are no messages to be sent
         return None
-
-    def prepare_timeout(self):
-        """Log a timeout event, tell mturk manager it occurred, return message
-        to return for the act call
-        """
-        shared_utils.print_and_log(
-            logging.INFO, '{} timed out before sending.'.format(self.id)
-        )
-        # TODO prepare_timeout and handling_turker_timeout can happen
-        # in the manager when an exception is thrown
-        self.m_handle_turker_timeout(self.worker_id, self.assignment_id)
-        return self._get_episode_done_msg(TIMEOUT_MESSAGE)
 
     def request_message(self):
         if not (
@@ -335,7 +342,7 @@ class MTurkAgent(Agent):
             if timeout:
                 # If time is exceeded, timeout
                 if time.time() - self.message_request_time > timeout:
-                    return self.prepare_timeout()
+                    raise AgentTimeoutError(timeout, self.worker_id, self.assignment_id)
 
             # Get a new message, if it's not None reset the timeout
             msg = self.get_new_act_message()
@@ -362,7 +369,9 @@ class MTurkAgent(Agent):
                     current_time = time.time()
                     if (current_time - start_time) > timeout:
                         self.message_request_time = None
-                        return self.prepare_timeout()
+                        raise AgentTimeoutError(
+                            timeout, self.worker_id, self.assignment_id
+                        )
                 time.sleep(shared_utils.THREAD_SHORT_SLEEP)
 
     def episode_done(self):
@@ -475,10 +484,15 @@ class MTurkAgent(Agent):
             )
             return False
 
-    def set_hit_is_abandoned(self):
+    def soft_block_worker(self, qual='block_qualification'):
+        """Assigns this worker a soft blocking qualification"""
+        self.m_soft_block_worker(self.worker_id, qual)
+
+    def DEPRECATED_set_hit_is_abandoned(self):
         """Update local state to abandoned and mark the HIT as expired"""
-        # TODO maybe this can be handled with throwing errors as well, thus
-        # removing the need for force_expire_hit here?
+        # TODO(wish) hit_is_abandoned could easily be bundled into a HIT being
+        # returned, as the end outcome of the two are functionally equivalent.
+        # New callsites should not be made for this function
         if not self.hit_is_abandoned:
             self.hit_is_abandoned = True
             self.m_force_expire_hit(self.worker_id, self.assignment_id)
@@ -539,7 +553,7 @@ class MTurkAgent(Agent):
                             self.worker_id, self.assignment_id, self.conversation_id
                         ),
                     )
-                    self.set_hit_is_abandoned()
+                    self.DEPRECATED_set_hit_is_abandoned()
                     self.m_free_workers([self])
                     return False
             shared_utils.print_and_log(
@@ -563,6 +577,8 @@ class MTurkAgent(Agent):
         """Shuts down a hit when it is completed"""
         # Timeout in seconds, after which the HIT will be expired automatically
         # TODO clean this up, a lot can be handled by the manager instead
+        # TODO it could make sense that rather than keeping the other cleanup
+        # methods, agents clean up after themselves when shutdown
         if not (
             self.hit_is_abandoned
             or self.hit_is_returned

--- a/parlai/mturk/core/dev/react_server/server/server.js
+++ b/parlai/mturk/core/dev/react_server/server/server.js
@@ -390,8 +390,6 @@ function handle_pong(data) {
 // and then forwarding the alive to the world if it came from a client. If
 // there is already an agent state for this agent, we handle the reconnection
 // event ourselves.
-// TODO handle specific agent alive messages sent after a task is already
-// completed
 function handle_alive(socket, data) {
   var sender_id = data['sender_id'];
   var in_connection_id = _get_from_conn_id(data);
@@ -512,7 +510,9 @@ wss.on('connection', function(socket) {
   // handles routing a packet to the desired recipient
   socket.on('message', function(data) {
     try {
-      // TODO add all of these to the data model, create them in SocketManager
+      // TODO(wish) It's somewhat annoying that these constants come up and
+      // redefined all over the place, would be useful to have a singular
+      // source for the API
       data = JSON.parse(data);
       if (data['type'] == AGENT_ALIVE) {
         handle_alive(socket, data['content']);

--- a/parlai/mturk/core/dev/worlds.py
+++ b/parlai/mturk/core/dev/worlds.py
@@ -25,6 +25,7 @@ class MTurkDataWorld(World):
                 'assignment_id': agent.assignment_id,
                 'messages': save_messages,
                 'given_feedback': agent.feedback,
+                'completed': self.episode_done(),
             }
 
         # In simple pairing case, attach the feedback right here
@@ -65,6 +66,17 @@ class MTurkOnboardWorld(MTurkDataWorld):
 
     def episode_done(self):
         return self.episodeDone
+
+    def review_work(self):
+        """This call is an opportunity to act on this worker based on their
+        onboarding work. Generally one could assign a qualification to soft
+        block members who didn't pass the onboarding world.
+        """
+        # if self.episodeDone and work_was_bad:
+        #   self.mturk_agent.soft_block_worker()
+        #   # Can set a flag for use later in the process
+        #   self.mturk_agent.failed_onboarding = True
+        pass
 
     def shutdown(self):
         """Clear up resources needed for this world"""
@@ -179,6 +191,7 @@ class StaticMTurkTaskWorld(MTurkDataWorld):
             'assignment_id': agent.assignment_id,
             'task_data': self.task_data,
             'response': self.response,
+            'completed': self.episode_done(),
         }
 
         return save_data


### PR DESCRIPTION
**Patch description**
In the past, disconnect events were something of a 'silent failure' from the perspective of the world, in that suddenly an agent would start responding with key text that was supposed to signal a disconnect having occurred. This behavior was pretty suboptimal, and was the cause of much confusion as to why certain tasks weren't working properly.

Now, the default behavior is that these events will case the `act` to raise an error, which is captured in `MTurkManager` who then handles the cleanup. In the rare cases that an end user wants to continue operating a world after an agent disconnects, they can wrap their `act` calls themselves to explicitly capture the disconnect and then operate differently.

**Testing steps**
Ran an updated version of qa_data_collection task. Completed a task normally, disconnected, and returned. All three versions saved data successfully.