### PR TITLE
[Bug Fix]Fix Metrics type issue in convai2 circleci test

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -428,7 +428,7 @@ class Metrics(object):
                 v_typ = type(v)
                 if 'Tensor' in str(v_typ):
                     self.metrics[k].zero_()
-                if 'int' in str(v_typ):
+                if isinstance(v, int):
                     self.metrics[k] = 0
                 else:
                     self.metrics[k] = 0.0

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -428,6 +428,8 @@ class Metrics(object):
                 v_typ = type(v)
                 if 'Tensor' in str(v_typ):
                     self.metrics[k].zero_()
+                if 'int' in str(v_typ):
+                    self.metrics[k] = 0
                 else:
                     self.metrics[k] = 0.0
                 self.metrics[k + '_cnt'] = 0


### PR DESCRIPTION
**Patch description**
The new metrics clear function ignores the original type and set all these to float, this cause issues in https://circleci.com/gh/facebookresearch/ParlAI/7930#tests/containers/2

This PR should fix it.

**Testing steps**
See the CI
