### PR TITLE
Fail loudly when running TorchAgent in mturk if interactive mode is False

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -432,6 +432,11 @@ class ParlaiParser(argparse.ArgumentParser):
             help='Specify location to use for scratch builds and such.',
         )
 
+        # it helps to indicaste to agents that they're in interactive mode, and
+        # can avoid some otherwise troublesome behavior (not having candidates,
+        # sharing self.replies, etc).
+        self.set_defaults(interactive_mode=True)
+
         mturk.set_defaults(is_sandbox=True)
         mturk.set_defaults(is_debug=False)
         mturk.set_defaults(verbose=False)

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -432,10 +432,10 @@ class ParlaiParser(argparse.ArgumentParser):
             help='Specify location to use for scratch builds and such.',
         )
 
-        # it helps to indicaste to agents that they're in interactive mode, and
+        # it helps to indicate to agents that they're in interactive mode, and
         # can avoid some otherwise troublesome behavior (not having candidates,
         # sharing self.replies, etc).
-        self.set_defaults(interactive_mode=True)
+        mturk.set_defaults(interactive_mode=True)
 
         mturk.set_defaults(is_sandbox=True)
         mturk.set_defaults(is_debug=False)

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -650,9 +650,10 @@ class TorchAgent(ABC, Agent):
         """Initialize agent."""
         super().__init__(opt, shared)
         opt = self.opt
-        if not shared:
+        if shared is None:
             # intitialize any important structures from scratch
             self.replies = {}  # past replies
+            self._replies_are_shared = False
             self.dict = self.build_dictionary()
             if opt.get('fp16'):
                 # Volta cores revert to FP32 hardware if tensors are not multiples
@@ -675,12 +676,14 @@ class TorchAgent(ABC, Agent):
             self.opt = shared['opt']
             self.dict = shared['dict']
             self.metrics = shared['metrics']
-            if self.opt['batchsize'] == 1:
+            if self.opt['batchsize'] == 1 or self.opt['interactive_mode']:
                 # if we're not using batching (e.g. mturk), then replies really need
                 # to stay separated
                 self.replies = {}
+                self._replies_are_shared = False
             else:
                 self.replies = shared['replies']
+                self._replies_are_shared = True
 
         if opt.get('numthreads', 1) > 1:
             torch.set_num_threads(1)
@@ -1662,6 +1665,11 @@ class TorchAgent(ABC, Agent):
 
     def act(self):
         """Call batch_act with the singleton batch."""
+        if self._replies_are_shared:
+            raise RuntimeError(
+                'act() will misbehave in batching mode. Set batchsize to 1, or '
+                '--interactive-mode true'
+            )
         return self.batch_act([self.observation])[0]
 
     def batch_act(self, observations):
@@ -1714,8 +1722,9 @@ class TorchAgent(ABC, Agent):
 
     def set_interactive_mode(self, mode, shared):
         """Set interactive mode on or off."""
-        # Base class is a no-op.
-        pass
+        if shared is None:
+            # Only print in the non-shared version.
+            print("[" + self.id + ': full interactive mode on.' + ']')
 
     def backward(self, loss):
         """

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -423,10 +423,8 @@ class TorchGeneratorAgent(TorchAgent):
         return self.dict.vec2txt(new_vec)
 
     def set_interactive_mode(self, mode, shared=False):
+        super().set_interactive_mode(mode, shared)
         if mode:
-            if not shared:
-                # Only print in the non-shared version.
-                print("[" + self.id + ': full interactive mode on.' + ']')
             self.skip_generation = False
         else:
             self.skip_generation = self.opt.get('skip_generation', False)

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -182,11 +182,9 @@ class TorchRankerAgent(TorchAgent):
             )
 
     def set_interactive_mode(self, mode, shared=False):
+        super().set_interactive_mode(mode, shared)
         self.candidates = self.opt['candidates']
         if mode:
-            if not shared:
-                # Only print in the non-shared version.
-                print("[" + self.id + ': full interactive mode on.' + ']')
             self.eval_candidates = 'fixed'
             self.ignore_bad_candidates = True
             self.encode_candidate_vecs = True


### PR DESCRIPTION
**Patch description**
If we create an mturk task, the shared TorchAgents need to ensure they don't share `self.replies`, otherwise different workers can trample all over each other. This was addressed in #1287, and worked around by not sharing replies when `batchsize == 1` .

However, it's still very easy to forget to set this work around! This patch attempts to make it so that TorchAgent would've loudly complained and crashed. This is done by:

1. Having mturk set interactive mode by default, which makes the default sane and
2. Having an assert in `act()` which will fail if we're in the dangerous setting.

**Testing steps**
Added two tests in TestTorchAgent. Before fixing TorchAgent, they both fail with:
```
$ python tests/test_torch_agent.py
/private/home/roller/working/parlai/parlai/core/metrics.py:38: UserWarning: Rouge metrics require py-rouge. Please run `pip install py-rouge`.
  warn_once('Rouge metrics require py-rouge. Please run `pip install py-rouge`.')
......F...F...
======================================================================
FAIL: test_interactive_mode (__main__.TestTorchAgent)
Test if conversation history is destroyed in MTurk mode.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_torch_agent.py", line 977, in test_interactive_mode
    response = shared.act()
AssertionError: RuntimeError not raised

======================================================================
FAIL: test_mturk_racehistory (__main__.TestTorchAgent)
Emulate a setting where batch_act misappropriately handles mturk.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_torch_agent.py", line 1000, in test_mturk_racehistory
    self.assertNotIn('thread2-msg1', share1.history.get_history_str())
AssertionError: 'thread2-msg1' unexpectedly found in 'thread1-msg1\nEvaluating 0 (responding to thread2-msg1)!\nthread1-msg2\nEvaluating 0 (responding to thread1-msg2)!\nthread1-msg3'

----------------------------------------------------------------------
Ran 14 tests in 0.117s
```

After patching TorchAgent:
```
$ python tests/test_torch_agent.py
/private/home/roller/working/parlai/parlai/core/metrics.py:38: UserWarning: Rouge metrics require py-rouge. Please run `pip install py-rouge`.
  warn_once('Rouge metrics require py-rouge. Please run `pip install py-rouge`.')
..............
----------------------------------------------------------------------
Ran 14 tests in 0.171s

OK
```