### PR TITLE
Disable distributed test.

### DIFF
--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -23,7 +23,7 @@ def _forced_parse(parser, opt):
     return popt
 
 
-@testing_utils.skipUnlessGPU
+@unittest.skip("Test disabled until #1974 is resolved.")
 class TestDistributed(unittest.TestCase):
     def _distributed_train_model(self, opt):
         # we have to delay our import to here, because the set_spawn_method call


### PR DESCRIPTION
**Patch description**
Temporarily disable the test_distributed test until #1974 is fixed.

**Testing steps**
```
$ python tests/test_distributed.py
s
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK (skipped=1)
```
