### PR TITLE
Update Poly-encoder Builds/README

### DIFF
--- a/parlai/zoo/pretrained_transformers/build.py
+++ b/parlai/zoo/pretrained_transformers/build.py
@@ -16,7 +16,7 @@ import torch
 def download(datapath):
     model_name = 'pretrained_transformers'
     mdir = os.path.join(get_model_dir(datapath), model_name)
-    version = 'v2.0'
+    version = 'v3.0'
     if not built(mdir, version):
         opt = {'datapath': datapath}
         fnames = ['pretrained_transformers.tgz']

--- a/projects/README.md
+++ b/projects/README.md
@@ -16,7 +16,7 @@ This directory also contains subfolders for some of the projects which are house
   _Analysis of the performance of search in generative models for chitchat tasks._
 
 ## Retrieval Models
-- **Poly-Encoders** [[project]](https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder) [[paper]](https://arxiv.org/abs/1905.01969).
+- **Poly-Encoders** [[project]](https://parl.ai/projects/polyencoder/) [[paper]](https://arxiv.org/abs/1905.01969).
   _State-of-the-art Transformer architectures + pretraining for dialogue retrieval._
 
 

--- a/projects/polyencoder/README.md
+++ b/projects/polyencoder/README.md
@@ -94,7 +94,7 @@ python -u examples/train_model.py \
   --learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 \
   --attention-dropout 0.1 --relu-dropout 0.0 --dropout 0.1 --n-positions 1024 \
   --embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 \
-  --learn-embeddings True --polyencoder-type n_first --poly-n-codes 64 \
+  --learn-embeddings True --polyencoder-type codes --poly-n-codes 64 \
   --poly-attention-type basic --dict-endtoken __start__ \
   --model-file <YOUR MODEL FILE>
 ```


### PR DESCRIPTION
**Patch description**
Per #1912, one could not load the poly-encoder/bi-encoder/cross-encoder models on computers without GPUs/fp16 support. I've updated the models in the zoo, and thus have updated the build version.

Also I updated the README in the projects folder to have the appropriate project page link (and the preferred poly-encoder, i.e. the one with codes)

**Testing steps**
Run any command from https://parl.ai/projects/polyencoder/ on a non-GPU laptop, confirm model loads

**Logs**
```
$ python -u examples/train_model.py     --init-model zoo:pretrained_transformers/bi_model_huge_reddit/model     --batchsize 2 -pyt convai2     --shuffle true --model transformer/biencoder --eval-batchsize 6     --warmup_updates 100 --lr-scheduler-patience 0     --lr-scheduler-decay 0.4 -lr 5e-05 --data-parallel True     --history-size 20 --label-truncate 72 --text-truncate 360     --num-epochs 10.0 --max_train_time 200000 -veps 0.5 -vme 8000     --validation-metric accuracy --validation-metric-mode max     --save-after-valid True --log_every_n_secs 20 --candidates batch     --dict-tokenizer bpe --dict-lower True --optimizer adamax     --output-scaling 0.06      --variant xlm --reduction-type mean --share-encoders False      --learn-positional-embeddings True --n-layers 12 --n-heads 12      --ffn-size 3072 --attention-dropout 0.1 --relu-dropout 0.0 --dropout 0.1      --n-positions 1024 --embedding-size 768 --activation gelu      --embeddings-scale False --n-segments 2 --learn-embeddings True      --share-word-embeddings False --dict-endtoken __start__ --fp16 True   --model-file /tmp/tmppolymodel -bs 2

...

[ downloading: http://parl.ai/downloads/_models/pretrained_transformers/pretrained_transformers.tgz to /Users/kshuster/ParlAI/data/models/pretrained_transformers/pretrained_transformers.tgz ]
Downloading pretrained_transformers.tgz: 100%|█████████████████████| 4.22G/4.22G [04:02<00:00, 17.4MB/s]
unpacking pretrained_transformers.tgz

....

[ training... ]
/Users/kshuster/ParlAI/parlai/core/torch_ranker_agent.py:545: UserWarning: [ Executing train mode with batch labels as set of candidates. ]
  ''.format(mode)
[ time:20.0s total_exs:6 epochs:0.0 time_left:4500697.0s ] {'exs': 6, 'lr': 1.505e-06, 'num_updates': 3, 'gnorm': 697.5, 'clip': 1.0, 'examples': 6, 'loss': 3.737, 'mean_loss': 0.6228, 'mean_rank': 1.167, 'mrr': 0.9167, 'train_accuracy': 0.8333}
```

