### PR TITLE
Fix distributed initialization of model copies.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,19 @@ jobs:
           name: Unit tests (py37)
           command: python setup.py test -s tests.suites.unittests -v
 
+  unittests_gpu:
+    <<: *gpu
+    working_directory: ~/ParlAI
+    steps:
+      - checkout
+      - <<: *fixgit
+      - <<: *setupcuda
+      - <<: *setup
+      - <<: *installdeps
+      - <<: *installtorchgpu
+      - run:
+          name: Unit tests (GPU)
+          command: python setup.py test -s tests.suites.unittests -v
   black:
     <<: *standard_cpu36
     working_directory: ~/ParlAI
@@ -286,6 +299,7 @@ workflows:
     jobs:
       - black
       - lint
+      - unittests_gpu
       - unittests_37
       - unittests_36
       - mturk_tests:
@@ -318,6 +332,7 @@ workflows:
     jobs:
       - unittests_36
       - unittests_37
+      - gpu_unittests
       - mturk_tests
       - nightly_gpu_tests
       - test_website

--- a/.circleci/triggers.py
+++ b/.circleci/triggers.py
@@ -13,7 +13,7 @@ words into your commit messages.
 [gpu]: Run the nightly GPU tests
 [mturk]: Run the mturk tests
 [data]: Run the data tests
-[long]: run all above
+[long] or [all]: run all above
 """
 
 import parlai.core.testing_utils as testing_utils
@@ -21,7 +21,7 @@ import parlai.core.testing_utils as testing_utils
 
 def detect_all():
     """Check if we should run all tests."""
-    return '[long]' in testing_utils.git_commit_messages()
+    return any(kw in testing_utils.git_commit_messages() for kw in ['[all]', '[long'])
 
 
 def detect_gpu():

--- a/.circleci/triggers.py
+++ b/.circleci/triggers.py
@@ -21,7 +21,7 @@ import parlai.core.testing_utils as testing_utils
 
 def detect_all():
     """Check if we should run all tests."""
-    return any(kw in testing_utils.git_commit_messages() for kw in ['[all]', '[long'])
+    return any(kw in testing_utils.git_commit_messages() for kw in ['[all]', '[long]'])
 
 
 def detect_gpu():

--- a/parlai/core/distributed_utils.py
+++ b/parlai/core/distributed_utils.py
@@ -14,6 +14,7 @@ in non-distributed mode.
 
 import builtins
 import pickle
+import contextlib
 
 try:
     import torch.version
@@ -73,12 +74,16 @@ def is_primary_worker():
     return not is_distributed() or dist.get_rank() == 0
 
 
+@contextlib.contextmanager
 def override_print(suppress=False, prefix=None):
     """
-    Override the builtin print to mute or annotate the output with a given prefix.
+    Context manager to override the print to suppress or modify output.
 
     Recommended usage is to call this with suppress=True for all non-primary workers,
-    or call with with a prefix of rank on all workers.
+    or call with a prefix of rank on all workers.
+
+    >>> with override_print(prefix="rank{}".format(rank)):
+    ...     my_computation()
 
     :param bool suppress:
         if true, all future print statements are noops.
@@ -97,7 +102,11 @@ def override_print(suppress=False, prefix=None):
             # default to normal print
             return builtin_print(*args, **kwargs)
 
+    # override the print for now
     builtins.print = new_print
+    yield
+    # bring it back at the end of the context
+    builtins.print = builtin_print
 
 
 def all_gather_list(data, max_size=16384):

--- a/parlai/core/testing_utils.py
+++ b/parlai/core/testing_utils.py
@@ -34,7 +34,7 @@ except ImportError:
     GIT_AVAILABLE = False
 
 
-DEBUG = False  # change this to true to print to stdout anyway
+DEBUG = True  # change this to true to print to stdout anyway
 
 
 def is_this_circleci():

