### PR TITLE
[MTurk] Testing for the dev branch

### DIFF
--- a/parlai/mturk/core/dev/agents.py
+++ b/parlai/mturk/core/dev/agents.py
@@ -276,6 +276,8 @@ class MTurkAgent(Agent):
 
     def put_data(self, id, data):
         """Put data into the message queue if it hasn't already been seen"""
+        if 'message_id' not in data:
+            data['message_id'] = id
         if id not in self.recieved_packets:
             self.state.append_message(data)  # append to message history
             self.recieved_packets[id] = True

--- a/parlai/mturk/core/dev/mturk_manager.py
+++ b/parlai/mturk/core/dev/mturk_manager.py
@@ -1365,14 +1365,14 @@ class MTurkManager:
     def mark_workers_done(self, workers):
         """Mark a group of agents as done to keep state consistent"""
         for agent in workers:
+            if not agent.is_final():
+                agent.set_status(AssignState.STATUS_DONE, 'done', None)
+
             if self.is_unique:
                 assert (
                     self.unique_qual_name is not None
                 ), 'Unique qual name must not be none to use is_unique'
                 self.give_worker_qualification(agent.worker_id, self.unique_qual_name)
-            if not agent.is_final():
-                agent.set_status(AssignState.STATUS_DONE, 'done', None)
-
             if self.max_hits_per_worker > 0:
                 worker_state = self.worker_manager._get_worker(agent.worker_id)
                 completed_assignments = worker_state.completed_assignments()

--- a/parlai/mturk/core/dev/mturk_manager.py
+++ b/parlai/mturk/core/dev/mturk_manager.py
@@ -680,7 +680,7 @@ class MTurkManager:
             """Onboarding wrapper to set state to onboarding properly"""
             if self.get_onboard_world:
                 conversation_id = 'o_' + str(uuid.uuid4())
-                agent.set_status(
+                mturk_agent.set_status(
                     AssignState.STATUS_ONBOARDING,
                     conversation_id=conversation_id,
                     agent_id='onboarding',

--- a/parlai/mturk/core/dev/socket_manager.py
+++ b/parlai/mturk/core/dev/socket_manager.py
@@ -382,7 +382,6 @@ class SocketManager:
             packet_dict['content']['type'] = packet_dict['type']
             packet = Packet.from_dict(packet_dict['content'])
             if packet is None:
-                print('no packet made', packet_dict)
                 return
             packet_id = packet.id
             packet_type = packet.type

--- a/parlai/mturk/core/dev/socket_manager.py
+++ b/parlai/mturk/core/dev/socket_manager.py
@@ -44,7 +44,7 @@ class Packet:
         Create a packet to be used for holding information before it is
         sent through the socket
         id:               Unique ID to distinguish this packet from others
-        type:             TYPE of packet (ACK, ALIVE, MESSAGE, HEARTBEAT)
+        type:             TYPE of packet (ACK, ALIVE, MESSAGE)
         sender_id:        Sender ID for this packet
         receiver_id:      Recipient ID for this packet
         assignment_id:    Assignment ID for this packet
@@ -198,8 +198,7 @@ class SocketManager:
         self.send_thread = None
         self.sending_queue = PriorityQueue()
         self.open_channels = set()
-        self.threads = {}
-        self.last_sent_ping_time = 0  # time of last heartbeat sent
+        self.last_sent_ping_time = 0  # time of last ping send
         self.pings_without_pong = 0
         self.processed_packets = set()
         self.packet_map = {}
@@ -383,6 +382,7 @@ class SocketManager:
             packet_dict['content']['type'] = packet_dict['type']
             packet = Packet.from_dict(packet_dict['content'])
             if packet is None:
+                print('no packet made', packet_dict)
                 return
             packet_id = packet.id
             packet_type = packet.type

--- a/parlai/mturk/core/dev/test/test_db_interactions.py
+++ b/parlai/mturk/core/dev/test/test_db_interactions.py
@@ -10,10 +10,10 @@ import time
 import uuid
 from datetime import datetime
 
-from parlai.mturk.core.mturk_data_handler import MTurkDataHandler
-from parlai.mturk.core.agents import AssignState
+from parlai.mturk.core.dev.mturk_data_handler import MTurkDataHandler
+from parlai.mturk.core.dev.agents import AssignState
 
-import parlai.mturk.core.mturk_data_handler as DataHandlerFile
+import parlai.mturk.core.dev.mturk_data_handler as DataHandlerFile
 
 data_dir = os.path.dirname(os.path.abspath(__file__))
 DataHandlerFile.data_dir = data_dir

--- a/parlai/mturk/core/dev/test/test_full_system.py
+++ b/parlai/mturk/core/dev/test/test_full_system.py
@@ -430,8 +430,8 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
             self.worlds_agents[key] = True
         self.mturk_manager.shutdown()
         self.fake_socket.close()
-        # if self.task_thread.isAlive():
-        #     self.task_thread.join()
+        if self.task_thread.isAlive():
+            self.task_thread.join()
 
     def get_onboard_world(self, mturk_agent):
         self.onboarding_agents[mturk_agent.worker_id] = False

--- a/parlai/mturk/core/dev/test/test_full_system.py
+++ b/parlai/mturk/core/dev/test/test_full_system.py
@@ -9,14 +9,15 @@ import time
 import uuid
 import os
 from unittest import mock
-from parlai.mturk.core.socket_manager import Packet, SocketManager
-from parlai.mturk.core.agents import AssignState
-from parlai.mturk.core.mturk_manager import MTurkManager
+from parlai.mturk.core.dev.socket_manager import Packet, SocketManager
+from parlai.mturk.core.dev.worlds import MTurkOnboardWorld, MTurkTaskWorld
+from parlai.mturk.core.dev.agents import AssignState
+from parlai.mturk.core.dev.mturk_manager import MTurkManager
 from parlai.core.params import ParlaiParser
 
-import parlai.mturk.core.mturk_manager as MTurkManagerFile
-import parlai.mturk.core.data_model as data_model
-import parlai.mturk.core.shared_utils as shared_utils
+import parlai.mturk.core.dev.mturk_manager as MTurkManagerFile
+import parlai.mturk.core.dev.data_model as data_model
+import parlai.mturk.core.dev.shared_utils as shared_utils
 import threading
 from websocket_server import WebsocketServer
 import json
@@ -44,7 +45,7 @@ MESSAGE_ID_3 = 'MESSAGE_ID_3'
 MESSAGE_ID_4 = 'MESSAGE_ID_4'
 COMMAND_ID_1 = 'COMMAND_ID_1'
 
-MESSAGE_TYPE = data_model.MESSAGE_TYPE_MESSAGE
+MESSAGE_TYPE = data_model.MESSAGE_TYPE_ACT
 COMMAND_TYPE = data_model.MESSAGE_TYPE_COMMAND
 
 MESSAGE_1 = {'message_id': MESSAGE_ID_1, 'type': MESSAGE_TYPE}
@@ -75,9 +76,7 @@ statuses = active_statuses + complete_statuses
 TASK_GROUP_ID_1 = 'TASK_GROUP_ID_1'
 
 SocketManager.DEF_MISSED_PONGS = 1
-SocketManager.HEARTBEAT_RATE = 0.4
 SocketManager.DEF_DEAD_TIME = 0.4
-SocketManager.ACK_TIME = {Packet.TYPE_ALIVE: 0.4, Packet.TYPE_MESSAGE: 0.2}
 
 shared_utils.THREAD_SHORT_SLEEP = 0.05
 shared_utils.THREAD_MEDIUM_SLEEP = 0.15
@@ -92,12 +91,45 @@ MTURK_PAGE_URL = 'mturk_page_url'
 FAKE_HIT_ID = 'fake_hit_id'
 
 
+class TestMTurkWorld(MTurkTaskWorld):
+    def __init__(self, workers, use_episode_done):
+        self.workers = workers
+
+        def episode_done():
+            return use_episode_done()
+
+        self.episode_done = episode_done
+
+    def parley(self):
+        for worker in self.workers:
+            worker.assert_connected()
+        time.sleep(0.5)
+
+    def shutdown(self):
+        for worker in self.workers:
+            worker.shutdown()
+
+
+class TestMTurkOnboardWorld(MTurkOnboardWorld):
+    def __init__(self, mturk_agent, use_episode_done):
+        self.mturk_agent = mturk_agent
+
+        def episode_done():
+            return use_episode_done()
+
+        self.episode_done = episode_done
+
+    def parley(self):
+        self.mturk_agent.assert_connected()
+        time.sleep(0.5)
+
+
 def assert_equal_by(val_func, val, max_time):
     start_time = time.time()
     while val_func() != val:
         assert (
             time.time() - start_time < max_time
-        ), "Value was not attained in specified time"
+        ), "Value was not attained in specified time, last {}".format(val_func())
         time.sleep(0.1)
 
 
@@ -108,7 +140,6 @@ class MockSocket:
         self.disconnected = False
         self.closed = False
         self.ws = None
-        self.should_heartbeat = True
         self.fake_workers = []
         self.port = None
         self.launch_socket()
@@ -139,21 +170,16 @@ class MockSocket:
             if packet_dict['content']['id'] == 'WORLD_ALIVE':
                 self.ws.send_message(client, json.dumps({'type': 'conn_success'}))
                 self.connected = True
-            elif packet_dict['content']['type'] == 'heartbeat':
+            elif packet_dict['type'] == data_model.WORLD_PING:
                 pong = packet_dict['content'].copy()
                 pong['type'] = 'pong'
                 self.ws.send_message(
                     client,
-                    json.dumps(
-                        {'type': data_model.SOCKET_ROUTE_PACKET_STRING, 'content': pong}
-                    ),
+                    json.dumps({'type': data_model.SERVER_PONG, 'content': pong}),
                 )
             if 'receiver_id' in packet_dict['content']:
                 receiver_id = packet_dict['content']['receiver_id']
-                assignment_id = packet_dict['content']['assignment_id']
-                use_func = self.handlers.get(
-                    receiver_id + assignment_id, self.do_nothing
-                )
+                use_func = self.handlers.get(receiver_id, self.do_nothing)
                 use_func(packet_dict['content'])
 
         def on_connect(client, server):
@@ -198,59 +224,46 @@ class MockAgent(object):
         self.disconnected = False
         self.task_group_id = task_group_id
         self.ws = None
-        self.always_beat = True
-        self.send_acks = True
         self.ready = False
         self.wants_to_send = False
-        self.acked_packet = []
-        self.incoming_hb = []
         self.message_packet = []
 
     def send_packet(self, packet):
         def callback(*args):
             pass
 
-        event_name = data_model.SOCKET_ROUTE_PACKET_STRING
+        event_name = data_model.MESSAGE_BATCH
         self.ws.send(json.dumps({'type': event_name, 'content': packet.as_dict()}))
 
-    def register_to_socket(self, ws):
-        handler = self.make_packet_handler()
+    def register_to_socket(self, ws, on_msg=None):
+        if on_msg is None:
+
+            def on_msg(packet):
+                self.message_packet.append(packet)
+                if packet.type == data_model.AGENT_STATE_CHANGE:
+                    if 'conversation_id' in packet.data:
+                        self.conversation_id = packet.data['conversation_id']
+                    if 'agent_id' in packet.data:
+                        self.id = packet.data['agent_id']
+
+        handler = self.make_packet_handler(on_msg)
         self.ws = ws
-        self.ws.handlers[self.worker_id + self.assignment_id] = handler
+        self.ws.handlers[self.worker_id] = handler
 
-    def on_msg(self, packet):
-        self.message_packet.append(packet)
-        if packet.data['text'] == data_model.COMMAND_CHANGE_CONVERSATION:
-            self.ready = False
-            self.conversation_id = packet.data['conversation_id']
-            self.id = packet.data['agent_id']
-            self.send_alive()
-
-    def make_packet_handler(self):
-        """A packet handler that properly sends heartbeats"""
-
-        def on_ack(*args):
-            self.acked_packet.append(args[0])
-
-        def on_hb(*args):
-            self.incoming_hb.append(args[0])
+    def make_packet_handler(self, on_msg):
+        """A packet handler"""
 
         def handler_mock(pkt):
-            if pkt['type'] == Packet.TYPE_ACK:
-                self.ready = True
+            if pkt['type'] == data_model.WORLD_MESSAGE:
                 packet = Packet.from_dict(pkt)
-                on_ack(packet)
-            elif pkt['type'] == Packet.TYPE_HEARTBEAT:
+                on_msg(packet)
+            elif pkt['type'] == data_model.MESSAGE_BATCH:
                 packet = Packet.from_dict(pkt)
-                on_hb(packet)
-                if self.always_beat:
-                    self.send_heartbeat()
-            elif pkt['type'] == Packet.TYPE_MESSAGE:
+                on_msg(packet)
+            elif pkt['type'] == data_model.AGENT_STATE_CHANGE:
                 packet = Packet.from_dict(pkt)
-                if self.send_acks:
-                    self.send_packet(packet.get_ack())
-                self.on_msg(packet)
-            elif pkt['type'] == Packet.TYPE_ALIVE:
+                on_msg(packet)
+            elif pkt['type'] == data_model.AGENT_ALIVE:
                 raise Exception('Invalid alive packet {}'.format(pkt))
             else:
                 raise Exception(
@@ -260,8 +273,9 @@ class MockAgent(object):
         return handler_mock
 
     def build_and_send_packet(self, packet_type, data):
+        msg_id = str(uuid.uuid4())
         msg = {
-            'id': str(uuid.uuid4()),
+            'id': msg_id,
             'type': packet_type,
             'sender_id': self.worker_id,
             'assignment_id': self.assignment_id,
@@ -270,10 +284,21 @@ class MockAgent(object):
             'data': data,
         }
 
-        event_name = data_model.SOCKET_ROUTE_PACKET_STRING
-        if packet_type == Packet.TYPE_ALIVE:
-            event_name = data_model.SOCKET_AGENT_ALIVE_STRING
-        self.ws.send(json.dumps({'type': event_name, 'content': msg}))
+        if packet_type == data_model.MESSAGE_BATCH:
+            msg['data'] = {
+                'messages': [
+                    {
+                        'id': msg_id,
+                        'type': packet_type,
+                        'sender_id': self.worker_id,
+                        'assignment_id': self.assignment_id,
+                        'conversation_id': self.conversation_id,
+                        'receiver_id': '[World_' + self.task_group_id + ']',
+                        'data': data,
+                    }
+                ]
+            }
+        self.ws.send(json.dumps({'type': packet_type, 'content': msg}))
         return msg['id']
 
     def send_message(self, text):
@@ -285,7 +310,18 @@ class MockAgent(object):
         }
 
         self.wants_to_send = False
-        return self.build_and_send_packet(Packet.TYPE_MESSAGE, data)
+        return self.build_and_send_packet(data_model.MESSAGE_BATCH, data)
+
+    def send_disconnect(self):
+        data = {
+            'hit_id': self.hit_id,
+            'assignment_id': self.assignment_id,
+            'worker_id': self.worker_id,
+            'conversation_id': self.conversation_id,
+            'connection_id': '{}_{}'.format(self.worker_id, self.assignment_id),
+        }
+
+        return self.build_and_send_packet(data_model.AGENT_DISCONNECT, data)
 
     def send_alive(self):
         data = {
@@ -294,33 +330,7 @@ class MockAgent(object):
             'worker_id': self.worker_id,
             'conversation_id': self.conversation_id,
         }
-        return self.build_and_send_packet(Packet.TYPE_ALIVE, data)
-
-    def send_heartbeat(self):
-        """Sends a heartbeat to the world"""
-        hb = {
-            'id': str(uuid.uuid4()),
-            'receiver_id': '[World_' + self.task_group_id + ']',
-            'assignment_id': self.assignment_id,
-            'sender_id': self.worker_id,
-            'conversation_id': self.conversation_id,
-            'type': Packet.TYPE_HEARTBEAT,
-            'data': None,
-        }
-        self.ws.send(
-            json.dumps({'type': data_model.SOCKET_ROUTE_PACKET_STRING, 'content': hb})
-        )
-
-    def wait_for_alive(self):
-        last_time = time.time()
-        while not self.ready:
-            self.send_alive()
-            time.sleep(0.5)
-            assert (
-                time.time() - last_time < 10
-            ), 'Timed out wating for server to acknowledge {} alive'.format(
-                self.worker_id
-            )
+        return self.build_and_send_packet(data_model.AGENT_ALIVE, data)
 
 
 class TestMTurkManagerWorkflows(unittest.TestCase):
@@ -372,6 +382,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         argparser.add_mturk_args()
         self.opt = argparser.parse_args(print_args=False)
         self.opt['task'] = 'unittest'
+        self.opt['frontend_version'] = 1
         self.opt['assignment_duration_in_seconds'] = 1
         self.opt['hit_title'] = 'test_hit_title'
         self.opt['hit_description'] = 'test_hit_description'
@@ -389,7 +400,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         self.mturk_manager.setup_server()
         self.mturk_manager.start_new_run()
         self.mturk_manager.ready_to_accept_workers()
-        self.mturk_manager.set_onboard_function(self.onboard_agent)
+        self.mturk_manager.set_get_onboard_world(self.get_onboard_world)
         self.mturk_manager.create_hits()
 
         def assign_worker_roles(workers):
@@ -398,7 +409,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
         def run_task_wait():
             self.mturk_manager.start_task(
-                lambda w: True, assign_worker_roles, self.run_conversation
+                lambda w: True, assign_worker_roles, self.get_task_world
             )
 
         self.task_thread = threading.Thread(target=run_task_wait)
@@ -415,35 +426,40 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         )
 
     def tearDown(self):
