### PR TITLE
Continued battle with test_distributed

### DIFF
--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -21,7 +21,11 @@ import hashlib
 import tqdm
 import math
 import zipfile
-from multiprocessing import Pool
+
+try:
+    from torch.multiprocessing import Pool
+except ImportError:
+    from multiprocessing import Pool
 
 
 class DownloadableFile:

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -27,7 +27,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from parlai.core.opt import Opt
-from parlai.utils.distributed import is_distributed, check_synced_parameters
+from parlai.utils.distributed import is_distributed, sync_parameters
 from parlai.core.torch_agent import TorchAgent, Batch, Output
 from parlai.utils.misc import round_sigfigs, warn_once
 from parlai.utils.torch import padded_tensor, neginf
@@ -347,7 +347,7 @@ class TorchGeneratorAgent(TorchAgent):
                 self.model.cuda()
                 self.criterion.cuda()
 
-            check_synced_parameters(self.model)
+            sync_parameters(self.model)
             print("Total parameters: {}".format(self._total_parameters()))
             print("Trainable parameters:  {}".format(self._trainable_parameters()))
 

--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -17,13 +17,6 @@ TorchRankerAgents and TorchGeneratorAgents support this.
 """
 
 import torch
-
-try:
-    # We need to run this *very first*, but subprocesses will throw an
-    # exception when running it
-    torch.multiprocessing.set_start_method("spawn")
-except RuntimeError:
-    pass
 import random
 import copy
 import os

--- a/parlai/utils/distributed.py
+++ b/parlai/utils/distributed.py
@@ -243,14 +243,17 @@ def sync_parameters(model: torch.nn.Module) -> bool:
         # if things aren't distributed, of course things are in sync
         return True
 
-    # syncrhonize all the parameters
+    # sync all the parameters
     with torch.no_grad():
         for p in model.parameters():
             if not is_primary_worker():
+                # zero out parameters on all workers EXCEPT the primary worker
                 p.data.zero_()
-            dist.all_reduce(p.data)
+            # sum the parameters across all workers, resulting in everyone having
+            # the parameters of the primary worker
+            dist.all_reduce(p.data, dist.ReduceOp.SUM)
 
-    # double check everything synced
+    # double check everything synced correctly
     norm2 = sum((p.data ** 2).sum().float() for p in model.parameters()).item()
     all_versions = all_gather_list(norm2)
     if not all(n == norm2 for n in all_versions):

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -24,6 +24,7 @@ def _forced_parse(parser, opt):
     return popt
 
 
+@testing_utils.skipUnlessGPU
 class TestDistributed(unittest.TestCase):
     def _distributed_train_model(self, opt):
         with testing_utils.capture_output() as output:

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -9,6 +9,7 @@ import unittest
 import torch.distributed as dist
 import parlai.utils.testing as testing_utils
 import parlai.scripts.build_dict as build_dict
+import parlai.scripts.multiprocessing_train as mp_train
 
 
 def _forced_parse(parser, opt):
@@ -23,14 +24,8 @@ def _forced_parse(parser, opt):
     return popt
 
 
-@unittest.skip("Test disabled until #1974 is resolved.")
 class TestDistributed(unittest.TestCase):
     def _distributed_train_model(self, opt):
-        # we have to delay our import to here, because the set_spawn_method call
-        # inside multiprocessing_train will break the multithreading tests, even
-        # when we skip the test.
-        import parlai.scripts.multiprocessing_train as mp_train
-
         with testing_utils.capture_output() as output:
             with testing_utils.tempdir() as tmpdir:
                 if 'model_file' not in opt:


### PR DESCRIPTION
**Patch description**
We're finding its very difficult to control for random seed exactly across all workers, causing models to initialize slightly differently. Previously, we just checked that the norm of the model parameters was the same, and raised an exception when they weren't. This test was failing quite frequently.

Now instead, we just explicitly use the primary worker's copy of the parameters, and force a sync at the beginning of the program. This is much easier than trying to control the random seed, and is relatively cheap compared to the full training run.

OLD MESSAGE: @gchanan and @mrshenli suggested we actually check all the parameters rather than an aggregation, possibly improving the reliability of distributed.

**Testing steps**
We're going to run CircleCI 20 times.