### PR TITLE
Fix QAngaroo bug

### DIFF
--- a/parlai/tasks/qangaroo/agents.py
+++ b/parlai/tasks/qangaroo/agents.py
@@ -50,7 +50,7 @@ class DefaultTeacher(FixedDialogTeacher):
             'text': '\n'.join(item['supports']) + '\n' + item['query'],
             'query': item['query'],
             'label_candidates': item['candidates'],
-            'label': [item['answer']],
+            'labels': [item['answer']],
             'supports': item['supports'],
             'episode_done': True,
         }


### PR DESCRIPTION
**Patch description**
Fixes issue in #1814 

**Testing steps**
`python ~/ParlAI/parlai/scripts/train_model.py -m hello -t qangaroo -mf hello_model`
See #1814 for implementation of `hello` model

**Logs**
```
Dictionary: loading dictionary from /tmp/hello_model.dict
[ num words =  343602 ]
[ Using CUDA ]
[creating task(s): qangaroo]
loading:  /private/home/kshuster/ParlAI/data/qangaroo/qangaroo_v1.1/wikihop/train.json
[ training... ]
train
[ time:2.0s total_exs:1 epochs:0.0 ] {'exs': 1, 'accuracy': 0, 'f1': 0, 'bleu': 0, 'num_updates': 0}
train
train
train
train
train
train
.....
```
cc @james-assiene