### PR TITLE
Flaky test fix.

### DIFF
--- a/tests/nightly/gpu/test_convai2.py
+++ b/tests/nightly/gpu/test_convai2.py
@@ -55,7 +55,7 @@ class TestConvai2KVMemnn(unittest.TestCase):
 
         with testing_utils.capture_output() as stdout:
             report = eval_f1.main()
-        self.assertEqual(report['f1'], 0.1173, str(stdout))
+        self.assertAlmostEqual(report['f1'], 0.1173, delta=.0002, str(stdout))
 
 
 @testing_utils.skipUnlessGPU

--- a/tests/nightly/gpu/test_convai2.py
+++ b/tests/nightly/gpu/test_convai2.py
@@ -55,7 +55,7 @@ class TestConvai2KVMemnn(unittest.TestCase):
 
         with testing_utils.capture_output() as stdout:
             report = eval_f1.main()
-        self.assertAlmostEqual(report['f1'], 0.1173, delta=.0002, str(stdout))
+        self.assertAlmostEqual(report['f1'], 0.1173, delta=0.0002, msg=str(stdout))
 
 
 @testing_utils.skipUnlessGPU


### PR DESCRIPTION
**Patch description**
This test is moderately flaky. Maybe once or twice a week, it fails because the score returns .1174 instead of .1173; rerunning nearly always fixes. This test just slightly increases the window of passing to reduce noise.

**Testing steps**
CircleCI.