### PR TITLE
[LIGHT] No affordance ablation

### DIFF
--- a/parlai/scripts/verify_data.py
+++ b/parlai/scripts/verify_data.py
@@ -41,7 +41,7 @@ def report(world, counts, log_time):
         'label_candidates_with_missing_label': counts[
             'label_candidates_with_missing_label'
         ],
-        'did_not_return_message': counts['returns_messages'],
+        'did_not_return_message': counts['did_not_return_message'],
     }
     text, log = log_time.log(report['exs'], world.num_examples(), log)
     return text, log

--- a/parlai/tasks/light_dialog/agents.py
+++ b/parlai/tasks/light_dialog/agents.py
@@ -87,9 +87,7 @@ class DefaultTeacher(ParlAIDialogTeacher):
             default='all',
             choices=['partner', 'self', 'all', 'none'],
         )
-        agent.add_argument(
-            '--light_use_affordances', type=str, default='all', choices=['all', 'none']
-        )
+        agent.add_argument('--light_use_affordances', type=bool, default=True)
         agent.add_argument(
             '--light_use_current_self_output',
             type=str,

--- a/parlai/tasks/light_dialog/agents.py
+++ b/parlai/tasks/light_dialog/agents.py
@@ -32,6 +32,7 @@ def _path(opt):
         'emote',
         'speech',
         'action',
+        'affordances',
         'repeat',
         'cands',
         'current_self_output',
@@ -85,6 +86,9 @@ class DefaultTeacher(ParlAIDialogTeacher):
             type=str,
             default='all',
             choices=['partner', 'self', 'all', 'none'],
+        )
+        agent.add_argument(
+            '--light_use_affordances', type=str, default='all', choices=['all', 'none']
         )
         agent.add_argument(
             '--light_use_current_self_output',

--- a/parlai/tasks/light_dialog/build.py
+++ b/parlai/tasks/light_dialog/build.py
@@ -10,7 +10,7 @@ from parlai.tasks.light_dialog.builder import build_from_db
 
 
 def download(opt):
-    version = 'v2.02'
+    version = 'v2.03'
     # download pickled database
     dpath = os.path.join(opt['datapath'], 'light_dialogue')
     if not build_data.built(dpath, version):
@@ -61,7 +61,7 @@ def build(opt):
     for f in fields:
         fpath += f + str(opt['light_use_' + f]) + "_"
     dpath2 = os.path.join(opt['datapath'], 'light_dialogue', fpath[:-1])
-    if True:  # not build_data.built(dpath2, version):
+    if not build_data.built(dpath2, version):
         if build_data.built(dpath2):
             # An older version exists, so remove these outdated files.
             build_data.remove_dir(dpath2)

--- a/parlai/tasks/light_dialog/build.py
+++ b/parlai/tasks/light_dialog/build.py
@@ -51,6 +51,7 @@ def build(opt):
         'emote',
         'speech',
         'action',
+        'affordances',
         'repeat',
         'cands',
         'current_self_output',
@@ -60,7 +61,7 @@ def build(opt):
     for f in fields:
         fpath += f + str(opt['light_use_' + f]) + "_"
     dpath2 = os.path.join(opt['datapath'], 'light_dialogue', fpath[:-1])
-    if not build_data.built(dpath2, version):
+    if True:  # not build_data.built(dpath2, version):
         if build_data.built(dpath2):
             # An older version exists, so remove these outdated files.
             build_data.remove_dir(dpath2)

--- a/parlai/tasks/light_dialog/builder.py
+++ b/parlai/tasks/light_dialog/builder.py
@@ -39,6 +39,47 @@ def fix_labels(act, opt):
             act['label_candidates'].append(l)
 
 
+def get_no_affordance_actions(in_room, carrying, other_carrying, other_name):
+    all_actions = []
+    # Drop "a" prefix from all
+    in_room = [i[2:] for i in in_room]
+    carrying = [i[2:] for i in carrying]
+    other_carrying = [i[2:] for i in other_carrying]
+    for obj in other_carrying:
+        all_actions.append('steal {} from {}'.format(obj, other_name))
+    for obj in in_room:
+        all_actions.append('get {}'.format(obj))
+    for obj in carrying:
+        for f in ['drop {}', 'wield {}', 'wear {}', 'remove {}', 'eat {}', 'drink {}']:
+            all_actions.append(f.format(obj))
+        all_actions.append('give {} to {}'.format(obj, other_name))
+        for obj2 in in_room:
+            all_actions.append('put {} in {}'.format(obj, obj2))
+        for obj2 in carrying:
+            if obj2 == obj:
+                continue
+            all_actions.append('put {} in {}'.format(obj, obj2))
+    return list(set(all_actions))
+
+
+def gen_no_affordance_actions_for_dialogue(d):
+    characters = [d['agents'][0]['name'], d['agents'][1]['name']]
+    other_char = 1
+    no_affordance_actions = []
+    last_carry = []
+    for idx in range(len(d['speech'])):
+        char = characters[other_char]
+        curr_carry = d['carrying'][idx] + d['wearing'][idx] + d['wielding'][idx]
+        no_affordance_actions_turn = get_no_affordance_actions(
+            d['room_objects'][idx], curr_carry, last_carry, char
+        )
+        no_affordance_actions_turn += d['available_actions'][idx]
+        no_affordance_actions.append(list(set(no_affordance_actions_turn)))
+        last_carry = curr_carry
+        other_char = 1 - other_char
+    d['no_affordance_actions'] = no_affordance_actions
+
+
 def write_dialog(opt, fw, d, label_type, split):
     l = len(d['speech'])
     msgs = []
@@ -149,6 +190,7 @@ def write_dialog(opt, fw, d, label_type, split):
                     label_type,
                     split,
                     int(opt.get('light_use_cands', 100)),
+                    opt.get('light_use_affordances', 'all'),
                 )
                 msgs.append(msg)
                 text = ''
