### PR TITLE
Move _build_encoder to class function

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -772,7 +772,7 @@ class TransformerGeneratorModel(TorchGeneratorModel):
         if n_positions < 0:
             raise ValueError('n_positions must be positive')
 
-        self.encoder = _build_encoder(
+        self._build_encoder(
             opt,
             dictionary,
             self.embeddings,
@@ -783,6 +783,26 @@ class TransformerGeneratorModel(TorchGeneratorModel):
         )
         self.decoder = _build_decoder(
             opt, dictionary, self.embeddings, self.pad_idx, n_positions=n_positions
+        )
+
+    def _build_encoder(
+        self,
+        opt,
+        dictionary,
+        embeddings,
+        pad_idx,
+        reduction_type=None,
+        n_positions=1024,
+        n_segments=0
+    ):
+        self.encoder = _build_encoder(
+            opt,
+            dictionary,
+            embeddings,
+            pad_idx,
+            reduction_type=reduction_type,
+            n_positions=n_positions,
+            n_segments=n_segments,
         )
 
     def reorder_encoder_states(self, encoder_states, indices):

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -793,7 +793,7 @@ class TransformerGeneratorModel(TorchGeneratorModel):
         pad_idx,
         reduction_type=None,
         n_positions=1024,
-        n_segments=0
+        n_segments=0,
     ):
         self.encoder = _build_encoder(
             opt,


### PR DESCRIPTION
**Patch description**
Makes `_build_encoder` a class function of `TransformerGeneratorModel`, which allows subclasses to easily modify the encoder. 

**Testing steps**
Tested internally