### PR TITLE
[Poly-encoders] [GPU] Updates to Poly-encoder (and some Bi-encoder)

### DIFF
--- a/parlai/agents/transformer/biencoder.py
+++ b/parlai/agents/transformer/biencoder.py
@@ -21,6 +21,13 @@ class BiencoderAgent(TransformerRankerAgent):
         obs = TorchRankerAgent.vectorize(self, *args, **kwargs)
         return obs
 
+    def _vectorize_text(self, *args, **kwargs):
+        """override to add start end tokens. necessary for fixed cands"""
+        if 'add_start' in kwargs:
+            kwargs['add_start'] = True
+            kwargs['add_end'] = True
+        return super()._vectorize_text(*args, **kwargs)
+
     def _set_text_vec(self, *args, **kwargs):
         """ Add the start and end token to the text.
         """

--- a/parlai/agents/transformer/biencoder.py
+++ b/parlai/agents/transformer/biencoder.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+"""Bi-encoder Agent."""
 
 from .transformer import TransformerRankerAgent
 from parlai.core.torch_ranker_agent import TorchRankerAgent
@@ -8,29 +9,28 @@ import torch
 
 
 class BiencoderAgent(TransformerRankerAgent):
-    """
+    """Bi-encoder Transformer Agent.
+
     Equivalent of bert_ranker/biencoder but does not rely on an external
     library (hugging face).
     """
 
     def vectorize(self, *args, **kwargs):
-        """ Add the start and end token to the text.
-        """
+        """Add the start and end token to the text."""
         kwargs['add_start'] = True
         kwargs['add_end'] = True
         obs = TorchRankerAgent.vectorize(self, *args, **kwargs)
         return obs
 
     def _vectorize_text(self, *args, **kwargs):
-        """override to add start end tokens. necessary for fixed cands"""
+        """Override to add start end tokens. necessary for fixed cands."""
         if 'add_start' in kwargs:
             kwargs['add_start'] = True
             kwargs['add_end'] = True
         return super()._vectorize_text(*args, **kwargs)
 
     def _set_text_vec(self, *args, **kwargs):
-        """ Add the start and end token to the text.
-        """
+        """Add the start and end token to the text."""
         obs = super()._set_text_vec(*args, **kwargs)
         if 'text_vec' in obs and 'added_start_end_tokens' not in obs:
             obs.force_set(

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -510,7 +510,7 @@ class TransformerEncoder(nn.Module):
             divisor = mask.float().sum(dim=1).unsqueeze(-1).clamp(min=1).type_as(tensor)
             output = tensor.sum(dim=1) / divisor
             return output
-        elif 'none' in self.reduction_type or self.reduction_type is None:
+        elif self.reduction_type is None or 'none' in self.reduction_type:
             output = tensor
             ret = (output, mask)
             if self.reduction_type == 'none_with_pos_embs':

--- a/parlai/agents/transformer/polyencoder.py
+++ b/parlai/agents/transformer/polyencoder.py
@@ -3,6 +3,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # hack to make sure -m transformer/generator works as expected
+"""Poly-encoder Agent."""
 from .modules import TransformerEncoder
 from .modules import get_n_positions_from_options
 from parlai.core.torch_ranker_agent import TorchRankerAgent
@@ -12,8 +13,10 @@ import torch
 
 
 class PolyencoderAgent(TorchRankerAgent):
-    """ Equivalent of bert_ranker/polyencoder and biencoder_multiple_output
-        but does not rely on an external library (hugging face).
+    """Poly-encoder Agent.
+
+    Equivalent of bert_ranker/polyencoder and biencoder_multiple_output
+    but does not rely on an external library (hugging face).
     """
 
     @classmethod
@@ -54,7 +57,7 @@ class PolyencoderAgent(TorchRankerAgent):
             choices=['context', 'position'],
             help='Input emb vectors for the first level of attention. '
             'Context refers to the context outputs; position refers to the '
