### PR TITLE
`url-loader` for svg/png/jpe/jpeg/ttf

### DIFF
--- a/parlai/mturk/core/react_server/webpack.config.js
+++ b/parlai/mturk/core/react_server/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
         loader: 'style-loader!css-loader',
       },
       {
-        test: /\.png$/,
+        test: /\.(svg|png|jpe?g|ttf)$/,
         loader: 'url-loader?limit=100000',
       },
       {


### PR DESCRIPTION
Add `url-loader` support for `svg/png/jpe/jpeg/ttf` files and not just `png`.