### PR TITLE
Add unzip to build_data and dnli dataset

### DIFF
--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -21,6 +21,7 @@ import hashlib
 import tqdm
 import math
 import traceback
+import zipfile
 from multiprocessing import Pool
 
 
@@ -184,6 +185,27 @@ def untar(path, fname, deleteTar=True):
     fullpath = os.path.join(path, fname)
     shutil.unpack_archive(fullpath, path)
     if deleteTar:
+        os.remove(fullpath)
+
+
+def unzip(path, fname, deleteZip=True):
+    """
+    Unzip the given archive file to the same directory.
+
+    :param str path:
+        The folder containing the archive. Will contain the contents.
+
+    :param str fname:
+        The filename of the archive file.
+
+    :param bool deleteZip:
+        If true, the archive will be deleted after extraction.
+    """
+    print('unzipping ' + fname)
+    fullpath = os.path.join(path, fname)
+    with zipfile.ZipFile(fullpath, "r") as zip_ref:
+        zip_ref.extractall(path)
+    if deleteZip:
         os.remove(fullpath)
 
 

--- a/parlai/tasks/dialogue_nli/__init__.py
+++ b/parlai/tasks/dialogue_nli/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/parlai/tasks/dialogue_nli/agents.py
+++ b/parlai/tasks/dialogue_nli/agents.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Dialogue safety related datasets and teachers."""
+
+import copy
+import json
+import os
+import random
+import sys as _sys
+
+import parlai.core.build_data as build_data
+from parlai.core.message import Message
+from parlai.core.teachers import FixedDialogTeacher
+
+from .build import build
+
+
+class DialogueNliTeacher(FixedDialogTeacher):
+    def __init__(self, opt, shared=None, extras=False):
+        super().__init__(opt, shared)
+
+        # Build the data if it doesn't exist.
+        build(opt)
+
+        suffix = self.datatype
+        if suffix.startswith('train'):
+            suffix = 'train'
+        elif suffix.startswith('test'):
+            suffix = 'test'
+        elif suffix.startswith('valid'):
+            suffix = 'dev'
+
+        if extras:
+            datapath = os.path.join(
+                opt['datapath'],
+                'dialogue_nli',
+                'dnli',
+                'dialogue_nli_extra',
+                'dialogue_nli_EXTRA_uu_' + suffix + '.jsonl',
+            )
+        else:
+            datapath = os.path.join(
+                opt['datapath'],
+                'dialogue_nli',
+                'dnli',
+                'dialogue_nli',
+                'dialogue_nli_' + suffix + '.jsonl',
+            )
+
+        self._setup_data(datapath)
+        self.id = 'dnli'
+        self.reset()
+
+    def _setup_data(self, path):
+        with open(path) as data_file:
+            if 'extra' in path and 'train' in path:
+                line = data_file.readline()
+
+                # trim corrupted JSON
+                line = line[: line.rfind("{")]
+                line = line[: line.rfind(",")] + "]"
+
+                self.data = json.loads(line)
+            else:
+                self.data = json.load(data_file)
+
+    def num_examples(self):
+        return len(self.data)
+
+    def num_episodes(self):
+        return self.num_examples()
+
+    def get(self, episode_idx, entry_idx=0):
+        entry = self.data[episode_idx]
+        entry['id'] = self.id
+        entry['episode_done'] = True
+        entry['labels'] = [entry['label']]
+        entry['text'] = entry['sentence1'] + '\n' + entry['sentence2']
+        return entry
+
+
+class ExtrasTeacher(DialogueNliTeacher):
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared, extras=True)
+
+
+class DefaultTeacher(DialogueNliTeacher):
+    pass

--- a/parlai/tasks/dialogue_nli/build.py
+++ b/parlai/tasks/dialogue_nli/build.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+
+import parlai.core.build_data as build_data
+
+
+def build(opt):
+    # get path to data directory
+    dpath = os.path.join(opt['datapath'], 'dialogue_nli')
+    # define version if any
+    version = '1.0'
+
+    # check if data had been previously built
+    if not build_data.built(dpath, version_string=version):
+        print('[building data: ' + dpath + ']')
+
+        # make a clean directory if needed
+        if build_data.built(dpath):
+            # an older version exists, so remove these outdated files.
+            build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # download the data.
+        fname = 'dialogue_nli.zip'
+        gd_id = '1WtbXCv3vPB5ql6w0FVDmAEMmWadbrCuG'
+        build_data.download_from_google_drive(gd_id, os.path.join(dpath, fname))
+
+        # uncompress it
+        build_data.unzip(dpath, fname)
+
+        # mark the data as built
+        build_data.mark_done(dpath, version_string=version)

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -167,6 +167,17 @@ task_list = [
         ),
     },
     {
+        "id": "dialogue-nli",
+        "display_name": "Dialogue NLI",
+        "task": "dialogue_nli",
+        "tags": ["All", "ChitChat", "NLI"],
+        "description": (
+            "Dialogue NLI is a dataset that addresses the issue of consistency in "
+            "dialogue models. "
+            "See: https://wellecks.github.io/dialogue_nli/"
+        ),
+    },
+    {
         "id": "dstc7",
         "display_name": "DSTC7 subtrack 1 - ubuntu",
         "task": "dstc7",


### PR DESCRIPTION
**Patch description**

Added the `dialogue NLI` dataset from [here](https://wellecks.github.io/dialogue_nli/). I also added an `unzip` function, since one wasn't present in `build_data`.

**Testing steps**

```
 python examples/display_data.py -t dialogue_nli -dt train
 python examples/display_data.py -t dialogue_nli -dt test
 python examples/display_data.py -t dialogue_nli -dt valid

python examples/display_data.py -t dialogue_nli:extras -dt train
python examples/display_data.py -t dialogue_nli:extras -dt test
python examples/display_data.py -t dialogue_nli:extras -dt valid
```

**Logs**

Output truncated:

```bash
- - - - - - - - - - - - - - - - - - - - -
~~
[label]: negative
[sentence1]: i have three tattoos .
[sentence2]: i have ten tattoos .
[triple1]:
  i
  have
  3 tattoos
[triple2]:
  i
  have
  10 tattoos
[dtype]: numerics
[dnli]: i have three tattoos .
i have ten tattoos .
[labels: negative]
- - - - - - - - - - - - - - - - - - - - -
[ loaded 310110 episodes with a total of 310110 examples ]
- - - - - - - - - - - - - - - - - - - - -
~~
[label]: neutral
[sentence1]: i have a dog named pedro .
[sentence2]: i have two children that are in their kindergarten .
[triple1]:
  i
  have_pet
  1 dog
[triple2]:
  i
  have
  2 children that are in their kindergarten
[dtype]: rswap_up
[dnli]: i have a dog named pedro .
i have two children that are in their kindergarten .
[eval_labels: neutral]
- - - - - - - - - - - - - - - - - - - - -
[ loaded 16500 episodes with a total of 16500 examples ]
- - - - - - - - - - - - - - - - - - - - -
~~
[label]: positive
[sentence1]: why is that ? i am also a musician .
[sentence2]: i am a musician .
[triple1]:
  i
  has_profession
  musician
[triple2]:
  i
  has_profession
  musician
[dtype]: matchingtriple_up
[dnli]: why is that ? i am also a musician .
i am a musician .
[eval_labels: positive]
- - - - - - - - - - - - - - - - - - - - -
[ loaded 16500 episodes with a total of 16500 examples ]


- - - - - - - - - - - - - - - - - - - - -
~~
[label]: positive
[sentence1]: cool , i go hiking with my gf i ride bikes .
[sentence2]: what is up ! ! welcome to hiking club .
[triple1]:
  i
  has_hobby
  hiking
[triple2]:
  i
  has_hobby
  hiking
[dtype]: matchingtriple_uu
[dnli]: cool , i go hiking with my gf i ride bikes .
what is up ! ! welcome to hiking club .
[labels: positive]
- - - - - - - - - - - - - - - - - - - - -
[ loaded 2209256 episodes with a total of 2209256 examples ]
- - - - - - - - - - - - - - - - - - - - -
~~
[label]: neutral
[sentence1]: that is cool , my mom is a doctor .
[sentence2]: hello ! i am well . being shy in class .
[triple1]:
  my mother
  has_profession
  doctor
[triple2]:
  i
  misc_attribute
  shy
[dtype]: personapairing_uu
[dnli]: that is cool , my mom is a doctor .
hello ! i am well . being shy in class .
[eval_labels: neutral]
- - - - - - - - - - - - - - - - - - - - -
[ loaded 237000 episodes with a total of 237000 examples ]
- - - - - - - - - - - - - - - - - - - - -
~~
[label]: negative
[sentence1]: i thought about being a chef for the army .
[sentence2]: i can teach you , i am a musician and a music teacher !
[triple1]:
  i
  has_profession
  chef
[triple2]:
  i
  has_profession
  musician
[dtype]: e2swap_uu
[dnli]: i thought about being a chef for the army .
i can teach you , i am a musician and a music teacher !
[eval_labels: negative]
- - - - - - - - - - - - - - - - - - - - -
[ loaded 249000 episodes with a total of 249000 examples ]
```

**Other information**

**Data tests (if applicable)**

```
$ python setup.py test -s tests.suites.datatests

running test
running egg_info
writing parlai.egg-info/PKG-INFO
writing dependency_links to parlai.egg-info/dependency_links.txt
writing requirements to parlai.egg-info/requires.txt
writing top-level names to parlai.egg-info/top_level.txt
reading manifest file 'parlai.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'parlai.egg-info/SOURCES.txt'
running build_ext
test_verify_data (test_new_tasks.TestNewTasks) ... ok

----------------------------------------------------------------------
Ran 1 test in 280.389s

OK
```

```
$ python tests/datatests/test_new_tasks.py

.
----------------------------------------------------------------------
Ran 1 test in 285.716s

OK
```