### PR TITLE
Fix CircleCI nightly typo.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ workflows:
     jobs:
       - unittests_36
       - unittests_37
-      - gpu_unittests
+      - unittests_gpu
       - mturk_tests
       - nightly_gpu_tests
       - test_website


### PR DESCRIPTION
**Patch description**
Nightly CircleCI broke due to this typo. https://circleci.com/gh/facebookresearch/ParlAI/7034