-        self.agent_1.always_beat = False
-        self.agent_2.always_beat = False
         for key in self.worlds_agents.keys():
             self.worlds_agents[key] = True
         self.mturk_manager.shutdown()
         self.fake_socket.close()
-        self.task_thread.join()
+        # if self.task_thread.isAlive():
+        #     self.task_thread.join()
 
-    def onboard_agent(self, worker):
-        self.onboarding_agents[worker.worker_id] = False
-        while (worker.worker_id in self.onboarding_agents) and (
-            self.onboarding_agents[worker.worker_id] is False
-        ):
-            time.sleep(0.05)
-        return
+    def get_onboard_world(self, mturk_agent):
+        self.onboarding_agents[mturk_agent.worker_id] = False
 
-    def run_conversation(self, mturk_manager, opt, workers):
+        def episode_done():
+            return not (
+                (mturk_agent.worker_id in self.onboarding_agents)
+                and (self.onboarding_agents[mturk_agent.worker_id] is False)
+            )
+
+        return TestMTurkOnboardWorld(mturk_agent, episode_done)
+
+    def get_task_world(self, mturk_manager, opt, workers):
         for worker in workers:
             self.worlds_agents[worker.worker_id] = False
-        for worker in workers:
-            while self.worlds_agents[worker.worker_id] is False:
-                time.sleep(0.05)
-        for worker in workers:
-            worker.shutdown(timeout=-1)
+
+        def episode_done():
+            for worker in workers:
+                if self.worlds_agents[worker.worker_id] is False:
+                    return False
+            return True
+
+        return TestMTurkWorld(workers, episode_done)
 
     def alive_agent(self, agent):
         agent.register_to_socket(self.fake_socket)
-        agent.wait_for_alive()
-        agent.send_heartbeat()
+        agent.send_alive()
+        time.sleep(0.3)
 
     def test_successful_convo(self):
         manager = self.mturk_manager
@@ -470,7 +486,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         self.assertFalse(self.onboarding_agents[agent_2.worker_id])
         self.assertEqual(agent_2_object.get_status(), AssignState.STATUS_ONBOARDING)
         self.onboarding_agents[agent_2.worker_id] = True
-        assert_equal_by(agent_2_object.get_status, AssignState.STATUS_WAITING, 2)
 
         # Assert agents move to task
         assert_equal_by(agent_2_object.get_status, AssignState.STATUS_IN_TASK, 2)
@@ -480,38 +495,13 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         # Complete agents
         self.worlds_agents[agent_1.worker_id] = True
         self.worlds_agents[agent_2.worker_id] = True
+        agent_1_object.set_completed_act({})
+        agent_2_object.set_completed_act({})
         assert_equal_by(agent_1_object.get_status, AssignState.STATUS_DONE, 2)
         assert_equal_by(agent_2_object.get_status, AssignState.STATUS_DONE, 2)
 
         # Assert conversation is complete for manager and agents
         assert_equal_by(lambda: manager.completed_conversations, 1, 2)
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_1.message_packet
-                    if p.data['text'] == data_model.COMMAND_SHOW_DONE_BUTTON
-                ]
-            ),
-            1,
-            2,
-        )
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_2.message_packet
-                    if p.data['text'] == data_model.COMMAND_SHOW_DONE_BUTTON
-                ]
-            ),
-            1,
-            2,
-        )
-
-        # Assert sockets are closed
-        assert_equal_by(
-            lambda: len([x for x in manager.socket_manager.run.values() if not x]), 2, 2
-        )
 
     def test_disconnect_end(self):
         manager = self.mturk_manager
@@ -538,7 +528,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         self.assertFalse(self.onboarding_agents[agent_2.worker_id])
         self.assertEqual(agent_2_object.get_status(), AssignState.STATUS_ONBOARDING)
         self.onboarding_agents[agent_2.worker_id] = True
-        assert_equal_by(agent_2_object.get_status, AssignState.STATUS_WAITING, 2)
 
         # Assert agents move to task
         assert_equal_by(agent_2_object.get_status, AssignState.STATUS_IN_TASK, 2)
@@ -546,47 +535,17 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         self.assertIn(agent_1.worker_id, self.worlds_agents)
 
         # Disconnect agent
-        agent_2.always_beat = False
+        agent_2.send_disconnect()
         assert_equal_by(
             agent_1_object.get_status, AssignState.STATUS_PARTNER_DISCONNECT, 3
         )
         assert_equal_by(agent_2_object.get_status, AssignState.STATUS_DISCONNECT, 3)
         self.worlds_agents[agent_1.worker_id] = True
         self.worlds_agents[agent_2.worker_id] = True
-        agent_2.always_beat = True
-        agent_2.send_alive()
-
-        # Assert workers get the correct command
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_1.message_packet
-                    if p.data['text'] == data_model.COMMAND_INACTIVE_DONE
-                ]
-            ),
-            1,
-            2,
-        )
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_2.message_packet
-                    if p.data['text'] == data_model.COMMAND_INACTIVE_HIT
-                ]
-            ),
-            1,
-            2,
-        )
 
         # assert conversation not marked as complete
         self.assertEqual(manager.completed_conversations, 0)
-
-        # Assert sockets are closed
-        assert_equal_by(
-            lambda: len([x for x in manager.socket_manager.run.values() if not x]), 2, 2
-        )
+        agent_1_object.set_completed_act({})
 
     def test_expire_onboarding(self):
         manager = self.mturk_manager
@@ -602,118 +561,9 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         self.assertEqual(agent_1_object.get_status(), AssignState.STATUS_ONBOARDING)
 
         manager._expire_onboarding_pool()
-
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_1.message_packet
-                    if p.data['text'] == data_model.COMMAND_EXPIRE_HIT
-                ]
-            ),
-            1,
-            10,
-        )
-
         self.onboarding_agents[agent_1.worker_id] = True
 
         self.assertEqual(agent_1_object.get_status(), AssignState.STATUS_EXPIRED)
-
-        # Assert sockets are closed
-        assert_equal_by(
-            lambda: len([x for x in manager.socket_manager.run.values() if not x]),
-            1,
-            10,
-        )
-
-    def test_reconnect_complete(self):
-        manager = self.mturk_manager
-
-        # Alive first agent
-        agent_1 = self.agent_1
-        self.alive_agent(agent_1)
-        assert_equal_by(lambda: agent_1.worker_id in self.onboarding_agents, True, 2)
-        agent_1_object = manager.worker_manager.get_agent_for_assignment(
-            agent_1.assignment_id
-        )
-        self.assertFalse(self.onboarding_agents[agent_1.worker_id])
-        self.assertEqual(agent_1_object.get_status(), AssignState.STATUS_ONBOARDING)
-        self.onboarding_agents[agent_1.worker_id] = True
-        assert_equal_by(agent_1_object.get_status, AssignState.STATUS_WAITING, 2)
-
-        # Alive second agent
-        agent_2 = self.agent_2
-        self.alive_agent(agent_2)
-        assert_equal_by(lambda: agent_2.worker_id in self.onboarding_agents, True, 2)
-        agent_2_object = manager.worker_manager.get_agent_for_assignment(
-            agent_2.assignment_id
-        )
-        self.assertFalse(self.onboarding_agents[agent_2.worker_id])
-        self.assertEqual(agent_2_object.get_status(), AssignState.STATUS_ONBOARDING)
-        self.onboarding_agents[agent_2.worker_id] = True
-        assert_equal_by(agent_2_object.get_status, AssignState.STATUS_WAITING, 2)
-
-        # Assert agents move to task
-        assert_equal_by(agent_2_object.get_status, AssignState.STATUS_IN_TASK, 2)
-        assert_equal_by(lambda: agent_2.worker_id in self.worlds_agents, True, 2)
-        self.assertIn(agent_1.worker_id, self.worlds_agents)
-
-        # Simulate reconnect to task
-        stored_conv_id = agent_2.conversation_id
-        stored_agent_id = agent_2.id
-        agent_2.conversation_id = None
-        agent_2.id = None
-        agent_2.send_alive()
-
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_2.message_packet
-                    if p.data['text'] == data_model.COMMAND_RESTORE_STATE
-                ]
-            ),
-            1,
-            4,
-        )
-        self.assertEqual(agent_2.id, stored_agent_id)
-        self.assertEqual(agent_2.conversation_id, stored_conv_id)
-
-        # Complete agents
-        self.worlds_agents[agent_1.worker_id] = True
-        self.worlds_agents[agent_2.worker_id] = True
-        assert_equal_by(agent_1_object.get_status, AssignState.STATUS_DONE, 2)
-        assert_equal_by(agent_2_object.get_status, AssignState.STATUS_DONE, 2)
-
-        # Assert conversation is complete for manager and agents
-        assert_equal_by(lambda: manager.completed_conversations, 1, 2)
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_1.message_packet
-                    if p.data['text'] == data_model.COMMAND_SHOW_DONE_BUTTON
-                ]
-            ),
-            1,
-            2,
-        )
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_2.message_packet
-                    if p.data['text'] == data_model.COMMAND_SHOW_DONE_BUTTON
-                ]
-            ),
-            1,
-            2,
-        )
-
-        # Assert sockets are closed
-        assert_equal_by(
-            lambda: len([x for x in manager.socket_manager.run.values() if not x]), 2, 2
-        )
 
     def test_attempt_break_unique(self):
         manager = self.mturk_manager
@@ -744,7 +594,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         self.assertFalse(self.onboarding_agents[agent_2.worker_id])
         self.assertEqual(agent_2_object.get_status(), AssignState.STATUS_ONBOARDING)
         self.onboarding_agents[agent_2.worker_id] = True
-        assert_equal_by(agent_2_object.get_status, AssignState.STATUS_WAITING, 2)
 
         # Assert agents move to task
         assert_equal_by(agent_2_object.get_status, AssignState.STATUS_IN_TASK, 2)
@@ -754,38 +603,13 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         # Complete agents
         self.worlds_agents[agent_1.worker_id] = True
         self.worlds_agents[agent_2.worker_id] = True
+        agent_1_object.set_completed_act({})
+        agent_2_object.set_completed_act({})
         assert_equal_by(agent_1_object.get_status, AssignState.STATUS_DONE, 2)
         assert_equal_by(agent_2_object.get_status, AssignState.STATUS_DONE, 2)
 
         # Assert conversation is complete for manager and agents
         assert_equal_by(lambda: manager.completed_conversations, 1, 2)
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_1.message_packet
-                    if p.data['text'] == data_model.COMMAND_SHOW_DONE_BUTTON
-                ]
-            ),
-            1,
-            2,
-        )
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_2.message_packet
-                    if p.data['text'] == data_model.COMMAND_SHOW_DONE_BUTTON
-                ]
-            ),
-            1,
-            2,
-        )
-
-        # Assert sockets are closed
-        assert_equal_by(
-            lambda: len([x for x in manager.socket_manager.run.values() if not x]), 2, 2
-        )
 
         # ensure qualification was 'granted'
         self.mturk_utils.find_qualification.assert_called_with(
@@ -808,23 +632,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
         # No worker should be created for a unique task
         self.assertIsNone(agent_1_2_object)
-
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_1_2.message_packet
-                    if p.data['text'] == data_model.COMMAND_EXPIRE_HIT
-                ]
-            ),
-            1,
-            2,
-        )
-
-        # Assert sockets are closed
-        assert_equal_by(
-            lambda: len([x for x in manager.socket_manager.run.values() if not x]), 3, 2
-        )
 
     def test_break_multi_convo(self):
         manager = self.mturk_manager
@@ -852,7 +659,6 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         self.assertFalse(self.onboarding_agents[agent_2.worker_id])
         self.assertEqual(agent_2_object.get_status(), AssignState.STATUS_ONBOARDING)
         self.onboarding_agents[agent_2.worker_id] = True
-        assert_equal_by(agent_2_object.get_status, AssignState.STATUS_WAITING, 2)
 
         # Assert agents move to task
         assert_equal_by(agent_2_object.get_status, AssignState.STATUS_IN_TASK, 2)
@@ -870,62 +676,19 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         # No worker should be created for a unique task
         self.assertIsNone(agent_1_2_object)
 
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_1_2.message_packet
-                    if p.data['text'] == data_model.COMMAND_EXPIRE_HIT
-                ]
-            ),
-            1,
-            2,
-        )
-
-        # Assert sockets are closed
-        assert_equal_by(
-            lambda: len([x for x in manager.socket_manager.run.values() if not x]), 1, 2
-        )
-
         # Complete agents
         self.worlds_agents[agent_1.worker_id] = True
         self.worlds_agents[agent_2.worker_id] = True
+        agent_1_object.set_completed_act({})
+        agent_2_object.set_completed_act({})
         assert_equal_by(agent_1_object.get_status, AssignState.STATUS_DONE, 2)
         assert_equal_by(agent_2_object.get_status, AssignState.STATUS_DONE, 2)
 
-        # Assert conversation is complete for manager and agents
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_1.message_packet
-                    if p.data['text'] == data_model.COMMAND_SHOW_DONE_BUTTON
-                ]
-            ),
-            1,
-            2,
-        )
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_2.message_packet
-                    if p.data['text'] == data_model.COMMAND_SHOW_DONE_BUTTON
-                ]
-            ),
-            1,
-            2,
-        )
         assert_equal_by(lambda: manager.completed_conversations, 1, 2)
-
-        # Assert sockets are closed
-        assert_equal_by(
-            lambda: len([x for x in manager.socket_manager.run.values() if not x]), 3, 2
-        )
 
     def test_no_onboard_expire_waiting(self):
         manager = self.mturk_manager
