### PR TITLE
Option for lenient argparser

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -881,7 +881,7 @@ class ParlaiParser(argparse.ArgumentParser):
 
         return opt
 
-    def parse_args(self, args=None, namespace=None, print_args=True):
+    def parse_args(self, args=None, namespace=None, print_args=True, force_known=True):
         """
         Parse the provided arguments and returns a dictionary of the ``args``.
 
@@ -890,7 +890,10 @@ class ParlaiParser(argparse.ArgumentParser):
         return ``None``.
         """
         self.add_extra_args(args)
-        self.args = super().parse_args(args=args)
+        if force_known:
+            self.args = super().parse_args(args=args)
+        else:
+            self.args, _unknown = super().parse_known_args(args=args)
         self.opt = Opt(vars(self.args))
 
         # custom post-parsing

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -941,6 +941,13 @@ class ParlaiParser(argparse.ArgumentParser):
         self.opt['starttime'] = datetime.datetime.today().strftime('%b%d_%H-%M')
 
     def parse_and_process_known_args(self, args=None):
+        """
+        Parse provided arguments and return parlai opts and unknown arg list.
+
+        Runs the same arg->opt parsing that parse_args does, but doesn't
+        throw an error if the args being parsed include additional command
+        line arguments that parlai doesn't know what to do with.
+        """
         self.args, unknowns = super().parse_known_args(args=args)
         self._process_args_to_opts()
         return self.opt, unknowns

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -940,7 +940,7 @@ class ParlaiParser(argparse.ArgumentParser):
         # add start time of an experiment
         self.opt['starttime'] = datetime.datetime.today().strftime('%b%d_%H-%M')
 
-    def parse_and_process_known_args(self):
+    def parse_and_process_known_args(self, args=None):
         self.args, unknowns = super().parse_known_args(args=args)
         self._process_args_to_opts()
         return self.opt, unknowns

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -881,19 +881,7 @@ class ParlaiParser(argparse.ArgumentParser):
 
         return opt
 
-    def parse_args(self, args=None, namespace=None, print_args=True, force_known=True):
-        """
-        Parse the provided arguments and returns a dictionary of the ``args``.
-
-        We specifically remove items with ``None`` as values in order
-        to support the style ``opt.get(key, default)``, which would otherwise
-        return ``None``.
-        """
-        self.add_extra_args(args)
-        if force_known:
-            self.args = super().parse_args(args=args)
-        else:
-            self.args, _unknown = super().parse_known_args(args=args)
+    def _process_args_to_opts(self):
         self.opt = Opt(vars(self.args))
 
         # custom post-parsing
@@ -951,6 +939,24 @@ class ParlaiParser(argparse.ArgumentParser):
 
         # add start time of an experiment
         self.opt['starttime'] = datetime.datetime.today().strftime('%b%d_%H-%M')
+
+    def parse_and_process_known_args(self):
+        self.args, unknowns = super().parse_known_args(args=args)
+        self._process_args_to_opts()
+        return self.opt, unknowns
+
+    def parse_args(self, args=None, namespace=None, print_args=True):
+        """
+        Parse the provided arguments and returns a dictionary of the ``args``.
+
+        We specifically remove items with ``None`` as values in order
+        to support the style ``opt.get(key, default)``, which would otherwise
+        return ``None``.
+        """
+        self.add_extra_args(args)
+        self.args = super().parse_args(args=args)
+
+        self._process_args_to_opts()
 
         if print_args:
             self.print_args()


### PR DESCRIPTION
**Patch description**
Sometimes it's appropriate to use a ParlAI argparser in a context where there might be other argparsers, some that may have different possible command line arguments attached to them. Rather than forcing a user to pass their specific argparser along to the downstream class that wants a ParlaiParser, or forcing the user to manipulate arguments after they've parsed out what they wanted, this allows a user to specify that the ParlaiParser shouldn't be so strict as to having to know all of the arguments passed to it. 

**Testing steps**
Ran tests
Used a parser in a script that accepted command line arguments way upstream. The script fails without setting `force_known` to False, and passes when the flag is set false.