### PR TITLE
Quiet the rouge warning.

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -33,8 +33,8 @@ except ImportError:
 try:
     import rouge
 except ImportError:
-    # User doesn't have rouge installed, so we can't use it for rouge
-    # We'll just turn off things, but we might want to warn the user
+    # User doesn't have py-rouge installed, so we can't use it.
+    # We'll just turn off rouge computations
     rouge = None
 
 re_art = re.compile(r'\b(a|an|the)\b')

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -31,11 +31,10 @@ except ImportError:
     nltkbleu = None
 
 try:
-    import rouge as rouge
+    import rouge
 except ImportError:
     # User doesn't have rouge installed, so we can't use it for rouge
     # We'll just turn off things, but we might want to warn the user
-    warn_once('Rouge metrics require py-rouge. Please run `pip install py-rouge`.')
     rouge = None
 
 re_art = re.compile(r'\b(a|an|the)\b')


### PR DESCRIPTION
**Patch description**
The py-rouge warning happens a lot (on import of metrics). We get rid of that warning.

**Testing steps**
test_torch_agent.py used to throw the warning, now it doesn't.

**Logs**
```
devfair0237 parlai quietrouge $ python tests/test_torch_agent.py
.............
----------------------------------------------------------------------
Ran 13 tests in 3.938s

OK
```