### PR TITLE
Suppress output for test_download_multiprocess.

### DIFF
--- a/tests/test_build_data.py
+++ b/tests/test_build_data.py
@@ -33,44 +33,50 @@ class TestBuildData(unittest.TestCase):
 
     def test_download_multiprocess(self):
         urls = [
-            'http://parl.ai/downloads/mnist/mnist.tar.gz',
-            'http://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
-            'http://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
+            'https://parl.ai/downloads/mnist/mnist.tar.gz',
+            'https://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
+            'https://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
         ]
 
-        with testing_utils.capture_output():
+        with testing_utils.capture_output() as stdout:
             download_results = build_data.download_multiprocess(
                 urls, self.datapath, dest_filenames=self.dest_filenames
             )
+        stdout = stdout.getvalue()
 
         output_filenames, output_statuses, output_errors = zip(*download_results)
         self.assertEqual(
-            output_filenames, self.dest_filenames, 'output filenames not correct'
+            output_filenames,
+            self.dest_filenames,
+            f'output filenames not correct\n{stdout}',
         )
         self.assertEqual(
-            output_statuses, (200, 403, 403), 'output http statuses not correct'
+            output_statuses,
+            (200, 403, 403),
+            f'output http statuses not correct\n{stdout}',
         )
 
     def test_download_multiprocess_chunks(self):
         # Tests that the three finish downloading but may finish in any order
         urls = [
-            'http://parl.ai/downloads/mnist/mnist.tar.gz',
-            'http://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
-            'http://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
+            'https://parl.ai/downloads/mnist/mnist.tar.gz',
+            'https://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
+            'https://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
         ]
 
-        with testing_utils.capture_output():
+        with testing_utils.capture_output() as stdout:
             download_results = build_data.download_multiprocess(
                 urls, self.datapath, dest_filenames=self.dest_filenames, chunk_size=1
             )
+        stdout = stdout.getvalue()
 
         output_filenames, output_statuses, output_errors = zip(*download_results)
 
-        self.assertIn('mnist0.tar.gz', output_filenames)
-        self.assertIn('mnist1.tar.gz', output_filenames)
-        self.assertIn('mnist2.tar.gz', output_filenames)
-        self.assertIn(200, output_statuses)
-        self.assertIn(403, output_statuses)
+        self.assertIn('mnist0.tar.gz', output_filenames, f'missing file:\n{stdout}')
+        self.assertIn('mnist1.tar.gz', output_filenames, f'missing file:\n{stdout}')
+        self.assertIn('mnist2.tar.gz', output_filenames, f'missing file:\n{stdout}')
+        self.assertIn(200, output_statuses, f'unexpected error code:\n{stdout}')
+        self.assertIn(403, output_statuses, f'unexpected error code:\n{stdout}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Patch description**
Suppress the output of test_build_data unless there's a failure. This keeps the noise down when reading logs for test failures.

Additionally update URLs to use 'https://' to lower our billing costs marginally.

**Logs**
```
$ python tests/test_build_data.py
..
----------------------------------------------------------------------
Ran 2 tests in 12.248s

OK
```

then made an edit:
```
$ git diff
diff --git a/tests/test_build_data.py b/tests/test_build_data.py
index 81bdff6f..47336551 100644
--- a/tests/test_build_data.py
+++ b/tests/test_build_data.py
@@ -59,7 +59,7 @@ class TestBuildData(unittest.TestCase):
     def test_download_multiprocess_chunks(self):
         # Tests that the three finish downloading but may finish in any order
         urls = [
-            'https://parl.ai/downloads/mnist/mnist.tar.gz',
+            'https://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
             'https://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
             'https://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
         ]
$ python tests/test_build_data.py
.F
======================================================================
FAIL: test_download_multiprocess_chunks (__main__.TestBuildData)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_build_data.py", line 78, in test_download_multiprocess_chunks
    self.assertIn(200, output_statuses, f'unexpected error code:\n{stdout}')
AssertionError: 200 not found in (403, 403, 403) : unexpected error code:
  0%|          | 0/3 [00:00<?, ?it/s]Of 3 items, 0 already existed; only going to download 3 items.
Going to download 3 chunks with 1 images per chunk using 32 processes.
Bad download - chunk: 0, dest_file: mnist2.tar.gz, http status code: 403, error_msg: [Response not OK] Response: <Response [403]>
Downloading:  33%|###3      | 1/3 [00:04<00:09,  4.77s/it]Bad download - chunk: 1, dest_file: mnist0.tar.gz, http status code: 403, error_msg: [Response not OK] Response: <Response [403]>
Downloading:  67%|######6   | 2/3 [00:05<00:03,  3.45s/it]Bad download - chunk: 2, dest_file: mnist1.tar.gz, http status code: 403, error_msg: [Response not OK] Response: <Response [403]>
Downloading: 100%|##########| 3/3 [00:05<00:00,  1.73s/it]
Of 3 items attempted downloading, 3 had errors.
Finished downloading chunks.


----------------------------------------------------------------------
Ran 2 tests in 11.328s

FAILED (failures=1)
python tests/test_build_data.py  103.12s user 129.35s system 1515% cpu 15.341 total
```