### PR TITLE
move build_model and build_criterion to TorchAgent

### DIFF
--- a/parlai/agents/bert_classifier/bert_classifier.py
+++ b/parlai/agents/bert_classifier/bert_classifier.py
@@ -132,6 +132,8 @@ class BertClassifierAgent(TorchClassifierAgent):
         self.model = BertWrapper(
             BertModel.from_pretrained(self.pretrained_path), num_classes
         )
+        if self.use_cuda:
+            self.model.cuda()
 
     def init_optim(self, params, optim_states=None, saved_optim_type=None):
         """Initialize the optimizer."""

--- a/parlai/agents/bert_classifier/bert_classifier.py
+++ b/parlai/agents/bert_classifier/bert_classifier.py
@@ -129,9 +129,7 @@ class BertClassifierAgent(TorchClassifierAgent):
     def build_model(self):
         """Construct the model."""
         num_classes = len(self.class_list)
-        return BertWrapper(
-            BertModel.from_pretrained(self.pretrained_path), num_classes
-        )
+        return BertWrapper(BertModel.from_pretrained(self.pretrained_path), num_classes)
 
     def init_optim(self, params, optim_states=None, saved_optim_type=None):
         """Initialize the optimizer."""

--- a/parlai/agents/bert_classifier/bert_classifier.py
+++ b/parlai/agents/bert_classifier/bert_classifier.py
@@ -129,7 +129,7 @@ class BertClassifierAgent(TorchClassifierAgent):
     def build_model(self):
         """Construct the model."""
         num_classes = len(self.class_list)
-        self.model = BertWrapper(
+        return BertWrapper(
             BertModel.from_pretrained(self.pretrained_path), num_classes
         )
 

--- a/parlai/agents/bert_classifier/bert_classifier.py
+++ b/parlai/agents/bert_classifier/bert_classifier.py
@@ -132,8 +132,6 @@ class BertClassifierAgent(TorchClassifierAgent):
         self.model = BertWrapper(
             BertModel.from_pretrained(self.pretrained_path), num_classes
         )
-        if self.use_cuda:
-            self.model.cuda()
 
     def init_optim(self, params, optim_states=None, saved_optim_type=None):
         """Initialize the optimizer."""

--- a/parlai/agents/bert_ranker/bi_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/bi_encoder_ranker.py
@@ -57,7 +57,7 @@ class BiEncoderRankerAgent(TorchRankerAgent):
         self.rank_loss = torch.nn.CrossEntropyLoss(reduce=True, size_average=True)
 
     def build_model(self):
-        self.model = BiEncoderModule(self.opt)
+        return BiEncoderModule(self.opt)
 
     @staticmethod
     def dictionary_class():

--- a/parlai/agents/bert_ranker/bi_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/bi_encoder_ranker.py
@@ -58,8 +58,6 @@ class BiEncoderRankerAgent(TorchRankerAgent):
 
     def build_model(self):
         self.model = BiEncoderModule(self.opt)
-        if self.use_cuda:
-            self.model.cuda()
 
     @staticmethod
     def dictionary_class():

--- a/parlai/agents/bert_ranker/bi_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/bi_encoder_ranker.py
@@ -58,6 +58,8 @@ class BiEncoderRankerAgent(TorchRankerAgent):
 
     def build_model(self):
         self.model = BiEncoderModule(self.opt)
+        if self.use_cuda:
+            self.model.cuda()
 
     @staticmethod
     def dictionary_class():

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -58,6 +58,8 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
             layer_pulled=self.opt['pull_from_layer'],
             aggregation=self.opt['bert_aggregation'],
         )