@@ -206,15 +248,20 @@ def write_alldata(opt, db, dpath, ltype, split):
         d2['action'].insert(0, None)
         d2['available_actions'] = list(d2['available_actions'])
         d2['available_actions'].insert(0, None)
+        d2['no_affordance_actions'] = list(d2['no_affordance_actions'])
+        d2['no_affordance_actions'].insert(0, None)
         write_dialog(opt, fw_tst, d2, ltype, split)
     fw_tst.close()
 
 
-def add_negs(msg, d, ind, label_type, split, num_cands):
+def add_negs(msg, d, ind, label_type, split, num_cands, affordances):
     if label_type == 'emote':
         msg['label_candidates'] = cands['emote']
     if label_type == 'action':
-        msg['label_candidates'] = d['available_actions'][ind]
+        if affordances == 'all':
+            msg['label_candidates'] = d['available_actions'][ind]
+        else:
+            msg['label_candidates'] = d['no_affordance_actions'][ind]
     if label_type == 'speech':
         cnt = 0
         label = msg['labels']
@@ -246,6 +293,7 @@ def write_out_candidates(db, dpath, dtype):
     cands['action'] = []
     cands['speech'] = []
     for d in db:
+        gen_no_affordance_actions_for_dialogue(d)
         if d['split'] != dtype:
             continue
         for e in d['emote']:

--- a/parlai/tasks/light_dialog/builder.py
+++ b/parlai/tasks/light_dialog/builder.py
@@ -190,7 +190,7 @@ def write_dialog(opt, fw, d, label_type, split):
                     label_type,
                     split,
                     int(opt.get('light_use_cands', 100)),
-                    opt.get('light_use_affordances', 'all'),
+                    opt.get('light_use_affordances', True),
                 )
                 msgs.append(msg)
                 text = ''
@@ -254,11 +254,11 @@ def write_alldata(opt, db, dpath, ltype, split):
     fw_tst.close()
 
 
-def add_negs(msg, d, ind, label_type, split, num_cands, affordances):
+def add_negs(msg, d, ind, label_type, split, num_cands, use_affordances):
     if label_type == 'emote':
         msg['label_candidates'] = cands['emote']
     if label_type == 'action':
-        if affordances == 'all':
+        if use_affordances:
             msg['label_candidates'] = d['available_actions'][ind]
         else:
             msg['label_candidates'] = d['no_affordance_actions'][ind]


### PR DESCRIPTION
**Patch description**
Based on reviews, we're adding an ablation to this task for not having affordance information. This PR adds an option to drop affordance information, which ends up creating a list of all possible object interactions if all of the objects were to have all of the affordances. 

**Testing steps**
```
python examples/display_data.py -t light_dialog -dt test --light_label_type action --light_use_affordances none
```

**Logs**
```
_task_action
_setting_name Castle Maids' Room, Inside Castle
_setting_desc Inside the maids room is dark and grey.  It is much different from the rest of the Castle which has grand walls and floors and paintings from famous painters around the wall.  The maid holds many secrets in this room.  One which is a secret door that holds paintings she should not have.
_partner_name worker
_self_name painter
_self_persona I was hired to paint a portrait of the noblewoman the king would eventually marry. It seems that the painting was too flattering and when the king lifted the veil, he was very angry. I have been imprisoned for four long years. I had a wife and six children, but they do not wait for me to return. I turn my agony into art.
_object_desc a floor : THe floor is dusty and broken in ...
I am just a lowly worker. I think the red paint looks good. I can assist you with painting.
_partner_act get brush
_self_say I will love that. Tell me, how long have you been here?

[eval_labels: give brush to worker]
[label_candidates: remove fresh red paint|eat shirt|wield fresh red paint|drop shirt|drop fresh red paint|...and 37 more]
```