### PR TITLE
OS X unit testing.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,13 @@ standard_cpu36: &standard_cpu36
   docker:
     - image: circleci/python:3.6.5-node
 
+osx_cpu37: &osx_cpu37
+  macos:
+    xcode: "10.1.0"
+  environment:
+    PYTHON: 3.7.1
+    HOMEBREW_NO_AUTO_UPDATE: 1
+
 gpu: &gpu
   environment:
     CUDA_VERSION: "10.0"
@@ -56,6 +63,12 @@ installtorchgpu: &installtorchgpu
       pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off torchtext
+
+installtorchcpuosx: &installtorchcpuosx
+  run:
+    name: Install torch CPU and dependencies
+    command: |
+      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.0.0-cp37-none-macosx_10_7_x86_64.whl
 
 installtorchcpu36: &installtorchcpu36
   run:
@@ -105,6 +118,19 @@ jobs:
       - run:
           name: Data tests
           command: python setup.py test -s tests.suites.datatests -v
+
+  unittests_osx:
+    <<: *osx_cpu37
+    working_directory: ~/ParlAI
+    steps:
+      - checkout
+      - <<: *fixgit
+      - <<: *setup
+      - <<: *installdeps
+      - <<: *installtorchcpuosx
+      - run:
+          name: Unit tests (OSX)
+          command: python setup.py test -s tests.suites.unittests -v
 
   unittests_36:
     <<: *standard_cpu36
@@ -302,6 +328,7 @@ workflows:
       - unittests_gpu
       - unittests_37
       - unittests_36
+      - unittests_osx
       - mturk_tests:
           filters:
             branches:
@@ -333,6 +360,7 @@ workflows:
       - unittests_36
       - unittests_37
       - unittests_gpu
+      - unittests_osx
       - mturk_tests
       - nightly_gpu_tests
       - test_website


### PR DESCRIPTION
**Patch description**
Based on #1805, it seems like there are some issues which may only crop up on OS X. Although we don't use OS X for development, it seems like many of our OSS users do. Therefore it seems reasonable to just have the unittests tracked in OS X.

This patch adds OS X testing to our CI framework.

**Testing steps**
CircleCI.