-        manager.set_onboard_function(None)
+        manager.set_get_onboard_world(None)
 
         # Alive first agent
         agent_1 = self.agent_1
@@ -937,71 +700,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
 
         manager._expire_agent_pool()
 
-        assert_equal_by(
-            lambda: len(
-                [
-                    p
-                    for p in agent_1.message_packet
-                    if p.data['text'] == data_model.COMMAND_EXPIRE_HIT
-                ]
-            ),
-            1,
-            2,
-        )
-
-        # Assert sockets are closed
-        assert_equal_by(
-            lambda: len([x for x in manager.socket_manager.run.values() if not x]), 1, 2
-        )
-
-    def test_return_to_waiting_on_world_start(self):
-        manager = self.mturk_manager
-
-        # Alive first agent
-        agent_1 = self.agent_1
-        self.alive_agent(agent_1)
-        assert_equal_by(lambda: agent_1.worker_id in self.onboarding_agents, True, 2)
-        agent_1_object = manager.worker_manager.get_agent_for_assignment(
-            agent_1.assignment_id
-        )
-        self.assertFalse(self.onboarding_agents[agent_1.worker_id])
-        self.assertEqual(agent_1_object.get_status(), AssignState.STATUS_ONBOARDING)
-        self.onboarding_agents[agent_1.worker_id] = True
-        assert_equal_by(agent_1_object.get_status, AssignState.STATUS_WAITING, 2)
-
-        # Make agent_1 no longer respond to change_conversation_requests
-        def replace_on_msg(packet):
-            agent_1.message_packet.append(packet)
-
-        agent_1.on_msg = replace_on_msg
-
-        # Alive second agent
-        agent_2 = self.agent_2
-        self.alive_agent(agent_2)
-        assert_equal_by(lambda: agent_2.worker_id in self.onboarding_agents, True, 2)
-        agent_2_object = manager.worker_manager.get_agent_for_assignment(
-            agent_2.assignment_id
-        )
-        self.assertFalse(self.onboarding_agents[agent_2.worker_id])
-        self.assertEqual(agent_2_object.get_status(), AssignState.STATUS_ONBOARDING)
-        self.onboarding_agents[agent_2.worker_id] = True
-        assert_equal_by(agent_2_object.get_status, AssignState.STATUS_WAITING, 2)
-
-        # Assert agents attempt to move to task, but then move back to waiting
-        assert_equal_by(agent_2_object.get_status, AssignState.STATUS_IN_TASK, 2)
-        assert_equal_by(agent_2_object.get_status, AssignState.STATUS_WAITING, 3)
-        agent_1.always_beat = False
-
-        # Assert no world ever started
-        self.assertNotIn(agent_2.worker_id, self.worlds_agents)
-
-        # Expire everything
-        manager.shutdown()
-
-        # Assert sockets are closed
-        assert_equal_by(
-            lambda: len([x for x in manager.socket_manager.run.values() if not x]), 2, 2
-        )
+        self.assertEqual(agent_1_object.get_status(), AssignState.STATUS_EXPIRED)
 
 
 if __name__ == '__main__':

--- a/parlai/mturk/core/dev/test/test_mturk_agent.py
+++ b/parlai/mturk/core/dev/test/test_mturk_agent.py
@@ -216,7 +216,6 @@ class TestMTurkAgent(unittest.TestCase):
         self.assertEqual(self.turk_agent.get_connection_id(), connection_id)
 
     def test_status_change(self):
-        has_changed = False
         self.turk_agent.set_status(AssignState.STATUS_ONBOARDING)
         time.sleep(0.07)
         self.assertEqual(self.turk_agent.get_status(), AssignState.STATUS_ONBOARDING)
@@ -256,12 +255,14 @@ class TestMTurkAgent(unittest.TestCase):
 
         self.turk_agent.disconnected = True
         with self.assertRaises(AgentDisconnectedError):
-            _disconnect_message = self.turk_agent.get_new_act_message()
+            # Expect this to be a disconnect message
+            self.turk_agent.get_new_act_message()
         self.turk_agent.disconnected = False
 
         self.turk_agent.hit_is_returned = True
         with self.assertRaises(AgentReturnedError):
-            _return_message = self.turk_agent.get_new_act_message()
+            # Expect this to be a returned message
+            self.turk_agent.get_new_act_message()
         self.turk_agent.hit_is_returned = False
 
         # Reduce state

--- a/parlai/mturk/core/dev/test/test_mturk_agent.py
+++ b/parlai/mturk/core/dev/test/test_mturk_agent.py
@@ -9,12 +9,18 @@ import os
 import time
 import threading
 from unittest import mock
-from parlai.mturk.core.agents import MTurkAgent, AssignState
-from parlai.mturk.core.mturk_manager import MTurkManager
+from parlai.mturk.core.dev.agents import (
+    MTurkAgent,
+    AssignState,
+    AgentTimeoutError,
+    AgentDisconnectedError,
+    AgentReturnedError,
+)
+from parlai.mturk.core.dev.mturk_manager import MTurkManager
 from parlai.core.params import ParlaiParser
 
-import parlai.mturk.core.worker_manager as WorkerManagerFile
-import parlai.mturk.core.data_model as data_model
+import parlai.mturk.core.dev.worker_manager as WorkerManagerFile
+import parlai.mturk.core.dev.data_model as data_model
 
 parent_dir = os.path.dirname(os.path.abspath(__file__))
 WorkerManagerFile.DISCONNECT_FILE_NAME = 'disconnect-test.pickle'
@@ -31,7 +37,7 @@ MESSAGE_ID_1 = 'MESSAGE_ID_1'
 MESSAGE_ID_2 = 'MESSAGE_ID_2'
 COMMAND_ID_1 = 'COMMAND_ID_1'
 
-MESSAGE_TYPE = data_model.MESSAGE_TYPE_MESSAGE
+MESSAGE_TYPE = data_model.MESSAGE_TYPE_ACT
 COMMAND_TYPE = data_model.MESSAGE_TYPE_COMMAND
 
 MESSAGE_1 = {'message_id': MESSAGE_ID_1, 'type': MESSAGE_TYPE}
@@ -84,11 +90,9 @@ class TestAssignState(unittest.TestCase):
         self.assertEqual(self.agent_state1.status, AssignState.STATUS_NONE)
         self.assertEqual(len(self.agent_state1.messages), 0)
         self.assertEqual(len(self.agent_state1.message_ids), 0)
-        self.assertIsNone(self.agent_state1.last_command)
         self.assertEqual(self.agent_state2.status, AssignState.STATUS_IN_TASK)
         self.assertEqual(len(self.agent_state1.messages), 0)
         self.assertEqual(len(self.agent_state1.message_ids), 0)
-        self.assertIsNone(self.agent_state1.last_command)
 
     def test_message_management(self):
         '''Test message management in an AssignState'''
@@ -106,15 +110,10 @@ class TestAssignState(unittest.TestCase):
         self.agent_state2.append_message(MESSAGE_1)
         self.assertEqual(len(self.agent_state2.message_ids), 1)
 
-        # Ensure command interactions work as expected
-        self.agent_state1.set_last_command(COMMAND_1)
-        self.assertEqual(self.agent_state1.get_last_command(), COMMAND_1)
-
         # Ensure clearing messages acts as intended and doesn't clear agent2
         self.agent_state1.clear_messages()
         self.assertEqual(len(self.agent_state1.messages), 0)
         self.assertEqual(len(self.agent_state1.message_ids), 0)
-        self.assertIsNone(self.agent_state1.last_command)
         self.assertEqual(len(self.agent_state2.message_ids), 1)
 
     def test_state_handles_status(self):
@@ -132,13 +131,6 @@ class TestAssignState(unittest.TestCase):
             self.agent_state1.set_status(status)
             self.assertTrue(self.agent_state1.is_final())
 
-        # TODO update the below once bonus is default
-        for status in complete_statuses:
-            self.agent_state1.set_status(status)
-            text, command = self.agent_state1.get_inactive_command_text()
-            self.assertIsNotNone(text)
-            self.assertIsNotNone(command)
-
 
 class TestMTurkAgent(unittest.TestCase):
     """Various unit tests for the MTurkAgent class"""
@@ -155,6 +147,9 @@ class TestMTurkAgent(unittest.TestCase):
             opt=self.opt.copy(), mturk_agent_ids=mturk_agent_ids
         )
         self.worker_manager = self.mturk_manager.worker_manager
+        self.mturk_manager.send_message = mock.MagicMock()
+        self.mturk_manager.send_state_change = mock.MagicMock()
+        self.mturk_manager.send_command = mock.MagicMock()
 
         self.turk_agent = MTurkAgent(
             self.opt.copy(),
@@ -183,7 +178,6 @@ class TestMTurkAgent(unittest.TestCase):
         self.assertFalse(self.turk_agent.hit_is_returned)
         self.assertFalse(self.turk_agent.hit_is_complete)
         self.assertFalse(self.turk_agent.disconnected)
-        self.assertTrue(self.turk_agent.alived)
 
     def test_state_wrappers(self):
         '''Test the mturk agent wrappers around its state'''
@@ -202,27 +196,17 @@ class TestMTurkAgent(unittest.TestCase):
             self.turk_agent.set_status(status)
             self.assertTrue(self.turk_agent.is_final())
 
-        self.turk_agent.append_message(MESSAGE_1)
+        self.turk_agent.state.append_message(MESSAGE_1)
         self.assertEqual(len(self.turk_agent.get_messages()), 1)
-        self.turk_agent.append_message(MESSAGE_2)
+        self.turk_agent.state.append_message(MESSAGE_2)
         self.assertEqual(len(self.turk_agent.get_messages()), 2)
-        self.turk_agent.append_message(MESSAGE_1)
+        self.turk_agent.state.append_message(MESSAGE_1)
         self.assertEqual(len(self.turk_agent.get_messages()), 2)
         self.assertIn(MESSAGE_1, self.turk_agent.get_messages())
         self.assertIn(MESSAGE_2, self.turk_agent.get_messages())
 
-        # Ensure command interactions work as expected
-        self.turk_agent.set_last_command(COMMAND_1)
-        self.assertEqual(self.turk_agent.get_last_command(), COMMAND_1)
-
         self.turk_agent.clear_messages()
         self.assertEqual(len(self.turk_agent.get_messages()), 0)
-
-        # In task checks
-        self.turk_agent.conversation_id = 't_12345'
-        self.assertTrue(self.turk_agent.is_in_task())
-        self.turk_agent.conversation_id = 'b_12345'
-        self.assertFalse(self.turk_agent.is_in_task())
 
     def test_connection_id(self):
         '''Ensure the connection_id hasn't changed'''
@@ -231,37 +215,17 @@ class TestMTurkAgent(unittest.TestCase):
         )
         self.assertEqual(self.turk_agent.get_connection_id(), connection_id)
 
-    def test_inactive_data(self):
-        '''Ensure data packet generated for inactive commands is valid'''
-        for status in complete_statuses:
-            self.turk_agent.set_status(status)
-            data = self.turk_agent.get_inactive_command_data()
-            self.assertIsNotNone(data['text'])
-            self.assertIsNotNone(data['inactive_text'])
-            self.assertEqual(data['conversation_id'], self.turk_agent.conversation_id)
-            self.assertEqual(data['agent_id'], TEST_WORKER_ID_1)
-
     def test_status_change(self):
         has_changed = False
         self.turk_agent.set_status(AssignState.STATUS_ONBOARDING)
-
-        def wait_for_status_wrap():
-            nonlocal has_changed  # noqa 999 we don't use python2
-            self.turk_agent.wait_for_status(AssignState.STATUS_WAITING)
-            has_changed = True
-
-        t = threading.Thread(target=wait_for_status_wrap, daemon=True)
-        t.start()
-        self.assertFalse(has_changed)
         time.sleep(0.07)
-        self.assertFalse(has_changed)
+        self.assertEqual(self.turk_agent.get_status(), AssignState.STATUS_ONBOARDING)
         self.turk_agent.set_status(AssignState.STATUS_WAITING)
         time.sleep(0.07)
-        self.assertTrue(has_changed)
+        self.assertEqual(self.turk_agent.get_status(), AssignState.STATUS_WAITING)
 
     def test_message_queue(self):
         '''Ensure observations and acts work as expected'''
