### PR TITLE
only print number of threads initialized, not init per thread

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -859,7 +859,6 @@ class HogwildProcess(Process):
             world = BatchWorld(self.opt, world)
         self.sync['threads_sem'].release()
         with world:
-            # print('[ thread {} initialized ]'.format(self.shared['threadindex']))
             while True:
                 if self.sync['term_flag'].value:
                     break  # time to close

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -859,7 +859,7 @@ class HogwildProcess(Process):
             world = BatchWorld(self.opt, world)
         self.sync['threads_sem'].release()
         with world:
-            print('[ thread {} initialized ]'.format(self.shared['threadindex']))
+            # print('[ thread {} initialized ]'.format(self.shared['threadindex']))
             while True:
                 if self.sync['term_flag'].value:
                     break  # time to close
@@ -952,6 +952,8 @@ class HogwildWorld(World):
             # this makes sure that no threads get examples before all are set up
             # otherwise they might reset one another after processing some exs
             self.sync['threads_sem'].acquire()
+
+        print(f'[ {self.numthreads} threads initialized ]')
 
     def display(self):
         """Unsupported operation. Raises a `NotImplementedError`."""


### PR DESCRIPTION
**Patch description**
Small change changing the logging of thread initialisation. We could add it back in if we had logging levels, but for now it just makes the logs much harder to read.


**Logs**
```
$ python {anyscript.py} -nt 20
...
[ 20 threads initialized ]
```