### PR TITLE
[TRA] dimension error with fixed candidates

### DIFF
--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -607,7 +607,7 @@ class TorchRankerAgent(TorchAgent):
                         self.NULL_IDX
                     )
                     if cand_vecs[i].size(0) < len(label_vec):
-                        label_vec = label_vec[0 : cand_vecs[i].size(1)]
+                        label_vec = label_vec[0 : cand_vecs[i].size(0)]
                     label_vec_pad[0 : label_vec.size(0)] = label_vec
                     label_inds[i] = self._find_match(cand_vecs, label_vec_pad)
                     if label_inds[i] == -1:

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -603,11 +603,11 @@ class TorchRankerAgent(TorchAgent):
                 label_inds = label_vecs.new_empty((batchsize))
                 bad_batch = False
                 for i, label_vec in enumerate(label_vecs):
-                    label_vec_pad = label_vec.new_zeros(cand_vecs[i].size(0)).fill_(
+                    label_vec_pad = label_vec.new_zeros(cand_vecs.size(1)).fill_(
                         self.NULL_IDX
                     )
-                    if cand_vecs[i].size(0) < len(label_vec):
-                        label_vec = label_vec[0 : cand_vecs[i].size(0)]
+                    if cand_vecs.size(1) < len(label_vec):
+                        label_vec = label_vec[0 : cand_vecs.size(1)]
                     label_vec_pad[0 : label_vec.size(0)] = label_vec
                     label_inds[i] = self._find_match(cand_vecs, label_vec_pad)
                     if label_inds[i] == -1:


### PR DESCRIPTION
**Patch description**
@alexholdenmiller discovered this bug. It was challenging to reproduce, as the condition `cand_vecs[i].size(0) < len(label_vec)` triggers rarely with fixed candidates (as the set of fixed candidates is often huge and padded to the maximum length candidate).

Since fixed candidates are built to dimension 2 instead of 3, we need to access the length with a `0` and not a `1` here.

Added this in a PR separate to #1894, as it's a bit tangential to the other improvements therein.