-        self.mturk_manager.send_message = mock.MagicMock()
         self.turk_agent.observe(ACT_1)
         self.mturk_manager.send_message.assert_called_with(
             TEST_WORKER_ID_1, TEST_ASSIGNMENT_ID_1, ACT_1
@@ -291,14 +255,13 @@ class TestMTurkAgent(unittest.TestCase):
         self.assertIsNone(blank_message)
 
         self.turk_agent.disconnected = True
-        disconnect_message = self.turk_agent.get_new_act_message()
+        with self.assertRaises(AgentDisconnectedError):
+            _disconnect_message = self.turk_agent.get_new_act_message()
         self.turk_agent.disconnected = False
-        self.assertEqual(
-            disconnect_message['text'], self.turk_agent.MTURK_DISCONNECT_MESSAGE
-        )
+
         self.turk_agent.hit_is_returned = True
-        return_message = self.turk_agent.get_new_act_message()
-        self.assertEqual(return_message['text'], self.turk_agent.RETURN_MESSAGE)
+        with self.assertRaises(AgentReturnedError):
+            _return_message = self.turk_agent.get_new_act_message()
         self.turk_agent.hit_is_returned = False
 
         # Reduce state
@@ -307,7 +270,6 @@ class TestMTurkAgent(unittest.TestCase):
         self.assertIsNone(self.turk_agent.recieved_packets)
 
     def test_message_acts(self):
-        self.mturk_manager.send_command = mock.MagicMock()
         self.mturk_manager.handle_turker_timeout = mock.MagicMock()
 
         # non-Blocking check
@@ -323,23 +285,17 @@ class TestMTurkAgent(unittest.TestCase):
         self.mturk_manager.send_command.assert_called_once()
 
         # non-Blocking timeout check
-        self.mturk_manager.send_command = mock.MagicMock()
-        returned_act = self.turk_agent.act(timeout=0.07, blocking=False)
-        self.assertIsNotNone(self.turk_agent.message_request_time)
-        self.assertIsNone(returned_act)
-        while returned_act is None:
+        with self.assertRaises(AgentTimeoutError):
+            self.mturk_manager.send_command = mock.MagicMock()
             returned_act = self.turk_agent.act(timeout=0.07, blocking=False)
-        self.mturk_manager.send_command.assert_called_once()
-        self.mturk_manager.handle_turker_timeout.assert_called_once()
-        self.assertEqual(returned_act['text'], self.turk_agent.TIMEOUT_MESSAGE)
+            self.assertIsNotNone(self.turk_agent.message_request_time)
+            self.assertIsNone(returned_act)
+            while returned_act is None:
+                returned_act = self.turk_agent.act(timeout=0.07, blocking=False)
 
         # Blocking timeout check
-        self.mturk_manager.send_command = mock.MagicMock()
-        self.mturk_manager.handle_turker_timeout = mock.MagicMock()
-        returned_act = self.turk_agent.act(timeout=0.07)
-        self.mturk_manager.send_command.assert_called_once()
-        self.mturk_manager.handle_turker_timeout.assert_called_once()
-        self.assertEqual(returned_act['text'], self.turk_agent.TIMEOUT_MESSAGE)
+        with self.assertRaises(AgentTimeoutError):
+            returned_act = self.turk_agent.act(timeout=0.07)
 
 
 if __name__ == '__main__':

--- a/parlai/mturk/core/dev/test/test_mturk_manager.py
+++ b/parlai/mturk/core/dev/test/test_mturk_manager.py
@@ -11,15 +11,16 @@ import json
 import threading
 import pickle
 from unittest import mock
-from parlai.mturk.core.worker_manager import WorkerManager
-from parlai.mturk.core.agents import MTurkAgent, AssignState
-from parlai.mturk.core.mturk_manager import MTurkManager
-from parlai.mturk.core.socket_manager import SocketManager, Packet
+from parlai.mturk.core.dev.worker_manager import WorkerManager
+from parlai.mturk.core.dev.agents import MTurkAgent, AssignState
+from parlai.mturk.core.dev.worlds import MTurkOnboardWorld, MTurkTaskWorld
+from parlai.mturk.core.dev.mturk_manager import MTurkManager
+from parlai.mturk.core.dev.socket_manager import SocketManager, Packet
 from parlai.core.params import ParlaiParser
 from websocket_server import WebsocketServer
 
-import parlai.mturk.core.mturk_manager as MTurkManagerFile
-import parlai.mturk.core.data_model as data_model
+import parlai.mturk.core.dev.mturk_manager as MTurkManagerFile
+import parlai.mturk.core.dev.data_model as data_model
 
 parent_dir = os.path.dirname(os.path.abspath(__file__))
 MTurkManagerFile.parent_dir = os.path.dirname(os.path.abspath(__file__))
@@ -50,6 +51,11 @@ def assert_equal_by(val_func, val, max_time):
         time.sleep(0.1)
 
 
+def get_onboard_world(mturk_agent=None):
+    time.sleep(1)
+    return MTurkOnboardWorld({}, mturk_agent)
+
+
 class MockSocket:
     def __init__(self):
         self.last_messages = {}
@@ -57,7 +63,6 @@ class MockSocket:
         self.disconnected = False
         self.closed = False
         self.ws = None
-        self.should_heartbeat = True
         self.fake_workers = []
         self.port = None
         self.launch_socket()
@@ -88,14 +93,12 @@ class MockSocket:
             if packet_dict['content']['id'] == 'WORLD_ALIVE':
                 self.ws.send_message(client, json.dumps({'type': 'conn_success'}))
                 self.connected = True
-            elif packet_dict['content']['type'] == 'heartbeat':
+            elif packet_dict['type'] == data_model.WORLD_PING:
                 pong = packet_dict['content'].copy()
                 pong['type'] = 'pong'
                 self.ws.send_message(
                     client,
-                    json.dumps(
-                        {'type': data_model.SOCKET_ROUTE_PACKET_STRING, 'content': pong}
-                    ),
+                    json.dumps({'type': data_model.SERVER_PONG, 'content': pong}),
                 )
             if 'receiver_id' in packet_dict['content']:
                 receiver_id = packet_dict['content']['receiver_id']
@@ -155,9 +158,9 @@ class InitTestMTurkManager(unittest.TestCase):
         self.assertIsNone(manager.task_group_id)
         self.assertIsNone(manager.run_id)
         self.assertIsNone(manager.task_files_to_copy)
-        self.assertIsNone(manager.onboard_function)
+        self.assertIsNone(manager.get_onboard_world)
         self.assertIsNone(manager.socket_manager)
-        self.assertFalse(manager.is_shutdown)
+        self.assertFalse(manager.is_shutdown.is_set())
         self.assertFalse(manager.is_unique)
         self.assertEqual(manager.opt, opt)
         self.assertEqual(manager.mturk_agent_ids, self.mturk_agent_ids)
@@ -212,6 +215,7 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
             opt=self.opt, mturk_agent_ids=self.mturk_agent_ids, is_test=True
         )
         self.mturk_manager._init_state()
+        self.mturk_manager.send_state_change = mock.MagicMock()
         self.mturk_manager.port = self.fake_socket.port
         self.agent_1 = MTurkAgent(
             self.opt,
@@ -241,7 +245,6 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
 
     def test_move_to_waiting(self):
         manager = self.mturk_manager
-        manager.worker_manager.change_agent_conversation = mock.MagicMock()
         manager.socket_manager = mock.MagicMock()
         manager.socket_manager.close_channel = mock.MagicMock()
         manager.force_expire_hit = mock.MagicMock()
@@ -256,7 +259,6 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         manager.socket_manager.close_channel.assert_called_once_with(
             self.agent_1.get_connection_id()
         )
-        manager.worker_manager.change_agent_conversation.assert_not_called()
         manager.force_expire_hit.assert_not_called()
         manager.socket_manager.close_channel.reset_mock()
 
@@ -264,20 +266,13 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         manager._move_agents_to_waiting([self.agent_2])
         self.agent_2.reduce_state.assert_not_called()
         manager.socket_manager.close_channel.assert_not_called()
-        manager.worker_manager.change_agent_conversation.assert_called_once()
-        args = manager.worker_manager.change_agent_conversation.call_args[1]
-        self.assertEqual(args['agent'], self.agent_2)
-        self.assertTrue(manager.is_waiting_world(args['conversation_id']))
-        self.assertEqual(args['new_agent_id'], 'waiting')
         manager.force_expire_hit.assert_not_called()
-        manager.worker_manager.change_agent_conversation.reset_mock()
 
         # Test when no longer accepting agents
         manager.accepting_workers = False
         manager._move_agents_to_waiting([self.agent_3])
         self.agent_3.reduce_state.assert_not_called()
         manager.socket_manager.close_channel.assert_not_called()
-        manager.worker_manager.change_agent_conversation.assert_not_called()
         manager.force_expire_hit.assert_called_once_with(
             self.agent_3.worker_id, self.agent_3.assignment_id
         )
@@ -375,196 +370,8 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         self.assertIsInstance(agent, MTurkAgent)
         self.assertEqual(agent.get_status(), AssignState.STATUS_NONE)
 
-        # Reconnect in various conditions
-        agent.set_status = mock.MagicMock(wraps=agent.set_status)
-        manager._add_agent_to_pool = mock.MagicMock()
-
-        # Reconnect when none state no connection_id
-        agent.log_reconnect = mock.MagicMock(wraps=agent.log_reconnect)
-        manager._on_alive(alive_packet)
-        manager.force_expire_hit.assert_called_once_with(
-            TEST_WORKER_ID_1, TEST_ASSIGNMENT_ID_1
-        )
-        manager.force_expire_hit.reset_mock()
-        agent.set_status.assert_not_called()
-        manager._add_agent_to_pool.assert_not_called()
-        agent.log_reconnect.assert_called_once()
-        agent.log_reconnect.reset_mock()
-
-        # Reconnect in None state onboarding conversation_id
-        alive_packet = Packet(
-            '',
-            '',
-            '',
-            '',
-            '',
-            {
-                'worker_id': TEST_WORKER_ID_1,
-                'hit_id': TEST_HIT_ID_1,
-                'assignment_id': TEST_ASSIGNMENT_ID_1,
-                'conversation_id': 'o_1234',
-            },
-            '',
-        )
-        manager._on_alive(alive_packet)
-        manager.force_expire_hit.assert_not_called()
-        agent.set_status.assert_called_once_with(AssignState.STATUS_ONBOARDING)
-        manager._add_agent_to_pool.assert_not_called()
-        agent.log_reconnect.assert_called_once()
-        agent.log_reconnect.reset_mock()
-
-        # Reconnect in None state waiting conversation_id
-        alive_packet = Packet(
-            '',
-            '',
-            '',
-            '',
-            '',
-            {
-                'worker_id': TEST_WORKER_ID_1,
-                'hit_id': TEST_HIT_ID_1,
-                'assignment_id': TEST_ASSIGNMENT_ID_1,
-                'conversation_id': 'w_1234',
-            },
-            '',
-        )
-        agent.set_status(AssignState.STATUS_NONE)
-        agent.set_status.reset_mock()
-        manager._on_alive(alive_packet)
-        manager.force_expire_hit.assert_not_called()
-        agent.set_status.assert_called_once_with(AssignState.STATUS_WAITING)
-        manager._add_agent_to_pool.assert_called_once_with(agent)
-        manager._add_agent_to_pool.reset_mock()
-        agent.log_reconnect.assert_called_once()
-        agent.log_reconnect.reset_mock()
-
-        # Reconnect in onboarding with waiting conversation id
-        agent.set_status(AssignState.STATUS_ONBOARDING)
-        agent.set_status.reset_mock()
-        manager._on_alive(alive_packet)
-        manager.force_expire_hit.assert_not_called()
-        agent.set_status.assert_called_once_with(AssignState.STATUS_WAITING)
-        manager._add_agent_to_pool.assert_called_once_with(agent)
-        manager._add_agent_to_pool.reset_mock()
-        agent.log_reconnect.assert_called_once()
-        agent.log_reconnect.reset_mock()
-
-        # Reconnect in onboarding with no conversation id
-        alive_packet = Packet(
-            '',
-            '',
-            '',
-            '',
-            '',
-            {
-                'worker_id': TEST_WORKER_ID_1,
-                'hit_id': TEST_HIT_ID_1,
-                'assignment_id': TEST_ASSIGNMENT_ID_1,
-                'conversation_id': None,
-            },
-            '',
-        )
-        agent.set_status(AssignState.STATUS_ONBOARDING)
-        agent.set_status.reset_mock()
-        manager._restore_agent_state = mock.MagicMock()
-        manager._on_alive(alive_packet)
-        manager.force_expire_hit.assert_not_called()
-        manager._restore_agent_state.assert_called_once_with(
-            TEST_WORKER_ID_1, TEST_ASSIGNMENT_ID_1
-        )
-        agent.set_status.assert_not_called()
-        manager._add_agent_to_pool.assert_not_called()
-        agent.log_reconnect.assert_called_once()
-        agent.log_reconnect.reset_mock()
-
-        # Reconnect in onboarding but not accepting new workers
-        manager.accepting_workers = False
-        agent.set_status(AssignState.STATUS_ONBOARDING)
-        agent.set_status.reset_mock()
-        manager._restore_agent_state = mock.MagicMock()
-        manager._on_alive(alive_packet)
-        manager.force_expire_hit.assert_called_once_with(
-            TEST_WORKER_ID_1, TEST_ASSIGNMENT_ID_1
-        )
-        manager.force_expire_hit.reset_mock()
-        manager._restore_agent_state.assert_not_called()
-        agent.set_status.assert_not_called()
-        manager._add_agent_to_pool.assert_not_called()
-        agent.log_reconnect.assert_called_once()
-        agent.log_reconnect.reset_mock()
-
-        # Reconnect in waiting no conv id
-        manager.accepting_workers = True
-        agent.set_status(AssignState.STATUS_WAITING)
-        agent.set_status.reset_mock()
-        manager._restore_agent_state = mock.MagicMock()
-        manager._on_alive(alive_packet)
-        manager.force_expire_hit.assert_not_called()
-        manager._restore_agent_state.assert_called_once_with(
-            TEST_WORKER_ID_1, TEST_ASSIGNMENT_ID_1
-        )
-        agent.set_status.assert_not_called()
-        manager._add_agent_to_pool.assert_called_once()
-        manager._add_agent_to_pool.reset_mock()
-        agent.log_reconnect.assert_called_once()
-        agent.log_reconnect.reset_mock()
-
-        # Reconnect in waiting with conv id
-        alive_packet = Packet(
-            '',
-            '',
-            '',
-            '',
-            '',
-            {
-                'worker_id': TEST_WORKER_ID_1,
-                'hit_id': TEST_HIT_ID_1,
-                'assignment_id': TEST_ASSIGNMENT_ID_1,
-                'conversation_id': 'w_1234',
-            },
-            '',
-        )
-        agent.set_status(AssignState.STATUS_WAITING)
-        agent.set_status.reset_mock()
-        manager._restore_agent_state = mock.MagicMock()
-        manager._on_alive(alive_packet)
-        manager.force_expire_hit.assert_not_called()
-        manager._restore_agent_state.assert_not_called()
-        agent.set_status.assert_not_called()
-        manager._add_agent_to_pool.assert_called_once()
-        manager._add_agent_to_pool.reset_mock()
-        agent.log_reconnect.assert_called_once()
-        agent.log_reconnect.reset_mock()
-
-        # Reconnect in waiting with task id
-        alive_packet = Packet(
-            '',
-            '',
-            '',
-            '',
-            '',
-            {
-                'worker_id': TEST_WORKER_ID_1,
-                'hit_id': TEST_HIT_ID_1,
-                'assignment_id': TEST_ASSIGNMENT_ID_1,
-                'conversation_id': 't_1234',
-            },
-            '',
-        )
-        agent.set_status(AssignState.STATUS_WAITING)
-        agent.set_status.reset_mock()
-        manager._restore_agent_state = mock.MagicMock()
-        manager._on_alive(alive_packet)
-        manager.force_expire_hit.assert_not_called()
-        manager._restore_agent_state.assert_not_called()
-        agent.set_status.assert_called_with(AssignState.STATUS_IN_TASK)
-        manager._add_agent_to_pool.assert_not_called()
-        agent.log_reconnect.assert_called_once()
-        agent.log_reconnect.reset_mock()
-
         # Test active convos failure
         agent.set_status(AssignState.STATUS_IN_TASK)
-        agent.set_status.reset_mock()
         alive_packet = Packet(
             '',
             '',
@@ -581,14 +388,12 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         )
         manager.opt['allowed_conversations'] = 1
         manager._on_alive(alive_packet)
-        agent.set_status.assert_not_called()
         manager.force_expire_hit.assert_called_once()
         manager._onboard_new_agent.assert_not_called()
         manager.force_expire_hit.reset_mock()
 
         # Test uniqueness failed
         agent.set_status(AssignState.STATUS_DONE)
-        agent.set_status.reset_mock()
         alive_packet = Packet(
             '',
             '',
@@ -605,53 +410,9 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         )
         manager.is_unique = True
         manager._on_alive(alive_packet)
-        agent.set_status.assert_not_called()
         manager.force_expire_hit.assert_called_once()
         manager._onboard_new_agent.assert_not_called()
         manager.force_expire_hit.reset_mock()
-
-        # Test in task reconnects
-        agent.set_status(AssignState.STATUS_IN_TASK)
-        agent.set_status.reset_mock()
-        alive_packet = Packet(
-            '',
-            '',
-            '',
-            '',
-            '',
-            {
-                'worker_id': TEST_WORKER_ID_1,
-                'hit_id': TEST_HIT_ID_1,
-                'assignment_id': TEST_ASSIGNMENT_ID_1,
-                'conversation_id': None,
-            },
-            '',
-        )
-        manager._on_alive(alive_packet)
-        manager._restore_agent_state.assert_called_once_with(
-            TEST_WORKER_ID_1, TEST_ASSIGNMENT_ID_1
-        )
-        agent.set_status.assert_not_called()
-        manager._add_agent_to_pool.assert_not_called()
-        agent.log_reconnect.assert_called_once()
-        agent.log_reconnect.reset_mock()
-
-        # Test all final states
-        for use_state in [
-            AssignState.STATUS_DISCONNECT,
-            AssignState.STATUS_DONE,
-            AssignState.STATUS_EXPIRED,
-            AssignState.STATUS_RETURNED,
-            AssignState.STATUS_PARTNER_DISCONNECT,
-        ]:
-            manager.send_command = mock.MagicMock()
-            agent.set_status(use_state)
-            agent.set_status.reset_mock()
-            manager._on_alive(alive_packet)
-            agent.set_status.assert_not_called()
-            manager._add_agent_to_pool.assert_not_called()
-            manager.force_expire_hit.assert_not_called()
-            manager.send_command.assert_called_once()
 
     def test_mturk_messages(self):
         '''Ensure incoming messages work as expected'''
@@ -680,9 +441,11 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         )
         manager._on_alive(alive_packet)
         agent = manager.worker_manager.get_agent_for_assignment(TEST_ASSIGNMENT_ID_1)
