### PR TITLE
print how long evals take during training

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -313,7 +313,8 @@ def run_eval(valid_worlds, opt, datatype, max_exs=-1, write_log=False):
         reports, tasks, micro=opt.get('aggregate_micro', True)
     )
 
-    metrics = f'[ eval completed in {round(timer.time(), 2)}s ]\n{datatype}:{report}'
+    metrics = f'{datatype}:{report}'
+    print(f'[ eval completed in {round(timer.time(), 2)}s ]')
     print(metrics)
 
     # write to file

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -302,6 +302,7 @@ def run_eval(valid_worlds, opt, datatype, max_exs=-1, write_log=False):
         return None
 
     print('[ running eval: ' + datatype + ' ]')
+    timer = Timer()
     reports = []
     for v_world in valid_worlds:
         task_report = _run_single_eval(opt, v_world, max_exs / len(valid_worlds))
@@ -312,7 +313,7 @@ def run_eval(valid_worlds, opt, datatype, max_exs=-1, write_log=False):
         reports, tasks, micro=opt.get('aggregate_micro', True)
     )
 
-    metrics = '{}:{}'.format(datatype, report)
+    metrics = f'[ eval completed in {round(timer.time(), 2)}s ]\n{datatype}:{report}'
     print(metrics)
 
     # write to file

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -314,7 +314,7 @@ def run_eval(valid_worlds, opt, datatype, max_exs=-1, write_log=False):
     )
 
     metrics = f'{datatype}:{report}'
-    print(f'[ eval completed in {round(timer.time(), 2)}s ]')
+    print(f'[ eval completed in {timer.time():.2f}s ]')
     print(metrics)
 
     # write to file


### PR DESCRIPTION
**Patch description**
Prints how long evaluations take during training and at the end of training.

**Testing steps**
```
$ py examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 32 -dt train:ordered -eps 5 -m seq2seq -veps 1
...
[ training... ]
[ time:2.0s total_exs:3616 epochs:0.4 time_left:24.0s ] {'exs': 3616, 'lr': 1, 'num_updates': 113, 'gnorm': 1.328, 'clip': 1.0, 'loss': 122.7, 'token_acc': 0.5689, 'nll_loss': 1.109, 'ppl': 3.031}
[ time:4.0s total_exs:7360 epochs:0.82 time_left:21.0s ] {'exs': 3744, 'lr': 1, 'num_updates': 230, 'gnorm': 1.19, 'clip': 1.0, 'loss': 107.5, 'token_acc': 0.6095, 'nll_loss': 0.9184, 'ppl': 2.505}
[creating task(s): babi:task10k:1]
[loading fbdialog data:/private/home/ahm/ParlAI/data/bAbI/tasks_1-20_v1-2/en-valid-10k-nosf/qa1_valid.txt]
[ running eval: valid ]
[ eval completed in 0.59s ]
valid:{'exs': 1000, 'accuracy': 0.452, 'f1': 0.452, 'bleu': 4.52e-10, 'lr': 1, 'num_updates': 282, 'loss': 28.08, 'token_acc': 0.726, 'nll_loss': 0.8082, 'ppl': 2.244}
[ new best accuracy: 0.452 ]
[ time:6.0s total_exs:9728 epochs:1.08 time_left:22.0s ] {'exs': 2368, 'lr': 1, 'num_updates': 304, 'gnorm': 1.307, 'clip': 1.0, 'loss': 17.45, 'token_acc': 0.7223, 'nll_loss': 0.7933, 'ppl': 2.211}
[ time:8.0s total_exs:13536 epochs:1.5 time_left:19.0s ] {'exs': 3808, 'lr': 1, 'num_updates': 423, 'gnorm': 1.387, 'clip': 1.0, 'loss': 90.93, 'token_acc': 0.7459, 'nll_loss': 0.7641, 'ppl': 2.147}
[ time:10.0s total_exs:17312 epochs:1.92 time_left:17.0s ] {'exs': 3776, 'lr': 1, 'num_updates': 541, 'gnorm': 1.473, 'clip': 1.0, 'loss': 85.93, 'token_acc': 0.7529, 'nll_loss': 0.7282, 'ppl': 2.071}
[ running eval: valid ]
[ eval completed in 0.59s ]
valid:{'exs': 1000, 'accuracy': 0.541, 'f1': 0.541, 'bleu': 5.41e-10, 'lr': 1, 'num_updates': 564, 'loss': 23.17, 'token_acc': 0.7705, 'nll_loss': 0.6623, 'ppl': 1.939}
[ new best accuracy: 0.541 (previous best was 0.452) ]
```