--- a/parlai/core/testing_utils.py
+++ b/parlai/core/testing_utils.py
@@ -34,7 +34,7 @@ except ImportError:
     GIT_AVAILABLE = False
 
 
-DEBUG = True  # change this to true to print to stdout anyway
+DEBUG = False  # change this to true to print to stdout anyway
 
 
 def is_this_circleci():

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -378,6 +378,7 @@ class TorchGeneratorAgent(TorchAgent):
 
             self.build_criterion()
             with torch.random.fork_rng(range(torch.cuda.device_count())):
+                # TODO: turn this into an option
                 torch.manual_seed(42)
                 self.build_model()
             check_synced_parameters(self.model)

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -29,7 +29,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from parlai.core.distributed_utils import is_distributed
+from parlai.core.distributed_utils import is_distributed, check_synced_parameters
 from parlai.core.thread_utils import SharedTable
 from parlai.core.torch_agent import TorchAgent, Batch, Output
 from parlai.core.utils import padded_tensor, round_sigfigs, warn_once, neginf
@@ -377,10 +377,10 @@ class TorchGeneratorAgent(TorchAgent):
                 print('[ Saving dot beam logs in {} ]'.format(self.beam_dot_dir))
 
             self.build_criterion()
-            # with torch.random.fork_rng():
-            #    torch.manual_seed(42)
-            #    self.build_model()
-            self.build_model()
+            with torch.random.fork_rng(range(torch.cuda.device_count())):
+                torch.manual_seed(42)
+                self.build_model()
+            check_synced_parameters(self.model)
             print("Total parameters: {}".format(self._total_parameters()))
             print("Trainable parameters:  {}".format(self._trainable_parameters()))
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -377,6 +377,9 @@ class TorchGeneratorAgent(TorchAgent):
                 print('[ Saving dot beam logs in {} ]'.format(self.beam_dot_dir))
 
             self.build_criterion()
+            # with torch.random.fork_rng():
+            #    torch.manual_seed(42)
+            #    self.build_model()
             self.build_model()
             print("Total parameters: {}".format(self._total_parameters()))
             print("Trainable parameters:  {}".format(self._trainable_parameters()))

--- a/setup.py
+++ b/setup.py
@@ -20,18 +20,20 @@ with open('LICENSE') as f:
 with open('requirements.txt') as f:
     reqs = f.read()
 
-setup(
-    name='parlai',
-    version='0.1.0',
-    description='Unified API for accessing dialog datasets.',
-    long_description=readme,
-    url='http://parl.ai/',
-    license=license,
-    python_requires='>=3.6',
-    packages=find_packages(
-        exclude=('data', 'docs', 'downloads', 'examples', 'logs', 'tests')
-    ),
-    install_requires=reqs.strip().split('\n'),
-    include_package_data=True,
-    test_suite='tests.suites.unittests',
-)
+
+if __name__ == '__main__':
+    setup(
+        name='parlai',
+        version='0.1.0',
+        description='Unified API for accessing dialog datasets.',
+        long_description=readme,
+        url='http://parl.ai/',
+        license=license,
+        python_requires='>=3.6',
+        packages=find_packages(
+            exclude=('data', 'docs', 'downloads', 'examples', 'logs', 'tests')
+        ),
+        install_requires=reqs.strip().split('\n'),
+        include_package_data=True,
+        test_suite='tests.suites.unittests',
+    )

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -47,11 +47,12 @@ class TestDistributed(unittest.TestCase):
 
                 valid, test = mp_train.launch_and_train(popt, 31337)
 
-                # we need to de-initialize the distributed world, otherwise other
-                # tests will they're we're distributed when we're really not.
-                dist.destroy_process_group()
-
         return (output.getvalue(), valid, test)
