### PR TITLE
Cleanup of tensorboard integration.

### DIFF
--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -9,24 +9,23 @@ Log metrics to tensorboard.
 This file provides interface to log any metrics in tensorboard, could be
 extended to any other tool like visdom.
 
-If you use tensorboard logging, all event folders will be stored in
-``PARLAI_DATA/tensorboard`` folder. In order to Open it with TB, launch
-tensorboard as:
-
 .. code-block: none
 
    tensorboard --logdir <PARLAI_DATA/tensorboard> --port 8888.
 """
 
-# TODO: update this with pytorch 1.1's tensorboard API
-
 import os
+import json
+import numbers
+
+try:
+    from tensorboardX import SummaryWriter
+except ImportError:
+    SummaryWriter = None
 
 
 class TensorboardLogger(object):
     """Log objects to tensorboard."""
-
-    _shared_state = {}
 
     @staticmethod
     def add_cmdline_args(argparser):
@@ -38,94 +37,32 @@ class TensorboardLogger(object):
             type='bool',
             default=False,
             help="Tensorboard logging of metrics, default is %(default)s",
-            hidden=True,
-        )
-        logger.add_argument(
-            '-tbtag',
-            '--tensorboard-tag',
-            type=str,
-            default=None,
-            help='Specify all opt keys which you want to be presented in in TB name',
-            hidden=True,
-        )
-        logger.add_argument(
-            '-tbmetrics',
-            '--tensorboard-metrics',
-            type=str,
-            default=None,
-            help='Specify metrics which you want to track, it will be extracted '
-            'from report dict.',
-            hidden=True,
-        )
-        logger.add_argument(
-            '-tbcomment',
-            '--tensorboard-comment',
-            type=str,
-            default='',
-            hidden=True,
-            help='Add any line here to distinguish your TB event file, optional',
+            hidden=False,
         )
 
     def __init__(self, opt):
-        self.__dict__ = self._shared_state
-        try:
-            from tensorboardX import SummaryWriter
-        except ImportError:
-            raise ImportError('Please `pip install tensorboardX` for logs with TB.')
+        if SummaryWriter is None:
+            raise RuntimeError('Please run `pip install tensorboard tensorboardX`.')
 
-        if opt['tensorboard_tag'] is None:
-            tensorboard_tag = opt['starttime']
-        else:
-            tensorboard_tag = opt['starttime'] + '__'.join(
-                [i + '-' + str(opt[i]) for i in opt['tensorboard_tag'].split(',')]
-            )
-        if opt['tensorboard_comment']:
-            tensorboard_tag += '__' + opt['tensorboard_comment']
-
-        tbpath = os.path.join(os.path.dirname(opt['model_file']), 'tensorboard')
-        print('[ Saving tensorboard logs here: {} ]'.format(tbpath))
+        tbpath = opt['model_file'] + '.tensorboard'
+        print('[ Saving tensorboard logs to: {} ]'.format(tbpath))
         if not os.path.exists(tbpath):
             os.makedirs(tbpath)
-        self.writer = SummaryWriter(logdir='{}/{}'.format(tbpath, tensorboard_tag))
-        if opt['tensorboard_metrics'] is None:
-            self.tbmetrics = ['ppl', 'loss']
-        else:
-            self.tbmetrics = opt['tensorboard_metrics'].split(',')
+        self.writer = SummaryWriter(tbpath, comment=json.dumps(opt))
 
-    def add_metrics(self, setting, step, report):
+    def log_metrics(self, setting, step, report):
         """
         Add all metrics from tensorboard_metrics opt key.
 
-        :param setting: whatever setting is used, train valid or test, it will
-            be just the title of the graph
-        :param step: num of parleys (x axis in graph), in train - parleys, in
-            valid - wall time
-        :param report: from TrainingLoop
-        :return:
-        """
-        for met in self.tbmetrics:
-            if met in report.keys():
-                self.writer.add_scalar(
-                    "{}/{}".format(setting, met), report[met], global_step=step
-                )
-
-    def add_scalar(self, name, y, step=None):
-        """
-        Add a scalar.
-
-        :param str name:
-            the title of the graph, use / to group like "train/loss/ce" or so
-        :param y:
-            value
+        :param setting:
+            One of train/valid/test. Will be used as the title for the graph.
         :param step:
-            x axis step
+            Number of parleys
+        :param report:
+            The report to log
         """
-        self.writer.add_scalar(name, y, step)
-
-    def add_histogram(self, name, vector, step=None):
-        """Add a histogram."""
-        self.writer.add_histogram(name, vector, step)
-
-    def add_text(self, name, text, step=None):
-        """Add text."""
-        self.writer.add_text(name, text, step)
+        for k, v in report.items():
+            if isinstance(v, numbers.Number):
+                self.writer.add_scalar(f'{setting}/{k}', v, global_step=step)
+            else:
+                print(f'k {k} v {v} is not a number')

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -441,7 +441,7 @@ class TrainLoop:
                 self.valid_reports = obj.get('valid_reports', [])
 
         if opt['tensorboard_log'] is True:
-            self.writer = TensorboardLogger(opt)
+            self.tb_logger = TensorboardLogger(opt)
 
     def save_model(self, suffix=None):
         """Save the model to disk, possibly with a suffix."""
@@ -504,8 +504,8 @@ class TrainLoop:
         v['train_time'] = self.train_time.time()
         self.valid_reports.append(v)
         # logging
-        if opt['tensorboard_log'] is True and is_primary_worker():
-            self.writer.add_metrics('valid', int(self.train_time.time()), valid_report)
+        if opt['tensorboard_log'] and is_primary_worker():
+            self.tb_logger.log_metrics('valid', self.parleys, valid_report)
         # saving
         if (
             opt.get('model_file')
@@ -694,8 +694,8 @@ class TrainLoop:
         print(log)
         self.log_time.reset()
 
-        if opt['tensorboard_log'] is True and is_primary_worker():
-            self.writer.add_metrics('train', self._total_exs, train_report)
+        if opt['tensorboard_log'] and is_primary_worker():
+            self.tb_logger.log_metrics('train', self.parleys, train_report)
 
     def train(self):
         """


### PR DESCRIPTION
**Patch description**
Small cleanup of tensorboard integration. Makes it so there's only one flag, `--tensorboard-log true` to enable it. It always gets saved to `model_file.tensorboard`. All numeric metrics are logged on every valid and every train log.

**Testing steps**
Manual testing. Will upload a screenshot later.