### PR TITLE
Check for shared before dataparallel call

### DIFF
--- a/parlai/agents/bert_ranker/bi_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/bi_encoder_ranker.py
@@ -46,7 +46,7 @@ class BiEncoderRankerAgent(TorchRankerAgent):
         super().__init__(opt, shared)
         # it's easier for now to use DataParallel when
         self.data_parallel = opt.get('data_parallel') and self.use_cuda
-        if self.data_parallel:
+        if self.data_parallel and shared is None:
             self.model = torch.nn.DataParallel(self.model)
         if is_distributed():
             raise ValueError('Cannot combine --data-parallel and distributed mode')

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -41,7 +41,7 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
         super().__init__(opt, shared)
         # it's easier for now to use DataParallel when
         self.data_parallel = opt.get('data_parallel') and self.use_cuda
-        if self.data_parallel:
+        if self.data_parallel and shared is None:
             self.model = torch.nn.DataParallel(self.model)
         if is_distributed():
             raise ValueError('Cannot combine --data-parallel and distributed mode')

--- a/parlai/agents/transformer/crossencoder.py
+++ b/parlai/agents/transformer/crossencoder.py
@@ -23,7 +23,8 @@ class CrossencoderAgent(TorchRankerAgent):
 
             if is_distributed():
                 raise ValueError('Cannot combine --data-parallel and distributed mode')
-            self.model = torch.nn.DataParallel(self.model)
+            if shared is None:
+                self.model = torch.nn.DataParallel(self.model)
 
     @classmethod
     def add_cmdline_args(cls, argparser):

--- a/parlai/agents/transformer/polyencoder.py
+++ b/parlai/agents/transformer/polyencoder.py
@@ -83,7 +83,8 @@ class PolyencoderAgent(TorchRankerAgent):
 
             if is_distributed():
                 raise ValueError('Cannot combine --data-parallel and distributed mode')
-            self.model = torch.nn.DataParallel(self.model)
+            if shared is None:
+                self.model = torch.nn.DataParallel(self.model)
 
     def build_model(self, states=None):
         return PolyEncoderModule(self.opt, self.dict, self.NULL_IDX)

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -147,7 +147,8 @@ class TorchClassifierAgent(TorchAgent):
                     raise ValueError(
                         'Cannot combine --data-parallel and distributed mode'
                     )
-                self.model = torch.nn.DataParallel(self.model)
+                if shared is None:
+                    self.model = torch.nn.DataParallel(self.model)
         if shared:
             # We don't use get here because hasattr is used on optimizer later.
             if 'optimizer' in shared:

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -141,13 +141,12 @@ class TorchClassifierAgent(TorchAgent):
             if init_model:
                 print('Loading existing model parameters from ' + init_model)
                 self.load(init_model)
-        if self.use_cuda:
-            if self.opt['data_parallel']:
-                if is_distributed():
-                    raise ValueError(
-                        'Cannot combine --data-parallel and distributed mode'
-                    )
-                if shared is None:
+            if self.use_cuda:
+                if self.opt['data_parallel']:
+                    if is_distributed():
+                        raise ValueError(
+                            'Cannot combine --data-parallel and distributed mode'
+                        )
                     self.model = torch.nn.DataParallel(self.model)
         if shared:
             # We don't use get here because hasattr is used on optimizer later.


### PR DESCRIPTION
**Patch description**
DataParallel objects get nested in at least these 5 files if __init__ is called with shared dict and data parallel is set to True. This isn't a problem is these nested DataParallel objects only observe, but it does become problematic if we want to call batch_act.

Fix is just to check for shared is None first