### PR TITLE
Fix clevr download link.

### DIFF
--- a/parlai/tasks/clevr/build.py
+++ b/parlai/tasks/clevr/build.py
@@ -22,7 +22,7 @@ def build(opt):
 
         # Download the data.
         fname = 'CLEVR_v1.0.zip'
-        url = 'https://s3-us-west-1.amazonaws.com/clevr/'
+        url = 'https://dl.fbaipublicfiles.com/clevr/'
 
         build_data.download(url + fname, dpath, fname)
         build_data.untar(dpath, fname)


### PR DESCRIPTION
**Patch description**
Fixes #1815.

**Testing steps**
`display_data.py -t clevr` started downloading the data. Didn't let it run all the way since it's 20gb...