### PR TITLE
fix dataloader sharing

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -221,7 +221,7 @@ class FixedDialogTeacher(Teacher):
 
         if hasattr(self, 'examples'):
             shared['examples'] = self.examples
-        
+
         if hasattr(self, 'data_loader'):
             shared['data_loader'] = self.data_loader
 

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -60,7 +60,7 @@ class DataLoader(Thread):
 
     def __init__(self, opt):
         Thread.__init__(self, daemon=True)
-        self.num_workers = opt.get('num_threads', 1)
+        self.num_workers = opt.get('num_load_threads', 1)
         self.request_queue = queue.Queue()
 
     def request_load(self, receive_fn, load_fn, args):

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -60,7 +60,7 @@ class DataLoader(Thread):
 
     def __init__(self, opt):
         Thread.__init__(self, daemon=True)
-        self.num_workers = opt.get('num_load_threads', 1)
+        self.num_workers = opt.get('num_threads', 1)
         self.request_queue = queue.Queue()
 
     def request_load(self, receive_fn, load_fn, args):
@@ -221,13 +221,15 @@ class FixedDialogTeacher(Teacher):
 
         if hasattr(self, 'examples'):
             shared['examples'] = self.examples
+        
+        if hasattr(self, 'data_loader'):
+            shared['data_loader'] = self.data_loader
 
         if self.opt.get('numthreads', 1) > 1:
             if type(self.index) is not multiprocessing.sharedctypes.Synchronized:
                 # for multithreading need to move index into threadsafe memory
                 self.index = Value('l', -1)
-        else:
-            shared['data_loader'] = self.data_loader
+
         shared['index'] = self.index
 
         return shared


### PR DESCRIPTION
**Patch description**
Python appears to have a limit on the total number of possible threads.
The DataLoader set up by FixedDialogTeacher creates additional threads.
Since the DataLoader was not shared in `share()` when nt > 1, `nt x bs` DataLoaders were being initialized.
At approx `nt x bs > 28k` (e.g. nt=40 bs=700), you get `RuntimeError: can't start new thread`.

**Testing steps**
```
py examples/train_model.py -m repeat_label -t babi:task10k:1 -nt 40 -bs 800 -df /tmp/dict_babi
```
master: `RuntimeError`
fix_dataloader: no problem