+
+    def tearDown(self):
+        # we need to de-initialize the distributed world, otherwise other
+        # tests will they're we're distributed when we're really not.
+        dist.destroy_process_group()
 
     def test_generator_distributed(self):
         stdout, valid, test = self._distributed_train_model(

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import unittest
+import parlai.core.testing_utils as testing_utils
+import parlai.scripts.multiprocessing_train as mp_train
+import parlai.scripts.build_dict as build_dict
+
+
+def _forced_parse(parser, opt):
+    parser.set_params(**opt)
+    parser.set_params(log_every_n_sec=10)
+    popt = parser.parse_args(print_args=False)
+    # in some rare cases, like for instance if the model class also
+    # overrides its default params, the params override will not
+    # be taken into account.   popt = parser.parse_args(print_args=False)
+    for k, v in opt.items():
+        popt[k] = v
+    return popt
+
+
+@testing_utils.skipUnlessGPU
+class TestDistributed(unittest.TestCase):
+    def _distributed_train_model(self, opt):
+        with testing_utils.capture_output() as output:
+            with testing_utils.tempdir() as tmpdir:
+                if 'model_file' not in opt:
+                    opt['model_file'] = os.path.join(tmpdir, 'model')
+                if 'dict_file' not in opt:
+                    opt['dict_file'] = os.path.join(tmpdir, 'model.dict')
+
+                parser = mp_train.setup_args()
+                popt = _forced_parse(parser, opt)
+
+                # we need a prebuilt dictionary
+                parser = build_dict.setup_args()
+                build_dict.build_dict(popt)
+
+                valid, test = mp_train.launch_and_train(popt, 31337)
+
+        return (output.getvalue(), valid, test)
+
+    def test_generator_distributed(self):
+        stdout, valid, test = self._distributed_train_model(
+            dict(
+                task='integration_tests:nocandidate',
+                model='transformer/generator',
+                optimizer='adamax',
+                learningrate=7e-3,
+                batchsize=32,
+                validation_every_n_epochs=5,
+                num_epochs=20,
+                n_layers=1,
+                n_heads=1,
+                ffn_size=32,
+                embedding_size=32,
+                beam_size=1,
+            )
+        )
+
+        self.assertLessEqual(
+            valid['ppl'], 1.20, "valid ppl = {}\nLOG:\n{}".format(valid['ppl'], stdout)
+        )
+        self.assertGreaterEqual(
+            valid['bleu'],
+            0.95,
+            "valid blue = {}\nLOG:\n{}".format(valid['bleu'], stdout),
+        )
+        self.assertLessEqual(
+            test['ppl'], 1.20, "test ppl = {}\nLOG:\n{}".format(test['ppl'], stdout)
+        )
+        self.assertGreaterEqual(
+            test['bleu'], 0.95, "test bleu = {}\nLOG:\n{}".format(test['bleu'], stdout)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -46,6 +46,9 @@ class TestDistributed(unittest.TestCase):
                 build_dict.build_dict(popt)
 
                 valid, test = mp_train.launch_and_train(popt, 31337)
+
+                # we need to de-initialize the distributed world, otherwise other
+                # tests will they're we're distributed when we're really not.
                 dist.destroy_process_group()
 
         return (output.getvalue(), valid, test)

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -8,7 +8,6 @@ import os
 import unittest
 import torch.distributed as dist
 import parlai.core.testing_utils as testing_utils
-import parlai.scripts.multiprocessing_train as mp_train
 import parlai.scripts.build_dict as build_dict
 
 
@@ -27,6 +26,11 @@ def _forced_parse(parser, opt):
 @testing_utils.skipUnlessGPU
 class TestDistributed(unittest.TestCase):
     def _distributed_train_model(self, opt):
+        # we have to delay our import to here, because the set_spawn_method call
+        # inside multiprocessing_train will break the multithreading tests, even
+        # when we skip the test.
+        import parlai.scripts.multiprocessing_train as mp_train
+
         with testing_utils.capture_output() as output:
             with testing_utils.tempdir() as tmpdir:
                 if 'model_file' not in opt:

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -6,6 +6,7 @@
 
 import os
 import unittest
+import torch.distributed as dist
 import parlai.core.testing_utils as testing_utils
 import parlai.scripts.multiprocessing_train as mp_train
 import parlai.scripts.build_dict as build_dict
@@ -17,7 +18,7 @@ def _forced_parse(parser, opt):
     popt = parser.parse_args(print_args=False)
     # in some rare cases, like for instance if the model class also
     # overrides its default params, the params override will not
-    # be taken into account.   popt = parser.parse_args(print_args=False)
+    # be taken into account.
     for k, v in opt.items():
         popt[k] = v
     return popt
@@ -41,6 +42,7 @@ class TestDistributed(unittest.TestCase):
                 build_dict.build_dict(popt)
 
                 valid, test = mp_train.launch_and_train(popt, 31337)
+                dist.destroy_process_group()
 
         return (output.getvalue(), valid, test)
 

--- a/tests/test_pytorch_data_teacher.py
+++ b/tests/test_pytorch_data_teacher.py
@@ -56,6 +56,8 @@ def solved_task(str_output, valid, test):
     )
 
 
+# this test actually runs fine on gpu, but it mixes poorly with test_distributed
+# due to distributed changing the spawn method.
 @testing_utils.skipIfGPU
 class TestPytorchDataTeacher(unittest.TestCase):
     """Various tests for PytorchDataTeacher"""

--- a/tests/test_pytorch_data_teacher.py
+++ b/tests/test_pytorch_data_teacher.py
@@ -56,6 +56,7 @@ def solved_task(str_output, valid, test):
     )
 
 
