### PR TITLE
[WIP] Adding BERT variant of the Transformer

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -498,7 +498,7 @@ class TransformerEncoder(nn.Module):
             or self.reduction_type is None
             and self.variant != 'bert'
         ):
-            # TODO: figure out: is the code that passes back the mask still usable? From
+            # TODO: is the code that passes back the mask still usable? From
             #  looking at the models that use this encoder, the output of the encoder is
             #  always assumed to be a Tensor, not a 2-ple of Tensors
             return output, mask

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -611,7 +611,7 @@ class TransformerDecoder(nn.Module):
 
         self.embeddings = embedding
 
-        if self.variant == ['bert', 'xlm']:
+        if self.variant in ['bert', 'xlm']:
             self.norm_embeddings = LayerNorm(self.dim, eps=LAYER_NORM_EPS)
         elif self.variant == 'aiayn':
             pass

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -493,14 +493,7 @@ class TransformerEncoder(nn.Module):
         if self.variant in 'bert':
             output = self.additional_linear_layer(output)
 
-        if (
-            self.reduction_type == 'none'
-            or self.reduction_type is None
-            and self.variant != 'bert'
-        ):
-            # TODO: is the code that passes back the mask still usable? From looking at
-            #  the models that use this encoder, the output of the encoder is always
-            #  assumed to be a Tensor, not a 2-ple of Tensors
+        if self.reduction_type == 'none' or self.reduction_type is None:
             return output, mask
         else:
             return output

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -498,9 +498,9 @@ class TransformerEncoder(nn.Module):
             or self.reduction_type is None
             and self.variant != 'bert'
         ):
-            # TODO: is the code that passes back the mask still usable? From
-            #  looking at the models that use this encoder, the output of the encoder is
-            #  always assumed to be a Tensor, not a 2-ple of Tensors
+            # TODO: is the code that passes back the mask still usable? From looking at
+            #  the models that use this encoder, the output of the encoder is always
+            #  assumed to be a Tensor, not a 2-ple of Tensors
             return output, mask
         else:
             return output

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -67,9 +67,15 @@ def add_common_cmdline_args(argparser):
     )
     argparser.add_argument(
         '--variant',
-        choices={'aiayn', 'xlm'},
+        choices={'aiayn', 'bert', 'xlm'},
         default='aiayn',
         help='Chooses locations of layer norms, etc.',
+    )
+    argparser.add_argument(
+        '--bert-final-layer-dim',
+        type=int,
+        default=300,
+        help='Output size of the final layer in the BERT variant',
     )
     argparser.add_argument(
         '--activation',


### PR DESCRIPTION
**Patch description**
Allows the Transformer to more closely resemble the architecture of the HuggingFace BERT model as wrapped by ParlAI. Can be called with `--variant bert`. Will be used to run inference on an EmpatheticDialogues model pre-trained/finetuned with HuggingFace BERT.

Features of this BERT variant of the Transformer:
- Like the XLM variant, performs layer norm on the summed token/position/segment embeddings. HuggingFace performs this in its `BertEmbeddings` class (https://github.com/huggingface/pytorch-transformers/blob/master/pytorch_transformers/modeling_bert.py#L269 )
- Adds an additional linear layer to the end of the encoder after reduction, analogous to in ParlAI's `BertWrapper` (https://github.com/facebookresearch/ParlAI/blob/master/parlai/agents/bert_ranker/helpers.py#L94 )


**Testing steps**
This PR is a work in progress: tests will be run soon.