### PR TITLE
[transformer] Raise the layer norm epsilon

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -32,7 +32,7 @@ except ImportError:
     warn_once("Installing APEX can give a significant speed boost.")
     from torch.nn import LayerNorm
 
-LAYER_NORM_EPS = 1e-12  # Epsilon for layer norm.
+LAYER_NORM_EPS = 1e-5  # Epsilon for layer norm.
 
 
 def _normalize(tensor, norm_layer):


### PR DESCRIPTION
**Patch description**
Raises the layer norm epsilon in all places in transformers. The new epsilon is the [default in pytorch](https://pytorch.org/docs/stable/nn.html#torch.nn.LayerNorm) and a bit more fp16 safe.

**Testing steps**
Been using in a private branch for a couple weeks; doesn't seem to make a difference, so might as well fall back to the default.