### PR TITLE
Allow pickle when loading personas

### DIFF
--- a/parlai/mturk/tasks/personachat/personachat_chat/worlds.py
+++ b/parlai/mturk/tasks/personachat/personachat_chat/worlds.py
@@ -64,7 +64,8 @@ class PersonasGenerator(object):
             self.add_idx_stack()
         idx = self.idx_stack.pop()
         data = np.load(
-            os.path.join(self.personas_path, self.personas_name_list[int(idx)])
+            os.path.join(self.personas_path, self.personas_name_list[int(idx)]),
+            allow_pickle=True,
         )
         return (idx, data)
 


### PR DESCRIPTION
**Patch description**
Numpy 1.16.3 and later default to refusing to load pickled object arrays in npy files for security reasons. This patch explicitly permits pickled objects in the case of loading in the personas file.

Numpy 1.15's `numpy.load()`: https://numpy.org/doc/1.15/reference/generated/numpy.load.html
Numpy 1.16's `numpy.load()`: https://numpy.org/doc/1.16/reference/generated/numpy.load.html

**Testing steps**
`ems@devfair0229:~/GitHub/facebookresearch/ParlAI/parlai/mturk/tasks/personachat/personachat_chat$ python run.py -nc 1 --sandbox`