+        if self.use_cuda:
+            self.model.cuda()
 
     def init_optim(self, params, optim_states=None, saved_optim_type=None):
         self.optimizer = get_bert_optimizer(

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -51,7 +51,7 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
         self.END_IDX = self.dict.end_idx
 
     def build_model(self):
-        self.model = BertWrapper(
+        return BertWrapper(
             BertModel.from_pretrained(self.pretrained_path),
             1,
             add_transformer_layer=self.opt['add_transformer_layer'],

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -58,8 +58,6 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
             layer_pulled=self.opt['pull_from_layer'],
             aggregation=self.opt['bert_aggregation'],
         )
-        if self.use_cuda:
-            self.model.cuda()
 
     def init_optim(self, params, optim_states=None, saved_optim_type=None):
         self.optimizer = get_bert_optimizer(

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -350,8 +350,8 @@ class FairseqAgent(TorchAgent):
             self.meters = defaultdict(AverageMeter)
 
             # actually construct the criterion, model and generator
-            self.build_criterion()
-            self.build_model()
+            self.criterion = self.build_criterion()
+            self.model = self.build_model()
 
             # Construct the generator and scorer
             self.generator = SequenceGenerator(
@@ -423,12 +423,12 @@ class FairseqAgent(TorchAgent):
             self._copy_embeddings(
                 model.encoder.embed_tokens.weight, self.args.embedding_type
             )
-        self.model = model
+        return model
 
     def build_criterion(self):
         """Set up the grader."""
         # TorchAgent will call this without ready=True before self.args is ready
-        self.criterion = criterions.build_criterion(self.args, self.task)
+        return criterions.build_criterion(self.args, self.task)
 
     def share(self):
         shared = super().share()

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -312,6 +312,8 @@ class FairseqAgent(TorchAgent):
 
         # one last time, restore any user set defaults
         argparser.set_defaults(**old_defaults)
+        # default weight decay in fairseq is zero not None
+        argparser.set_defaults(weight_decay=0.0)
 
     @staticmethod
     def dictionary_class():

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -330,7 +330,7 @@ class FairseqAgent(TorchAgent):
             model_file_exists = self.opt.get('model_file') and os.path.isfile(
                 self.opt['model_file']
             )
-            
+
             # fairseq expects options to be in argparse format, instead of a dict
             # We also need to do some argument postprocessing and whatnot
             # We'll skip pretrained embeddings if we're going to override them with
@@ -424,7 +424,7 @@ class FairseqAgent(TorchAgent):
                 model.encoder.embed_tokens.weight, self.args.embedding_type
             )
         self.model = model
-    
+
     def build_criterion(self):
         """Set up the grader."""
         # TorchAgent will call this without ready=True before self.args is ready

--- a/parlai/agents/memnn/memnn.py
+++ b/parlai/agents/memnn/memnn.py
@@ -104,6 +104,9 @@ class MemnnAgent(TorchRankerAgent):
             **kwargs,
         )
 
+        if self.use_cuda:
+            self.model.cuda()
+
     def _score(self, output, cands):
         if cands.dim() == 2:
             return torch.matmul(output, cands.t())

--- a/parlai/agents/memnn/memnn.py
+++ b/parlai/agents/memnn/memnn.py
@@ -104,9 +104,6 @@ class MemnnAgent(TorchRankerAgent):
             **kwargs,
         )
 
-        if self.use_cuda:
-            self.model.cuda()
-
     def _score(self, output, cands):
         if cands.dim() == 2:
             return torch.matmul(output, cands.t())

--- a/parlai/agents/memnn/memnn.py
+++ b/parlai/agents/memnn/memnn.py
@@ -97,7 +97,7 @@ class MemnnAgent(TorchRankerAgent):
     def build_model(self):
         """Build MemNN model."""
         kwargs = opt_to_kwargs(self.opt)
-        self.model = MemNN(
+        return MemNN(
             len(self.dict),
             self.opt['embedding_size'],
             padding_idx=self.NULL_IDX,

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -187,9 +187,6 @@ class Seq2seqAgent(TorchGeneratorAgent):
             # set loaded states if applicable
             self.model.load_state_dict(states['model'])
 
-        if self.use_cuda:
-            self.model.cuda()
-
         if opt['embedding_type'].endswith('fixed'):
             print('Seq2seq: fixing embedding weights.')
             self.model.decoder.lt.weight.requires_grad = False
@@ -197,22 +194,14 @@ class Seq2seqAgent(TorchGeneratorAgent):
             if opt['lookuptable'] in ['dec_out', 'all']:
                 self.model.decoder.e2s.weight.requires_grad = False
 
-        if self.use_cuda:
-            self.model.cuda()
-
     def build_criterion(self):
         # set up criteria
         if self.opt.get('numsoftmax', 1) > 1:
-            self.criterion = nn.NLLLoss(
-                ignore_index=self.NULL_IDX, reduction='sum'
-            )
+            self.criterion = nn.NLLLoss(ignore_index=self.NULL_IDX, reduction='sum')
         else:
             self.criterion = nn.CrossEntropyLoss(
                 ignore_index=self.NULL_IDX, reduction='sum'
             )
-
-        if self.use_cuda:
-            self.criterion.cuda()
 
     def batchify(self, *args, **kwargs):
         """Override batchify options for seq2seq."""

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -176,23 +176,23 @@ class Seq2seqAgent(TorchGeneratorAgent):
             print('skipping preinitialization of embeddings for bpe')
         elif not states and opt['embedding_type'] != 'random':
             # `not states`: only set up embeddings if not loading model
-            self._copy_embeddings(self.model.decoder.lt.weight, opt['embedding_type'])
+            self._copy_embeddings(model.decoder.lt.weight, opt['embedding_type'])
             if opt['lookuptable'] in ['unique', 'dec_out']:
                 # also set encoder lt, since it's not shared
                 self._copy_embeddings(
-                    self.model.encoder.lt.weight, opt['embedding_type'], log=False
+                    model.encoder.lt.weight, opt['embedding_type'], log=False
                 )
 
         if states:
             # set loaded states if applicable
-            self.model.load_state_dict(states['model'])
+            model.load_state_dict(states['model'])
 
         if opt['embedding_type'].endswith('fixed'):
             print('Seq2seq: fixing embedding weights.')
-            self.model.decoder.lt.weight.requires_grad = False
-            self.model.encoder.lt.weight.requires_grad = False
+            model.decoder.lt.weight.requires_grad = False
+            model.encoder.lt.weight.requires_grad = False
             if opt['lookuptable'] in ['dec_out', 'all']:
-                self.model.decoder.e2s.weight.requires_grad = False
+                model.output.weight.requires_grad = False
 
         return model
 

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -200,15 +200,15 @@ class Seq2seqAgent(TorchGeneratorAgent):
         if self.use_cuda:
             self.model.cuda()
 
-        return self.model
-
     def build_criterion(self):
         # set up criteria
         if self.opt.get('numsoftmax', 1) > 1:
-            self.criterion = nn.NLLLoss(ignore_index=self.NULL_IDX, size_average=False)
+            self.criterion = nn.NLLLoss(
+                ignore_index=self.NULL_IDX, reduction='sum'
+            )
         else:
             self.criterion = nn.CrossEntropyLoss(
-                ignore_index=self.NULL_IDX, size_average=False
+                ignore_index=self.NULL_IDX, reduction='sum'
             )
 
         if self.use_cuda:

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -160,7 +160,7 @@ class Seq2seqAgent(TorchGeneratorAgent):
             states = {}
 
         kwargs = opt_to_kwargs(opt)
-        self.model = Seq2seq(
+        model = Seq2seq(
             len(self.dict),
             opt['embeddingsize'],
             opt['hiddensize'],
@@ -194,14 +194,14 @@ class Seq2seqAgent(TorchGeneratorAgent):
             if opt['lookuptable'] in ['dec_out', 'all']:
                 self.model.decoder.e2s.weight.requires_grad = False
 
+        return model
+
     def build_criterion(self):
         # set up criteria
         if self.opt.get('numsoftmax', 1) > 1:
-            self.criterion = nn.NLLLoss(ignore_index=self.NULL_IDX, reduction='sum')
+            return nn.NLLLoss(ignore_index=self.NULL_IDX, reduction='sum')
         else:
-            self.criterion = nn.CrossEntropyLoss(
-                ignore_index=self.NULL_IDX, reduction='sum'
-            )
+            return nn.CrossEntropyLoss(ignore_index=self.NULL_IDX, reduction='sum')
 
     def batchify(self, *args, **kwargs):
         """Override batchify options for seq2seq."""

--- a/parlai/agents/transformer/biencoder.py
+++ b/parlai/agents/transformer/biencoder.py
@@ -8,16 +8,10 @@ import torch
 
 
 class BiencoderAgent(TransformerRankerAgent):
-    """ Equivalent of bert_ranker/biencoder but does not rely on an external
-        library (hugging face).
     """
-
-    def __init__(self, opt, shared=None):
-        super().__init__(opt, shared)
-        # favor average instead of sum for the loss.
-        self.rank_loss = torch.nn.CrossEntropyLoss(reduce=True, size_average=True)
-        if self.use_cuda:
-            self.rank_loss.cuda()
+    Equivalent of bert_ranker/biencoder but does not rely on an external
+    library (hugging face).
+    """
 
     def vectorize(self, *args, **kwargs):
         """ Add the start and end token to the text.

--- a/parlai/agents/transformer/crossencoder.py
+++ b/parlai/agents/transformer/crossencoder.py
@@ -17,9 +17,6 @@ class CrossencoderAgent(TorchRankerAgent):
 
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
-        self.rank_loss = torch.nn.CrossEntropyLoss(reduce=True, size_average=True)
-        if self.use_cuda:
-            self.rank_loss.cuda()
         self.data_parallel = opt.get('data_parallel') and self.use_cuda
         if self.data_parallel:
             from parlai.core.distributed_utils import is_distributed
@@ -35,8 +32,7 @@ class CrossencoderAgent(TorchRankerAgent):
         return argparser
 
     def build_model(self, states=None):
-        self.model = CrossEncoderModule(self.opt, self.dict, self.NULL_IDX)
-        return self.model
+        return CrossEncoderModule(self.opt, self.dict, self.NULL_IDX)
 
     def vectorize(self, *args, **kwargs):
         """ Add the start and end token to the text.

--- a/parlai/agents/transformer/polyencoder.py
+++ b/parlai/agents/transformer/polyencoder.py
@@ -87,7 +87,8 @@ class PolyencoderAgent(TorchRankerAgent):
 
     def build_model(self, states=None):
         self.model = PolyEncoderModule(self.opt, self.dict, self.NULL_IDX)
-        return self.model
+        if self.use_cuda:
+            self.model.cuda()
 
     def vectorize(self, *args, **kwargs):
         """ Add the start and end token to the labels.

--- a/parlai/agents/transformer/polyencoder.py
+++ b/parlai/agents/transformer/polyencoder.py
@@ -86,7 +86,7 @@ class PolyencoderAgent(TorchRankerAgent):
             self.model = torch.nn.DataParallel(self.model)
 
     def build_model(self, states=None):
-        self.model = PolyEncoderModule(self.opt, self.dict, self.NULL_IDX)
+        return PolyEncoderModule(self.opt, self.dict, self.NULL_IDX)
 
     def vectorize(self, *args, **kwargs):
         """ Add the start and end token to the labels.

--- a/parlai/agents/transformer/polyencoder.py
+++ b/parlai/agents/transformer/polyencoder.py
@@ -87,8 +87,6 @@ class PolyencoderAgent(TorchRankerAgent):
 
     def build_model(self, states=None):
         self.model = PolyEncoderModule(self.opt, self.dict, self.NULL_IDX)
-        if self.use_cuda:
-            self.model.cuda()
 
     def vectorize(self, *args, **kwargs):
         """ Add the start and end token to the labels.

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -188,11 +188,12 @@ class TransformerRankerAgent(TorchRankerAgent):
             )
 
     def build_model(self, states=None):
-        self.model = TransformerMemNetModel(self.opt, self.dict)
+        model = TransformerMemNetModel(self.opt, self.dict)
         if self.opt['embedding_type'] != 'random':
             self._copy_embeddings(
-                self.model.embeddings.weight, self.opt['embedding_type']
+                model.embeddings.weight, self.opt['embedding_type']
             )
+        return model
 
     def batchify(self, obs_batch, sort=False):
         """Override so that we can add memories to the Batch object."""
@@ -263,8 +264,9 @@ class TransformerGeneratorAgent(TorchGeneratorAgent):
         return agent
 
     def build_model(self, states=None):
-        self.model = TransformerGeneratorModel(self.opt, self.dict)
+        model = TransformerGeneratorModel(self.opt, self.dict)
         if self.opt['embedding_type'] != 'random':
             self._copy_embeddings(
-                self.model.encoder.embeddings.weight, self.opt['embedding_type']
+                model.encoder.embeddings.weight, self.opt['embedding_type']
             )
+        return model

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -193,7 +193,8 @@ class TransformerRankerAgent(TorchRankerAgent):
             self._copy_embeddings(
                 self.model.embeddings.weight, self.opt['embedding_type']
             )
-        return self.model
+        if self.use_cuda:
+            self.model.cuda()
 
     def batchify(self, obs_batch, sort=False):
         """Override so that we can add memories to the Batch object."""
@@ -271,4 +272,3 @@ class TransformerGeneratorAgent(TorchGeneratorAgent):
             )
         if self.use_cuda:
             self.model.cuda()
-        return self.model

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -193,8 +193,6 @@ class TransformerRankerAgent(TorchRankerAgent):
             self._copy_embeddings(
                 self.model.embeddings.weight, self.opt['embedding_type']
             )
-        if self.use_cuda:
-            self.model.cuda()
 
     def batchify(self, obs_batch, sort=False):
         """Override so that we can add memories to the Batch object."""
@@ -270,5 +268,3 @@ class TransformerGeneratorAgent(TorchGeneratorAgent):
             self._copy_embeddings(
                 self.model.encoder.embeddings.weight, self.opt['embedding_type']
             )
-        if self.use_cuda:
-            self.model.cuda()

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -193,6 +193,10 @@ class TransformerRankerAgent(TorchRankerAgent):
             self._copy_embeddings(model.embeddings.weight, self.opt['embedding_type'])
         return model
 
+    def build_criterion(self):
+        """Build and return criterion, favoring average instead of sum for the loss."""
+        return torch.nn.CrossEntropyLoss(reduction='mean')
+
     def batchify(self, obs_batch, sort=False):
         """Override so that we can add memories to the Batch object."""
         batch = super().batchify(obs_batch, sort)

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -190,9 +190,7 @@ class TransformerRankerAgent(TorchRankerAgent):
     def build_model(self, states=None):
         model = TransformerMemNetModel(self.opt, self.dict)
         if self.opt['embedding_type'] != 'random':
-            self._copy_embeddings(
-                model.embeddings.weight, self.opt['embedding_type']
-            )
+            self._copy_embeddings(model.embeddings.weight, self.opt['embedding_type'])
         return model
 
     def batchify(self, obs_batch, sort=False):

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -783,6 +783,31 @@ class TorchAgent(ABC, Agent):
 
         return init_model, is_finetune
 
+    @abstractmethod
+    def build_model(self):
+        """
+        Construct the model.
+
+        The model should be set to self.model.
+        """
+        pass
+    
+    def build_criterion(self):
+        """
+        Construct the loss function.
+
+        By default torch.nn.CrossEntropyLoss.  The criterion function should be
+        set to self.criterion.
+
+        If overridden, this model should (1) handle calling cuda and (2)
+        produce a sum that can be used for a per-token loss.
+        """
+        self.criterion = torch.nn.CrossEntropyLoss(
+            ignore_index=self.NULL_IDX, reduction='sum'
+        )
+        if self.use_cuda:
+            self.criterion.cuda()
+
     def init_optim(self, params, optim_states=None, saved_optim_type=None):
         """
         Initialize optimizer with model parameters.

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -665,7 +665,7 @@ class TorchAgent(ABC, Agent):
             # intitialize any important structures from scratch
             self.replies = {}  # past replies
             self.dict = self.build_dictionary()
-            
+
             if opt.get('fp16'):
                 # Volta cores revert to FP32 hardware if tensors are not multiples
                 # of 8 in all dimensions. This INCLUDES the embeddings layer! As

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -796,20 +796,6 @@ class TorchAgent(ABC, Agent):
         """
         pass
 
-    def build_criterion(self):
-        """
-        Construct the loss function.
-
-        By default torch.nn.CrossEntropyLoss.  The criterion function should be
-        set to self.criterion.
-
-        If overridden, this model should (1) handle calling cuda and (2)
-        produce a sum that can be used for a per-token loss.
-        """
-        self.criterion = torch.nn.CrossEntropyLoss(
-            ignore_index=self.NULL_IDX, reduction='sum'
-        )
-
     def init_optim(self, params, optim_states=None, saved_optim_type=None):
         """
         Initialize optimizer with model parameters.

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -787,10 +787,9 @@ class TorchAgent(ABC, Agent):
 
         return init_model, is_finetune
 
-    @abstractmethod
     def build_model(self):
         """Construct the model and return it."""
-        pass
+        raise NotImplementedError('not implemented for this class')
 
     def init_optim(self, params, optim_states=None, saved_optim_type=None):
         """

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -809,8 +809,6 @@ class TorchAgent(ABC, Agent):
         self.criterion = torch.nn.CrossEntropyLoss(
             ignore_index=self.NULL_IDX, reduction='sum'
         )
-        if self.use_cuda:
-            self.criterion.cuda()
 
     def init_optim(self, params, optim_states=None, saved_optim_type=None):
         """

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -791,7 +791,7 @@ class TorchAgent(ABC, Agent):
         The model should be set to self.model.
         """
         pass
-    
+
     def build_criterion(self):
         """
         Construct the loss function.

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -789,11 +789,7 @@ class TorchAgent(ABC, Agent):
 
     @abstractmethod
     def build_model(self):
-        """
-        Construct the model.
-
-        The model should be set to self.model.
-        """
+        """Construct the model and return it."""
         pass
 
     def init_optim(self, params, optim_states=None, saved_optim_type=None):

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1161,10 +1161,8 @@ class TorchAgent(ABC, Agent):
         shared['metrics'] = self.metrics
 
         shared['dict'] = self.dict
-        if hasattr(self, 'model'):
-            shared['model'] = self.model
-        if hasattr(self, 'criterion'):
-            shared['criterion'] = self.criterion
+        shared['model'] = self.model
+        shared['criterion'] = self.criterion
         shared['opt'] = self.opt
         shared['replies'] = self.replies
         return shared

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -129,8 +129,8 @@ class TorchClassifierAgent(TorchAgent):
         if shared:
             self.model = shared['model']
         else:
-            self.build_model()
-            self.build_criterion()
+            self.model = self.build_model()
+            self.criterion = self.build_criterion()
             if self.use_cuda:
                 self.model.cuda()
                 self.critieron.cuda()
@@ -155,7 +155,7 @@ class TorchClassifierAgent(TorchAgent):
 
     def build_criterion(self):
         weight_tensor = torch.FloatTensor(self.class_weights)
-        self.criterion = torch.nn.CrossEntropyLoss(weight_tensor)
+        return torch.nn.CrossEntropyLoss(weight_tensor)
 
     def share(self):
         """Share model parameters."""

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -128,9 +128,15 @@ class TorchClassifierAgent(TorchAgent):
 
         if shared:
             self.model = shared['model']
-        elif init_model:
-            print('Loading existing model parameters from ' + init_model)
-            self.load(init_model)
+        else:
+            self.build_model()
+            self.build_criterion()
+            if self.use_cuda:
+                self.model.cuda()
+                self.critieron.cuda()
+            if init_model:
+                print('Loading existing model parameters from ' + init_model)
+                self.load(init_model)
         if self.use_cuda:
             if self.opt['data_parallel']:
                 if is_distributed():

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -131,6 +131,10 @@ class TorchClassifierAgent(TorchAgent):
         else:
             self.model = self.build_model()
             self.criterion = self.build_criterion()
+            if self.model is not None and self.criterion is not None:
+                raise AttributeError(
+                    'build_model() and build_criterion() need to return the model or criterion'
+                )
             if self.use_cuda:
                 self.model.cuda()
                 self.critieron.cuda()

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -131,7 +131,7 @@ class TorchClassifierAgent(TorchAgent):
         else:
             self.model = self.build_model()
             self.criterion = self.build_criterion()
-            if self.model is not None and self.criterion is not None:
+            if self.model is None or self.criterion is None:
                 raise AttributeError(
                     'build_model() and build_criterion() need to return the model or criterion'
                 )

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -352,8 +352,6 @@ class TorchGeneratorAgent(TorchAgent):
 
         if shared:
             # set up shared properties
-            self.model = shared['model']
-            self.criterion = shared['criterion']
             states = shared.get('states', {})
         else:
             # Note: we cannot change the type of metrics ahead of time, so you
@@ -371,9 +369,13 @@ class TorchGeneratorAgent(TorchAgent):
                     )
                 )
                 print('[ Saving dot beam logs in {} ]'.format(self.beam_dot_dir))
-
+            
             self.build_criterion()
             self.build_model()
+            if self.use_cuda:
+                self.model.cuda()
+                self.criterion.cuda()
+
             check_synced_parameters(self.model)
             print("Total parameters: {}".format(self._total_parameters()))
             print("Trainable parameters:  {}".format(self._trainable_parameters()))
@@ -477,7 +479,6 @@ class TorchGeneratorAgent(TorchAgent):
     def share(self):
         """Share internal states between parent and child instances."""
         shared = super().share()
-        shared['criterion'] = self.criterion
         if self.opt.get('numthreads', 1) > 1:
             shared['states'] = {  # don't share optimizer states
                 'optimizer_type': self.opt['optimizer']

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -370,8 +370,8 @@ class TorchGeneratorAgent(TorchAgent):
                 )
                 print('[ Saving dot beam logs in {} ]'.format(self.beam_dot_dir))
 
-            self.build_criterion()
-            self.build_model()
+            self.criterion = self.build_criterion()
+            self.model = self.build_model()
             if self.use_cuda:
                 self.model.cuda()
                 self.criterion.cuda()
@@ -414,15 +414,13 @@ class TorchGeneratorAgent(TorchAgent):
 
     def build_criterion(self):
         """
-        Construct the loss function.
+        Construct and return the loss function.
 
-        By default torch.nn.CrossEntropyLoss.  The criterion function should be
-        set to self.criterion.
+        By default torch.nn.CrossEntropyLoss.
 
-        If overridden, this model should (1) handle calling cuda and (2)
-        produce a sum that can be used for a per-token loss.
+        If overridden, this model should produce a sum that can be used for a per-token loss.
         """
-        self.criterion = torch.nn.CrossEntropyLoss(
+        return torch.nn.CrossEntropyLoss(
             ignore_index=self.NULL_IDX, reduction='sum'
         )
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -369,7 +369,7 @@ class TorchGeneratorAgent(TorchAgent):
                     )
                 )
                 print('[ Saving dot beam logs in {} ]'.format(self.beam_dot_dir))
-            
+
             self.build_criterion()
             self.build_model()
             if self.use_cuda:

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -412,6 +412,20 @@ class TorchGeneratorAgent(TorchAgent):
 
         self.reset()
 
+    def build_criterion(self):
+        """
+        Construct the loss function.
+
+        By default torch.nn.CrossEntropyLoss.  The criterion function should be
+        set to self.criterion.
+
+        If overridden, this model should (1) handle calling cuda and (2)
+        produce a sum that can be used for a per-token loss.
+        """
+        self.criterion = torch.nn.CrossEntropyLoss(
+            ignore_index=self.NULL_IDX, reduction='sum'
+        )
+
     def _v2t(self, vec):
         """Convert token indices to string of tokens."""
         new_vec = []

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -431,32 +431,6 @@ class TorchGeneratorAgent(TorchAgent):
         else:
             self.skip_generation = self.opt.get('skip_generation', False)
 
-    @abstractmethod
-    def build_model(self):
-        """
-        Construct the model.
-
-        The model should be set to self.model, and support
-        the TorchGeneratorModel interface.
-        """
-        pass
-
-    def build_criterion(self):
-        """
-        Construct the loss function.
-
-        By default torch.nn.CrossEntropyLoss.  The criterion function should be
-        set to self.criterion.
-
-        If overridden, this model should (1) handle calling cuda and (2)
-        produce a sum that can be used for a per-token loss.
-        """
-        self.criterion = nn.CrossEntropyLoss(
-            ignore_index=self.NULL_IDX, reduction='sum'
-        )
-        if self.use_cuda:
-            self.criterion.cuda()
-
     def _dummy_batch(self, batchsize, maxlen):
         """
         Create a dummy batch.

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -420,9 +420,7 @@ class TorchGeneratorAgent(TorchAgent):
 
         If overridden, this model should produce a sum that can be used for a per-token loss.
         """
-        return torch.nn.CrossEntropyLoss(
-            ignore_index=self.NULL_IDX, reduction='sum'
-        )
+        return torch.nn.CrossEntropyLoss(ignore_index=self.NULL_IDX, reduction='sum')
 
     def _v2t(self, vec):
         """Convert token indices to string of tokens."""

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -372,7 +372,7 @@ class TorchGeneratorAgent(TorchAgent):
 
             self.criterion = self.build_criterion()
             self.model = self.build_model()
-            if self.model is not None and self.criterion is not None:
+            if self.model is None or self.criterion is None:
                 raise AttributeError(
                     'build_model() and build_criterion() need to return the model or criterion'
                 )

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -372,6 +372,10 @@ class TorchGeneratorAgent(TorchAgent):
 
             self.criterion = self.build_criterion()
             self.model = self.build_model()
+            if self.model is not None and self.criterion is not None:
+                raise AttributeError(
+                    'build_model() and build_criterion() need to return the model or criterion'
+                )
             if self.use_cuda:
                 self.model.cuda()
                 self.criterion.cuda()

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -147,7 +147,7 @@ class TorchRankerAgent(TorchAgent):
 
             self.criterion = self.build_criterion()
             self.model = self.build_model()
-            if self.model is not None and self.criterion is not None:
+            if self.model is None or self.criterion is None:
                 raise AttributeError(
                     'build_model() and build_criterion() need to return the model or criterion'
                 )

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -135,7 +135,6 @@ class TorchRankerAgent(TorchAgent):
         super().__init__(opt, shared)
 
         if shared:
-            self.model = shared['model']
             states = None
         else:
             # Note: we cannot change the type of metrics ahead of time, so you
@@ -148,6 +147,10 @@ class TorchRankerAgent(TorchAgent):
 
             self.build_criterion()
             self.build_model()
+            if self.use_cuda:
+                self.model.cuda()
+                self.criterion.cuda()
+                
             if self.fp16:
                 self.model = self.model.half()
             if init_model:

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -147,6 +147,10 @@ class TorchRankerAgent(TorchAgent):
 
             self.criterion = self.build_criterion()
             self.model = self.build_model()
+            if self.model is not None and self.criterion is not None:
+                raise AttributeError(
+                    'build_model() and build_criterion() need to return the model or criterion'
+                )
             if self.use_cuda:
                 self.model.cuda()
                 self.criterion.cuda()

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -181,6 +181,18 @@ class TorchRankerAgent(TorchAgent):
                 self.model, device_ids=[self.opt['gpu']], broadcast_buffers=False
             )
 
+    def build_criterion(self):
+        """
+        Construct the loss function.
+
+        By default torch.nn.CrossEntropyLoss.  The criterion function should be
+        set to self.criterion.
+
+        If overridden, this model should (1) handle calling cuda and (2)
+        produce a sum that can be used for a per-token loss.
+        """
+        self.criterion = torch.nn.CrossEntropyLoss(reduction='sum')
+
     def set_interactive_mode(self, mode, shared=False):
         self.candidates = self.opt['candidates']
         if mode:

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -145,8 +145,8 @@ class TorchRankerAgent(TorchAgent):
             self.metrics['mrr'] = 0.0
             self.metrics['train_accuracy'] = 0.0
 
-            self.build_criterion()
-            self.build_model()
+            self.criterion = self.build_criterion()
+            self.model = self.build_model()
             if self.use_cuda:
                 self.model.cuda()
                 self.criterion.cuda()
@@ -183,15 +183,11 @@ class TorchRankerAgent(TorchAgent):
 
     def build_criterion(self):
         """
-        Construct the loss function.
+        Construct and return the loss function.
 
-        By default torch.nn.CrossEntropyLoss.  The criterion function should be
-        set to self.criterion.
-
-        If overridden, this model should (1) handle calling cuda and (2)
-        produce a sum that can be used for a per-token loss.
+        By default torch.nn.CrossEntropyLoss.
         """
-        self.criterion = torch.nn.CrossEntropyLoss(reduction='sum')
+        return torch.nn.CrossEntropyLoss(reduction='sum')
 
     def set_interactive_mode(self, mode, shared=False):
         self.candidates = self.opt['candidates']

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -150,7 +150,7 @@ class TorchRankerAgent(TorchAgent):
             if self.use_cuda:
                 self.model.cuda()
                 self.criterion.cuda()
-                
+
             if self.fp16:
                 self.model = self.model.half()
             if init_model:

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -146,6 +146,7 @@ class TorchRankerAgent(TorchAgent):
             self.metrics['mrr'] = 0.0
             self.metrics['train_accuracy'] = 0.0
 
+            self.build_criterion()
             self.build_model()
             if self.fp16:
                 self.model = self.model.half()

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -156,10 +156,6 @@ class TorchRankerAgent(TorchAgent):
                 states = {}
 
         self.rank_top_k = opt.get('rank_top_k', -1)
-        self.rank_loss = nn.CrossEntropyLoss(reduce=True, size_average=False)
-        if self.use_cuda:
-            self.model.cuda()
-            self.rank_loss.cuda()
 
         # Vectorize and save fixed/vocab candidates once upfront if applicable
         self.set_fixed_candidates(shared)
@@ -234,11 +230,6 @@ class TorchRankerAgent(TorchAgent):
             where we cache the candidate encodings), you do not need to call
             self.model on cand_vecs
         """
-        pass
-
-    @abstractmethod
-    def build_model(self):
-        """Build a new model (implemented by children classes)."""
         pass
 
     def _get_batch_train_metrics(self, scores):
@@ -327,7 +318,7 @@ class TorchRankerAgent(TorchAgent):
         )
         try:
             scores = self.score_candidates(batch, cand_vecs)
-            loss = self.rank_loss(scores, label_inds)
+            loss = self.criterion(scores, label_inds)
             self.backward(loss)
             self.update_params()
         except RuntimeError as e:
@@ -392,7 +383,7 @@ class TorchRankerAgent(TorchAgent):
 
         # Update metrics
         if label_inds is not None:
-            loss = self.rank_loss(scores, label_inds)
+            loss = self.criterion(scores, label_inds)
             self.metrics['loss'] += loss.item()
             self.metrics['examples'] += batchsize
             for b in range(batchsize):

--- a/projects/controllable_dialogue/controllable_seq2seq/controllable_seq2seq.py
+++ b/projects/controllable_dialogue/controllable_seq2seq/controllable_seq2seq.py
@@ -428,10 +428,10 @@ class ControllableSeq2seqAgent(TorchAgent):
 
         if opt['embedding_type'].endswith('fixed'):
             print('Seq2seq: fixing embedding weights.')
-            self.model.decoder.lt.weight.requires_grad = False
-            self.model.encoder.lt.weight.requires_grad = False
+            model.decoder.lt.weight.requires_grad = False
+            model.encoder.lt.weight.requires_grad = False
             if opt['lookuptable'] in ['dec_out', 'all']:
-                self.model.decoder.e2s.weight.requires_grad = False
+                model.decoder.output.e2s.weight.requires_grad = False
 
         return model
 

--- a/projects/self_feeding/self_feeding_agent.py
+++ b/projects/self_feeding/self_feeding_agent.py
@@ -502,7 +502,7 @@ class SelfFeedingAgent(TransformerRankerAgent):
         if label_inds is None:
             loss = None
         else:
-            loss = self.rank_loss(scores, label_inds)
+            loss = self.criterion(scores, label_inds)
             self.update_dia_metrics(loss, ranks, label_inds, batchsize)
         return loss, preds, cand_ranked
 
@@ -536,7 +536,7 @@ class SelfFeedingAgent(TransformerRankerAgent):
         if label_inds is None:
             loss = None
         else:
-            loss = self.rank_loss(scores, label_inds)
+            loss = self.criterion(scores, label_inds)
             self.update_fee_metrics(loss, ranks, label_inds, batchsize)
         return loss, preds, cand_ranked
 

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -74,6 +74,9 @@ class TorchAgent(TorchAgent):
     def dictionary_class():
         """Replace normal dictionary class with mock one."""
         return MockDict
+    
+    def build_model(self):
+        self.model = None
 
     def train_step(self, batch):
         """Return confirmation of training."""

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -74,7 +74,7 @@ class TorchAgent(TorchAgent):
     def dictionary_class():
         """Replace normal dictionary class with mock one."""
         return MockDict
-    
+
     def build_model(self):
         self.model = None
 

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -69,11 +69,12 @@ class MockDict(Agent):
 
 class TorchAgent(TorchAgent):
     """Use MockDict instead of regular DictionaryAgent."""
+
     def __init__(self, opt, shared=None):
         self.model = self.build_model()
         self.criterion = self.build_criterion()
         super().__init__(opt, shared)
-    
+
     def build_model(self):
         return {}
 

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -69,6 +69,16 @@ class MockDict(Agent):
 
 class TorchAgent(TorchAgent):
     """Use MockDict instead of regular DictionaryAgent."""
+    def __init__(self, opt, shared=None):
+        self.model = self.build_model()
+        self.criterion = self.build_criterion()
+        super().__init__(opt, shared)
+    
+    def build_model(self):
+        return {}
+
+    def build_criterion(self):
+        return {}
 
     @staticmethod
     def dictionary_class():

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -75,9 +75,6 @@ class TorchAgent(TorchAgent):
         """Replace normal dictionary class with mock one."""
         return MockDict
 
-    def build_model(self):
-        self.model = None
-
     def train_step(self, batch):
         """Return confirmation of training."""
         return Output(['Training {}!'.format(i) for i in range(len(batch.text_vec))])


### PR DESCRIPTION
**Patch description**
- make build_model and build_criterion standard TorchAgent* functions that return either the model or the criterion
- move `if use_cuda: X.cuda()` checks to the TorchAgent* class inits
- make criterion more consistently called `criterion`

Fixes #1887.

**Testing steps**
Ran the following commands to kick off agent initialisation / training. Did not train to convergence.
```
# train seq2seq with overridden loss
py examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 32 -veps 1 -vcut 0.95 -m seq2seq -mom 0.95 -soft 5
# seq2seq with other options
py examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 32 -veps 1 -vcut 0.95 -m seq2seq -mom 0.95 -lt dec_out --embedding-type glove-fixed
# train transformer/generator
py examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 32 -veps 1 -vcut 0.95 -m transformer/generator
# train transformer/biencoder
py examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 32 -veps 3 -vcut 0.95 -m transformer/biencoder
# train transformer/crossencoder
py examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 32 -veps 3 -vcut 0.95 -m transformer/crossencoder
# train memnn without cuda
py examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 16 -nt 8 -veps 3 -vcut 0.95 -m memnn --no-cuda
# train memnn with cuda
py examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 32 -veps 3 -vcut 0.95 -m memnn
# train bert bi encoder
py examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 32 -veps 3 -vcut 0.95 -m bert_ranker/bi_encoder_ranker
# train fairseq
py examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 32 -veps 3 -vcut 0.95 -m fairseq -a fconv
```