### PR TITLE
fix rouge setup errors

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -32,7 +32,10 @@ except ImportError:
 
 try:
     import rouge
-except ImportError:
+    import nltk
+
+    nltk.tokenize.load('tokenizers/punkt/{0}.pickle'.format('en'))
+except (ImportError, LookupError):
     # User doesn't have py-rouge installed, so we can't use it.
     # We'll just turn off rouge computations
     rouge = None
@@ -247,11 +250,14 @@ class Metrics(object):
             optional_metrics_list = set(metrics_arg.split(','))
             optional_metrics_list.add('correct')
         for each_m in optional_metrics_list:
-            if each_m.startswith('rouge') and rouge is not None:
-                self.metrics_list.add('rouge')
-            elif each_m == 'bleu' and nltkbleu is None:
-                # only compute bleu if we can
-                pass
+            if each_m.startswith('rouge'):
+                if rouge is not None:
+                    # only compute rouge if rouge is available
+                    self.metrics_list.add('rouge')
+            elif each_m == 'bleu':
+                if nltkbleu is None:
+                    # only compute bleu if bleu is available
+                    pass
             else:
                 self.metrics_list.add(each_m)
         metrics_list = (

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -32,9 +32,6 @@ except ImportError:
 
 try:
     import rouge
-    import nltk
-
-    nltk.tokenize.load('tokenizers/punkt/{0}.pickle'.format('en'))
 except (ImportError, LookupError):
     # User doesn't have py-rouge installed, so we can't use it.
     # We'll just turn off rouge computations
@@ -349,7 +346,7 @@ class Metrics(object):
                 if 'bleu' in self.metrics:
                     self.metrics['bleu'] += bleu
                     self.metrics['bleu_cnt'] += 1
-                if 'rouge-L' in self.metrics:
+                if 'rouge-L' in self.metrics and rouge1 is not None:
                     self.metrics['rouge-1'] += rouge1
                     self.metrics['rouge-1_cnt'] += 1
                     self.metrics['rouge-2'] += rouge2

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -32,7 +32,7 @@ except ImportError:
 
 try:
     import rouge
-except (ImportError, LookupError):
+except ImportError:
     # User doesn't have py-rouge installed, so we can't use it.
     # We'll just turn off rouge computations
     rouge = None

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -254,10 +254,9 @@ class Metrics(object):
                 if rouge is not None:
                     # only compute rouge if rouge is available
                     self.metrics_list.add('rouge')
-            elif each_m == 'bleu':
-                if nltkbleu is None:
-                    # only compute bleu if bleu is available
-                    pass
+            elif each_m == 'bleu' and nltkbleu is None:
+                # only compute bleu if bleu is available
+                pass
             else:
                 self.metrics_list.add(each_m)
         metrics_list = (


### PR DESCRIPTION
**Patch description**
Rouge needs nltk punkt tokenizer set up in order to work, so unit tests fail if user does not have nltk installed and the punkt tokenizer downloaded.

Now, rouge will be set to None if the punkt tokenizer is not set up.

After fixing that, unit tests still fail because rouge is still added to the metrics list even if rouge is not set up due to the `else` block catching when `rouge is None`.

**Testing steps**
`python tests/test_eval_model.py`

**Results on master branch**
If you don't happen to have the punk tokenizer set up, you get the following:
```
======================================================================
ERROR: test_metrics_select (__main__.TestEvalModel)
Test output of running eval_model
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_eval_model.py", line 91, in test_metrics_select
    str_output, valid, test = testing_utils.eval_model(opt)
  File "/Users/ahm/ParlAI/parlai/core/testing_utils.py", line 272, in eval_model
    valid = None if skip_valid else ems.eval_model(popt)
  File "/Users/ahm/ParlAI/parlai/scripts/eval_model.py", line 117, in eval_model
    task_report = _eval_single_world(opt, agent, task)
  File "/Users/ahm/ParlAI/parlai/scripts/eval_model.py", line 83, in _eval_single_world
    world.parley()
  File "/Users/ahm/ParlAI/parlai/core/worlds.py", line 275, in parley
    agents[0].observe(validate(acts[1]))
  File "/Users/ahm/ParlAI/parlai/core/teachers.py", line 351, in observe
    self.metrics.update(observation, self.lastY)
  File "/Users/ahm/ParlAI/parlai/core/metrics.py", line 348, in update
    self.metrics['rouge-1'] += rouge1
TypeError: unsupported operand type(s) for +=: 'float' and 'NoneType
```