### PR TITLE
Update masking for Torch 1.2

### DIFF
--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -663,7 +663,7 @@ class AttentionLayer(nn.Module):
             # calculate activation scores, apply mask if needed
             if attn_mask is not None:
                 # remove activation from NULL symbols
-                attn_w_premask.masked_fill_((1 - attn_mask), -NEAR_INF)
+                attn_w_premask.masked_fill_((~attn_mask), -NEAR_INF)
             attn_weights = F.softmax(attn_w_premask, dim=1)
 
         # apply the attention weights to the encoder states


### PR DESCRIPTION
**Patch description**
PyTorch 1.2 breaking change - can no longer do `1 - mask` to invert mask; must use `~`.

**Testing steps**
Confirm `tests/test_seq2seq.py` works

**Logs**
Before:
```
...
 File "/home/circleci/ParlAI/parlai/agents/seq2seq/modules.py", line 666, in forward
    attn_w_premask.masked_fill_((1 - attn_mask), -NEAR_INF)
  File "/home/circleci/venv/lib/python3.6/site-packages/torch/tensor.py", line 325, in __rsub__
    return _C._VariableFunctions.rsub(self, other)
RuntimeError: Subtraction, the `-` operator, with a bool tensor is not supported. If you are trying to invert a mask, use the `~` or `bitwise_not()` operator instead.
```
After:
```

```