### PR TITLE
Cosine Learning rate

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1745,14 +1745,11 @@ class TorchAgent(ABC, Agent):
                 cycle_steps = self._lr_period * lr_mult ** passes
                 self.scheduler.T_max = cycle_steps
 
-            if step == 0:
-                # the height of the peak of the cosine wave is multiplied by
-                # decay every period
-                mult_max = self.opt['lr_scheduler_decay'] ** passes
-                lr = self.opt['learningrate']
-                self.scheduler.base_lrs = [
-                    lr * mult_max for _ in self.scheduler.base_lrs
-                ]
+            # the height of the peak of the cosine wave is multiplied by
+            # decay every period
+            mult_max = self.opt['lr_scheduler_decay'] ** passes
+            lr = self.opt['learningrate']
+            self.scheduler.base_lrs = [lr * mult_max for _ in self.scheduler.base_lrs]
 
             self.scheduler.step(step)
 

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -486,7 +486,7 @@ class TorchAgent(ABC, Agent):
             '--lr-scheduler',
             type=str,
             default='reduceonplateau',
-            choices=['reduceonplateau', 'none', 'fixed', 'invsqrt'],
+            choices=['reduceonplateau', 'none', 'fixed', 'invsqrt', 'cosine'],
             help='Learning rate scheduler.',
         )
         lr_group.add_argument(
@@ -885,6 +885,14 @@ class TorchAgent(ABC, Agent):
                 return decay_factor / np.sqrt(max(1, step))
 
             self.scheduler = optim.lr_scheduler.LambdaLR(optimizer, _invsqrt_lr)
+        elif self.opt.get('lr_scheduler') == 'cosine':
+            if self.opt.get('warmup_updates', -1) <= 0:
+                raise ValueError(
+                    '--lr-scheduler cosine requires setting --warmup-updates'
+                )
+            self.scheduler = optim.lr_scheduler.CosineAnnealingLR(
+                optimizer, self.opt['warmup_updates']
+            )
         else:
             raise ValueError(
                 "Don't know what to do with lr_scheduler '{}'".format(
@@ -973,7 +981,7 @@ class TorchAgent(ABC, Agent):
             self.scheduler.step(metrics_dict['loss'])
         elif self.opt['lr_scheduler'] == 'fixed':
             self.scheduler.step()
-        elif self.opt['lr_scheduler'] == 'invsqrt':
+        elif self.opt['lr_scheduler'] in ['invsqrt', 'cosine']:
             # this is a training step lr scheduler, nothing to adjust in validation
             pass
         else:
@@ -1673,6 +1681,11 @@ class TorchAgent(ABC, Agent):
         if self.opt.get('lr_scheduler') == 'invsqrt' and not self._is_lr_warming_up():
             # training step scheduler
             self.scheduler.step(self._number_training_updates)
+        elif self.opt.get('lr_scheduler') == 'cosine' and not self._is_lr_warming_up():
+            self.scheduler.step(
+                (self._number_training_updates - self.opt['warmup_updates'])
+                % self.opt['warmup_updates']
+            )
 
         if self.fp16:
             # we've been accumulating grads in fp16 and delaying the fp32 copy update.

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -500,8 +500,21 @@ class TorchAgent(ABC, Agent):
             '--lr-scheduler-decay',
             type=float,
             default=0.5,
-            help='Decay factor for LR scheduler, or how much LR is multiplied by '
-            'when it is lowered.',
+            help=(
+                'Decay factor for LR scheduler, or how much LR is multiplied by '
+                'when it is lowered (on plataue with --lr-scheduler reduceonplateau '
+                'and on periods in --lr-scheduler cosine)'
+            ),
+        )
+        lr_group.add_argument(
+            '--lr-period-mult',
+            type=int,
+            default=2,
+            hidden=True,
+            help=(
+                '(Cosine only) LR period multiplier. The period between LR resets '
+                'is lengthened by this factor each reset.'
+            ),
         )
         lr_group.add_argument(
             '--lr-period-updates',
@@ -863,9 +876,9 @@ class TorchAgent(ABC, Agent):
         else:
             self.warmup_scheduler = None
 
-        lr_period = self.opt.get('lr_period_updates')
-        if lr_period is None or lr_period <= 0:
-            lr_period = self.opt.get('warmup_updates', -1)
+        self._lr_period = self.opt.get('lr_period_updates')
+        if self._lr_period is None or self._lr_period <= 0:
+            self._lr_period = self.opt.get('warmup_updates', -1)
 
         patience = self.opt.get('lr_scheduler_patience', 3)
         decay = self.opt.get('lr_scheduler_decay', 0.5)
@@ -886,24 +899,26 @@ class TorchAgent(ABC, Agent):
         elif self.opt.get('lr_scheduler') == 'fixed':
             self.scheduler = optim.lr_scheduler.StepLR(optimizer, patience, gamma=decay)
         elif self.opt.get('lr_scheduler') == 'invsqrt':
-            if lr_period is None or lr_period <= 0:
+            if self._lr_period is None or self._lr_period <= 0:
                 raise ValueError(
                     '--lr-scheduler invsqrt requires setting --warmup-updates '
                     'or --lr-period-updates'
                 )
-            decay_factor = np.sqrt(max(1, lr_period))
+            decay_factor = np.sqrt(max(1, self._lr_period))
 
             def _invsqrt_lr(step):
                 return decay_factor / np.sqrt(max(1, step))
 
             self.scheduler = optim.lr_scheduler.LambdaLR(optimizer, _invsqrt_lr)
         elif self.opt.get('lr_scheduler') == 'cosine':
-            if lr_period is None or lr_period <= 0:
+            if self._lr_period is None or self._lr_period <= 0:
                 raise ValueError(
                     '--lr-scheduler cosine requires setting --warmup-updates '
                     'or --lr-period-updates'
                 )
-            self.scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, lr_period)
+            self.scheduler = optim.lr_scheduler.CosineAnnealingLR(
+                optimizer, self._lr_period, eta_min=self.opt['warmup_rate']
+            )
         else:
             raise ValueError(
                 "Don't know what to do with lr_scheduler '{}'".format(
@@ -1691,22 +1706,54 @@ class TorchAgent(ABC, Agent):
             # training step scheduler
             self.scheduler.step(self._number_training_updates)
         elif self.opt.get('lr_scheduler') == 'cosine' and not self._is_lr_warming_up():
-            # how many steps since warmup?
-            step = self._number_training_updates - self.opt['warmup_updates']
-            # how long is the current cycle
-            cycle_len = self.opt['warmup_updates']
-            current_cycle = step // cycle_len
-            # where are we in the current cycle
-            cycle_step = step % cycle_len
+            # The cosine scheduler is a funny beast. It has the LR multiplier go
+            # from 1 .. 0 on a cosine half period. Then it jumps immediately back
+            # to 1 and goes down to 0 again. There are two additional
+            # modifications. On the end of the period, we do two things: we
+            # multiply the length of the period by --lr-period-mult and we
+            # multiply the maximum learning rate by --lr-decay-rate. You can
+            # see an illustration of --lr-period-mult here:
+            # https://cdn-images-1.medium.com/max/1600/1*dMvU26iOxbkQ9sTqhaWrsg.png
 
-            if cycle_step == 0:
-                mult_max = self.opt['lr_scheduler_decay'] ** current_cycle
+            if not hasattr(self, '_lr_period'):
+                raise RuntimeError('Looks like you forgot to call build_lr_scheduler')
+
+            # how many steps since warmup?
+            warmup_updates = max(0, self.opt['warmup_updates'])
+            cosine_steps = self._number_training_updates - warmup_updates
+
+            # factor we lengthen the cosine period by
+            lr_mult = self.opt['lr_period_mult']
+
+            # passes contains the number of periods we have iterated
+            # step contains the number of steps relative to the last reset
+            if lr_mult == 1:
+                # special case, do this
+                passes = cosine_steps // self._lr_period
+                step = cosine_steps % self._lr_period
+            else:
+                # total number of cycles completed
+                # see http://mathworld.wolfram.com/ExponentialSumFormulas.html
+                n = cosine_steps / self._lr_period
+                passes = np.floor(np.log((lr_mult - 1) * n + 1) / np.log(lr_mult))
+                last_reset_step = (
+                    self._lr_period * (1 - lr_mult ** passes) / (1 - lr_mult)
+                )
+                step = cosine_steps - last_reset_step
+                # cycle_steps contains the total length of this period
+                cycle_steps = self._lr_period * lr_mult ** passes
+                self.scheduler.T_max = cycle_steps
+
+            if step == 0:
+                # the height of the peak of the cosine wave is multiplied by
+                # decay every period
+                mult_max = self.opt['lr_scheduler_decay'] ** passes
                 lr = self.opt['learningrate']
                 self.scheduler.base_lrs = [
                     lr * mult_max for _ in self.scheduler.base_lrs
                 ]
 
-            self.scheduler.step(cycle_step)
+            self.scheduler.step(step)
 
         if self.fp16:
             # we've been accumulating grads in fp16 and delaying the fp32 copy update.

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -420,11 +420,12 @@ class TorchAgent(ABC, Agent):
             'correct size. If the dimensions are the same, this is '
             'ignored unless you append "-force" to your choice.',
         )
-        # optimizer arguments
         agent.add_argument(
             '--fp16', type='bool', default=False, help='Use fp16 computations.'
         )
-        agent.add_argument(
+        # optimizer arguments
+        optim_group = agent.add_argument_group('Optimizer Arguments')
+        optim_group.add_argument(
             '-opt',
             '--optimizer',
             default='sgd',
@@ -432,30 +433,30 @@ class TorchAgent(ABC, Agent):
             help='Choose between pytorch optimizers. Any member of torch.optim'
             ' should be valid.',
         )
-        agent.add_argument(
+        optim_group.add_argument(
             '-lr', '--learningrate', type=float, default=1, help='learning rate'
         )
-        agent.add_argument(
+        optim_group.add_argument(
             '-clip',
             '--gradient-clip',
             type=float,
             default=0.1,
             help='gradient clipping using l2 norm',
         )
-        agent.add_argument(
+        optim_group.add_argument(
             '-mom',
             '--momentum',
             default=0,
             type=float,
             help='if applicable, momentum value for optimizer.',
         )
-        agent.add_argument(
+        optim_group.add_argument(
             '--nesterov',
             default=True,
             type='bool',
             help='if applicable, whether to use nesterov momentum.',
         )
-        agent.add_argument(
+        optim_group.add_argument(
             '-nu',
             '--nus',
             default='0.7',
@@ -463,7 +464,7 @@ class TorchAgent(ABC, Agent):
             help='if applicable, nu value(s) for optimizer. can use a single '
             'value like 0.7 or a comma-separated tuple like 0.7,1.0',
         )
-        agent.add_argument(
+        optim_group.add_argument(
             '-beta',
             '--betas',
             default='0.9,0.999',
@@ -471,29 +472,38 @@ class TorchAgent(ABC, Agent):
             help='if applicable, beta value(s) for optimizer. can use a single '
             'value like 0.9 or a comma-separated tuple like 0.9,0.999',
         )
+        optim_group.add_argument(
+            '-wd',
+            '--weight-decay',
+            type=float,
+            default=None,
+            help='Weight decay on the weights.',
+        )
+
         # lr scheduler
-        agent.add_argument(
+        lr_group = agent.add_argument_group('Learning Rate Scheduler')
+        lr_group.add_argument(
             '--lr-scheduler',
             type=str,
             default='reduceonplateau',
             choices=['reduceonplateau', 'none', 'fixed', 'invsqrt'],
             help='Learning rate scheduler.',
         )
-        agent.add_argument(
+        lr_group.add_argument(
             '--lr-scheduler-patience',
             type=int,
             default=3,
             help='LR scheduler patience. In number of validation runs. If using '
             'fixed scheduler, LR is decayed every <patience> validations.',
         )
-        agent.add_argument(
+        lr_group.add_argument(
             '--lr-scheduler-decay',
             type=float,
             default=0.5,
             help='Decay factor for LR scheduler, or how much LR is multiplied by '
             'when it is lowered.',
         )
-        agent.add_argument(
+        lr_group.add_argument(
             '--warmup-updates',
             type=int,
             default=-1,
@@ -501,7 +511,7 @@ class TorchAgent(ABC, Agent):
             help='Learning rate warmup period, in number of SGD updates. '
             'Linearly scales up LR over period. Only enabled if > 0.',
         )
-        agent.add_argument(
+        lr_group.add_argument(
             '--warmup-rate',
             type=float,
             default=1e-4,
@@ -510,13 +520,14 @@ class TorchAgent(ABC, Agent):
             'this value. Linearly adjusted up to 1.0 across --warmup-updates '
             'steps.',
         )
-        agent.add_argument(
+        lr_group.add_argument(
             '--update-freq',
             type=int,
             default=-1,
             hidden=True,
             help='Accumulate gradients N times before performing an optimizer.step().',
         )
+
         # preprocessing arguments
         agent.add_argument(
             '-rc',


### PR DESCRIPTION
**Patch description**
Implements Cosine Learning Rate annealing with warm restarts ("SGDR", https://arxiv.org/abs/1608.03983).

Also adds `--lr-period-updates` which can stretch the length of `--lr-scheduler invsqrt` to be different than that of `--warmup-updates`. The default behavior remains the same still.

Needs to be resolved with #1812 still. I don't think it will work when merged into master.

Additionally, I think this code is begging for a refactor now, but not sure if I want to put in the love right now.

**Testing steps**
Desperately needs a unit test. 

**Logs**
```
If applicable, please paste the command line from your testing:
```

**Other information**
Any other information or context you would like to provide.

**Data tests (if applicable)**
If you added a new teacher, you will be asked to run
`python setup.py test -s tests.suites.datatests`. Please paste this log here.
