### PR TITLE
[MTurk] Better hit status tracking via complete post

### DIFF
--- a/parlai/mturk/core/dev/agents.py
+++ b/parlai/mturk/core/dev/agents.py
@@ -503,7 +503,6 @@ class MTurkAgent(Agent):
     # TODO cleanup timeout now that it's not used.
     def wait_for_hit_completion(self, timeout=None):
         """Waits for a hit to be marked as complete"""
-        sync_attempts = 0
         WAIT_TIME = 45 * 60
         start_time = time.time()
         while not self.hit_is_complete:
@@ -516,7 +515,7 @@ class MTurkAgent(Agent):
                 return False
             # FIXME if hit_is_complete was a threading.Event() this
             # function would be cleaner and not have sleeps
-            time.sleep(shared_utils.thread_medium_sleep)
+            time.sleep(shared_utils.THREAD_MEDIUM_SLEEP)
 
         shared_utils.print_and_log(
             logging.INFO,

--- a/parlai/mturk/core/dev/data_model.py
+++ b/parlai/mturk/core/dev/data_model.py
@@ -17,6 +17,7 @@ COMMAND_SUBMIT_HIT = 'COMMAND_SUBMIT_HIT'
 
 # Socket function names / packet types
 # TODO document
+# WISH pull all of these from one area, or test equivalence
 WORLD_MESSAGE = 'world message'  # Message from world to agent
 AGENT_MESSAGE = 'agent message'  # Message from agent to world
 WORLD_PING = 'world ping'  # Ping from the world for this server uptime
@@ -24,7 +25,7 @@ SERVER_PONG = 'server pong'  # pong to confirm uptime
 MESSAGE_BATCH = 'message batch'  # packet containing batch of messages
 AGENT_DISCONNECT = 'agent disconnect'  # Notes an agent disconnecting
 SNS_MESSAGE = 'sns message'  # packet from an SNS message
-STATIC_MESSAGE = 'static message'  # packet from static done POST
+SUBMIT_MESSAGE = 'submit message'  # packet from done POST
 AGENT_STATE_CHANGE = 'agent state change'  # state change from parlai
 AGENT_ALIVE = 'agent alive'  # packet from an agent alive event
 

--- a/parlai/mturk/core/dev/mturk_manager.py
+++ b/parlai/mturk/core/dev/mturk_manager.py
@@ -1389,9 +1389,6 @@ class MTurkManager:
 
     # Amazon MTurk Server Functions #
 
-    def get_agent_work_status(self, assignment_id):
-        return self.worker_manager.get_agent_work_status(assignment_id)
-
     def get_qualification_list(self, qualifications=None):
         if self.qualifications is not None:
             return self.qualifications.copy()

--- a/parlai/mturk/core/dev/mturk_manager.py
+++ b/parlai/mturk/core/dev/mturk_manager.py
@@ -608,7 +608,6 @@ class MTurkManager:
             # Treat as a socket_dead event
             self._on_socket_dead(agent.worker_id, assignment_id)
         elif mturk_event_type == SNS_ASSIGN_ABANDONDED:
-            agent.DEPRECATED_set_hit_is_abandoned()
             agent.hit_is_returned = True
             # Treat as a socket_dead event
             self._on_socket_dead(agent.worker_id, assignment_id)

--- a/parlai/mturk/core/dev/react_server/dev/app.jsx
+++ b/parlai/mturk/core/dev/react_server/dev/app.jsx
@@ -19,7 +19,6 @@ import SocketHandler from './components/socket_handler.jsx';
 import {
   MTurkSubmitForm,
   allDoneCallback,
-  staticAllDoneCallback,
 } from './components/mturk_submit_form.jsx';
 import 'fetch';
 import $ from 'jquery';
@@ -198,7 +197,12 @@ class MainApp extends React.Component {
             })
           }
           onRequestMessage={() => this.setState({ chat_state: 'text_input' })}