+        self.assertIn(
+            agent.get_status(), [AssignState.STATUS_NONE, AssignState.STATUS_WAITING]
+        )
         self.assertIsInstance(agent, MTurkAgent)
-        self.assertEqual(agent.get_status(), AssignState.STATUS_NONE)
-        agent.set_hit_is_abandoned = mock.MagicMock()
+        manager._on_socket_dead = mock.MagicMock()
 
         # Test SNS_ASSIGN_ABANDONDED
         message_packet = Packet(
@@ -695,8 +458,6 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
             '',
         )
         manager._handle_mturk_message(message_packet)
-        agent.set_hit_is_abandoned.assert_called_once()
-        agent.set_hit_is_abandoned.reset_mock()
         manager._on_socket_dead.assert_called_once_with(
             TEST_WORKER_ID_1, TEST_ASSIGNMENT_ID_1
         )
@@ -779,8 +540,8 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
 
     def test_onboarding_function(self):
         manager = self.mturk_manager
-        manager.onboard_function = mock.MagicMock()
-        manager.worker_manager.change_agent_conversation = mock.MagicMock()
+        manager.get_onboard_world = mock.MagicMock(wraps=get_onboard_world)
+        manager.send_message = mock.MagicMock()
         manager._move_agents_to_waiting = mock.MagicMock()
         manager.worker_manager.get_agent_for_assignment = mock.MagicMock(
             return_value=self.agent_1
@@ -790,24 +551,19 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         did_launch = manager._onboard_new_agent(self.agent_1)
         assert_equal_by(onboard_threads[self.agent_1.assignment_id].isAlive, True, 0.2)
         time.sleep(0.1)
-        manager.worker_manager.change_agent_conversation.assert_called_once()
-        manager.worker_manager.change_agent_conversation.reset_mock()
-        manager.onboard_function.assert_not_called()
         self.assertTrue(did_launch)
+        manager.get_onboard_world.assert_called_with(self.agent_1)
+        manager.get_onboard_world.reset_mock()
 
         # Thread will be waiting for agent_1 status to go to ONBOARDING, ensure
         # won't start new thread on a repeat call when first still alive
         did_launch = manager._onboard_new_agent(self.agent_1)
-        time.sleep(0.2)
-        manager.worker_manager.change_agent_conversation.assert_not_called()
         manager.worker_manager.get_agent_for_assignment.assert_not_called()
-        manager.onboard_function.assert_not_called()
+        manager.get_onboard_world.assert_not_called()
         self.assertFalse(did_launch)
 
-        # Advance the worker to simulate a connection, assert onboarding goes
-        self.agent_1.set_status(AssignState.STATUS_ONBOARDING)
-        assert_equal_by(onboard_threads[self.agent_1.assignment_id].isAlive, False, 0.6)
-        manager.onboard_function.assert_called_with(self.agent_1)
+        # wait for the task to finally pass along
+        assert_equal_by(onboard_threads[self.agent_1.assignment_id].isAlive, False, 3)
         manager._move_agents_to_waiting.assert_called_once()
 
         # Try to launch a new onboarding world for the same agent still in
@@ -820,11 +576,11 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         self.agent_1.set_status(AssignState.STATUS_NONE)
         did_launch = manager._onboard_new_agent(self.agent_1)
         self.assertTrue(did_launch)
-        self.agent_1.set_status(AssignState.STATUS_ONBOARDING)
 
     def test_agents_incomplete(self):
         agents = [self.agent_1, self.agent_2, self.agent_3]
         manager = self.mturk_manager
+        manager.send_state_change = mock.MagicMock()
         self.assertFalse(manager._no_agents_incomplete(agents))
         self.agent_1.set_status(AssignState.STATUS_DISCONNECT)
         self.assertFalse(manager._no_agents_incomplete(agents))
@@ -874,6 +630,7 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         manager = self.mturk_manager
         manager.opt['assignment_duration_in_seconds'] = 0.5
         manager.expire_all_unassigned_hits = mock.MagicMock()
+        manager.update_hit_status = mock.MagicMock()
         manager.hit_id_list = [1, 2, 3]
 
         def run_task_wait():
@@ -883,10 +640,11 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         wait_thread.start()
         time.sleep(0.1)
         self.assertTrue(wait_thread.isAlive())
-        assert_equal_by(wait_thread.isAlive, False, 0.6)
+        assert_equal_by(wait_thread.isAlive, False, 3)
 
     def test_mark_workers_done(self):
         manager = self.mturk_manager
+        manager.send_state_change = mock.MagicMock()
         manager.give_worker_qualification = mock.MagicMock()
         manager._log_working_time = mock.MagicMock()
         manager.has_time_limit = False
@@ -1154,9 +912,6 @@ class TestMTurkManagerLifecycleFunctions(unittest.TestCase):
         MTurkManagerFile.server_utils.setup_server = mock.MagicMock(
             return_value=server_url
         )
-        MTurkManagerFile.server_utils.setup_legacy_server = mock.MagicMock(
-            return_value=server_url
-        )
 
         # Currently in state created. Try steps that are too soon to work
         with self.assertRaises(AssertionError):
@@ -1166,6 +921,7 @@ class TestMTurkManagerLifecycleFunctions(unittest.TestCase):
 
         # Setup the server but fail due to insufficent funds
         manager.opt['local'] = True
+        manager.opt['frontend_version'] = 1
         MTurkManagerFile.input = mock.MagicMock()
         MTurkManagerFile.mturk_utils.setup_aws_credentials = mock.MagicMock()
         MTurkManagerFile.mturk_utils.check_mturk_balance = mock.MagicMock(
@@ -1248,14 +1004,14 @@ class TestMTurkManagerLifecycleFunctions(unittest.TestCase):
         manager._expire_agent_pool.assert_called_once()
 
         # shutdown
-        manager.expire_all_unassigned_hits = mock.MagicMock()
+        manager.expire_all_hits = mock.MagicMock()
         manager._expire_onboarding_pool = mock.MagicMock()
         manager._expire_agent_pool = mock.MagicMock()
         manager._wait_for_task_expirations = mock.MagicMock()
         MTurkManagerFile.mturk_utils.delete_sns_topic = mock.MagicMock()
         manager.shutdown()
         self.assertTrue(manager.is_shutdown)
-        manager.expire_all_unassigned_hits.assert_called_once()
+        manager.expire_all_hits.assert_called_once()
         manager._expire_onboarding_pool.assert_called_once()
         manager._expire_agent_pool.assert_called_once()
         manager._wait_for_task_expirations.assert_called_once()
@@ -1425,18 +1181,16 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         agent = self.agent_1
         worker_id = self.agent_1.worker_id
         assignment_id = self.agent_1.assignment_id
-        agent.set_last_command = mock.MagicMock()
         manager.socket_manager.queue_packet = mock.MagicMock()
 
         # Send a command
         data = {'text': data_model.COMMAND_SEND_MESSAGE}
         manager.send_command(worker_id, assignment_id, data)
 
-        agent.set_last_command.assert_called_once_with(data)
         manager.socket_manager.queue_packet.assert_called_once()
         packet = manager.socket_manager.queue_packet.call_args[0][0]
         self.assertIsNotNone(packet.id)
-        self.assertEqual(packet.type, Packet.TYPE_MESSAGE)
+        self.assertEqual(packet.type, data_model.WORLD_MESSAGE)
         self.assertEqual(packet.receiver_id, worker_id)
         self.assertEqual(packet.assignment_id, assignment_id)
         self.assertEqual(packet.data, data)
@@ -1444,20 +1198,18 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
 
         # Send a message
         data = {'text': 'This is a test message'}
-        agent.set_last_command.reset_mock()
         manager.socket_manager.queue_packet.reset_mock()
         message_id = manager.send_message(worker_id, assignment_id, data)
-        agent.set_last_command.assert_not_called()
         manager.socket_manager.queue_packet.assert_called_once()
         packet = manager.socket_manager.queue_packet.call_args[0][0]
         self.assertIsNotNone(packet.id)
-        self.assertEqual(packet.type, Packet.TYPE_MESSAGE)
+        self.assertEqual(packet.type, data_model.WORLD_MESSAGE)
         self.assertEqual(packet.receiver_id, worker_id)
         self.assertEqual(packet.assignment_id, assignment_id)
         self.assertNotEqual(packet.data, data)
         self.assertEqual(data['text'], packet.data['text'])
         self.assertEqual(packet.data['message_id'], message_id)
-        self.assertEqual(packet.data['type'], data_model.MESSAGE_TYPE_MESSAGE)
+        self.assertEqual(packet.data['type'], data_model.MESSAGE_TYPE_ACT)
 
     def test_free_workers(self):
         manager = self.mturk_manager
@@ -1474,6 +1226,7 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         assignment_id = agent.assignment_id
         socket_manager = manager.socket_manager
         manager.send_command = mock.MagicMock()
+        manager.send_state_change = mock.MagicMock()
         socket_manager.close_channel = mock.MagicMock()
 
         # Test expiring finished worker
@@ -1485,24 +1238,24 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
 
         # Test expiring not finished worker with default args
         agent.set_status(AssignState.STATUS_ONBOARDING)
+        manager.send_state_change.reset_mock()
         manager.force_expire_hit(worker_id, assignment_id)
-        manager.send_command.assert_called_once()
-        args = manager.send_command.call_args[0]
+        manager.send_state_change.assert_called_once()
+        args = manager.send_state_change.call_args[0]
         used_worker_id, used_assignment_id, data = args[0], args[1], args[2]
-        ack_func = manager.send_command.call_args[1]['ack_func']
+        ack_func = manager.send_state_change.call_args[1]['ack_func']
         ack_func()
         self.assertEqual(worker_id, used_worker_id)
         self.assertEqual(assignment_id, used_assignment_id)
-        self.assertEqual(data['text'], data_model.COMMAND_EXPIRE_HIT)
         self.assertEqual(agent.get_status(), AssignState.STATUS_EXPIRED)
         self.assertTrue(agent.hit_is_expired)
-        self.assertIsNotNone(data['inactive_text'])
+        self.assertIsNotNone(data['done_text'])
         socket_manager.close_channel.assert_called_once_with(agent.get_connection_id())
 
         # Test expiring not finished worker with custom arguments
         agent.set_status(AssignState.STATUS_ONBOARDING)
         agent.hit_is_expired = False
-        manager.send_command = mock.MagicMock()
+        manager.send_state_change.reset_mock()
         socket_manager.close_channel = mock.MagicMock()
         special_disconnect_text = 'You were disconnected as part of a test'
         test_ack_function = mock.MagicMock()
@@ -1512,17 +1265,16 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
             text=special_disconnect_text,
             ack_func=test_ack_function,
         )
-        manager.send_command.assert_called_once()
-        args = manager.send_command.call_args[0]
+        manager.send_state_change.assert_called_once()
+        args = manager.send_state_change.call_args[0]
         used_worker_id, used_assignment_id, data = args[0], args[1], args[2]
-        ack_func = manager.send_command.call_args[1]['ack_func']
+        ack_func = manager.send_state_change.call_args[1]['ack_func']
         ack_func()
         self.assertEqual(worker_id, used_worker_id)
         self.assertEqual(assignment_id, used_assignment_id)
-        self.assertEqual(data['text'], data_model.COMMAND_EXPIRE_HIT)
         self.assertEqual(agent.get_status(), AssignState.STATUS_EXPIRED)
         self.assertTrue(agent.hit_is_expired)
-        self.assertEqual(data['inactive_text'], special_disconnect_text)
+        self.assertEqual(data['done_text'], special_disconnect_text)
         socket_manager.close_channel.assert_called_once_with(agent.get_connection_id())
         test_ack_function.assert_called()
 
@@ -1629,17 +1381,12 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
     def test_expire_all_hits(self):
         manager = self.mturk_manager
         worker_manager = manager.worker_manager
-        completed_hit_id = 'completed'
         incomplete_1 = 'incomplete_1'
         incomplete_2 = 'incomplete_2'
         MTurkManagerFile.mturk_utils.expire_hit = mock.MagicMock()
-        worker_manager.get_complete_hits = mock.MagicMock(
-            return_value=[completed_hit_id]
-        )
-        manager.hit_id_list = [completed_hit_id, incomplete_1, incomplete_2]
+        manager.hit_id_list = [incomplete_1, incomplete_2]
 
         manager.expire_all_unassigned_hits()
-        worker_manager.get_complete_hits.assert_called_once()
         expire_calls = MTurkManagerFile.mturk_utils.expire_hit.call_args_list
         self.assertEqual(len(expire_calls), 2)
         for hit in [incomplete_1, incomplete_2]:
@@ -1697,50 +1444,16 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
 
     def test_partner_disconnect(self):
         manager = self.mturk_manager
-        manager.send_command = mock.MagicMock()
+        manager.send_state_change = mock.MagicMock()
         self.agent_1.set_status(AssignState.STATUS_IN_TASK)
         manager._handle_partner_disconnect(self.agent_1)
         self.assertEqual(
             self.agent_1.get_status(), AssignState.STATUS_PARTNER_DISCONNECT
         )
-        args = manager.send_command.call_args[0]
+        args = manager.send_state_change.call_args[0]
         worker_id, assignment_id, data = args[0], args[1], args[2]
         self.assertEqual(worker_id, self.agent_1.worker_id)
         self.assertEqual(assignment_id, self.agent_1.assignment_id)
-        self.assertDictEqual(data, self.agent_1.get_inactive_command_data())
-
-    def test_restore_state(self):
-        manager = self.mturk_manager
-        worker_manager = manager.worker_manager
-        worker_manager.change_agent_conversation = mock.MagicMock()
-        manager.send_command = mock.MagicMock()
-
-        agent = self.agent_1
-        agent.conversation_id = 'Test_conv_id'
-        agent.id = 'test_agent_id'
-        agent.request_message = mock.MagicMock()
-        agent.message_request_time = time.time()
-        test_message = {
-            'text': 'this_is_a_message',
-            'message_id': 'test_id',
-            'type': data_model.MESSAGE_TYPE_MESSAGE,
-        }
-        agent.append_message(test_message)
-        manager._restore_agent_state(agent.worker_id, agent.assignment_id)
-        self.assertFalse(agent.alived)
-        manager.send_command.assert_not_called()
-        worker_manager.change_agent_conversation.assert_called_once_with(
-            agent=agent, conversation_id=agent.conversation_id, new_agent_id=agent.id
-        )
-        agent.alived = True
-        assert_equal_by(lambda: len(agent.request_message.call_args_list), 1, 0.6)
-        manager.send_command.assert_called_once()
-        args = manager.send_command.call_args[0]
-        worker_id, assignment_id, data = args[0], args[1], args[2]
-        self.assertEqual(worker_id, agent.worker_id)
-        self.assertEqual(assignment_id, agent.assignment_id)
-        self.assertListEqual(data['messages'], agent.get_messages())
-        self.assertEqual(data['text'], data_model.COMMAND_RESTORE_STATE)
 
     def test_expire_onboarding(self):
         manager = self.mturk_manager

--- a/parlai/mturk/core/dev/test/test_mturk_manager.py
+++ b/parlai/mturk/core/dev/test/test_mturk_manager.py
@@ -1178,7 +1178,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
 
     def test_send_message_command(self):
         manager = self.mturk_manager
-        agent = self.agent_1
         worker_id = self.agent_1.worker_id
         assignment_id = self.agent_1.assignment_id
         manager.socket_manager.queue_packet = mock.MagicMock()
@@ -1380,7 +1379,6 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
 
     def test_expire_all_hits(self):
         manager = self.mturk_manager
-        worker_manager = manager.worker_manager
         incomplete_1 = 'incomplete_1'
         incomplete_2 = 'incomplete_2'
         MTurkManagerFile.mturk_utils.expire_hit = mock.MagicMock()
@@ -1451,7 +1449,7 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
             self.agent_1.get_status(), AssignState.STATUS_PARTNER_DISCONNECT
         )
         args = manager.send_state_change.call_args[0]
