### PR TITLE
fixed bug in fixed candidate ranking and add speedup option for ranking eval

### DIFF
--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -156,7 +156,7 @@ class TorchRankerAgent(TorchAgent):
                 states = {}
 
         self.rank_top_k = opt.get('rank_top_k', -1)
-        self.rank_loss = self.build_loss(opt)
+        self.rank_loss = nn.CrossEntropyLoss(reduce=True, size_average=False)
         if self.use_cuda:
             self.model.cuda()
             self.rank_loss.cuda()
@@ -180,9 +180,6 @@ class TorchRankerAgent(TorchAgent):
             self.model = torch.nn.parallel.DistributedDataParallel(
                 self.model, device_ids=[self.opt['gpu']], broadcast_buffers=False
             )
-
-    def build_loss(self, opt):
-        return nn.CrossEntropyLoss(reduce=True, size_average=False)
 
     def set_interactive_mode(self, mode, shared=False):
         self.candidates = self.opt['candidates']

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -625,11 +625,9 @@ class TorchRankerAgent(TorchAgent):
                 bad_batch = False
                 for batch_idx, label_vec in enumerate(label_vecs):
                     max_c_len = cand_vecs.size(1)
-                    label_vec_pad = label_vec.new_zeros(max_c_len).fill_(
-                        self.NULL_IDX
-                    )
+                    label_vec_pad = label_vec.new_zeros(max_c_len).fill_(self.NULL_IDX)
                     if max_c_len < len(label_vec):
-                        label_vec = label_vec[0 : max_c_len]
+                        label_vec = label_vec[0:max_c_len]
                     label_vec_pad[0 : label_vec.size(0)] = label_vec
                     label_inds[batch_idx] = self._find_match(cand_vecs, label_vec_pad)
                     if label_inds[batch_idx] == -1:

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -269,7 +269,9 @@ class TorchRankerAgent(TorchAgent):
         # TODO: speed these calculations up
         batchsize = scores.size(0)
         if self.rank_top_k > 0:
-            _, ranks = scores.topk(self.rank_top_k, 1, largest=True)
+            _, ranks = scores.topk(
+                min(self.rank_top_k, scores.size(1)), 1, largest=True
+            )
         else:
             _, ranks = scores.sort(1, descending=True)
         for b in range(batchsize):
@@ -377,7 +379,9 @@ class TorchRankerAgent(TorchAgent):
 
         scores = self.score_candidates(batch, cand_vecs, cand_encs=cand_encs)
         if self.rank_top_k > 0:
-            _, ranks = scores.topk(self.rank_top_k, 1, largest=True)
+            _, ranks = scores.topk(
+                min(self.rank_top_k, scores.size(1)), 1, largest=True
+            )
         else:
             _, ranks = scores.sort(1, descending=True)
 


### PR DESCRIPTION
**Patch description**
1) fix error setting up fixed candidates
~~2) separate loss instantiation into separate function~~ -> moved to #1899
3) add rank_top_k option to do top-k selection instead of sorting all candidates by score. if you're just looking for hits@ metrics this is much faster, though this makes mean_rank / mrr calculations a bit wonky (it doesn't sort anything beyond the k). I'm open to suggestions on how to handle this--maybe good to zero them out?
4) switch pad handling to be a bit faster when using inline candidates


**Testing steps**
The following run uses a relatively large 75k candidate set with fixed encodings during evaluation. I added a timer around valid/test in train_mode.py.
```
$ python examples/train_model.py -t wikimovies --dict-file /tmp/dict_wikimovies -bs 128 -nt 10 -eps 5 -m memnn --no-cuda -cands batch -ecands fixed -fcp /private/home/ahm/ParlAI/data/WikiMovies/movieqa/knowledge_source/entities.txt -dt train:ordered --ignore-bad-candidates True -mf /tmp/run
```
master: `~48s training / IndexError on eval`
master + error fix: `~48s training / ~49s valid + test`
rank_speed: `~46s training / ~47s valid + test` (slightly faster training + slightly faster eval)
rank_top_k=100: `~46s training / ~36s valid + test` (faster eval if you just want hits@100)
rank_top_k=1: `~47s training / ~32s valid + test` (faster eval if you just want hits@1)

The biggest speedup you'll see is when using inline candidates due to the change in the "ordering" code.
```
python examples/train_model.py -t wikimovies --dict-file /tmp/dict_wikimovies -bs 4 -esz 1 -hops 0 --memsize 0 -tf False -nt 10 -eps 1 -m memnn --no-cuda -cands batch -ecands inline -dt train:ordered -vme 1000 --short-final-eval True -mf /tmp/run
```
master: `467s valid + test`
rank_speed: `402s valid + test`
rank_top_k=100: `388s valid + test`

You might notice that this is a no-hop memnn with esz of only 1, and it still takes forever to do just 1000 examples here. Precomputing the candidate vectors helps a lot. (Or even better, the candidate vectors.)