### PR TITLE
Pytorch version tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,14 +55,24 @@ installdeps: &installdeps
       python setup.py develop
       python -c "import nltk; nltk.download('punkt')"
 
-installtorchgpu: &installtorchgpu
+installtorchgpu: &installtorchgpu11
   run:
     name: Install torch GPU and dependencies
     command: |
-      pip3 install --progress-bar off torch
+      pip3 install --progress-bar off 'torch<1.2.0'
       pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off torchtext
+
+installtorchgpu: &installtorchgpu12
+  run:
+    name: Install torch GPU and dependencies
+    command: |
+      pip3 install --progress-bar off 'torch>=1.2.0'
+      pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
+      pip3 install --progress-bar off pytorch-pretrained-bert
+      pip3 install --progress-bar off torchtext
+
 
 installtorchcpuosx: &installtorchcpuosx
   run:
@@ -158,7 +168,7 @@ jobs:
           name: Unit tests (py37)
           command: python setup.py test -s tests.suites.unittests -v
 
-  unittests_gpu:
+  unittests_gpu11:
     <<: *gpu
     working_directory: ~/ParlAI
     steps:
@@ -167,10 +177,25 @@ jobs:
       - <<: *setupcuda
       - <<: *setup
       - <<: *installdeps
-      - <<: *installtorchgpu
+      - <<: *installtorchgpu11
       - run:
-          name: Unit tests (GPU)
+          name: Unit tests (GPU; pytorch 1.1)
           command: python setup.py test -s tests.suites.unittests -v
+
+  unittests_gpu12:
+    <<: *gpu
+    working_directory: ~/ParlAI
+    steps:
+      - checkout
+      - <<: *fixgit
+      - <<: *setupcuda
+      - <<: *setup
+      - <<: *installdeps
+      - <<: *installtorchgpu12
+      - run:
+          name: Unit tests (GPU; pytorch 1.2)
+          command: python setup.py test -s tests.suites.unittests -v
+
   black:
     <<: *standard_cpu36
     working_directory: ~/ParlAI
@@ -223,7 +248,7 @@ jobs:
       - <<: *setupcuda
       - <<: *setup
       - <<: *installdeps
-      - <<: *installtorchgpu
+      - <<: *installtorchgpu12
       - run:
           name: Nightly GPU tests
           no_output_timeout: 60m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ installdeps: &installdeps
       python setup.py develop
       python -c "import nltk; nltk.download('punkt')"
 
-installtorchgpu: &installtorchgpu11
+installtorchgpu11: &installtorchgpu11
   run:
     name: Install torch GPU and dependencies
     command: |
@@ -64,7 +64,8 @@ installtorchgpu: &installtorchgpu11
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off torchtext
 
-installtorchgpu: &installtorchgpu12
+
+installtorchgpu12: &installtorchgpu12
   run:
     name: Install torch GPU and dependencies
     command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,8 @@ workflows:
     jobs:
       - black
       - lint
-      - unittests_gpu
+      - unittests_gpu11
+      - unittests_gpu12
       - unittests_37
       - unittests_36
       - unittests_osx
@@ -385,7 +386,8 @@ workflows:
     jobs:
       - unittests_36
       - unittests_37
-      - unittests_gpu
+      - unittests_gpu11
+      - unittests_gpu12
       - unittests_osx
       - mturk_tests
       - nightly_gpu_tests

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ See the [news page](https://github.com/facebookresearch/ParlAI/blob/master/NEWS.
 
 ## Installing ParlAI
 
-ParlAI currently requires Python3. Dependencies of the core modules are listed in `requirement.txt`. Some models included (in `parlai/agents`) have additional requirements.
+ParlAI currently requires Python3 and [Pytorch](https://pytorch.org) 1.1 or
+newer. Dependencies of the core modules are listed in `requirement.txt`. Some
+models included (in `parlai/agents`) have additional requirements.
 
 Run the following commands to clone the repository and install ParlAI:
 


### PR DESCRIPTION
**Patch description**
We decided to support a rolling pytorch release (past 2 versions). So let's explicitly test them.

**Testing steps**
CircleCI should run with two versions of pytorch.