### PR TITLE
[TRA] vocab candidates bug fix

### DIFF
--- a/parlai/agents/transformer/polyencoder.py
+++ b/parlai/agents/transformer/polyencoder.py
@@ -115,12 +115,12 @@ class PolyencoderAgent(TorchRankerAgent):
         kwargs['add_end'] = True
         return super().vectorize_fixed_candidates(*args, **kwargs)
 
-    def _make_candidate_encs(self, vecs, path):
+    def _make_candidate_encs(self, vecs):
         """ (used in interactive mode only) The polyencoder module expects
             cand vecs to be 3D while torch_ranker_agent expects it to be 2D.
             This requires a little adjustment
         """
-        rep = super()._make_candidate_encs(vecs, path)
+        rep = super()._make_candidate_encs(vecs)
         return rep.transpose(0, 1).contiguous()
 
     def encode_candidates(self, padded_cands):


### PR DESCRIPTION
**Patch description**
Fixes #1920. If `encode_candidate_vecs` was set to True and the type of candidates being used was `vocab`, it expected them to be built already.

Another small change: the function `_make_candidate_encs` was not using the argument `path` so I got rid of it.

**Testing steps**
Run `python examples/train_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -bs 1 -nt 4 -eps 5 -m memnn --no-cuda` followed by `python examples/display_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -ecands vocab`.


**Logs**
```
[creating task(s): babi:task10k:1]
[loading fbdialog data:/private/home/edinan/ParlAI/data/bAbI/tasks_1-20_v1-2/en-valid-10k-nosf/qa1_valid.txt]
/private/home/edinan/ParlAI/parlai/core/torch_ranker_agent.py:678: UserWarning: [ Executing eval mode with tokens from vocabulary as candidates. ]
  ''.format(mode)
[babi:task10k:1]: Sandra travelled to the office.
Sandra went to the bathroom.
Where is Sandra?
[label_candidates: bathroom|kitchen|office|garden|hallway|...and 1 more]
[eval_labels: bathroom]
   [Memnn]: bathroom
   [text_candidates: bathroom|journeyed|__tf12__|__tf8__|
|...and 52 more]
~~
[babi:task10k:1]: Mary went to the bedroom.
Daniel moved to the hallway.
Where is Sandra?
[label_candidates: bathroom|kitchen|office|garden|hallway|...and 1 more]
[eval_labels: bathroom]
   [Memnn]: bathroom
   [text_candidates: bathroom|__tf14__|__tf6__|journeyed|office|...and 52 more]
~~
[babi:task10k:1]: John went to the garden.
John travelled to the office.
Where is Sandra?
[label_candidates: bathroom|kitchen|office|garden|hallway|...and 1 more]
[eval_labels: bathroom]
   [Memnn]: bathroom
   [text_candidates: bathroom|__unk__|__tf6__|journeyed|
|...and 52 more]
~~
[babi:task10k:1]: Daniel journeyed to the bedroom.
Daniel travelled to the hallway.
Where is John?
[label_candidates: bathroom|kitchen|office|garden|hallway|...and 1 more]
[eval_labels: office]
   [Memnn]: office
   [text_candidates: office|__tf5__|to|__tf24__|
|...and 52 more]
~~
[babi:task10k:1]: John went to the bedroom.
John travelled to the office.
Where is Daniel?
[label_candidates: bathroom|kitchen|office|garden|hallway|...and 1 more]
[eval_labels: hallway]
   [Memnn]: hallway
   [text_candidates: hallway|journeyed|Mary|__tf2__|__tf12__|...and 52 more]
- - - - - - - - - - - - - - - - - - - - -
~~
[babi:task10k:1]: Sandra went back to the bathroom.
Mary moved to the garden.
Where is Mary?
[label_candidates: bathroom|kitchen|office|garden|hallway|...and 1 more]
[eval_labels: garden]
   [Memnn]: garden
   [text_candidates: garden|journeyed|Mary|__tf21__|__tf5__|...and 52 more]
~~
[babi:task10k:1]: Mary went back to the hallway.
Sandra went to the office.
Where is Sandra?
[label_candidates: bathroom|kitchen|office|garden|hallway|...and 1 more]
[eval_labels: office]
   [Memnn]: office
   [text_candidates: office|__tf17__|__tf5__|?|moved|...and 52 more]
~~
[babi:task10k:1]: John went back to the hallway.
John travelled to the office.
Where is Sandra?
[label_candidates: bathroom|kitchen|office|garden|hallway|...and 1 more]
[eval_labels: office]
   [Memnn]: office
   [text_candidates: office|__tf5__|?|__tf17__|__tf6__|...and 52 more]
~~
[babi:task10k:1]: Sandra journeyed to the hallway.
Daniel moved to the office.
Where is John?
[label_candidates: bathroom|kitchen|office|garden|hallway|...and 1 more]
[eval_labels: office]
   [Memnn]: office
   [text_candidates: office|__tf5__|John|__tf24__|Mary|...and 52 more]
~~
[babi:task10k:1]: Mary went to the office.
Sandra went to the office.
Where is John?
[label_candidates: bathroom|kitchen|office|garden|hallway|...and 1 more]
[eval_labels: office]
   [Memnn]: office
   [text_candidates: office|Mary|hallway|moved|__tf5__|...and 52 more]
- - - - - - - - - - - - - - - - - - - - -
```