-            'computed position embeddings.'
+            'computed position embeddings.',
         )
         agent.add_argument(
             '--poly-attention-num-heads',
@@ -79,7 +82,6 @@ class PolyencoderAgent(TorchRankerAgent):
             help='In case codes-attention-type is multihead, '
             'specify the number of heads',
         )
-        argparser.set_defaults(get_pos_embs=True)
         return agent
 
     def __init__(self, opt, shared=None):
@@ -96,20 +98,18 @@ class PolyencoderAgent(TorchRankerAgent):
             self.model = torch.nn.DataParallel(self.model)
 
     def build_model(self, states=None):
-        self.model = PolyEncoderModule(self.opt, self.dict, self.NULL_IDX)
-        return self.model
+        """Return built model."""
+        return PolyEncoderModule(self.opt, self.dict, self.NULL_IDX)
 
     def vectorize(self, *args, **kwargs):
-        """ Add the start and end token to the labels.
-        """
+        """Add the start and end token to the labels."""
         kwargs['add_start'] = True
         kwargs['add_end'] = True
         obs = super().vectorize(*args, **kwargs)
         return obs
 
     def _set_text_vec(self, *args, **kwargs):
-        """ Add the start and end token to the text.
-        """
+        """Add the start and end token to the text."""
         obs = super()._set_text_vec(*args, **kwargs)
         if 'text_vec' in obs and 'added_start_end_tokens' not in obs:
             obs.force_set(
@@ -119,27 +119,38 @@ class PolyencoderAgent(TorchRankerAgent):
         return obs
 
     def vectorize_fixed_candidates(self, *args, **kwargs):
-        """ Add the start and end token when computing the candidate encodings
-            in interactive mode.
+        """Vectorize fixed candidates.
+
+        Override to add start and end token when computing the candidate encodings
+        in interactive mode.
         """
         kwargs['add_start'] = True
         kwargs['add_end'] = True
         return super().vectorize_fixed_candidates(*args, **kwargs)
 
     def _make_candidate_encs(self, vecs):
-        """ (used in interactive mode only) The polyencoder module expects
-            cand vecs to be 3D while torch_ranker_agent expects it to be 2D.
-            This requires a little adjustment
+        """Make candidate encs.
+
+        The polyencoder module expects
+        cand vecs to be 3D while torch_ranker_agent expects it to be 2D.
+        This requires a little adjustment (used in interactive mode only)
         """
         rep = super()._make_candidate_encs(vecs)
         return rep.transpose(0, 1).contiguous()
 
     def encode_candidates(self, padded_cands):
+        """Encode candidates."""
         padded_cands = padded_cands.unsqueeze(1)
         _, _, _, cand_rep = self.model(cand_tokens=padded_cands)
         return cand_rep
 
     def score_candidates(self, batch, cand_vecs, cand_encs=None):
+        """Score candidates.
+
+        The Poly-encoder encodes the candidate and context independently. Then,
+        the model applies additional attention before ultimately scoring a
+        candidate.
+        """
         bsz = batch.text_vec.size(0)
         ctxt_rep, ctxt_rep_mask, ctxt_pos, _ = self.model(ctxt_tokens=batch.text_vec)
 
@@ -158,25 +169,30 @@ class PolyencoderAgent(TorchRankerAgent):
             cand_rep = cand_rep.expand(num_cands, bsz, -1).transpose(0, 1).contiguous()
 
         scores = self.model(
-            ctxt_rep=ctxt_rep, ctxt_rep_mask=ctxt_rep_mask, cand_rep=cand_rep, ctxt_pos=ctxt_pos
+            ctxt_rep=ctxt_rep,
+            ctxt_rep_mask=ctxt_rep_mask,
+            cand_rep=cand_rep,
+            ctxt_pos=ctxt_pos,
         )
         return scores
 
     def load_state_dict(self, state_dict):
-        """Override to account for codes"""
+        """Override to account for codes."""
         if self.model.type == 'codes' and 'codes' not in state_dict:
             state_dict['codes'] = self.model.codes
         super().load_state_dict(state_dict)
 
 
 class PolyEncoderModule(torch.nn.Module):
-    """ See https://arxiv.org/abs/1905.01969
+    """Poly-encoder model.
+
+    See https://arxiv.org/abs/1905.01969 for more details
     """
 
     def __init__(self, opt, dict, null_idx):
         super(PolyEncoderModule, self).__init__()
         self.null_idx = null_idx
-        self.encoder_ctxt = self.get_encoder(opt, dict, null_idx, 'none')
+        self.encoder_ctxt = self.get_encoder(opt, dict, null_idx, 'none_with_pos_embs')
         self.encoder_cand = self.get_encoder(opt, dict, null_idx, opt['reduction_type'])
 
         self.type = opt['polyencoder_type']
@@ -216,10 +232,28 @@ class PolyEncoderModule(torch.nn.Module):
             )
         else:
             self.attention = PolyBasicAttention(
-                self.type, self.n_codes, dim=2, attn=self.attention_type, get_weights=False
+                self.type,
+                self.n_codes,
+                dim=2,
+                attn=self.attention_type,
+                get_weights=False,
             )
 
     def get_encoder(self, opt, dict, null_idx, reduction_type):
+        """Return encoder, given options.
+
+        :param opt:
+            opt dict
+        :param dict:
+            dictionary agent
+        :param null_idx:
+            null/pad index into dict
+        :reduction_type:
+            reduction type for the encoder
+
+        :return:
+            a TransformerEncoder, initialized correctly
+        """
         n_positions = get_n_positions_from_options(opt)
         embeddings = torch.nn.Embedding(
             len(dict), opt['embedding_size'], padding_idx=null_idx
@@ -247,8 +281,22 @@ class PolyEncoderModule(torch.nn.Module):
         )
 
     def attend(self, attention_layer, queries, keys, values, mask):
-        """ Unify the API of MultiHeadAttention and
-            BasicAttention that are slightly different
+        """Apply attention.
+
+        :param attention_layer:
+            nn.Module attention layer to use for the attention
+        :param queries:
+            the queries for attention
+        :param keys:
+            the keys for attention
+        :param values:
+            the values for attention
+        :param mask:
+            mask for the attention keys
+
+        :return:
+            the result of applying attention to the values, with weights computed
+            wrt to the queries and keys.
         """
         if keys is None:
             keys = values
@@ -260,19 +308,21 @@ class PolyEncoderModule(torch.nn.Module):
             raise Exception('Unrecognized type of attention')
 
     def encode(self, ctxt_tokens, cand_tokens):
-        """
-            :param ctxt_tokens:
-                2D long tensor, batchsize x sent_len
-            :param cand_tokens:
-                3D long tensor, batchsize x num_cands x sent_len
-                Note this will actually view it as a 2D tensor
-            :returns: (ctxt_rep, ctxt_mask, ctxt_pos, cand_rep)
-                - ctxt_rep 3D float tensor, batchsize x n_codes x dim
-                - ctxt_mask byte:  batchsize x n_codes (all 1 in case
-                    of polyencoder with code. Which are the vectors to use
-                    in the ctxt_rep)
-                - ctxt_pos 3D float tensor, batchsize x sent_len x dim
-                - cand_rep (3D float tensor) batchsize x num_cands x dim
+        """Encode a text sequence.
+
+        :param ctxt_tokens:
+            2D long tensor, batchsize x sent_len
+        :param cand_tokens:
+            3D long tensor, batchsize x num_cands x sent_len
+            Note this will actually view it as a 2D tensor
+        :return:
+            (ctxt_rep, ctxt_mask, ctxt_pos, cand_rep)
+            - ctxt_rep 3D float tensor, batchsize x n_codes x dim
+            - ctxt_mask byte:  batchsize x n_codes (all 1 in case
+            of polyencoder with code. Which are the vectors to use
+            in the ctxt_rep)
+            - ctxt_pos 3D float tensor, batchsize x sent_len x dim
+            - cand_rep (3D float tensor) batchsize x num_cands x dim
         """
         cand_embed = None
         ctxt_rep = None
@@ -321,17 +371,20 @@ class PolyEncoderModule(torch.nn.Module):
         return ctxt_rep, ctxt_rep_mask, ctxt_pos, cand_embed
 
     def score(self, ctxt_rep, ctxt_rep_mask, ctxt_pos, cand_embed):
-        """
-            Scores the candidates
-            :param ctxt_rep: 3D float tensor, bsz x ctxt_len x dim
-            :param ctxt_rep_mask: 2D byte tensor, bsz x ctxt_len, in case
-                there are some elements of the ctxt that we should not take into
-                account.
-            :param ctx_pos: 3D float tensor, bsz x sent_len x dim
-            :param cand_embed: 3D float tensor, bsz x num_cands x dim
+        """Score the candidates.
 
-            :returns: scores, 2D float tensor: bsz x num_cands
+        :param ctxt_rep:
+            3D float tensor, bsz x ctxt_len x dim
+        :param ctxt_rep_mask:
+            2D byte tensor, bsz x ctxt_len, in case there are some elements
+            of the ctxt that we should not take into account.
+        :param ctx_pos: 3D float tensor, bsz x sent_len x dim
+        :param cand_embed: 3D float tensor, bsz x num_cands x dim
+
+        :return: scores, 2D float tensor: bsz x num_cands
         """
+        # Attention keys determined by self.attention_keys
+        # 'context' == use context final rep; otherwise use context position embs
         keys = ctxt_rep if self.attention_keys == 'context' else ctxt_pos
         # reduces the context representation to a 3D tensor bsz x num_cands x dim
         ctxt_final_rep = self.attend(
@@ -349,10 +402,29 @@ class PolyEncoderModule(torch.nn.Module):
         ctxt_pos=None,
         cand_rep=None,
     ):
-        """ Due to a limitation of parlai, we have to have one single model
-            in the agent. And because we want to be able to use data-parallel,
-            we need to have one single forward() method.
-            Therefore the operation_type can be either 'encode' or 'score'.
+        """Forward pass of the model.
+
+        Due to a limitation of parlai, we have to have one single model
+        in the agent. And because we want to be able to use data-parallel,
+        we need to have one single forward() method.
+        Therefore the operation_type can be either 'encode' or 'score'.
+
+        :param ctxt_tokens:
+            tokenized contexts
+        :param cand_tokens:
+            tokenized candidates
+        :param ctxt_rep:
+            (bsz x num_codes x hsz)
+            encoded representation of the context. If self.type == 'codes', these
+            are the context codes. Otherwise, they are the outputs from the
+            encoder
+        :param ctxt_rep_mask:
+            mask for ctxt rep
+        :param ctxt_pos:
+            position embeddings for the ctxt_rep. If self.type == 'codes', these
+            are None, as their use is earlier in the pipeline.
+        :param cand_rep:
+            encoded representation of the candidates
         """
         if ctxt_tokens is not None or cand_tokens is not None:
             return self.encode(ctxt_tokens, cand_tokens)
@@ -365,12 +437,19 @@ class PolyEncoderModule(torch.nn.Module):
 
 
 class PolyBasicAttention(BasicAttention):
+    """Override basic attention to account for edge case for polyencoder."""
+
     def __init__(self, poly_type, n_codes, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.poly_type = poly_type
         self.n_codes = n_codes
 
     def forward(self, *args, **kwargs):
+        """Forward pass.
+
+        Account for accidental dimensionality reduction when num_codes is 1
+        and the polyencoder type is 'codes'
+        """
         lhs_emb = super().forward(*args, **kwargs)
         if self.poly_type == 'codes' and self.n_codes == 1 and len(lhs_emb.shape) == 2:
             lhs_emb = lhs_emb.unsqueeze(self.dim - 1)

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -91,6 +91,13 @@ def add_common_cmdline_args(argparser):
         help='Share word embeddings table for candidate and context'
         'in the memory network',
     )
+    argparser.add_argument(
+        '--get-pos-embs',
+        type='bool',
+        default=False,
+        help='If true, return the position embeddings from the encoder '
+        'when reduction type is None'
+    )
 
 
 class Transformer(Agent):

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
+"""Transformer Agents."""
 from parlai.core.agents import Agent
 from parlai.core.utils import warn_once
 from parlai.core.utils import padded_3d
@@ -15,6 +15,7 @@ import torch
 
 
 def add_common_cmdline_args(argparser):
+    """Add common command line args."""
     argparser.add_argument(
         '-esz',
         '--embedding-size',
@@ -91,17 +92,11 @@ def add_common_cmdline_args(argparser):
         help='Share word embeddings table for candidate and context'
         'in the memory network',
     )
-    argparser.add_argument(
-        '--get-pos-embs',
-        type='bool',
-        default=False,
-        help='If true, return the position embeddings from the encoder '
-        'when reduction type is None'
-    )
 
 
 class Transformer(Agent):
-    """
+    """Placeholder Transformer Agent.
+
     Placeholder class, which just throws an error telling the user to specify
     whether they want the ranker or the generator.
     """
@@ -114,6 +109,11 @@ class Transformer(Agent):
 
 
 class TransformerRankerAgent(TorchRankerAgent):
+    """Transformer Ranker Agent.
+
+    Implementation of a TorchRankerAgent, where the model is a Transformer
+    """
+
     @classmethod
     def add_cmdline_args(cls, argparser):
         """Add command-line arguments specifically for this agent."""
@@ -195,6 +195,7 @@ class TransformerRankerAgent(TorchRankerAgent):
             )
 
     def build_model(self, states=None):