-        worker_id, assignment_id, data = args[0], args[1], args[2]
+        worker_id, assignment_id = args[0], args[1]
         self.assertEqual(worker_id, self.agent_1.worker_id)
         self.assertEqual(assignment_id, self.agent_1.assignment_id)
 

--- a/parlai/mturk/core/dev/test/test_socket_manager.py
+++ b/parlai/mturk/core/dev/test/test_socket_manager.py
@@ -395,17 +395,6 @@ class MockAgent(object):
         }
         return self.build_and_send_packet(data_model.AGENT_ALIVE, data)
 
-    def wait_for_alive(self):
-        last_time = time.time()
-        while not self.ready:
-            self.send_alive()
-            time.sleep(0.5)
-            assert (
-                time.time() - last_time < 10
-            ), 'Timed out wating for server to acknowledge {} alive'.format(
-                self.worker_id
-            )
-
 
 class TestSocketManagerSetupAndFunctions(unittest.TestCase):
     """Unit/integration tests for starting up a socket"""

--- a/parlai/mturk/core/dev/test/test_socket_manager.py
+++ b/parlai/mturk/core/dev/test/test_socket_manager.py
@@ -8,11 +8,11 @@ import unittest
 import time
 import uuid
 from unittest import mock
-from parlai.mturk.core.socket_manager import Packet, SocketManager
-from parlai.mturk.core.agents import AssignState
+from parlai.mturk.core.dev.socket_manager import Packet, SocketManager
+from parlai.mturk.core.dev.agents import AssignState
 
-import parlai.mturk.core.data_model as data_model
-import parlai.mturk.core.shared_utils as shared_utils
+import parlai.mturk.core.dev.data_model as data_model
+import parlai.mturk.core.dev.shared_utils as shared_utils
 import threading
 from websocket_server import WebsocketServer
 import json
@@ -32,7 +32,7 @@ MESSAGE_ID_3 = 'MESSAGE_ID_3'
 MESSAGE_ID_4 = 'MESSAGE_ID_4'
 COMMAND_ID_1 = 'COMMAND_ID_1'
 
-MESSAGE_TYPE = data_model.MESSAGE_TYPE_MESSAGE
+MESSAGE_TYPE = data_model.MESSAGE_TYPE_ACT
 COMMAND_TYPE = data_model.MESSAGE_TYPE_COMMAND
 
 MESSAGE_1 = {'message_id': MESSAGE_ID_1, 'type': MESSAGE_TYPE}
@@ -63,9 +63,7 @@ statuses = active_statuses + complete_statuses
 TASK_GROUP_ID_1 = 'TASK_GROUP_ID_1'
 
 SocketManager.DEF_MISSED_PONGS = 3
-SocketManager.HEARTBEAT_RATE = 0.6
 SocketManager.DEF_DEAD_TIME = 0.6
-SocketManager.ACK_TIME = {Packet.TYPE_ALIVE: 0.4, Packet.TYPE_MESSAGE: 0.2}
 
 shared_utils.THREAD_SHORT_SLEEP = 0.05
 shared_utils.THREAD_MEDIUM_SLEEP = 0.15
@@ -80,26 +78,22 @@ class TestPacket(unittest.TestCase):
     ASSIGNMENT_ID = 'ASSIGNMENT_ID'
     DATA = 'DATA'
     CONVERSATION_ID = 'CONVERSATION_ID'
