### PR TITLE
[TransformerRanker] Allow passing context segments into MemNet forward

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -220,7 +220,7 @@ class TransformerMemNetModel(nn.Module):
 
         return encoded
 
-    def encode_context_memory(self, context_w, memories_w):
+    def encode_context_memory(self, context_w, memories_w, context_segments=None):
         """Encode the memories."""
         # [batch, d]
         if context_w is None:
@@ -228,7 +228,7 @@ class TransformerMemNetModel(nn.Module):
             # forward function, return None here for LHS representation
             return None, None
 
-        context_h = self.context_encoder(context_w)
+        context_h = self.context_encoder(context_w, segments=context_segments)
 
         if memories_w is None:
             return [], context_h
@@ -243,9 +243,11 @@ class TransformerMemNetModel(nn.Module):
 
         return weights, context_h
 
-    def forward(self, xs, mems, cands):
+    def forward(self, xs, mems, cands, context_segments=None):
         """Forward pass."""
-        weights, context_h = self.encode_context_memory(xs, mems)
+        weights, context_h = self.encode_context_memory(
+            xs, mems, context_segments=context_segments
+        )
         cands_h = self.encode_cand(cands)
 
         if self.opt['normalize_sent_emb']:

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -221,7 +221,7 @@ class TransformerMemNetModel(nn.Module):
         return encoded
 
     def encode_context_memory(self, context_w, memories_w, context_segments=None):
-        """Encode the memories."""
+        """Encode the context and memories."""
         # [batch, d]
         if context_w is None:
             # it's possible that only candidates were passed into the
@@ -244,12 +244,23 @@ class TransformerMemNetModel(nn.Module):
         return weights, context_h
 
     def forward(self, xs, mems, cands, context_segments=None):
-        """Forward pass."""
+        """
+        Forward pass.
+
+        :param LongTensor[batch,seqlen] xs: input tokens IDs
+        :param LongTensor[batch,num_mems,seqlen] mems: memory token IDs
+        :param LongTensor[batch,num_cands,seqlen] cands: candidate token IDs
+        :param LongTensor[batch,seqlen] context_segments: segment IDs for xs,
+            used if n_segments is > 0 for the context encoder
+        """
+        # encode the context and memories together
         weights, context_h = self.encode_context_memory(
             xs, mems, context_segments=context_segments
         )
+        # encode the candidates
         cands_h = self.encode_cand(cands)
 
+        # possibly normalize the context and candidate representations
         if self.opt['normalize_sent_emb']:
             context_h = context_h / context_h.norm(2, dim=1, keepdim=True)
             cands_h = cands_h / cands_h.norm(2, dim=1, keepdim=True)


### PR DESCRIPTION
**Patch description**
Allow passing segments for the context encoder through the forward for the TransformerMemNet module (which is used by the bi-ranker). cc @hadasah 
