### PR TITLE
Install `url-loader` into react_server.

### DIFF
--- a/parlai/mturk/core/react_server/package.json
+++ b/parlai/mturk/core/react_server/package.json
@@ -28,6 +28,7 @@
     "babel-loader": "^8.0.2",
     "css-loader": "^1.0.0",
     "style-loader": "^0.23.0",
+    "url-loader": "^2.0.1",
     "webpack": "^4.19.1",
     "webpack-cli": "^3.1.1"
   }


### PR DESCRIPTION
`url-loader` need to be install to support `{test: /\.(svg|png)$/, loader: 'url-loader?limit=100000',}` in the `ParlAI/parlai/mturk/core/react_server/webpack.config.js` file.