### PR TITLE
Solve opt key indexing issues using get

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -690,7 +690,7 @@ class TorchAgent(ABC, Agent):
             self.model = shared['model']
             self.criterion = shared['criterion']
             self.metrics = shared['metrics']
-            if self.opt['batchsize'] == 1 or self.opt['interactive_mode']:
+            if self.opt['batchsize'] == 1 or self.opt.get('interactive_mode', False):
                 # if we're not using batching (e.g. mturk), then replies really need
                 # to stay separated
                 self.replies = {}
@@ -734,7 +734,7 @@ class TorchAgent(ABC, Agent):
         self.rank_candidates = opt['rank_candidates']
         self.add_person_tokens = opt.get('person_tokens', False)
         # set interactive mode or not according to options.
-        self.set_interactive_mode(opt['interactive_mode'], shared)
+        self.set_interactive_mode(opt.get('interactive_mode', False), shared)
 
     def build_history(self):
         """Return the constructed history object."""

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -75,13 +75,14 @@ def _eval_single_world(opt, agent, task):
     log_time = TimeLogger()
 
     # max number of examples to evaluate
-    max_cnt = opt['num_examples'] if opt['num_examples'] > 0 else float('inf')
+    num_ex = opt.get('num_examples', 0)
+    max_cnt = num_ex if num_ex > 0 else float('inf')
     cnt = 0
 
     while not world.epoch_done() and cnt < max_cnt:
         cnt += opt.get('batchsize', 1)
         world.parley()
-        if opt['display_examples']:
+        if opt.get('display_examples', False):
             # display examples
             print(world.display() + '\n~~')
         if log_time.time() > log_every_n_secs:


### PR DESCRIPTION
**Patch description**
Argument parsing without **explicitly** using the parser (by passing in an argument dictionary) causes issues with certain fields not being set for the model resulting in a key error when trying to access ```opt['keyname']```. This was fixed in this patch by swapping ```[]``` with the get method and setting defaults.

**Testing steps**
- Navigate to /parlai/scripts/eval_model.py
- Comment out everything in main
- Add the following to main:
```
opt = {"datapath": "../../data/", "datatype": "test"}
opt.update({"task": "convai2", "model_file": "models:controllable_dialogue/convai2_finetuned_baseline", 'log_every_n_secs': 2})
eval_model(opt)
```
**Logs**
Truncated Output:
```
[loading fbdialog data:../../data/ConvAI2/valid_self_original.txt]
2s elapsed: {'exs': 1, '%done': '0.01%', 'time_left': '16792s', 'accuracy': 0, 'f1': 0.2609, 'bleu': 1.018e-07, 'token_acc': 0.2778, 'loss': 2.567, 'ppl': 13.03}
4s elapsed: {'exs': 2, '%done': '0.03%', 'time_left': '17108s', 'accuracy': 0, 'f1': 0.2257, 'bleu': 5.098e-08, 'token_acc': 0.3548, 'loss': 2.757, 'ppl': 15.75}
```