+@testing_utils.skipIfGPU
 class TestPytorchDataTeacher(unittest.TestCase):
     """Various tests for PytorchDataTeacher"""
 

--- a/tests/test_threadutils.py
+++ b/tests/test_threadutils.py
@@ -5,11 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 from parlai.core.thread_utils import SharedTable
 from multiprocessing import Process
+import parlai.core.testing_utils as testing_utils
 import unittest
 import random
 import time
 
 
+@testing_utils.skipIfGPU
 class TestSharedTable(unittest.TestCase):
     """Make sure the package is alive."""
 


### PR DESCRIPTION
**Patch description**

If you've been using distributed mode without setting a random seed yourself (which we don't do in ParlAI), then all the copies of the model were using different initializations, making learning very difficult: gradients would be synchronized, so models would head in the right direction, but still produce highly varied gradients.

This manifested in a few strange behaviors:
- As the number of distributed copies and model size increased, model training became more difficult.
- Models could appear to overfit extremely quickly, with training loss continuing to go down but validation loss exploding. This is because some hosts would be improving and broadcasting their lower losses, but the validation host (rank 0) would be super far off.
- If training was preempted, then loss would significantly improve very rapidly after resuming, since model weights would be initialized from disk and therefore synchronized.

With synchronized parameters, this issue goes away.

Plan:
- [x] Add fast GPU unittests to CircleCI (same as what runs on our dev machines).
- [x] Add a distributed test, which ensures training happens
- [x] ~Maybe: support CPU distributed?~
- [x] Check synced parameters manually in a test
- [x] Actually fix the distributed sync bug.

**Testing steps**
Fixed manually once, saw issues go away. The finalized version of this PR should contain unit tests that will catch all these issues, and add distributed tests.

**Logs**
```
$ python tests/test_distributed.py
/private/home/roller/working/parlai/parlai/agents/transformer/transformer.py:18: UserWarning: Public release transformer models are currently in beta. The name of command line options may change or
disappear before a stable release. We welcome your feedback. Please file feedback as issues at https://github.com/facebookresearch/ParlAI/issues/new
  "Public release transformer models are currently in beta. The name of "
/private/home/roller/working/parlai/parlai/scripts/train_model.py:696: UserWarning: Distributed training outputs average-per-worker metrics during training, and may be slightly distorted. Validation/test are unadulterated.
  "Distributed training outputs average-per-worker metrics during "
.
----------------------------------------------------------------------
Ran 1 test in 13.685s

OK
```
