### PR TITLE
Output git commit during parse_args.

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -12,10 +12,32 @@ import pickle
 import json
 import sys as _sys
 import datetime
+import parlai
+import git
+
 from parlai.core.agents import get_agent_module, get_task_module
 from parlai.core.build_data import modelzoo_path
 from parlai.tasks.tasks import ids_to_tasks
 from parlai.core.utils import Opt, load_opt_file
+
+
+def print_git_commit():
+    """Print the current git commit of ParlAI and parlai_internal."""
+    root = os.path.dirname(os.path.dirname(parlai.__file__))
+    internal_root = os.path.join(root, 'parlai_internal')
+    try:
+        git_ = git.Git(root)
+        current_commit = git_.rev_parse('HEAD')
+        print(f'[ Current ParlAI commit: {current_commit} ]')
+    except git.GitCommandNotFound:
+        raise
+
+    try:
+        git_ = git.Git(internal_root)
+        internal_commit = git_.rev_parse('HEAD')
+        print(f'[ Current internal commit: {internal_commit} ]')
+    except git.GitCommandNotFound:
+        pass
 
 
 def print_announcements(opt):
@@ -960,6 +982,7 @@ class ParlaiParser(argparse.ArgumentParser):
 
         if print_args:
             self.print_args()
+            print_git_commit()
             print_announcements(self.opt)
 
         return self.opt


### PR DESCRIPTION
**Patch description**
Whenever we run parser.parse_args, additionally output the current git commit of ParlAI, and if available, parlai_internal. This is a small detail that might help with recreating experiments from older stored logs. It might also help debug issues with external issues.

**Logs**
```
$ python examples/display_data.py -t convai2 -ne 1
...
[ Current ParlAI commit: cb8639f79a5b4d747b91fadcbc5a159a28faf611 ]
[ Current internal commit: e335995cdca07b0e0f6d35fbf2b82c60cbcfeac0 ]
[creating task(s): convai2]
[loading fbdialog data:/private/home/roller/working/parlai/data/ConvAI2/train_self_original.txt]
[convai2]: your persona: i like to remodel homes.
...
```