### PR TITLE
[WIP] Optionally evaluate EmpatheticDialogues on listener responses only

### DIFF
--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -119,16 +119,16 @@ class EmpatheticDialogueTeacher(FixedDialogTeacher):
                     continue
 
                 dialogue_parts = [
-                        contextt,
-                        label,
-                        prompt,
-                        sit,
-                        context_emb,
-                        cand_emb,
-                        ft_ctx,
-                        ft_cand,
-                        inline_label_candidates,
-                    ]
+                    contextt,
+                    label,
+                    prompt,
+                    sit,
+                    context_emb,
+                    cand_emb,
+                    ft_ctx,
+                    ft_cand,
+                    inline_label_candidates,
+                ]
                 if j % 2 == 0:
                     listener_dialogue.append(dialogue_parts)
                 else:

--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -78,13 +78,10 @@ class EmpatheticDialogueTeacher(FixedDialogTeacher):
                 prompt = sparts[2]
                 sit = sparts[3].replace("_comma_", ",")
                 if len(sparts) == 9:
-                    if sparts[8] != '':
-                        inline_label_candidates = [
-                            cand.replace("_comma_", ",").replace("_pipe_", "|")
-                            for cand in sparts[8].split('|')
-                        ]
-                    else:
-                        inline_label_candidates = []
+                    inline_label_candidates = [
+                        cand.replace("_comma_", ",").replace("_pipe_", "|")
+                        for cand in sparts[8].split('|')
+                    ]
                 elif len(sparts) == 8:
                     inline_label_candidates = []
                 else:

--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -30,8 +30,8 @@ class EmpatheticDialogueTeacher(FixedDialogTeacher):
         agent = argparser.add_argument_group('Empathetic Dialogue teacher arguments')
         agent.add_argument(
             '--reactions-only',
-            type='bool',
-            default=True,
+            action='store_true',
+            default=False,
             help='Only use Listener reactions as examples in the validation/test sets',
         )
 

--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -138,9 +138,9 @@ class EmpatheticDialogueTeacher(FixedDialogTeacher):
 
     def get(self, episode_idx, entry_idx=0):
         ep = self.data[episode_idx]
-        i = entry_idx * 2
-        ep_i = ep[i]
-        episode_done = i >= (len(ep) - 2)
+        ep_i = ep[entry_idx]
+        episode_done = entry_idx >= (len(ep) - 1)
+        # TODO: confirm this indexing
         action = {
             'situation': ep_i[3],
             'emotion': ep_i[2],

--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -118,34 +118,21 @@ class EmpatheticDialogueTeacher(FixedDialogTeacher):
                     # label candidates
                     continue
 
+                dialogue_parts = [
+                        contextt,
+                        label,
+                        prompt,
+                        sit,
+                        context_emb,
+                        cand_emb,
+                        ft_ctx,
+                        ft_cand,
+                        inline_label_candidates,
+                    ]
                 if j % 2 == 0:
-                    listener_dialogue.append(
-                        [
-                            contextt,
-                            label,
-                            prompt,
-                            sit,
-                            context_emb,
-                            cand_emb,
-                            ft_ctx,
-                            ft_cand,
-                            inline_label_candidates,
-                        ]
-                    )
+                    listener_dialogue.append(dialogue_parts)
                 else:
-                    speaker_dialogue.append(
-                        [
-                            contextt,
-                            label,
-                            prompt,
-                            sit,
-                            context_emb,
-                            cand_emb,
-                            ft_ctx,
-                            ft_cand,
-                            inline_label_candidates,
-                        ]
-                    )
+                    speaker_dialogue.append(dialogue_parts)
                 j += 1
 
             else:

--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -109,15 +109,6 @@ class EmpatheticDialogueTeacher(FixedDialogTeacher):
                     for f in gettop:
                         ft_cand = f.split("_")[-1] + " " + ft_cand
 
-                if (
-                    len(inline_label_candidates) == 0
-                    and fold != 'train'
-                    and self.opt['eval_candidates'] == 'inline'
-                ):
-                    # We can't use this example for eval because there are no
-                    # label candidates
-                    continue
-
                 dialogue_parts = [
                     contextt,
                     label,


### PR DESCRIPTION
**Patch description**
If the `--reactions-only` flag is used, only evaluate the EmpatheticDialogues dataset on Listener responses and not Speaker utterances, as is done when running evaluation in https://arxiv.org/abs/1811.00207 .

(Thanks to @hadasah for her help with this a few months back.)

**Testing steps**
- Displaying both Listener responses and Speaker utterances as labels: `python examples/display_data.py -t empathetic_dialogues -ne 100 -dt valid`
- Displaying only Listener responses as labels: `python examples/display_data.py -t empathetic_dialogues -ne 100 -dt valid --reactions-only`