### PR TITLE
[TA] Report GPU memory usage.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1007,7 +1007,7 @@ class TorchAgent(ABC, Agent):
             metrics['clip'] = round_sigfigs(self.metrics['clip'] / steps, 2)
 
         if self.use_cuda:
-            metrics['gpumempct'] = round_sigfigs(self._gpu_usage(), sigfigs=3)
+            metrics['gpu_mem_percent'] = round_sigfigs(self._gpu_usage(), sigfigs=3)
 
         return metrics
 
@@ -1015,8 +1015,10 @@ class TorchAgent(ABC, Agent):
         """
         Computes GPU memory usage.
 
-        Only computes the *maximum* memory used, but this is the most useful
-        metric for ensuring OOMs don't happen.
+        Includes both allocated and cached memory; this should be close to the
+        output of nvidia-smi, but not reflect of how much is currently demanded
+        by the program. It may be viewed as a rough approximation of
+        worst-case-until-now.
 
         :return: Percent of allocated GPU memory as a fraction of available.
         """


### PR DESCRIPTION
**Patch description**
Have TA report GPU usage. Whether making this as close to 100 as possible is good for your use case depends on your use case, but it's a convenient metric to have.

**Testing steps**
```
# two GPUS
$ rm -rf foo/* ; python examples/train_model.py -m transformer/generator -opt adamax -lr 5e-4 -eps 5 -nl 1 --n-heads 4 -esz 256 --skip-generation true -mf foo/model -t convai2 -tblog true  -veps 0.25 -bs 256 -tr 128 --ffn-size 1024 -vmt ppl -nl 12
[ time:16.0s total_exs:5632 epochs:0.04 time_left:1884.0s ] {'exs': 768, 'lr': 0.0005, 'num_updates': 18, 'gnorm': 1.408, 'clip': 1.0, 'gpumempct': 0.478, 'loss': 21.64, 'token_acc': 0.07881, 'nll_l
oss': 7.217, 'ppl': 1363.0, 'total_skipped_batches': 4}

# CUDA VISIBLE DEVICES
$ rm -rf foo/* ; CUDA_VISIBLE_DEVICES=0 python examples/train_model.py -m transformer/generator -opt adamax -lr 5e-4 -eps 5 -nl 1 --n-heads 4 -esz 256 --skip-generation true -mf foo/model -t convai2 -tblog true  -veps 0.25 -bs 256 -tr 128 --ffn-size 1024 -vmt ppl -nl 12
...
[ time:69.0s total_exs:22784 epochs:0.17 time_left:1922.0s ] {'exs': 768, 'lr': 0.0005, 'num_updates': 89, 'gnorm': 0.4317, 'clip': 1.0, 'gpumempct': 0.852, 'loss': 17.12, 'token_acc': 0.07713, 'nll
_loss': 5.708, 'ppl': 301.2}

# Manually setting -gpu
$ rm -rf foo/* ; python examples/train_model.py -m transformer/generator -opt adamax -lr 5e-4 -eps 5 -nl 1 --n-heads 4 -esz 256 --skip-generation true -mf foo/model -t convai2 -tblog true  -veps 0.25 -bs 256 -tr 128 --ffn-size 1024 -vmt ppl -nl 12 -gpu 1
...
[ time:98.0s total_exs:32768 epochs:0.25 time_left:1871.0s ] {'exs': 768, 'lr': 0.0005, 'num_updates': 128, 'gnorm': 0.4474, 'clip': 1.0, 'gpumempct': 0.855, 'loss': 17.1, 'token_acc': 0.07785, 'nll_loss': 5.7, 'ppl': 299.0}

# data parallel
$ rm -rf foo/* ; python examples/train_model.py -m transformer/ranker -opt adamax -lr 5e-4 -eps 5 -nl 1 --n-heads 4 -esz 256 -mf foo/model -t convai2 -veps 0.25 -bs 32 -tr
128 --ffn-size 1024 -vmt ppl -nl 12 --data-parallel true
[ time:26.0s total_exs:3296 epochs:0.03 time_left:5278.0s ] {'exs': 320, 'lr': 0.0005, 'num_updates': 103, 'gnorm': 0.009195, 'clip': 0, 'gpumempct': 0.355, 'examples': 320, 'loss': 29.96, 'mean_los
s': 0.09362}
```