### PR TITLE
make codec dir

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -820,6 +820,9 @@ class _BPEHelper(object):
             num_symbols = 30000
         if minfreq <= 0:
             minfreq = 2
+
+        codec_dir, _ = os.path.split(self.codecs)
+        os.makedirs(codec_dir, exist_ok=True)
         with open(self.codecs, 'w', encoding='utf-8') as outstream:
             learn_bpe.learn_bpe(
                 dictionary,


### PR DESCRIPTION
**Patch description**
Ensure codec dir exists for before saving BPE codecs

**Testing steps**
Previously, the command from the pretrained transformers model zoo failed with `-pyt`; this fixes that.

**Logs**
Previously the following command:
```
python -u examples/train_model.py \
  --init-model zoo:pretrained_transformers/poly_model_huge_reddit/model \
  -pyt convai2 --shuffle true \
  --model transformer/polyencoder --batchsize 256 --eval-batchsize 10 \
  --warmup_updates 100 --lr-scheduler-patience 0 --lr-scheduler-decay 0.4 \
  -lr 5e-05 --data-parallel True --history-size 20 --label-truncate 72 \
  --text-truncate 360 --num-epochs 8.0 --max_train_time 200000 -veps 0.5 \
  -vme 8000 --validation-metric accuracy --validation-metric-mode max \
  --save-after-valid True --log_every_n_secs 20 --candidates batch --fp16 True \
  --dict-file ./data/models/pretrained_transformers/model_bi.dict \
  --dict-tokenizer bpe --dict-lower True --optimizer adamax --output-scaling 0.06 \
  --variant xlm --reduction-type mean --share-encoders False \
  --learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 \
  --attention-dropout 0.1 --relu-dropout 0.0 --dropout 0.1 --n-positions 1024 \
  --embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 \
  --learn-embeddings True --polyencoder-type n_first --poly-n-codes 64 \
  --poly-attention-type basic --dict-endtoken __start__ \
  --model-file <YOUR MODEL FILE>
```
Resulted in:
```
Traceback (most recent call last):
  File "examples/train_model.py", line 16, in <module>
    TrainLoop(opt).train()
  File ".../ParlAI/parlai/scripts/train_model.py", line 373, in __init__
    build_dict(opt, skip_if_built=True)
  File ".../ParlAI/parlai/scripts/build_dict.py", line 145, in build_dict
    dictionary.save(opt['dict_file'], sort=True)
  File ".../ParlAI/parlai/core/dict.py", line 601, in save
    self.freq, num_symbols=self.maxtokens, minfreq=self.minfreq
  File ".../ParlAI/parlai/core/dict.py", line 823, in finalize
    with open(self.codecs, 'w', encoding='utf-8') as outstream:
FileNotFoundError: [Errno 2] No such file or directory: '.../ParlAI/data/convai2_pyt_data/train/dict.codecs'
```

Now, there is no error.