-    REQUIRES_ACK = True
-    BLOCKING = False
     ACK_FUNCTION = 'ACK_FUNCTION'
 
     def setUp(self):
         self.packet_1 = Packet(
             self.ID,
-            Packet.TYPE_MESSAGE,
+            data_model.MESSAGE_BATCH,
             self.SENDER_ID,
             self.RECEIVER_ID,
             self.ASSIGNMENT_ID,
             self.DATA,
             conversation_id=self.CONVERSATION_ID,
-            requires_ack=self.REQUIRES_ACK,
-            blocking=self.BLOCKING,
             ack_func=self.ACK_FUNCTION,
         )
         self.packet_2 = Packet(
             self.ID,
-            Packet.TYPE_HEARTBEAT,
+            data_model.SNS_MESSAGE,
             self.SENDER_ID,
             self.RECEIVER_ID,
             self.ASSIGNMENT_ID,
@@ -107,7 +101,7 @@ class TestPacket(unittest.TestCase):
         )
         self.packet_3 = Packet(
             self.ID,
-            Packet.TYPE_ALIVE,
+            data_model.AGENT_ALIVE,
             self.SENDER_ID,
             self.RECEIVER_ID,
             self.ASSIGNMENT_ID,
@@ -120,36 +114,30 @@ class TestPacket(unittest.TestCase):
     def test_packet_init(self):
         '''Test proper initialization of packet fields'''
         self.assertEqual(self.packet_1.id, self.ID)
-        self.assertEqual(self.packet_1.type, Packet.TYPE_MESSAGE)
+        self.assertEqual(self.packet_1.type, data_model.MESSAGE_BATCH)
         self.assertEqual(self.packet_1.sender_id, self.SENDER_ID)
         self.assertEqual(self.packet_1.receiver_id, self.RECEIVER_ID)
         self.assertEqual(self.packet_1.assignment_id, self.ASSIGNMENT_ID)
         self.assertEqual(self.packet_1.data, self.DATA)
         self.assertEqual(self.packet_1.conversation_id, self.CONVERSATION_ID)
-        self.assertEqual(self.packet_1.requires_ack, self.REQUIRES_ACK)
-        self.assertEqual(self.packet_1.blocking, self.BLOCKING)
         self.assertEqual(self.packet_1.ack_func, self.ACK_FUNCTION)
         self.assertEqual(self.packet_1.status, Packet.STATUS_INIT)
         self.assertEqual(self.packet_2.id, self.ID)
-        self.assertEqual(self.packet_2.type, Packet.TYPE_HEARTBEAT)
+        self.assertEqual(self.packet_2.type, data_model.SNS_MESSAGE)
         self.assertEqual(self.packet_2.sender_id, self.SENDER_ID)
         self.assertEqual(self.packet_2.receiver_id, self.RECEIVER_ID)
         self.assertEqual(self.packet_2.assignment_id, self.ASSIGNMENT_ID)
         self.assertEqual(self.packet_2.data, self.DATA)
         self.assertIsNone(self.packet_2.conversation_id)
-        self.assertFalse(self.packet_2.requires_ack)
-        self.assertFalse(self.packet_2.blocking)
         self.assertIsNone(self.packet_2.ack_func)
         self.assertEqual(self.packet_2.status, Packet.STATUS_INIT)
         self.assertEqual(self.packet_3.id, self.ID)
-        self.assertEqual(self.packet_3.type, Packet.TYPE_ALIVE)
+        self.assertEqual(self.packet_3.type, data_model.AGENT_ALIVE)
         self.assertEqual(self.packet_3.sender_id, self.SENDER_ID)
         self.assertEqual(self.packet_3.receiver_id, self.RECEIVER_ID)
         self.assertEqual(self.packet_3.assignment_id, self.ASSIGNMENT_ID)
         self.assertEqual(self.packet_3.data, self.DATA)
         self.assertIsNone(self.packet_3.conversation_id)
-        self.assertTrue(self.packet_3.requires_ack)
-        self.assertTrue(self.packet_3.blocking)
         self.assertIsNone(self.packet_3.ack_func)
         self.assertEqual(self.packet_3.status, Packet.STATUS_INIT)
 
@@ -190,8 +178,6 @@ class TestPacket(unittest.TestCase):
         self.assertEqual(
             message_packet_copy.conversation_id, self.packet_1.conversation_id
         )
-        self.assertEqual(message_packet_copy.requires_ack, self.packet_1.requires_ack)
-        self.assertEqual(message_packet_copy.blocking, self.packet_1.blocking)
         self.assertIsNone(message_packet_copy.ack_func)
         self.assertEqual(message_packet_copy.status, Packet.STATUS_INIT)
 
@@ -205,36 +191,22 @@ class TestPacket(unittest.TestCase):
         self.assertEqual(hb_packet_copy.assignment_id, self.packet_2.assignment_id)
         self.assertEqual(hb_packet_copy.data, self.packet_2.data)
         self.assertEqual(hb_packet_copy.conversation_id, self.packet_2.conversation_id)
-        self.assertEqual(hb_packet_copy.requires_ack, self.packet_2.requires_ack)
-        self.assertEqual(hb_packet_copy.blocking, self.packet_2.blocking)
         self.assertIsNone(hb_packet_copy.ack_func)
         self.assertEqual(hb_packet_copy.status, Packet.STATUS_INIT)
-
-        # ack important packet
-        ack_packet = self.packet_1.get_ack()
-        self.assertEqual(ack_packet.id, self.ID)
-        self.assertEqual(ack_packet.type, Packet.TYPE_ACK)
-        self.assertEqual(ack_packet.sender_id, self.RECEIVER_ID)
-        self.assertEqual(ack_packet.receiver_id, self.SENDER_ID)
-        self.assertEqual(ack_packet.assignment_id, self.ASSIGNMENT_ID)
-        self.assertEqual(ack_packet.data, '')
-        self.assertEqual(ack_packet.conversation_id, self.CONVERSATION_ID)
-        self.assertFalse(ack_packet.requires_ack)
-        self.assertFalse(ack_packet.blocking)
-        self.assertIsNone(ack_packet.ack_func)
-        self.assertEqual(ack_packet.status, Packet.STATUS_INIT)
 
     def test_packet_modifications(self):
         '''Ensure that packet copies and acts are produced properly'''
         # All operations return the packet
         self.assertEqual(self.packet_1.swap_sender(), self.packet_1)
-        self.assertEqual(self.packet_1.set_type(Packet.TYPE_ACK), self.packet_1)
+        self.assertEqual(
+            self.packet_1.set_type(data_model.MESSAGE_BATCH), self.packet_1
+        )
         self.assertEqual(self.packet_1.set_data(None), self.packet_1)
 
         # Ensure all of the operations worked
         self.assertEqual(self.packet_1.sender_id, self.RECEIVER_ID)
         self.assertEqual(self.packet_1.receiver_id, self.SENDER_ID)
-        self.assertEqual(self.packet_1.type, Packet.TYPE_ACK)
+        self.assertEqual(self.packet_1.type, data_model.MESSAGE_BATCH)
         self.assertIsNone(self.packet_1.data)
 
 
@@ -245,7 +217,6 @@ class MockSocket:
         self.disconnected = False
         self.closed = False
         self.ws = None
-        self.should_heartbeat = True
         self.fake_workers = []
         self.port = None
         self.launch_socket()
@@ -276,14 +247,12 @@ class MockSocket:
             if packet_dict['content']['id'] == 'WORLD_ALIVE':
                 self.ws.send_message(client, json.dumps({'type': 'conn_success'}))
                 self.connected = True
-            elif packet_dict['content']['type'] == 'heartbeat':
+            elif packet_dict['type'] == data_model.WORLD_PING:
                 pong = packet_dict['content'].copy()
                 pong['type'] = 'pong'
                 self.ws.send_message(
                     client,
-                    json.dumps(
-                        {'type': data_model.SOCKET_ROUTE_PACKET_STRING, 'content': pong}
-                    ),
+                    json.dumps({'type': data_model.SERVER_PONG, 'content': pong}),
                 )
             if 'receiver_id' in packet_dict['content']:
                 receiver_id = packet_dict['content']['receiver_id']
@@ -332,8 +301,6 @@ class MockAgent(object):
         self.disconnected = False
         self.task_group_id = task_group_id
         self.ws = None
-        self.always_beat = True
-        self.send_acks = True
         self.ready = False
         self.wants_to_send = False
 
@@ -341,33 +308,25 @@ class MockAgent(object):
         def callback(*args):
             pass
 
-        event_name = data_model.SOCKET_ROUTE_PACKET_STRING
+        event_name = data_model.MESSAGE_BATCH
         self.ws.send(json.dumps({'type': event_name, 'content': packet.as_dict()}))
 
-    def register_to_socket(self, ws, on_ack, on_hb, on_msg):
-        handler = self.make_packet_handler(on_ack, on_hb, on_msg)
+    def register_to_socket(self, ws, on_msg):
+        handler = self.make_packet_handler(on_msg)
         self.ws = ws
         self.ws.handlers[self.worker_id] = handler
 
-    def make_packet_handler(self, on_ack, on_hb, on_msg):
-        """A packet handler that properly sends heartbeats"""
+    def make_packet_handler(self, on_msg):
+        """A packet handler"""
 
         def handler_mock(pkt):
-            if pkt['type'] == Packet.TYPE_ACK:
-                self.ready = True
+            if pkt['type'] == data_model.WORLD_MESSAGE:
                 packet = Packet.from_dict(pkt)
-                on_ack(packet)
-            elif pkt['type'] == Packet.TYPE_HEARTBEAT:
-                packet = Packet.from_dict(pkt)
-                on_hb(packet)
-                if self.always_beat:
-                    self.send_heartbeat()
-            elif pkt['type'] == Packet.TYPE_MESSAGE:
-                packet = Packet.from_dict(pkt)
-                if self.send_acks:
-                    self.send_packet(packet.get_ack())
                 on_msg(packet)
-            elif pkt['type'] == Packet.TYPE_ALIVE:
+            elif pkt['type'] == data_model.MESSAGE_BATCH:
+                packet = Packet.from_dict(pkt)
+                on_msg(packet)
+            elif pkt['type'] == data_model.AGENT_ALIVE:
                 raise Exception('Invalid alive packet {}'.format(pkt))
             else:
                 raise Exception(
@@ -377,8 +336,9 @@ class MockAgent(object):
         return handler_mock
 
     def build_and_send_packet(self, packet_type, data):
+        msg_id = str(uuid.uuid4())
         msg = {
-            'id': str(uuid.uuid4()),
+            'id': msg_id,
             'type': packet_type,
             'sender_id': self.worker_id,
             'assignment_id': self.assignment_id,
@@ -387,10 +347,21 @@ class MockAgent(object):
             'data': data,
         }
 
-        event_name = data_model.SOCKET_ROUTE_PACKET_STRING
-        if packet_type == Packet.TYPE_ALIVE:
-            event_name = data_model.SOCKET_AGENT_ALIVE_STRING
-        self.ws.send(json.dumps({'type': event_name, 'content': msg}))
+        if packet_type == data_model.MESSAGE_BATCH:
+            msg['data'] = {
+                'messages': [
+                    {
+                        'id': msg_id,
+                        'type': packet_type,
+                        'sender_id': self.worker_id,
+                        'assignment_id': self.assignment_id,
+                        'conversation_id': self.conversation_id,
+                        'receiver_id': '[World_' + self.task_group_id + ']',
+                        'data': data,
+                    }
+                ]
+            }
+        self.ws.send(json.dumps({'type': packet_type, 'content': msg}))
         return msg['id']
 
     def send_message(self, text):
@@ -402,7 +373,18 @@ class MockAgent(object):
         }
 
         self.wants_to_send = False
-        return self.build_and_send_packet(Packet.TYPE_MESSAGE, data)
+        return self.build_and_send_packet(data_model.MESSAGE_BATCH, data)
+
+    def send_disconnect(self):
+        data = {
+            'hit_id': self.hit_id,
+            'assignment_id': self.assignment_id,
+            'worker_id': self.worker_id,
+            'conversation_id': self.conversation_id,
+            'connection_id': '{}_{}'.format(self.worker_id, self.assignment_id),
+        }
+
+        return self.build_and_send_packet(data_model.AGENT_DISCONNECT, data)
 
     def send_alive(self):
         data = {
@@ -411,22 +393,7 @@ class MockAgent(object):
             'worker_id': self.worker_id,
             'conversation_id': self.conversation_id,
         }
-        return self.build_and_send_packet(Packet.TYPE_ALIVE, data)
-
-    def send_heartbeat(self):
-        """Sends a heartbeat to the world"""
-        hb = {
-            'id': str(uuid.uuid4()),
-            'receiver_id': '[World_' + self.task_group_id + ']',
-            'assignment_id': self.assignment_id,
-            'sender_id': self.worker_id,
-            'conversation_id': self.conversation_id,
-            'type': Packet.TYPE_HEARTBEAT,
-            'data': None,
-        }
-        self.ws.send(
-            json.dumps({'type': data_model.SOCKET_ROUTE_PACKET_STRING, 'content': hb})
-        )
+        return self.build_and_send_packet(data_model.AGENT_ALIVE, data)
 
     def wait_for_alive(self):
         last_time = time.time()
@@ -479,6 +446,7 @@ class TestSocketManagerSetupAndFunctions(unittest.TestCase):
         self.assertFalse(socket_manager.is_shutdown)
         self.assertTrue(socket_manager.alive)
         socket_manager.shutdown()
+        time.sleep(0.3)
         self.assertTrue(self.fake_socket.disconnected)
         self.assertTrue(socket_manager.is_shutdown)
         self.assertFalse(nop_called)
@@ -528,12 +496,8 @@ class TestSocketManagerSetupAndFunctions(unittest.TestCase):
         self.assertFalse(socket_manager.is_shutdown)
         self.assertTrue(socket_manager.alive)
         self.fake_socket.close()
-        self.assertEqualBy(
-            lambda: socket_manager.alive, False, 8 * socket_manager.HEARTBEAT_RATE
-        )
-        self.assertEqualBy(
-            lambda: server_death_called, True, 4 * socket_manager.HEARTBEAT_RATE
-        )
+        self.assertEqualBy(lambda: socket_manager.alive, False, 8)
+        self.assertEqualBy(lambda: server_death_called, True, 20)
         self.assertFalse(nop_called)
         socket_manager.shutdown()
 
@@ -573,14 +537,10 @@ class TestSocketManagerSetupAndFunctions(unittest.TestCase):
         self.assertFalse(socket_manager.is_shutdown)
         self.assertTrue(socket_manager.alive)
         self.fake_socket.close()
-        self.assertEqualBy(
-            lambda: socket_manager.alive, False, 8 * socket_manager.HEARTBEAT_RATE
-        )
+        self.assertEqualBy(lambda: socket_manager.alive, False, 8)
         self.assertFalse(socket_manager.alive)
         self.fake_socket = MockSocket()
-        self.assertEqualBy(
-            lambda: socket_manager.alive, True, 4 * socket_manager.HEARTBEAT_RATE
-        )
+        self.assertEqualBy(lambda: socket_manager.alive, True, 4)
         self.assertFalse(nop_called)
         self.assertFalse(server_death_called)
         socket_manager.shutdown()
@@ -627,8 +587,6 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
     ASSIGNMENT_ID = 'ASSIGNMENT_ID'
     DATA = 'DATA'
     CONVERSATION_ID = 'CONVERSATION_ID'
-    REQUIRES_ACK = True
-    BLOCKING = False
     ACK_FUNCTION = 'ACK_FUNCTION'
     WORLD_ID = '[World_{}]'.format(TASK_GROUP_ID_1)
 
@@ -646,19 +604,9 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         self.server_died = True
 
     def setUp(self):
-        self.AGENT_HEARTBEAT_PACKET = Packet(
-            self.ID,
-            Packet.TYPE_HEARTBEAT,
-            self.SENDER_ID,
-            self.WORLD_ID,
-            self.ASSIGNMENT_ID,
-            self.DATA,
-            self.CONVERSATION_ID,
-        )
-
         self.AGENT_ALIVE_PACKET = Packet(
             MESSAGE_ID_1,
-            Packet.TYPE_ALIVE,
+            data_model.AGENT_ALIVE,
             self.SENDER_ID,
             self.WORLD_ID,
             self.ASSIGNMENT_ID,
@@ -668,7 +616,7 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
 
         self.MESSAGE_SEND_PACKET_1 = Packet(
             MESSAGE_ID_2,
-            Packet.TYPE_MESSAGE,
+            data_model.WORLD_MESSAGE,
             self.WORLD_ID,
             self.SENDER_ID,
             self.ASSIGNMENT_ID,
@@ -678,24 +626,22 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
 
         self.MESSAGE_SEND_PACKET_2 = Packet(
             MESSAGE_ID_3,
-            Packet.TYPE_MESSAGE,
+            data_model.MESSAGE_BATCH,
             self.WORLD_ID,
             self.SENDER_ID,
             self.ASSIGNMENT_ID,
             self.DATA,
             self.CONVERSATION_ID,
-            requires_ack=False,
         )
 
         self.MESSAGE_SEND_PACKET_3 = Packet(
             MESSAGE_ID_4,
-            Packet.TYPE_MESSAGE,
+            data_model.MESSAGE_BATCH,
             self.WORLD_ID,
             self.SENDER_ID,
             self.ASSIGNMENT_ID,
             self.DATA,
             self.CONVERSATION_ID,
-            blocking=False,
         )
 
         self.fake_socket = MockSocket()
@@ -730,174 +676,31 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         self.assertEqual(self.socket_manager.socket_dead_callback, self.on_worker_death)
         self.assertEqual(self.socket_manager.task_group_id, TASK_GROUP_ID_1)
         self.assertEqual(
-            self.socket_manager.missed_pongs, 1 + (1 / SocketManager.HEARTBEAT_RATE)
+            self.socket_manager.missed_pongs, 1 + (1 / SocketManager.PING_RATE)
         )
         self.assertIsNotNone(self.socket_manager.ws)
         self.assertTrue(self.socket_manager.keep_running)
         self.assertIsNotNone(self.socket_manager.listen_thread)
-        self.assertDictEqual(self.socket_manager.queues, {})
-        self.assertDictEqual(self.socket_manager.threads, {})
-        self.assertDictEqual(self.socket_manager.run, {})
-        self.assertDictEqual(self.socket_manager.last_sent_heartbeat_time, {})
-        self.assertDictEqual(self.socket_manager.last_received_heartbeat, {})
-        self.assertDictEqual(self.socket_manager.pongs_without_heartbeat, {})
+        self.assertSetEqual(self.socket_manager.open_channels, set())
         self.assertDictEqual(self.socket_manager.packet_map, {})
         self.assertTrue(self.socket_manager.alive)
         self.assertFalse(self.socket_manager.is_shutdown)
         self.assertEqual(self.socket_manager.get_my_sender_id(), self.WORLD_ID)
 
-    def test_needed_heartbeat(self):
-        '''Ensure needed heartbeat sends heartbeats at the right time'''
-        self.socket_manager._safe_send = mock.MagicMock()
-        connection_id = self.AGENT_HEARTBEAT_PACKET.get_sender_connection_id()
-
-        # Ensure no failure under uninitialized cases
-        self.socket_manager._send_needed_heartbeat(connection_id)
-        self.socket_manager.last_received_heartbeat[connection_id] = None
-        self.socket_manager._send_needed_heartbeat(connection_id)
-
-        self.socket_manager._safe_send.assert_not_called()
-
-        # assert not called when called too recently
-        self.socket_manager.last_received_heartbeat[
-            connection_id
-        ] = self.AGENT_HEARTBEAT_PACKET
-        self.socket_manager.last_sent_heartbeat_time[connection_id] = time.time() + 10
-
-        self.socket_manager._send_needed_heartbeat(connection_id)
-
-        self.socket_manager._safe_send.assert_not_called()
-
-        # Assert called when supposed to
-        self.socket_manager.last_sent_heartbeat_time[connection_id] = (
-            time.time() - SocketManager.HEARTBEAT_RATE
-        )
-        self.assertGreater(
-            time.time() - self.socket_manager.last_sent_heartbeat_time[connection_id],
-            SocketManager.HEARTBEAT_RATE,
-        )
-        self.socket_manager._send_needed_heartbeat(connection_id)
-        self.assertLess(
-            time.time() - self.socket_manager.last_sent_heartbeat_time[connection_id],
-            SocketManager.HEARTBEAT_RATE,
-        )
-        used_packet_json = self.socket_manager._safe_send.call_args[0][0]
-        used_packet_dict = json.loads(used_packet_json)
-        self.assertEqual(
-            used_packet_dict['type'], data_model.SOCKET_ROUTE_PACKET_STRING
-        )
-        used_packet = Packet.from_dict(used_packet_dict['content'])
-        self.assertNotEqual(self.AGENT_HEARTBEAT_PACKET.id, used_packet.id)
-        self.assertEqual(used_packet.type, Packet.TYPE_HEARTBEAT)
-        self.assertEqual(used_packet.sender_id, self.WORLD_ID)
-        self.assertEqual(used_packet.receiver_id, self.SENDER_ID)
-        self.assertEqual(used_packet.assignment_id, self.ASSIGNMENT_ID)
-        self.assertEqual(used_packet.data, '')
-        self.assertEqual(used_packet.conversation_id, self.CONVERSATION_ID)
-        self.assertEqual(used_packet.requires_ack, False)
-        self.assertEqual(used_packet.blocking, False)
-
-    def test_ack_send(self):
-        '''Ensure acks are being properly created and sent'''
-        self.socket_manager._safe_send = mock.MagicMock()
-        self.socket_manager._send_ack(self.AGENT_ALIVE_PACKET)
-        used_packet_json = self.socket_manager._safe_send.call_args[0][0]
-        used_packet_dict = json.loads(used_packet_json)
-        self.assertEqual(
-            used_packet_dict['type'], data_model.SOCKET_ROUTE_PACKET_STRING
-        )
-        used_packet = Packet.from_dict(used_packet_dict['content'])
-        self.assertEqual(self.AGENT_ALIVE_PACKET.id, used_packet.id)
-        self.assertEqual(used_packet.type, Packet.TYPE_ACK)
-        self.assertEqual(used_packet.sender_id, self.WORLD_ID)
-        self.assertEqual(used_packet.receiver_id, self.SENDER_ID)
-        self.assertEqual(used_packet.assignment_id, self.ASSIGNMENT_ID)
-        self.assertEqual(used_packet.conversation_id, self.CONVERSATION_ID)
-        self.assertEqual(used_packet.requires_ack, False)
-        self.assertEqual(used_packet.blocking, False)
-        self.assertEqual(self.AGENT_ALIVE_PACKET.status, Packet.STATUS_SENT)
-
     def _send_packet_in_background(self, packet, send_time):
         '''creates a thread to handle waiting for a packet send'''
 
         def do_send():
-            self.socket_manager._send_packet(
-                packet, packet.get_receiver_connection_id(), send_time
-            )
+            self.socket_manager._send_packet(packet, send_time)
             self.sent = True
 
         send_thread = threading.Thread(target=do_send, daemon=True)
         send_thread.start()
         time.sleep(0.02)
 
-    def test_blocking_ack_packet_send(self):
-        '''Checks to see if ack'ed blocking packets are working properly'''
+    def test_packet_send(self):
+        '''Checks to see if packets are working'''
         self.socket_manager._safe_send = mock.MagicMock()
-        self.socket_manager._safe_put = mock.MagicMock()
-        self.sent = False
-
-        # Test a blocking acknowledged packet
-        send_time = time.time()
-        self.assertEqual(self.MESSAGE_SEND_PACKET_1.status, Packet.STATUS_INIT)
-        self._send_packet_in_background(self.MESSAGE_SEND_PACKET_1, send_time)
-        self.assertEqual(self.MESSAGE_SEND_PACKET_1.status, Packet.STATUS_SENT)
-        self.socket_manager._safe_send.assert_called_once()
-
-        connection_id = self.MESSAGE_SEND_PACKET_1.get_receiver_connection_id()
-        self.socket_manager._safe_put.assert_called_once_with(
-            connection_id, (send_time, self.MESSAGE_SEND_PACKET_1)
-        )
-        self.assertTrue(self.sent)
-
-        self.socket_manager._safe_send.reset_mock()
-        self.socket_manager._safe_put.reset_mock()
-
-        # Send it again - end outcome should be a call to send only
-        # with sent set
-        self.MESSAGE_SEND_PACKET_1.status = Packet.STATUS_ACK
-        self._send_packet_in_background(self.MESSAGE_SEND_PACKET_1, send_time)
-        self.socket_manager._safe_send.assert_not_called()
-        self.socket_manager._safe_put.assert_not_called()
-
-    def test_non_blocking_ack_packet_send(self):
-        '''Checks to see if ack'ed non-blocking packets are working'''
-        self.socket_manager._safe_send = mock.MagicMock()
-        self.socket_manager._safe_put = mock.MagicMock()
-        self.sent = False
-
-        # Test a blocking acknowledged packet
-        send_time = time.time()
-        self.assertEqual(self.MESSAGE_SEND_PACKET_3.status, Packet.STATUS_INIT)
-        self._send_packet_in_background(self.MESSAGE_SEND_PACKET_3, send_time)
-        self.assertEqual(self.MESSAGE_SEND_PACKET_3.status, Packet.STATUS_SENT)
-        self.socket_manager._safe_send.assert_called_once()
-        self.socket_manager._safe_put.assert_called_once()
-        self.assertTrue(self.sent)
-
-        call_args = self.socket_manager._safe_put.call_args[0]
-        connection_id = call_args[0]
-        queue_item = call_args[1]
-        self.assertEqual(
-            connection_id, self.MESSAGE_SEND_PACKET_3.get_receiver_connection_id()
-        )
-        expected_send_time = (
-            send_time + SocketManager.ACK_TIME[self.MESSAGE_SEND_PACKET_3.type]
-        )
-        self.assertAlmostEqual(queue_item[0], expected_send_time, places=2)
-        self.assertEqual(queue_item[1], self.MESSAGE_SEND_PACKET_3)
-        used_packet_json = self.socket_manager._safe_send.call_args[0][0]
-        used_packet_dict = json.loads(used_packet_json)
-        self.assertEqual(
-            used_packet_dict['type'], data_model.SOCKET_ROUTE_PACKET_STRING
-        )
-        self.assertDictEqual(
-            used_packet_dict['content'], self.MESSAGE_SEND_PACKET_3.as_dict()
-        )
-
-    def test_non_ack_packet_send(self):
-        '''Checks to see if non-ack'ed packets are working'''
-        self.socket_manager._safe_send = mock.MagicMock()
-        self.socket_manager._safe_put = mock.MagicMock()
         self.sent = False
 
         # Test a blocking acknowledged packet
@@ -906,14 +709,11 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         self._send_packet_in_background(self.MESSAGE_SEND_PACKET_2, send_time)
         self.assertEqual(self.MESSAGE_SEND_PACKET_2.status, Packet.STATUS_SENT)
         self.socket_manager._safe_send.assert_called_once()
-        self.socket_manager._safe_put.assert_not_called()
         self.assertTrue(self.sent)
 
         used_packet_json = self.socket_manager._safe_send.call_args[0][0]
         used_packet_dict = json.loads(used_packet_json)
-        self.assertEqual(
-            used_packet_dict['type'], data_model.SOCKET_ROUTE_PACKET_STRING
-        )
+        self.assertEqual(used_packet_dict['type'], data_model.MESSAGE_BATCH)
         self.assertDictEqual(
             used_packet_dict['content'], self.MESSAGE_SEND_PACKET_2.as_dict()
         )
@@ -922,7 +722,6 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         '''Ensure that channels are created, managed, and then removed
         as expected
         '''
-        self.socket_manager._safe_put = mock.MagicMock()
         use_packet = self.MESSAGE_SEND_PACKET_1
         worker_id = use_packet.receiver_id
         assignment_id = use_packet.assignment_id
@@ -931,24 +730,13 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         self.socket_manager.open_channel(worker_id, assignment_id)
         time.sleep(0.1)
         connection_id = use_packet.get_receiver_connection_id()
-        self.assertTrue(self.socket_manager.run[connection_id])
 
-        self.assertIsNotNone(self.socket_manager.queues[connection_id])
-        self.assertEqual(self.socket_manager.last_sent_heartbeat_time[connection_id], 0)
-        self.assertEqual(self.socket_manager.pongs_without_heartbeat[connection_id], 0)
-        self.assertIsNone(self.socket_manager.last_received_heartbeat[connection_id])
+        self.assertIn(connection_id, self.socket_manager.open_channels)
         self.assertTrue(self.socket_manager.socket_is_open(connection_id))
         self.assertFalse(self.socket_manager.socket_is_open(FAKE_ID))
 
-        # Send a bad packet, ensure it is ignored
-        resp = self.socket_manager.queue_packet(self.AGENT_ALIVE_PACKET)
-        self.socket_manager._safe_put.assert_not_called()
-        self.assertFalse(resp)
-        self.assertNotIn(self.AGENT_ALIVE_PACKET.id, self.socket_manager.packet_map)
-
         # Send a packet to an open socket, ensure it got queued
         resp = self.socket_manager.queue_packet(use_packet)
-        self.socket_manager._safe_put.assert_called_once()
         self.assertIn(use_packet.id, self.socket_manager.packet_map)
         self.assertTrue(resp)
 
@@ -962,47 +750,17 @@ class TestSocketManagerRoutingFunctionality(unittest.TestCase):
         # Assert that closing a thread does the correct cleanup work
         self.socket_manager.close_channel(connection_id)
         time.sleep(0.2)
-        self.assertFalse(self.socket_manager.run[connection_id])
-        self.assertNotIn(connection_id, self.socket_manager.queues)
-        self.assertNotIn(connection_id, self.socket_manager.threads)
+        self.assertNotIn(connection_id, self.socket_manager.open_channels)
         self.assertNotIn(use_packet.id, self.socket_manager.packet_map)
 
-        # Assert that opening multiple threads and closing them is possible
+        # Assert that opening multiple and closing them is possible
         self.socket_manager.open_channel(worker_id, assignment_id)
         self.socket_manager.open_channel(worker_id + '2', assignment_id)
         time.sleep(0.1)
-        self.assertEqual(len(self.socket_manager.queues), 2)
+        self.assertEqual(len(self.socket_manager.open_channels), 2)
         self.socket_manager.close_all_channels()
         time.sleep(0.1)
-        self.assertEqual(len(self.socket_manager.queues), 0)
-
-    def test_safe_put(self):
-        '''Test safe put and queue retrieval mechanisms'''
-        self.socket_manager._send_packet = mock.MagicMock()
-        use_packet = self.MESSAGE_SEND_PACKET_1
-        worker_id = use_packet.receiver_id
-        assignment_id = use_packet.assignment_id
-        connection_id = use_packet.get_receiver_connection_id()
-
-        # Open a channel and assert it is there
-        self.socket_manager.open_channel(worker_id, assignment_id)
-        send_time = time.time()
-        self.socket_manager._safe_put(connection_id, (send_time, use_packet))
-
-        # Wait for the sending thread to try to pull the packet from the queue
-        time.sleep(0.3)
-
-        # Ensure the right packet was popped and sent.
-        self.socket_manager._send_packet.assert_called_once()
-        call_args = self.socket_manager._send_packet.call_args[0]
-        self.assertEqual(use_packet, call_args[0])
-        self.assertEqual(connection_id, call_args[1])
-        self.assertEqual(send_time, call_args[2])
-
-        self.socket_manager.close_all_channels()
-        time.sleep(0.1)
-        self.socket_manager._safe_put(connection_id, (send_time, use_packet))
-        self.assertEqual(use_packet.status, Packet.STATUS_FAIL)
+        self.assertEqual(len(self.socket_manager.open_channels), 0)
 
 
 class TestSocketManagerMessageHandling(unittest.TestCase):
@@ -1063,54 +821,26 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         self.fake_socket.close()
 
     def test_alive_send_and_disconnect(self):
-        acked_packet = None
-        incoming_hb = None
         message_packet = None
-        hb_count = 0
-
-        def on_ack(*args):
-            nonlocal acked_packet
-            acked_packet = args[0]
-
-        def on_hb(*args):
-            nonlocal incoming_hb, hb_count
-            incoming_hb = args[0]
-            hb_count += 1
 
         def on_msg(*args):
             nonlocal message_packet
             message_packet = args[0]
 
-        self.agent1.register_to_socket(self.fake_socket, on_ack, on_hb, on_msg)
-        self.assertIsNone(acked_packet)
-        self.assertIsNone(incoming_hb)
+        self.agent1.register_to_socket(self.fake_socket, on_msg)
         self.assertIsNone(message_packet)
-        self.assertEqual(hb_count, 0)
 
         # Assert alive is registered
         alive_id = self.agent1.send_alive()
-        self.assertEqualBy(lambda: acked_packet is None, False, 8)
-        self.assertIsNone(incoming_hb)
         self.assertIsNone(message_packet)
         self.assertIsNone(self.message_packet)
         self.assertEqualBy(lambda: self.alive_packet is None, False, 8)
         self.assertEqual(self.alive_packet.id, alive_id)
-        self.assertEqual(acked_packet.id, alive_id, 'Alive was not acked')
-        acked_packet = None
-
-        # assert sending heartbeats actually works, and that heartbeats don't
-        # get acked
-        self.agent1.send_heartbeat()
-        self.assertEqualBy(lambda: incoming_hb is None, False, 8)
-        self.assertIsNone(acked_packet)
-        self.assertGreater(hb_count, 0)
 
         # Test message send from agent
         test_message_text_1 = 'test_message_text_1'
         msg_id = self.agent1.send_message(test_message_text_1)
         self.assertEqualBy(lambda: self.message_packet is None, False, 8)
-        self.assertEqualBy(lambda: acked_packet is None, False, 8)
-        self.assertEqual(self.message_packet.id, acked_packet.id)
         self.assertEqual(self.message_packet.id, msg_id)
         self.assertEqual(self.message_packet.data['text'], test_message_text_1)
 
@@ -1119,7 +849,7 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         test_message_text_2 = 'test_message_text_2'
         message_send_packet = Packet(
             manager_message_id,
-            Packet.TYPE_MESSAGE,
+            data_model.MESSAGE_BATCH,
             self.socket_manager.get_my_sender_id(),
             TEST_WORKER_ID_1,
             TEST_ASSIGNMENT_ID_1,
@@ -1131,136 +861,30 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         self.assertEqual(message_packet.id, manager_message_id)
         self.assertEqual(message_packet.data, test_message_text_2)
         self.assertIn(manager_message_id, self.socket_manager.packet_map)
-        self.assertEqualBy(
-            lambda: self.socket_manager.packet_map[manager_message_id].status,
-            Packet.STATUS_ACK,
-            6,
-        )
 
         # Test agent disconnect
-        self.agent1.always_beat = False
+        self.agent1.send_disconnect()
         self.assertEqualBy(lambda: self.dead_worker_id, TEST_WORKER_ID_1, 8)
         self.assertEqual(self.dead_assignment_id, TEST_ASSIGNMENT_ID_1)
-        self.assertGreater(hb_count, 1)
-
-    def test_failed_ack_resend(self):
-        '''Ensures when a message from the manager is dropped, it gets
-        retried until it works as long as there hasn't been a disconnect
-        '''
-        acked_packet = None
-        incoming_hb = None
-        message_packet = None
-        hb_count = 0
-
-        def on_ack(*args):
-            nonlocal acked_packet
-            acked_packet = args[0]
-
-        def on_hb(*args):
-            nonlocal incoming_hb, hb_count
-            incoming_hb = args[0]
-            hb_count += 1
-
-        def on_msg(*args):
-            nonlocal message_packet
-            message_packet = args[0]
-
-        self.agent1.register_to_socket(self.fake_socket, on_ack, on_hb, on_msg)
-        self.assertIsNone(acked_packet)
-        self.assertIsNone(incoming_hb)
-        self.assertIsNone(message_packet)
-        self.assertEqual(hb_count, 0)
-
-        # Assert alive is registered
-        alive_id = self.agent1.send_alive()
-        self.assertEqualBy(lambda: acked_packet is None, False, 8)
-        self.assertIsNone(incoming_hb)
-        self.assertIsNone(message_packet)
-        self.assertIsNone(self.message_packet)
-        self.assertEqualBy(lambda: self.alive_packet is None, False, 8)
-        self.assertEqual(self.alive_packet.id, alive_id)
-        self.assertEqual(acked_packet.id, alive_id, 'Alive was not acked')
-        acked_packet = None
-
-        # assert sending heartbeats actually works, and that heartbeats don't
-        # get acked
-        self.agent1.send_heartbeat()
-        self.assertEqualBy(lambda: incoming_hb is None, False, 8)
-        self.assertIsNone(acked_packet)
-        self.assertGreater(hb_count, 0)
-
-        # Test message send to agent
-        manager_message_id = 'message_id_from_manager'
-        test_message_text_2 = 'test_message_text_2'
-        self.agent1.send_acks = False
-        message_send_packet = Packet(
-            manager_message_id,
-            Packet.TYPE_MESSAGE,
-            self.socket_manager.get_my_sender_id(),
-            TEST_WORKER_ID_1,
-            TEST_ASSIGNMENT_ID_1,
-            test_message_text_2,
-            't2',
-        )
-        self.socket_manager.queue_packet(message_send_packet)
-        self.assertEqualBy(lambda: message_packet is None, False, 8)
-        self.assertEqual(message_packet.id, manager_message_id)
-        self.assertEqual(message_packet.data, test_message_text_2)
-        self.assertIn(manager_message_id, self.socket_manager.packet_map)
-        self.assertNotEqual(
-            self.socket_manager.packet_map[manager_message_id].status, Packet.STATUS_ACK
-        )
-        message_packet = None
-        self.agent1.send_acks = True
-        self.assertEqualBy(lambda: message_packet is None, False, 8)
-        self.assertEqual(message_packet.id, manager_message_id)
-        self.assertEqual(message_packet.data, test_message_text_2)
-        self.assertIn(manager_message_id, self.socket_manager.packet_map)
-        self.assertEqualBy(
-            lambda: self.socket_manager.packet_map[manager_message_id].status,
-            Packet.STATUS_ACK,
-            6,
-        )
 
     def test_one_agent_disconnect_other_alive(self):
-        acked_packet = None
-        incoming_hb = None
         message_packet = None
-        hb_count = 0
-
-        def on_ack(*args):
-            nonlocal acked_packet
-            acked_packet = args[0]
-
-        def on_hb(*args):
-            nonlocal incoming_hb, hb_count
-            incoming_hb = args[0]
-            hb_count += 1
 
         def on_msg(*args):
             nonlocal message_packet
             message_packet = args[0]
 
-        self.agent1.register_to_socket(self.fake_socket, on_ack, on_hb, on_msg)
-        self.agent2.register_to_socket(self.fake_socket, on_ack, on_hb, on_msg)
-        self.assertIsNone(acked_packet)
-        self.assertIsNone(incoming_hb)
+        self.agent1.register_to_socket(self.fake_socket, on_msg)
+        self.agent2.register_to_socket(self.fake_socket, on_msg)
         self.assertIsNone(message_packet)
-        self.assertEqual(hb_count, 0)
 
         # Assert alive is registered
         self.agent1.send_alive()
         self.agent2.send_alive()
-        self.assertEqualBy(lambda: acked_packet is None, False, 8)
-        self.assertIsNone(incoming_hb)
         self.assertIsNone(message_packet)
 
-        # Start sending heartbeats
-        self.agent1.send_heartbeat()
-        self.agent2.send_heartbeat()
-
         # Kill second agent
-        self.agent2.always_beat = False
+        self.agent2.send_disconnect()
         self.assertEqualBy(lambda: self.dead_worker_id, TEST_WORKER_ID_2, 8)
         self.assertEqual(self.dead_assignment_id, TEST_ASSIGNMENT_ID_2)
 
@@ -1270,8 +894,6 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         test_message_text_1 = 'test_message_text_1'
         msg_id = self.agent1.send_message(test_message_text_1)
         self.assertEqualBy(lambda: self.message_packet is None, False, 8)
-        self.assertEqualBy(lambda: acked_packet is None, False, 8)
-        self.assertEqual(self.message_packet.id, acked_packet.id)
         self.assertEqual(self.message_packet.id, msg_id)
         self.assertEqual(self.message_packet.data['text'], test_message_text_1)
 
@@ -1280,7 +902,7 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         test_message_text_2 = 'test_message_text_2'
         message_send_packet = Packet(
             manager_message_id,
-            Packet.TYPE_MESSAGE,
+            data_model.WORLD_MESSAGE,
             self.socket_manager.get_my_sender_id(),
             TEST_WORKER_ID_1,
             TEST_ASSIGNMENT_ID_1,
@@ -1292,14 +914,9 @@ class TestSocketManagerMessageHandling(unittest.TestCase):
         self.assertEqual(message_packet.id, manager_message_id)
         self.assertEqual(message_packet.data, test_message_text_2)
         self.assertIn(manager_message_id, self.socket_manager.packet_map)
-        self.assertEqualBy(
-            lambda: self.socket_manager.packet_map[manager_message_id].status,
-            Packet.STATUS_ACK,
-            6,
-        )
 
         # Test agent disconnect
-        self.agent1.always_beat = False
+        self.agent1.send_disconnect()
         self.assertEqualBy(lambda: self.dead_worker_id, TEST_WORKER_ID_1, 8)
         self.assertEqual(self.dead_assignment_id, TEST_ASSIGNMENT_ID_1)
 


### PR DESCRIPTION
**Patch description**
As I destroyed many assumptions about the underlying structure that the MTurk unit and integration tests had made, it was time to revamp all of these tests to actually work again. This PR fixes all of these tests. In some cases it involved transitioning to new implementation details, and in many it involved removing tests that were covering weird corner cases that the new simpler infrastructure had removed (for a net change of -1014 lines!).

**Testing steps**
```
python test_db_interactions.py; python test_full_system.py; python test_mturk_agent.py; python test_mturk_manager.py; python test_socket_manager.py; python test_worker_manager.py
....
----------------------------------------------------------------------
Ran 4 tests in 0.042s
OK
......
----------------------------------------------------------------------
Ran 6 tests in 31.458s
OK
.........
----------------------------------------------------------------------
Ran 9 tests in 0.349s
OK
...........................
----------------------------------------------------------------------
Ran 27 tests in 58.393s
OK
..............
----------------------------------------------------------------------
Ran 14 tests in 53.030s
OK
.........
----------------------------------------------------------------------
Ran 9 tests in 0.042s
```
No test failures