### PR TITLE
Downgrade docutils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ websocket-client
 websocket-server
 py-rouge
 pre-commit
+docutils<0.15


### PR DESCRIPTION
**Patch description**
[botocore 1.12.192 was released](https://github.com/boto/botocore/commit/4ed4391abc252dfea4062dd125b6a6bcbfdf5992), which blacklisted docutils 0.15. This was unfortunately the version we were installing from another packages, thus [all of CircleCI broke](https://circleci.com/gh/facebookresearch/ParlAI/7200).

This patch attempts to fix it by manually installing docutils < 0.15.

**Testing steps**
CircleCI.