### PR TITLE
Explicit metric shortcutting with --metrics

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -10,10 +10,6 @@ Uses locking and shared memory when ``numthreads`` is set to >1 to share metrics
 between processes.
 """
 
-DEFAULT_METRICS = set(['correct', 'bleu', 'accuracy', 'f1'])
-ROUGE__METRICS = set(['rouge-1', 'rouge-2', 'rouge-L'])
-ALL__METRICS = set(DEFAULT_METRICS | ROUGE__METRICS)
-
 from parlai.core.thread_utils import SharedTable
 from parlai.core.utils import round_sigfigs, no_lock
 from collections import Counter
@@ -21,6 +17,11 @@ from parlai.core.utils import warn_once
 from numbers import Number
 
 import re
+
+DEFAULT_METRICS = set(['correct', 'bleu', 'accuracy', 'f1'])
+ROUGE__METRICS = set(['rouge-1', 'rouge-2', 'rouge-L'])
+ALL__METRICS = set(DEFAULT_METRICS | ROUGE__METRICS)
+
 
 try:
     from nltk.translate import bleu_score as nltkbleu

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -255,7 +255,12 @@ class Metrics(object):
                 pass
             else:
                 self.metrics_list.add(each_m)
-        for k in self.metrics_list:
+        metrics_list = (
+            self.metrics_list
+            if 'rouge' not in self.metrics_list
+            else self.metrics_list | ROUGE_METRICS
+        )
+        for k in metrics_list:
             self.metrics[k] = 0.0
             self.metrics[k + '_cnt'] = 0
         self.eval_pr = [1, 5, 10, 100]

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -289,18 +289,7 @@ class DialogPartnerWorld(World):
     def report(self):
         """Report all metrics of all subagents."""
 
-        def show(metric):
-            if (
-                'all' in self.show_metrics
-                or metric in self.show_metrics
-                or metric == 'exs'
-            ):
-                return True
-            return False
-
         # DEPRECATIONDAY: should we get rid of this option?
-        show_metrics = self.opt.get('metrics', "all")
-        self.show_metrics = show_metrics.split(',')
         metrics = {}
         for a in self.agents:
             if hasattr(a, 'report'):
@@ -309,8 +298,7 @@ class DialogPartnerWorld(World):
                     if k not in metrics:
                         # first agent gets priority in settings values for keys
                         # this way model can't e.g. override accuracy to 100%
-                        if show(k):
-                            metrics[k] = v
+                        metrics[k] = v
         if metrics:
             self.total_exs += metrics.get('exs', 0)
             return metrics

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -50,8 +50,8 @@ def setup_args(parser=None):
         default='default',
         help='list of metrics to show/compute, e.g. all, default,'
         'or give a list split by , like '
-        'ppl, f1, accuracy, hits@1, rouge-l, rouge-1, rouge-2, bleu'
-        'the rouge metrics will be computed up to the max n you give',
+        'ppl, f1, accuracy, hits@1, rouge, bleu'
+        'the rouge metrics will be computed as rouge-1, rouge-2 and rouge-l',
     )
     TensorboardLogger.add_cmdline_args(parser)
     parser.set_defaults(datatype='valid')

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -44,12 +44,14 @@ def setup_args(parser=None):
         'number of tasks.',
     )
     parser.add_argument(
+        '-mcs',
         '--metrics',
         type=str,
-        default='all',
-        help='list of metrics to show/compute, e.g. '
-        'ppl, f1, accuracy, hits@1.'
-        'If `all` is specified [default] all are shown.',
+        default='default',
+        help='list of metrics to show/compute, e.g. all, default,'
+        'or give a list split by , like '
+        'ppl, f1, accuracy, hits@1, rouge-l, rouge-1, rouge-2, bleu'
+        'the rouge metrics will be computed up to the max n you give',
     )
     TensorboardLogger.add_cmdline_args(parser)
     parser.set_defaults(datatype='valid')

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -50,7 +50,7 @@ def setup_args(parser=None):
         default='default',
         help='list of metrics to show/compute, e.g. all, default,'
         'or give a list split by , like '
-        'ppl, f1, accuracy, hits@1, rouge, bleu'
+        'ppl,f1,accuracy,hits@1,rouge,bleu'
         'the rouge metrics will be computed as rouge-1, rouge-2 and rouge-l',
     )
     TensorboardLogger.add_cmdline_args(parser)

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -192,6 +192,16 @@ def setup_args(parser=None) -> ParlaiParser:
         help='If multitasking, average metrics over the number of examples. '
         'If false, averages over the number of tasks.',
     )
+    train.add_argument(
+        '-mcs',
+        '--metrics',
+        type=str,
+        default='default',
+        help='list of metrics to show/compute, e.g. all, default,'
+        'or give a list split by , like '
+        'ppl, f1, accuracy, hits@1, rouge-l, rouge-1, rouge-2, bleu'
+        'the rouge metrics will be computed up to the max n you give',
+    )
     TensorboardLogger.add_cmdline_args(parser)
     parser = setup_dict_args(parser)
     return parser

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -199,8 +199,8 @@ def setup_args(parser=None) -> ParlaiParser:
         default='default',
         help='list of metrics to show/compute, e.g. all, default,'
         'or give a list split by , like '
-        'ppl, f1, accuracy, hits@1, rouge-l, rouge-1, rouge-2, bleu'
-        'the rouge metrics will be computed up to the max n you give',
+        'ppl, f1, accuracy, hits@1, rouge, bleu'
+        'the rouge metrics will be computed as rouge-1, rouge-2 and rouge-l',
     )
     TensorboardLogger.add_cmdline_args(parser)
     parser = setup_dict_args(parser)

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -199,7 +199,7 @@ def setup_args(parser=None) -> ParlaiParser:
         default='default',
         help='list of metrics to show/compute, e.g. all, default,'
         'or give a list split by , like '
-        'ppl, f1, accuracy, hits@1, rouge, bleu'
+        'ppl,f1,accuracy,hits@1,rouge,bleu'
         'the rouge metrics will be computed as rouge-1, rouge-2 and rouge-l',
     )
     TensorboardLogger.add_cmdline_args(parser)

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -36,10 +36,13 @@ class TestEvalModel(unittest.TestCase):
             # check totals
             self.assertEqual(score['exs'], i, "Total is incorrect")
             # accuracy should be one
-            self.assertEqual('accuracy' in score, True, "Accuracy is missing from default")
+            self.assertEqual(
+                'accuracy' in score, True, "Accuracy is missing from default"
+            )
             self.assertEqual(score['accuracy'], 1, "Accuracy != 1")
-            self.assertEqual('rouge-1' in score, False, "Rouge is in the default metrics")
-
+            self.assertEqual(
+                'rouge-1' in score, False, "Rouge is in the default metrics"
+            )
 
     def test_metrics_all(self):
         """Test output of running eval_model"""
@@ -50,7 +53,7 @@ class TestEvalModel(unittest.TestCase):
             datatype='valid',
             num_examples=5,
             display_examples=False,
-            metrics='all'
+            metrics='all',
         )
 
         opt = parser.parse_args(print_args=False)
@@ -72,7 +75,6 @@ class TestEvalModel(unittest.TestCase):
             self.assertEqual(score['rouge-2'], 1, 'rouge-2 != 1')
             self.assertEqual(score['rouge-L'], 1, 'rouge-L != 1')
 
-
     def test_metrics_select(self):
         """Test output of running eval_model"""
         parser = setup_args()
@@ -82,7 +84,7 @@ class TestEvalModel(unittest.TestCase):
             datatype='valid',
             num_examples=5,
             display_examples=False,
-            metrics='accuracy, rouge'
+            metrics='accuracy, rouge',
         )
 
         opt = parser.parse_args(print_args=False)
@@ -97,13 +99,16 @@ class TestEvalModel(unittest.TestCase):
             # check totals
             self.assertEqual(score['exs'], i, "Total is incorrect")
             # accuracy should be one
-            self.assertEqual('accuracy' in score, True, "Accuracy is missing from selection")
+            self.assertEqual(
+                'accuracy' in score, True, "Accuracy is missing from selection"
+            )
             self.assertEqual(score['accuracy'], 1, "Accuracy != 1")
-            self.assertEqual('rouge-1' in score, True, "Rouge is missing from selection")
+            self.assertEqual(
+                'rouge-1' in score, True, "Rouge is missing from selection"
+            )
             self.assertEqual(score['rouge-1'], 1, 'rouge1 != 1')
             self.assertEqual(score['rouge-2'], 1, 'rouge-2 != 1')
             self.assertEqual(score['rouge-L'], 1, 'rouge-L != 1')
-
 
     def test_multitasking_metrics(self):
         stdout, valid, test = testing_utils.eval_model(

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -36,11 +36,74 @@ class TestEvalModel(unittest.TestCase):
             # check totals
             self.assertEqual(score['exs'], i, "Total is incorrect")
             # accuracy should be one
-            self.assertEqual(score['accuracy'], 1, "accuracy != 1")
-            if 'rouge-1' in score:
-                self.assertEqual(score['rouge-1'], 1, 'rouge1 != 1')
-                self.assertEqual(score['rouge-2'], 1, 'rouge-2 != 1')
-                self.assertEqual(score['rouge-L'], 1, 'rouge-L != 1')
+            self.assertEqual('accuracy' in score, True, "Accuracy is missing from default")
+            self.assertEqual(score['accuracy'], 1, "Accuracy != 1")
+            self.assertEqual('rouge-1' in score, False, "Rouge is in the default metrics")
+
+
+    def test_metrics_all(self):
+        """Test output of running eval_model"""
+        parser = setup_args()
+        parser.set_defaults(
+            task='integration_tests',
+            model='repeat_label',
+            datatype='valid',
+            num_examples=5,
+            display_examples=False,
+            metrics='all'
+        )
+
+        opt = parser.parse_args(print_args=False)
+        str_output, valid, test = testing_utils.eval_model(opt)
+        self.assertGreater(len(str_output), 0, "Output is empty")
+
+        # decode the output
+        scores = str_output.split("\n---\n")
+
+        for i in range(1, len(scores)):
+            score = ast.literal_eval(scores[i])
+            # check totals
+            self.assertEqual(score['exs'], i, "Total is incorrect")
+            # accuracy should be one
+            self.assertEqual('accuracy' in score, True, "Accuracy is missing from all")
+            self.assertEqual(score['accuracy'], 1, "Accuracy != 1")
+            self.assertEqual('rouge-1' in score, True, "Rouge is missing from all")
+            self.assertEqual(score['rouge-1'], 1, 'rouge1 != 1')
+            self.assertEqual(score['rouge-2'], 1, 'rouge-2 != 1')
+            self.assertEqual(score['rouge-L'], 1, 'rouge-L != 1')
+
+
+    def test_metrics_select(self):
+        """Test output of running eval_model"""
+        parser = setup_args()
+        parser.set_defaults(
+            task='integration_tests',
+            model='repeat_label',
+            datatype='valid',
+            num_examples=5,
+            display_examples=False,
+            metrics='accuracy, rouge'
+        )
+
+        opt = parser.parse_args(print_args=False)
+        str_output, valid, test = testing_utils.eval_model(opt)
+        self.assertGreater(len(str_output), 0, "Output is empty")
+
+        # decode the output
+        scores = str_output.split("\n---\n")
+
+        for i in range(1, len(scores)):
+            score = ast.literal_eval(scores[i])
+            # check totals
+            self.assertEqual(score['exs'], i, "Total is incorrect")
+            # accuracy should be one
+            self.assertEqual('accuracy' in score, True, "Accuracy is missing from selection")
+            self.assertEqual(score['accuracy'], 1, "Accuracy != 1")
+            self.assertEqual('rouge-1' in score, True, "Rouge is missing from selection")
+            self.assertEqual(score['rouge-1'], 1, 'rouge1 != 1')
+            self.assertEqual(score['rouge-2'], 1, 'rouge-2 != 1')
+            self.assertEqual(score['rouge-L'], 1, 'rouge-L != 1')
+
 
     def test_multitasking_metrics(self):
         stdout, valid, test = testing_utils.eval_model(

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -84,7 +84,7 @@ class TestEvalModel(unittest.TestCase):
             datatype='valid',
             num_examples=5,
             display_examples=False,
-            metrics='accuracy, rouge',
+            metrics='accuracy,rouge',
         )
 
         opt = parser.parse_args(print_args=False)


### PR DESCRIPTION
**Patch description**
This allows us to select what metrics we want to compute, not only filtering them, but also preventing them from being computed.
For all :  `['correct', 'rouge-1', 'rouge-2', 'rouge-L', 'bleu' 'accuracy', 'f1', 'loss', 'ppl']`
For default : ` ['correct', 'bleu', 'accuracy', 'f1', 'loss', 'ppl']`
'correct' is always added since it is required for computing accuracy, and we don't want dependency in metrics. 


Usage: You can choose 'all', 'default', or you can add your metrics you like as 'rouge-1', 'bleu'.

**Testing steps**
```

python examples/train_model.py -m transformer/generator  -t quac  -bs 32 -mf /tmp/tg01  --truncate 1024 --metrics all
{'exs': 384, 'lr': 1, 'num_updates': 22, 'loss': 112.6, 'token_acc': 0.05282, 'nll_loss': 9.398, 'ppl': 12060.0}


python examples/train_model.py -m transformer/generator  -t quac  -bs 32 -mf /tmp/tg01  --truncate 1024 
 time:6.0s total_exs:1056 epochs:0.01 ] {'exs': 384, 'lr': 1, 'num_updates': 33, 'loss': 107.9, 'token_acc': 0.05236, 'nll_loss': 8.995, 'ppl': 8067.0}
```