### PR TITLE
Enable fairseq unit test.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ installtorchgpu: &installtorchgpu
       pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off torchtext
+      pip3 install --progress-bar off fairseq
 
 installtorchcpuosx: &installtorchcpuosx
   run:

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -17,7 +17,7 @@ Fairseq models can be used for many default tasks by combining a
 
 
 from parlai.core.dict import DictionaryAgent
-from parlai.core.utils import argsort, padded_tensor
+from parlai.core.utils import argsort, padded_tensor, warn_once
 
 try:
     from fairseq import models, optim, criterions
@@ -330,6 +330,10 @@ class FairseqAgent(TorchAgent):
 
     def __init__(self, opt, shared=None):
         # In general use a basic TorchAgent wherever possible
+        warn_once(
+            "Fairseq interop is somewhat unmaintained and may have recent bugs. "
+            "Please file an issue on GitHub if you have problems."
+        )
         super().__init__(opt, shared)
         if not shared:
             # this is not a shared instance of this class, so do full initialization

--- a/parlai/agents/fairseq/fairseq.py
+++ b/parlai/agents/fairseq/fairseq.py
@@ -269,12 +269,12 @@ class FairseqAgent(TorchAgent):
         options.add_checkpoint_args(argparser)
         from fairseq.registry import REGISTRIES
 
-        crit_reg = REGISTRIES['criterion']
-        argparser.add_argument(
-            '--criterion',
-            default=crit_reg['default'],
-            choices=crit_reg['registry'].keys(),
-        )
+        for k, registry in REGISTRIES.items():
+            argparser.add_argument(
+                '--' + k.replace('_', '-'),
+                default=registry['default'],
+                choices=registry['registry'].keys(),
+            )
 
         # restore any user set defaults that fairseq possibly overrode
         argparser.set_defaults(**old_defaults)


### PR DESCRIPTION
**Patch description**
CircleCI has supported GPU for a while now, so we could've been testing the fairseq module using the test we *already have*. However, this test is skipped because fairseq isn't installed.

This patch adds fairseq installation to the GPU tests, so that test also runs.

**Testing steps**
CircleCI.