+        """Build and return model."""
         model = TransformerMemNetModel(self.opt, self.dict)
         if self.opt['embedding_type'] != 'random':
             self._copy_embeddings(model.embeddings.weight, self.opt['embedding_type'])
@@ -223,6 +224,7 @@ class TransformerRankerAgent(TorchRankerAgent):
         )
 
     def vectorize(self, *args, **kwargs):
+        """Override to include vectorization of memories."""
         kwargs['add_start'] = False
         kwargs['add_end'] = False
         obs = super().vectorize(*args, **kwargs)
@@ -231,11 +233,13 @@ class TransformerRankerAgent(TorchRankerAgent):
         return obs
 
     def encode_candidates(self, padded_cands):
+        """Encode candidates."""
         _, cands = self.model(xs=None, mems=None, cands=padded_cands)
 
         return cands
 
     def score_candidates(self, batch, cand_vecs, cand_encs=None):
+        """Score candidates."""
         # convoluted check that not all memories are empty
         if (
             self.opt['use_memories']
@@ -262,6 +266,11 @@ class TransformerRankerAgent(TorchRankerAgent):
 
 
 class TransformerGeneratorAgent(TorchGeneratorAgent):
+    """TransformerGeneratorAgent.
+
+    Implementation of TorchGeneratorAgent, where the model is a Transformer
+    """
+
     @classmethod
     def add_cmdline_args(cls, argparser):
         """Add command-line arguments specifically for this agent."""
@@ -273,6 +282,7 @@ class TransformerGeneratorAgent(TorchGeneratorAgent):
         return agent
 
     def build_model(self, states=None):
+        """Build and return model."""
         model = TransformerGeneratorModel(self.opt, self.dict)
         if self.opt['embedding_type'] != 'random':
             self._copy_embeddings(


### PR DESCRIPTION
**Patch description**
This patch does the following:

1. Bi-encoder:
    - updates to work with a fixed-candidate-set
2. TransformerEncoder:
    - updates to allow returning the position embeddings if reduction type is none
3. BasicAttention:
    - updates to allow an optional `values` arg, which can be separate from the `ys` (which are assumed to be the keys in the attention)
4. Poly-encoder:
    - Fixes an issue when loading a pretrained model when using `--polyencoder-type codes`
    - Allows for using the position embeddings as keys into the attention
    - override `BasicAttention`, as there is a squeeze issue when using `--polyencoder-type codes --poly-n-codes 1`
     

**Testing steps**
Thoroughly tested via sweeps. 

**Logs**
Previously, when running the poly-encoder training script from https://parl.ai/projects/polyencoder/ with `--polyencoder-type codes`, one gets the following error:
```
RuntimeError: Error(s) in loading state_dict for PolyEncoderModule:
	Missing key(s) in state_dict: "codes".
```
Now, we no longer get this issue

Additionally, when running with `--polyencoder-type codes --poly-n-codes 1`, one gets the following error: 
```
Traceback (most recent call last):
  File "examples/train_model.py", line 16, in <module>
    TrainLoop(opt).train()
  File "/private/home/kshuster/TestParlAI/parlai/scripts/train_model.py", line 719, in train
    world.parley()
  File "/private/home/kshuster/TestParlAI/parlai/core/worlds.py", line 737, in parley
    batch_act = self.batch_act(agent_idx, batch_observations[agent_idx])
  File "/private/home/kshuster/TestParlAI/parlai/core/worlds.py", line 705, in batch_act
    batch_actions = a.batch_act(batch_observation)
  File "/private/home/kshuster/TestParlAI/parlai/core/torch_agent.py", line 1720, in batch_act
    output = self.train_step(batch)
  File "/private/home/kshuster/TestParlAI/parlai/core/torch_ranker_agent.py", line 352, in train_step
    scores = self.score_candidates(batch, cand_vecs)
  File "/private/home/kshuster/TestParlAI/parlai/agents/transformer/polyencoder.py", line 149, in score_candidates
    ctxt_rep=ctxt_rep, ctxt_rep_mask=ctxt_rep_mask, cand_rep=cand_rep
  File "/private/home/kshuster/miniconda3/lib/python3.6/site-packages/torch/nn/modules/module.py", line 493, in __call__
    result = self.forward(*input, **kwargs)
  File "/private/home/kshuster/miniconda3/lib/python3.6/site-packages/torch/nn/parallel/data_parallel.py", line 152, in forward
    outputs = self.parallel_apply(replicas, inputs, kwargs)
  File "/private/home/kshuster/miniconda3/lib/python3.6/site-packages/torch/nn/parallel/data_parallel.py", line 162, in parallel_apply
    return parallel_apply(replicas, inputs, kwargs, self.device_ids[:len(replicas)])
  File "/private/home/kshuster/miniconda3/lib/python3.6/site-packages/torch/nn/parallel/parallel_apply.py", line 83, in parallel_apply
    raise output
  File "/private/home/kshuster/miniconda3/lib/python3.6/site-packages/torch/nn/parallel/parallel_apply.py", line 59, in _worker
    output = module(*input, **kwargs)
  File "/private/home/kshuster/miniconda3/lib/python3.6/site-packages/torch/nn/modules/module.py", line 493, in __call__
    result = self.forward(*input, **kwargs)
  File "/private/home/kshuster/TestParlAI/parlai/agents/transformer/polyencoder.py", line 339, in forward
    return self.score(ctxt_rep, ctxt_rep_mask, cand_rep)
  File "/private/home/kshuster/TestParlAI/parlai/agents/transformer/polyencoder.py", line 316, in score
    self.attention, cand_embed, ctxt_rep, ctxt_rep_mask
  File "/private/home/kshuster/TestParlAI/parlai/agents/transformer/polyencoder.py", line 241, in attend
    return attention_layer(queries, keys, mask)
  File "/private/home/kshuster/miniconda3/lib/python3.6/site-packages/torch/nn/modules/module.py", line 493, in __call__
    result = self.forward(*input, **kwargs)
  File "/private/home/kshuster/TestParlAI/parlai/agents/transformer/modules.py", line 854, in forward
    l1 = torch.bmm(xs, ys.transpose(1, 2))
IndexError: Dimension out of range (expected to be in range of [-2, 1], but got 2)
```
With the fix, this no longer happens

