### PR TITLE
Fix try/catch in `print_git_commit`

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -31,6 +31,8 @@ def print_git_commit():
         print(f'[ Current ParlAI commit: {current_commit} ]')
     except git.GitCommandNotFound:
         pass
+    except git.GitCommandError:
+        pass
 
     try:
         git_ = git.Git(internal_root)

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -30,7 +30,7 @@ def print_git_commit():
         current_commit = git_.rev_parse('HEAD')
         print(f'[ Current ParlAI commit: {current_commit} ]')
     except git.GitCommandNotFound:
-        raise
+        pass
 
     try:
         git_ = git.Git(internal_root)


### PR DESCRIPTION
**Patch description**
Changes a `raise` to a `pass` In `print_git_commit`, so that `parse_args` does not break if being called within a ParlAI directory that is _NOT_ a git repository (and adds an additional `except`)

**Testing steps**
Tested internally 