### PR TITLE
Change short option for --weight-decay.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -497,7 +497,7 @@ class TorchAgent(ABC, Agent):
             'value like 0.9 or a comma-separated tuple like 0.9,0.999',
         )
         optim_group.add_argument(
-            '-wd',
+            '-wdecay',
             '--weight-decay',
             type=float,
             default=None,


### PR DESCRIPTION
**Patch description**
#1835 added weight decay as a CLI option for optimizers. However, I failed to notice that the controllable dialogue models also used `-wd`. Given that they were there first, it makes sense to have their short option remain.

**Testing steps**
```
python projects/controllable_dialogue/interactive.py \
-mf models:controllable_dialogue/control_questionb11e10 \
-wd extrep_nonstopword:-1e20,intrep_nonstopword:-1e20 \
--set-controls question:10 --beam-reorder best_extrep2gram_qn
```

doesn't crash anymore
