### PR TITLE
build_candidates avoids failure hogwild.

### DIFF
--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -227,7 +227,6 @@ class TorchRankerAgent(TorchAgent):
         opt['datatype'] = 'train:evalmode'
         opt['interactive_task'] = False
         opt['batchsize'] = 1
-        opt['numthreads'] = 1
         build_cands(opt)
         return path
 

--- a/parlai/scripts/build_candidates.py
+++ b/parlai/scripts/build_candidates.py
@@ -23,6 +23,9 @@ import tempfile
 
 def build_cands(opt):
     # create repeat label agent and assign it to the specified task
+    if opt['numthreads'] > 1:
+        # Broken in hogwild mode. Just fall back to single processing mode
+        opt['numthreads'] = 1
     agent = RepeatLabelAgent(opt)
     world = create_task(opt, agent)
     if opt['outfile'] is None:


### PR DESCRIPTION
**Patch description**
Fixes #1954. Related to #1920.

TRA uses the build_candidates script to get access to the candidates. However, this script assumes no Hogwild, even thought the QuickStart actually uses it. This makes build_candidates do something a bit safer/smarter.

**Testing steps**
```
$ python examples/train_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -bs 1 -nt 4 -eps 5 -m memnn --no-cuda
$ python examples/interactive.py -mf /tmp/babi_memnn -ecands vocab
```

**Logs**
```
$ python examples/interactive.py -mf /tmp/babi_memnn -ecands vocab
...
[ Vectorizing fixed candidate set (18 batch(es) of up to 512) ]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 18/18 [00:00<00:00, 303.17it/s][ Saving fixed candidate set vectors to /tmp/babi_memnn.babi_memnn.cands-babi:task10k:1.vecs ]
[ Encoding fixed candidates set from (36 batch(es) of up to 256) ]
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 36/36 [00:00<00:00, 8025.24it/s]
[ Saving fixed candidate set encodings to /tmp/babi_memnn.babi_memnn.cands-babi:task10k:1.encs ]
[ Loaded fixed candidate set (n = 57) from vocabulary ]
...
Enter Your Message:
```
