### PR TITLE
Support setting adam epsilon.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -448,7 +448,7 @@ class TorchAgent(ABC, Agent):
             ' should be valid.',
         )
         optim_group.add_argument(
-            '-lr', '--learningrate', type=float, default=1, help='learning rate'
+            '-lr', '--learningrate', type=float, default=1, help='Learning rate'
         )
         optim_group.add_argument(
             '-clip',
@@ -456,6 +456,14 @@ class TorchAgent(ABC, Agent):
             type=float,
             default=0.1,
             help='gradient clipping using l2 norm',
+        )
+        optim_group.add_argument(
+            '--adam-eps',
+            type=float,
+            default=None,
+            hidden=True,
+            help='Epsilon value for Adam optimizers. Set to 1e-6 if your '
+            'large model has stability issues, but prefer the default.'
         )
         optim_group.add_argument(
             '-mom',
@@ -800,6 +808,9 @@ class TorchAgent(ABC, Agent):
         if opt['optimizer'] in ['adam', 'sparseadam', 'fused_adam', 'adamax', 'qhadam']:
             # set betas for optims that use it
             kwargs['betas'] = opt.get('betas', (0.9, 0.999))
+            # set adam optimizer, but only if user specified it
+            if opt.get('adam_eps'):
+                kwargs['eps'] = opt['adam_eps']
 
         optim_class = self.optim_opts()[opt['optimizer']]
         self.optimizer = optim_class(params, **kwargs)

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -460,7 +460,7 @@ class TorchAgent(ABC, Agent):
         optim_group.add_argument(
             '--adam-eps',
             type=float,
-            default=None,
+            default=1e-8,
             hidden=True,
             help='Epsilon value for Adam optimizers. Set to 1e-6 if your '
             'large model has stability issues, but prefer the default.',

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -463,7 +463,7 @@ class TorchAgent(ABC, Agent):
             default=None,
             hidden=True,
             help='Epsilon value for Adam optimizers. Set to 1e-6 if your '
-            'large model has stability issues, but prefer the default.'
+            'large model has stability issues, but prefer the default.',
         )
         optim_group.add_argument(
             '-mom',

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -393,6 +393,7 @@ class TestTransformerGenerator(unittest.TestCase):
                 variant='xlm',
                 activation='gelu',
                 n_segments=8,  # doesn't do anything but still good to test
+                adam_eps=1e-6,  # just to test another flag simultaneously
             )
         )
 


### PR DESCRIPTION
**Patch description**
Support setting adam epsilon with --adam-eps.

Most users will never care about this flag, but when training very large models I've found it setting it to 1e-6 increases stability, and others in the lab report this. 

**Testing steps**
Been using it. Added it as a flag in one of the transformer tests to make sure it has coverage in CircleCI.