### PR TITLE
Added multi-turn teacher for Ubuntu task

### DIFF
--- a/parlai/tasks/ubuntu/agents.py
+++ b/parlai/tasks/ubuntu/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import DialogTeacher
+from parlai.core.teachers import DialogTeacher, FixedDialogTeacher
 from .build import build
 
 import csv
@@ -46,3 +46,73 @@ class DefaultTeacher(DialogTeacher):
                     cands.append(response)
                     random.shuffle(cands)
                 yield (context, [response], None, cands), True
+
+
+class MultiTeacher(FixedDialogTeacher):
+    def __init__(self, opt, shared=None):
+        self.datatype = opt['datatype']
+        opt['datafile'] = os.path.join(
+            opt['datapath'], 'Ubuntu', opt['datatype'].split(':')[0] + '.csv'
+        )
+        super().__init__(opt, shared)
+
+        self.opt = opt
+        if shared:
+            self.data = shared['data']
+        else:
+            build(opt)
+            # '/Users/shaojie/src/ParlAI/data/Ubuntu/train.csv'
+            fold = opt.get('datatype', 'train').split(':')[0]
+            self._setup_data(fold)
+
+        self.num_exs = sum(len(d) for d in self.data)
+
+        # we learn from both sides of every conversation
+        self.num_eps = 2 * len(self.data)
+        self.reset()
+
+    def num_episodes(self):
+        return self.num_eps
+
+    def num_examples(self):
+        return self.num_exs
+
+    def _setup_data(self, fold):
+        self.data = []
+        fpath = os.path.join(self.opt['datapath'], 'Ubuntu', fold + '.csv')
+        print('loading: ' + fpath)
+        with open(fpath, 'r', newline='') as read:
+            csv_read = csv.reader(read)
+            next(csv_read)  # eat header
+
+            for line in csv_read:
+                fields = line[0].strip().split('__eou__ __eot__')
+                fields.append(line[1].strip())
+                dialog = []
+                for field in fields:
+                    if field != '':
+                        dialog.append(field.replace('__eou__', '.').strip())
+                self.data.append(dialog)
+
+    def get(self, episode_idx, entry_idx=0):
+        # Sometimes we're speaker 1 and sometimes we're speaker 2
+        speaker_id = episode_idx % 2
+        full_eps = self.data[episode_idx // 2]
+
+        entries = full_eps
+        their_turn = entries[speaker_id + 2 * entry_idx]
+        my_turn = entries[1 + speaker_id + 2 * entry_idx]
+
+        episode_done = 1 + speaker_id + 2 * entry_idx >= len(full_eps) - 2
+
+        action = {
+            'text': their_turn,
+            'labels': [my_turn],
+            'episode_done': episode_done,
+        }
+        return action
+
+    def share(self):
+        shared = super().share()
+        shared['data'] = self.data
+        return shared

--- a/parlai/tasks/ubuntu/agents.py
+++ b/parlai/tasks/ubuntu/agents.py
@@ -92,7 +92,8 @@ class MultiTeacher(FixedDialogTeacher):
                 for field in fields:
                     if field != '':
                         dialog.append(field.replace('__eou__', '.').strip())
-                self.data.append(dialog)
+                if len(dialog) > 2:
+                    self.data.append(dialog)
 
     def get(self, episode_idx, entry_idx=0):
         # Sometimes we're speaker 1 and sometimes we're speaker 2

--- a/parlai/tasks/ubuntu/agents.py
+++ b/parlai/tasks/ubuntu/agents.py
@@ -104,11 +104,7 @@ class MultiturnTeacher(FixedDialogTeacher):
 
         episode_done = 1 + speaker_id + 2 * entry_idx >= len(full_eps) - 2
 
-        action = {
-            'text': their_turn,
-            'labels': [my_turn],
-            'episode_done': episode_done,
-        }
+        action = {'text': their_turn, 'labels': [my_turn], 'episode_done': episode_done}
         return action
 
     def share(self):

--- a/parlai/tasks/ubuntu/agents.py
+++ b/parlai/tasks/ubuntu/agents.py
@@ -48,7 +48,7 @@ class DefaultTeacher(DialogTeacher):
                 yield (context, [response], None, cands), True
 
 
-class MultiTeacher(FixedDialogTeacher):
+class MultiturnTeacher(FixedDialogTeacher):
     def __init__(self, opt, shared=None):
         self.datatype = opt['datatype']
         opt['datafile'] = os.path.join(
@@ -56,16 +56,14 @@ class MultiTeacher(FixedDialogTeacher):
         )
         super().__init__(opt, shared)
 
-        self.opt = opt
         if shared:
             self.data = shared['data']
         else:
             build(opt)
-            # '/Users/shaojie/src/ParlAI/data/Ubuntu/train.csv'
             fold = opt.get('datatype', 'train').split(':')[0]
             self._setup_data(fold)
 
-        self.num_exs = sum(len(d) for d in self.data)
+        self.num_exs = 2 * sum(len(d) for d in self.data)
 
         # we learn from both sides of every conversation
         self.num_eps = 2 * len(self.data)

--- a/parlai/tasks/ubuntu/agents.py
+++ b/parlai/tasks/ubuntu/agents.py
@@ -63,7 +63,7 @@ class MultiturnTeacher(FixedDialogTeacher):
             fold = opt.get('datatype', 'train').split(':')[0]
             self._setup_data(fold)
 
-        self.num_exs = 2 * sum(len(d) for d in self.data)
+        self.num_exs = sum(len(d) for d in self.data)
 
         # we learn from both sides of every conversation
         self.num_eps = 2 * len(self.data)


### PR DESCRIPTION
**Patch description**
Although Ubuntu task contains multiple turns for each dialogue, in the default teacher, only the final turn is used as training label while all previous are used as context.
To fully utilize the training data, I added a multi-turn teacher that is a modified version from DailyDialog default teacher.

**Testing steps**
Tested with `-m transformer/generator -t ubuntu:multi`. Worked fine for train/valid/test sets.

**Data tests (if applicable)**
Here is the log for `python setup.py test -s tests.suites.datatests`:
```
running test
Searching for pre-commit
Best match: pre-commit 1.17.0
Processing pre_commit-1.17.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/pre_commit-1.17.0-py3.7.egg
Searching for websocket-server
Best match: websocket-server 0.4
Processing websocket_server-0.4-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/websocket_server-0.4-py3.7.egg
Searching for websocket-client
Best match: websocket-client 0.56.0
Processing websocket_client-0.56.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/websocket_client-0.56.0-py3.7.egg
Searching for sphinx_rtd_theme
Best match: sphinx-rtd-theme 0.4.3
Processing sphinx_rtd_theme-0.4.3-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/sphinx_rtd_theme-0.4.3-py3.7.egg
Searching for sphinx
Best match: Sphinx 2.1.2
Processing Sphinx-2.1.2-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/Sphinx-2.1.2-py3.7.egg
Searching for sh
Best match: sh 1.12.14
Processing sh-1.12.14-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/sh-1.12.14-py3.7.egg
Searching for scikit-learn
Best match: scikit-learn 0.21.2
Processing scikit_learn-0.21.2-py3.7-macosx-10.7-x86_64.egg

Using /Users/shaojie/src/ParlAI/.eggs/scikit_learn-0.21.2-py3.7-macosx-10.7-x86_64.egg
Searching for regex
Best match: regex 2019.6.8
Processing regex-2019.6.8-py3.7-macosx-10.7-x86_64.egg

Using /Users/shaojie/src/ParlAI/.eggs/regex-2019.6.8-py3.7-macosx-10.7-x86_64.egg
Searching for py-gfm
Best match: py-gfm 0.1.4
Processing py_gfm-0.1.4-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/py_gfm-0.1.4-py3.7.egg
Searching for joblib
Best match: joblib 0.13.2
Processing joblib-0.13.2-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/joblib-0.13.2-py3.7.egg
Searching for flake8
Best match: flake8 3.7.7
Processing flake8-3.7.7-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/flake8-3.7.7-py3.7.egg
Searching for flake8-bugbear
Best match: flake8-bugbear 19.3.0
Processing flake8_bugbear-19.3.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/flake8_bugbear-19.3.0-py3.7.egg
Searching for flake8-docstrings
Best match: flake8-docstrings 1.3.0
Processing flake8_docstrings-1.3.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/flake8_docstrings-1.3.0-py3.7.egg
Searching for flake8-rst-docstrings
Best match: flake8-rst-docstrings 0.0.10
Processing flake8_rst_docstrings-0.0.10-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/flake8_rst_docstrings-0.0.10-py3.7.egg
Searching for botocore
Best match: botocore 1.12.183
Processing botocore-1.12.183-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/botocore-1.12.183-py3.7.egg
Searching for boto3
Best match: boto3 1.9.183
Processing boto3-1.9.183-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/boto3-1.9.183-py3.7.egg
Searching for virtualenv>=15.2
Best match: virtualenv 16.6.1
Processing virtualenv-16.6.1-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/virtualenv-16.6.1-py3.7.egg
Searching for toml
Best match: toml 0.10.0
Processing toml-0.10.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/toml-0.10.0-py3.7.egg
Searching for pyyaml
Best match: PyYAML 5.1.1
Processing PyYAML-5.1.1-py3.7-macosx-10.7-x86_64.egg

Using /Users/shaojie/src/ParlAI/.eggs/PyYAML-5.1.1-py3.7-macosx-10.7-x86_64.egg
Searching for nodeenv>=0.11.1
Best match: nodeenv 1.3.3
Processing nodeenv-1.3.3-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/nodeenv-1.3.3-py3.7.egg
Searching for importlib-metadata
Best match: importlib-metadata 0.18
Processing importlib_metadata-0.18-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/importlib_metadata-0.18-py3.7.egg
Searching for identify>=1.0.0
Best match: identify 1.4.5
Processing identify-1.4.5-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/identify-1.4.5-py3.7.egg
Searching for cfgv>=2.0.0
Best match: cfgv 2.0.0
Processing cfgv-2.0.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/cfgv-2.0.0-py3.7.egg
Searching for aspy.yaml
Best match: aspy.yaml 1.3.0
Processing aspy.yaml-1.3.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/aspy.yaml-1.3.0-py3.7.egg
Searching for sphinxcontrib-serializinghtml
Best match: sphinxcontrib-serializinghtml 1.1.3
Processing sphinxcontrib_serializinghtml-1.1.3-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/sphinxcontrib_serializinghtml-1.1.3-py3.7.egg
Searching for sphinxcontrib-qthelp
Best match: sphinxcontrib-qthelp 1.0.2
Processing sphinxcontrib_qthelp-1.0.2-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/sphinxcontrib_qthelp-1.0.2-py3.7.egg
Searching for sphinxcontrib-jsmath
Best match: sphinxcontrib-jsmath 1.0.1
Processing sphinxcontrib_jsmath-1.0.1-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/sphinxcontrib_jsmath-1.0.1-py3.7.egg
Searching for sphinxcontrib-htmlhelp
Best match: sphinxcontrib-htmlhelp 1.0.2
Processing sphinxcontrib_htmlhelp-1.0.2-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/sphinxcontrib_htmlhelp-1.0.2-py3.7.egg
Searching for sphinxcontrib-devhelp
Best match: sphinxcontrib-devhelp 1.0.1
Processing sphinxcontrib_devhelp-1.0.1-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/sphinxcontrib_devhelp-1.0.1-py3.7.egg
Searching for sphinxcontrib-applehelp
Best match: sphinxcontrib-applehelp 1.0.1
Processing sphinxcontrib_applehelp-1.0.1-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/sphinxcontrib_applehelp-1.0.1-py3.7.egg
Searching for snowballstemmer>=1.1
Best match: snowballstemmer 1.9.0
Processing snowballstemmer-1.9.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/snowballstemmer-1.9.0-py3.7.egg
Searching for packaging
Best match: packaging 19.0
Processing packaging-19.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/packaging-19.0-py3.7.egg
Searching for imagesize
Best match: imagesize 1.1.0
Processing imagesize-1.1.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/imagesize-1.1.0-py3.7.egg
Searching for docutils>=0.12
Best match: docutils 0.14
Processing docutils-0.14-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/docutils-0.14-py3.7.egg
Searching for babel!=2.0,>=1.3
Best match: Babel 2.7.0
Processing Babel-2.7.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/Babel-2.7.0-py3.7.egg
Searching for alabaster<0.8,>=0.7
Best match: alabaster 0.7.12
Processing alabaster-0.7.12-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/alabaster-0.7.12-py3.7.egg
Searching for markdown<3.0
Best match: Markdown 2.6.11
Processing Markdown-2.6.11-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/Markdown-2.6.11-py3.7.egg
Searching for pyflakes<2.2.0,>=2.1.0
Best match: pyflakes 2.1.1
Processing pyflakes-2.1.1-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/pyflakes-2.1.1-py3.7.egg
Searching for pycodestyle<2.6.0,>=2.5.0
Best match: pycodestyle 2.5.0
Processing pycodestyle-2.5.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/pycodestyle-2.5.0-py3.7.egg
Searching for mccabe<0.7.0,>=0.6.0
Best match: mccabe 0.6.1
Processing mccabe-0.6.1-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/mccabe-0.6.1-py3.7.egg
Searching for entrypoints<0.4.0,>=0.3.0
Best match: entrypoints 0.3
Processing entrypoints-0.3-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/entrypoints-0.3-py3.7.egg
Searching for attrs
Best match: attrs 19.1.0
Processing attrs-19.1.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/attrs-19.1.0-py3.7.egg
Searching for pydocstyle>=2.1
Best match: pydocstyle 3.0.0
Processing pydocstyle-3.0.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/pydocstyle-3.0.0-py3.7.egg
Searching for flake8-polyfill
Best match: flake8-polyfill 1.0.2
Processing flake8_polyfill-1.0.2-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/flake8_polyfill-1.0.2-py3.7.egg
Searching for restructuredtext_lint
Best match: restructuredtext-lint 1.3.0
Processing restructuredtext_lint-1.3.0-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/restructuredtext_lint-1.3.0-py3.7.egg
Searching for jmespath<1.0.0,>=0.7.1
Best match: jmespath 0.9.4
Processing jmespath-0.9.4-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/jmespath-0.9.4-py3.7.egg
Searching for s3transfer<0.3.0,>=0.2.0
Best match: s3transfer 0.2.1
Processing s3transfer-0.2.1-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/s3transfer-0.2.1-py3.7.egg
Searching for zipp>=0.5
Best match: zipp 0.5.1
Processing zipp-0.5.1-py3.7.egg

Using /Users/shaojie/src/ParlAI/.eggs/zipp-0.5.1-py3.7.egg
running egg_info
writing parlai.egg-info/PKG-INFO
writing dependency_links to parlai.egg-info/dependency_links.txt
writing requirements to parlai.egg-info/requires.txt
writing top-level names to parlai.egg-info/top_level.txt
reading manifest file 'parlai.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'parlai.egg-info/SOURCES.txt'
running build_ext
test_verify_data (test_new_tasks.TestNewTasks) ... ok

----------------------------------------------------------------------
Ran 1 test in 8644.994s

OK
```
