### PR TITLE
Don't round_sigfigs num_updates in distributed mode.

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -585,6 +585,8 @@ class TrainLoop:
             else:
                 # all other cases, take the mean across the workers
                 finalized[k] = np.mean(values)
+                if all(isinstance(v, int) for v in values):
+                    finalized[k] = int(finalized[k])
         return finalized
 
     def _cleanup_inaccurate_metrics(self, metrics):


### PR DESCRIPTION
**Patch description**
Right now, if you use distributed mode, then `num_updates` keys in your output metrics are averaged across workers, converting them to floats. This then gets caught in a case that has it be hit by `round_sigfigs`, leading to a slightly misleading output that's not really necessary.

This patch just makes sure we don't convert these integers to floats, and so they won't be hit by `round_sigfigs`

**Testing steps**
Ran a train with distributed mode, noticed I could now see `num_updates` with more than 4 significant figures.