-          onForceDone={allDoneCallback}
+          onForceDone={() => allDoneCallback(
+            this.state.agent_id,
+            this.state.assignment_id,
+            this.state.worker_id,
+            [],
+          )}
           onSuccessfulSend={() =>
             this.setState({
               chat_state: 'waiting',
@@ -247,7 +251,12 @@ class MainApp extends React.Component {
           task_data={this.state.task_data}
           world_state={this.state.agent_state}
           v_id={this.state.agent_id}
-          allDoneCallback={() => allDoneCallback()}
+          allDoneCallback={() => allDoneCallback(
+            this.state.agent_id,
+            this.state.assignment_id,
+            this.state.worker_id,
+            [],
+          )}
           volume={this.state.volume}
           onVolumeChange={v => this.setState({ volume: v })}
           display_feedback={DISPLAY_FEEDBACK}
@@ -415,7 +424,7 @@ class StaticApp extends React.Component {
           task_data={this.state.task_data}
           world_state={this.state.world_state}
           v_id={this.state.agent_id}
-          allDoneCallback={() => staticAllDoneCallback(
+          allDoneCallback={() => allDoneCallback(
             this.state.agent_id,
             this.state.assignment_id,
             this.state.worker_id,

--- a/parlai/mturk/core/dev/react_server/dev/components/mturk_submit_form.jsx
+++ b/parlai/mturk/core/dev/react_server/dev/components/mturk_submit_form.jsx
@@ -34,15 +34,8 @@ function postData(url = ``, data = {}) {
   });
 }
 
-// Callback for submission
-function allDoneCallback() {
-  if (inMTurkHITPage()) {
-    $('input#mturk_submit_button').click();
-  }
-}
-
 // Callback for static submission
-function staticAllDoneCallback(sender_id, assign_id, worker_id, response_data) {
+function allDoneCallback(sender_id, assign_id, worker_id, response_data) {
   if (inMTurkHITPage()) {
     let server_url = window.location.origin;
     let post_data = {
@@ -52,10 +45,10 @@ function staticAllDoneCallback(sender_id, assign_id, worker_id, response_data) {
       response_data: response_data,
       task_group_id: TASK_GROUP_ID,
     };
-    // We allow workers to submit even if our server goes down.
-    // TODO reconcile this data with the fact that we'll likely mark as an
+    // TODO We allow workers to submit even if our server goes down.
+    // reconcile this data with the fact that we'll likely mark as an
     // abandon on our end and will want to query the data from amazon instead
-    postData(server_url + '/submit_static', post_data).then(
+    postData(server_url + '/submit_hit', post_data).then(
       res => { $('input#mturk_submit_button').click(); }
     );
   }
@@ -115,4 +108,4 @@ class MTurkSubmitForm extends React.Component {
   }
 }
 
-export { allDoneCallback, staticAllDoneCallback, MTurkSubmitForm };
+export { allDoneCallback, MTurkSubmitForm };

--- a/parlai/mturk/core/dev/react_server/package.json
+++ b/parlai/mturk/core/dev/react_server/package.json
@@ -28,6 +28,7 @@
     "babel-loader": "^8.0.2",
     "css-loader": "^1.0.0",
     "style-loader": "^0.23.0",
+    "url-loader": "^2.0.1",
     "webpack": "^4.19.1",
     "webpack-cli": "^3.1.1"
   }

--- a/parlai/mturk/core/dev/react_server/server/server.js
+++ b/parlai/mturk/core/dev/react_server/server/server.js
@@ -274,7 +274,7 @@ class LocalAgentState {
 // ======================= <Socket> =======================
 
 // Socket function types
-// TODO move to constants
+// WISH move to constants
 const AGENT_MESSAGE = 'agent message'  // Message from an agent
 const WORLD_MESSAGE = 'world message'  // Message from world to agent
 const HEARTBEAT = 'heartbeat'   // Heartbeat from agent, carries current state
@@ -283,7 +283,7 @@ const SERVER_PONG = 'server pong'  // pong to confirm uptime
 const MESSAGE_BATCH = 'message batch' // packet containing batch of messages
 const AGENT_DISCONNECT = 'agent disconnect'  // Notes an agent disconnecting
 const SNS_MESSAGE = 'sns message'   // packet from an SNS message
-const STATIC_MESSAGE = 'static message'  // packet from static done POST
+const SUBMIT_MESSAGE = 'submit message'  // packet from done POST
 const AGENT_STATE_CHANGE = 'agent state change'  // state change from parlai
 const AGENT_ALIVE = 'agent alive'  // packet from an agent alive event
 const UPDATE_STATE = 'update state'  // packet for updating agent client state
@@ -319,7 +319,7 @@ var connection_id_to_agent_state = {};
 var NOTIF_ID = 'MTURK_NOTIFICATIONS';
 
 // Handles sending a message through the socket
-// TODO create a version that handles wrapping into a packet?
+// WISH create a version that handles wrapping into a packet?
 function _send_message(connection_id, event_name, event_data) {
   // Find the connection's socket
   var socket = connection_id_to_socket[connection_id];
@@ -510,7 +510,7 @@ wss.on('connection', function(socket) {
   // handles routing a packet to the desired recipient
   socket.on('message', function(data) {
     try {
-      // TODO(wish) It's somewhat annoying that these constants come up and
+      // WISH It's somewhat annoying that these constants come up and
       // redefined all over the place, would be useful to have a singular
       // source for the API
       data = JSON.parse(data);
@@ -655,15 +655,15 @@ app.post('/sns_posts', async function(req, res, next) {
   }
 });
 
-app.post('/submit_static', async function(req, res, next) {
-  res.end('Successful static POST');
+app.post('/submit_hit', async function(req, res, next) {
+  res.end('Successful submit POST');
   let content = req.body;
   var task_group_id = content['task_group_id'];
   var agent_id = content['agent_id'];
   var assignment_id = content['assignment_id'];
   var worker_id = content['worker_id'];
   var response_data = content['response_data'];
-  var message_id = assignment_id + '_' + worker_id + '_static_submit';
+  var message_id = assignment_id + '_' + worker_id + '_submit';
 
   var data = {
     text: '[DATA_SUBMIT]',
@@ -680,7 +680,7 @@ app.post('/submit_static', async function(req, res, next) {
     receiver_id: world_id,
     data: data,
   };
-  _send_message(world_id, STATIC_MESSAGE, msg);
+  _send_message(world_id, SUBMIT_MESSAGE, msg);
   /// TODO on submit clean up static tasks  (must be by assign id)
 });
 

--- a/parlai/mturk/core/dev/react_server/server/server.js
+++ b/parlai/mturk/core/dev/react_server/server/server.js
@@ -274,7 +274,7 @@ class LocalAgentState {
 // ======================= <Socket> =======================
 
 // Socket function types
-// WISH move to constants
+// FIXME move to constants
 const AGENT_MESSAGE = 'agent message'  // Message from an agent
 const WORLD_MESSAGE = 'world message'  // Message from world to agent
 const HEARTBEAT = 'heartbeat'   // Heartbeat from agent, carries current state
@@ -319,7 +319,7 @@ var connection_id_to_agent_state = {};
 var NOTIF_ID = 'MTURK_NOTIFICATIONS';
 
 // Handles sending a message through the socket
-// WISH create a version that handles wrapping into a packet?
+// FIXME create a version that handles wrapping into a packet?
 function _send_message(connection_id, event_name, event_data) {
   // Find the connection's socket
   var socket = connection_id_to_socket[connection_id];
@@ -510,7 +510,7 @@ wss.on('connection', function(socket) {
   // handles routing a packet to the desired recipient
   socket.on('message', function(data) {
     try {
-      // WISH It's somewhat annoying that these constants come up and
+      // FIXME It's somewhat annoying that these constants come up and
       // redefined all over the place, would be useful to have a singular
       // source for the API
       data = JSON.parse(data);

--- a/parlai/mturk/core/dev/react_server/webpack.config.js
+++ b/parlai/mturk/core/dev/react_server/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
         loader: 'style-loader!css-loader',
       },
       {
-        test: /\.png$/,
+        test: /\.(svg|png|jpe?g|ttf)$/,
         loader: 'url-loader?limit=100000',
       },
       {

--- a/parlai/mturk/core/dev/socket_manager.py
+++ b/parlai/mturk/core/dev/socket_manager.py
@@ -373,7 +373,7 @@ class SocketManager:
 
         def on_message(*args):
             """Incoming message handler for SERVER_PONG, MESSAGE_BATCH,
-            AGENT_DISCONNECT, SNS_MESSAGE, STATIC_MESSAGE, AGENT_ALIVE
+            AGENT_DISCONNECT, SNS_MESSAGE, SUBMIT_MESSAGE, AGENT_ALIVE
             """
             packet_dict = json.loads(args[1])
             if packet_dict['type'] == 'conn_success':  # TODO make socket func
@@ -415,7 +415,7 @@ class SocketManager:
             elif packet_type == data_model.SNS_MESSAGE:
                 # Treated as a regular message
                 self.message_callback(packet)
-            elif packet_type == data_model.STATIC_MESSAGE:
+            elif packet_type == data_model.SUBMIT_MESSAGE:
                 # Treated as a regular message
                 self.message_callback(packet)
 

--- a/parlai/mturk/core/dev/worker_manager.py
+++ b/parlai/mturk/core/dev/worker_manager.py
@@ -12,6 +12,7 @@ import time
 from botocore.exceptions import ClientError
 
 from parlai.mturk.core.dev.agents import MTurkAgent, AssignState
+import parlai.mturk.core.dev.data_model as data_model
 import parlai.mturk.core.dev.mturk_utils as mturk_utils
 import parlai.mturk.core.dev.shared_utils as shared_utils
 
@@ -141,8 +142,13 @@ class WorkerManager:
                 'Manager received: {}'.format(pkt),
                 should_print=self.opt['verbose'],
             )
-            # Push the message to the agent
-            agent.put_data(pkt.id, pkt.data)
+            # WISH worker_manager shouldn't need to know packet types
+            if pkt.type == data_model.SUBMIT_MESSAGE:
+                # Mark the agent as submitted with this packet
+                agent.set_completed_act(pkt.data)
+            else:
+                # Push the message to the agent
+                agent.put_data(pkt.id, pkt.data)
 
     def map_over_agents(self, map_function, filter_func=None):
         """Take an action over all the agents we have access to, filters if
@@ -285,36 +291,6 @@ class WorkerManager:
             if agent.hit_is_complete:
                 hit_ids.append(hit_id)
         return hit_ids
-
-    # TODO update this once using submitted state via POST
-    def get_agent_work_status(self, assignment_id):
-        """Get the current status of an assignment's work"""
-        client = mturk_utils.get_mturk_client(self.is_sandbox)
-        try:
-            response = client.get_assignment(AssignmentId=assignment_id)
-            status = response['Assignment']['AssignmentStatus']
-            worker_id = self.assignment_to_worker_id[assignment_id]
-            agent = self._get_agent(worker_id, assignment_id)
-            if agent is not None and status == MTurkAgent.ASSIGNMENT_DONE:
-                agent.hit_is_complete = True
-            return status
-        except ClientError as e:
-            # If the assignment isn't done, asking for the assignment will fail
-            not_done_message = (
-                'This operation can be called with a status '
-                'of: Reviewable,Approved,Rejected'
-            )
-            if not_done_message in e.response['Error']['Message']:
-                return MTurkAgent.ASSIGNMENT_NOT_DONE
-            else:
-                shared_utils.print_and_log(
-                    logging.WARN,
-                    'Unanticipated error in `get_agent_work_status`: '
-                    + e.response['Error']['Message'],
-                    should_print=True,
-                )
-                # Assume not done if status check seems to be faulty.
-                return MTurkAgent.ASSIGNMENT_NOT_DONE
 
     def _log_missing_agent(self, worker_id, assignment_id):
         """Logs when an agent was expected to exist, yet for some reason it

--- a/parlai/mturk/core/dev/worker_manager.py
+++ b/parlai/mturk/core/dev/worker_manager.py
@@ -142,7 +142,7 @@ class WorkerManager:
                 'Manager received: {}'.format(pkt),
                 should_print=self.opt['verbose'],
             )
-            # WISH worker_manager shouldn't need to know packet types
+            # FIXME worker_manager shouldn't need to know packet types
             if pkt.type == data_model.SUBMIT_MESSAGE:
                 # Mark the agent as submitted with this packet
                 agent.set_completed_act(pkt.data)

--- a/parlai/mturk/core/dev/worlds.py
+++ b/parlai/mturk/core/dev/worlds.py
@@ -175,7 +175,7 @@ class StaticMTurkTaskWorld(MTurkDataWorld):
             {'id': 'System', 'text': '[TASK_DATA]', 'task_data': self.task_data}
         )
         agent.set_status(AssignState.STATUS_STATIC)
-        self.response = agent.act()
+        self.response = agent.get_completed_act()
         self.episodeDone = True
 
     def prep_save_data(self, workers):


### PR DESCRIPTION
**Patch description**
Back in the day, we used to rely solely on hit status checks that pinged amazon's server directly to tell whether or not an assignment was completed. This behavior was wasteful, so we moved to SNS messages to tell us when a HIT had been submitted. These still had delays and a chance of being missed.

In #1610 I introduced static tasks, which relied on HIT triggering a POST event to determine when a HIT was submitted. This PR applies the same flow to regular tasks, and removes the old flow for checking the completion status of a HIT.

**Changes summary**
`Agents`: Created a `completed_act` which stores the value POSTed when a hit is completed on the MTurk side. Setters and getters followed. Removed all mentions of `get_agent_work_status` and replaced with checks against `hit_is_complete`.

`data_model`, `server.js`, `socket_manager`: Renamed `STATIC_MESSAGE` to `SUBMIT_MESSAGE` to reflect the new behavior of this flag. Similar renames around this idea.

`react_server/dev`: Merged `staticAllDoneCallback` and `allDoneCallback` as they now have the same behavior.

`WorkerManager`: special cases around the `SUBMIT_MESSAGE` to mark an agent as done when received.


**Testing steps**
Run `qa_data_collection`, ensure hits get marked complete and the manager cleans up.
Run a static task, ensure the same.