### PR TITLE
Divide the loss by update_freq when using gradient accumulation.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1666,6 +1666,10 @@ class TorchAgent(ABC, Agent):
         loss.backward(), for integration with distributed training and FP16
         training.
         """
+        if self.opt.get('update_freq', 1) > 1:
+            # gradient accumulation, but still need to average across the minibatches
+            loss = loss / self.opt['update_freq']
+
         if self.fp16:
             self.optimizer.backward(loss, update_master_grads=False)
         else:

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -527,7 +527,7 @@ class TorchAgent(ABC, Agent):
         agent.add_argument(
             '--update-freq',
             type=int,
-            default=-1,
+            default=1,
             hidden=True,
             help='Accumulate gradients N times before performing an optimizer.step().',
         )


### PR DESCRIPTION
**Patch description**
Presently in ParlAI, gradient accumulate just continuously sums gradients into the appropriate `grad` tensors. However, to be roughly more congruent with simply increasing the batch size, fairseq and others actually *average* over the gradient accumulation. This ensures the semantics of a learning rate stay *roughly* fixed over different levels of gradient accumulation.

**Testing steps**
Been using on a private branch for a few weeks now. Doesn't make a huge difference, but I prefer to be congruent with others.