### PR TITLE
[Bug Fix]put model in eval when encode candidates

### DIFF
--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -921,6 +921,8 @@ class TorchRankerAgent(TorchAgent):
             "[ Encoding fixed candidates set from ({} batch(es) of up to 256) ]"
             "".format(len(vec_batches))
         )
+        # Put model into eval mode when encode candidates
+        self.model.eval()
         with torch.no_grad():
             for vec_batch in tqdm(vec_batches):
                 cand_encs.append(self.encode_candidates(vec_batch))


### PR DESCRIPTION
**Patch description**
This will switch model to eval when encoding fixed list of candidates.
