### PR TITLE
 Deprecate Torch < 1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,10 @@ installtorchcpuosx: &installtorchcpuosx
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch>=1.1.0'
+      source /Users/distiller/miniconda/etc/profile.d/conda.sh
+      conda config --set always_yes yes
+      conda activate base
+      conda install --quiet 'pytorch>=1.1.0' -c pytorch
 
 installtorchcpu36: &installtorchcpu36
   run:
@@ -106,6 +109,15 @@ setupcuda: &setupcuda
       sudo apt-key add /var/cuda-repo-10-1-local-10.1.105-418.39/7fa2af80.pub
       nvidia-smi
       pyenv global 3.6.5
+
+installconda: &installconda
+  run:
+    name: Install Anaconda
+    working_directory: ~/
+    command: |
+      brew install wget --with-libressl
+      wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
+      bash miniconda.sh -b -p "$HOME"/miniconda
 
 buildwebsite: &buildwebsite
   run:
@@ -136,12 +148,16 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
+      - <<: *installconda
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchcpuosx
       - run:
           name: Unit tests (OSX)
-          command: python setup.py test -s tests.suites.unittests -v
+          command: |
+            source /Users/distiller/miniconda/etc/profile.d/conda.sh
+            conda activate base
+            python setup.py test -s tests.suites.unittests -v
 
   unittests_36:
     <<: *standard_cpu36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ installtorchgpu11: &installtorchgpu11
   run:
     name: Install torch GPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch>=1.1.0'
+      pip3 install --progress-bar off 'torch>=1.3.0'
       pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off torchtext
@@ -69,7 +69,7 @@ installtorchgpu12: &installtorchgpu12
   run:
     name: Install torch GPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch>=1.1.0'
+      pip3 install --progress-bar off 'torch>=1.3.0'
       pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off torchtext
@@ -79,22 +79,19 @@ installtorchcpuosx: &installtorchcpuosx
   run:
     name: Install torch CPU and dependencies
     command: |
-      source /Users/distiller/miniconda/etc/profile.d/conda.sh
-      conda config --set always_yes yes
-      conda activate base
-      conda install --quiet 'pytorch>=1.1.0' -c pytorch
+      pip3 install --progress-bar off 'torch>=1.3.0'
 
 installtorchcpu36: &installtorchcpu36
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch>=1.1.0'
+      pip3 install --progress-bar off 'torch>=1.3.0'
 
 installtorchcpu37: &installtorchcpu37
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch>=1.1.0'
+      pip3 install --progress-bar off 'torch>=1.3.0'
 
 setupcuda: &setupcuda
   run:
@@ -109,15 +106,6 @@ setupcuda: &setupcuda
       sudo apt-key add /var/cuda-repo-10-1-local-10.1.105-418.39/7fa2af80.pub
       nvidia-smi
       pyenv global 3.6.5
-
-installconda: &installconda
-  run:
-    name: Install Anaconda
-    working_directory: ~/
-    command: |
-      brew install wget --with-libressl
-      wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
-      bash miniconda.sh -b -p "$HOME"/miniconda
 
 buildwebsite: &buildwebsite
   run:
@@ -148,7 +136,6 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
-      - <<: *installconda
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchcpuosx

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ installtorchgpu11: &installtorchgpu11
   run:
     name: Install torch GPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch<1.2.0'
+      pip3 install --progress-bar off 'torch>=1.2.0'
       pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off torchtext
@@ -79,19 +79,19 @@ installtorchcpuosx: &installtorchcpuosx
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.0.0-cp37-none-macosx_10_7_x86_64.whl
+      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.2.0-cp37-none-macosx_10_7_x86_64.whl
 
 installtorchcpu36: &installtorchcpu36
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp36-cp36m-linux_x86_64.whl
+      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.2.0.post2-cp36-cp36m-linux_x86_64.whl
 
 installtorchcpu37: &installtorchcpu37
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp37-cp37m-linux_x86_64.whl
+      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.2.0.post2-cp37-cp37m-linux_x86_64.whl
 
 setupcuda: &setupcuda
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,8 +142,6 @@ jobs:
       - run:
           name: Unit tests (OSX)
           command: |
-            source /Users/distiller/miniconda/etc/profile.d/conda.sh
-            conda activate base
             python setup.py test -s tests.suites.unittests -v
 
   unittests_36:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ installtorchgpu11: &installtorchgpu11
   run:
     name: Install torch GPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch>=1.2.0'
+      pip3 install --progress-bar off 'torch>=1.1.0'
       pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off torchtext
@@ -69,7 +69,7 @@ installtorchgpu12: &installtorchgpu12
   run:
     name: Install torch GPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch>=1.2.0'
+      pip3 install --progress-bar off 'torch>=1.1.0'
       pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off torchtext
@@ -79,19 +79,19 @@ installtorchcpuosx: &installtorchcpuosx
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.2.0-cp37-none-macosx_10_7_x86_64.whl
+      pip3 install --progress-bar off 'torch>=1.1.0'
 
 installtorchcpu36: &installtorchcpu36
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.2.0.post2-cp36-cp36m-linux_x86_64.whl
+      pip3 install --progress-bar off 'torch>=1.1.0'
 
 installtorchcpu37: &installtorchcpu37
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.2.0.post2-cp37-cp37m-linux_x86_64.whl
+      pip3 install --progress-bar off 'torch>=1.1.0'
 
 setupcuda: &setupcuda
   run:

--- a/parlai/agents/drqa/drqa.py
+++ b/parlai/agents/drqa/drqa.py
@@ -18,11 +18,7 @@ To automatically download glove, use:
 --embedding_file zoo:glove_vectors/glove.840B.300d.txt
 """
 
-try:
-    import torch
-except ImportError:
-    raise ImportError('Need to install pytorch: go to pytorch.org')
-
+import torch
 import bisect
 import os
 import numpy as np

--- a/parlai/agents/legacy_agents/seq2seq/torch_agent_v1.py
+++ b/parlai/agents/legacy_agents/seq2seq/torch_agent_v1.py
@@ -17,23 +17,21 @@ Contains the following main utilities:
 See below for documentation on each specific tool.
 """
 
+import json
+import random
+import math
+
+import torch
+from torch import optim
+
 from parlai.core.agents import Agent
 from parlai.core.build_data import modelzoo_path
 from .dict_v1 import DictionaryAgent
 from .utils_v1 import set_namedtuple_defaults, argsort, padded_tensor, NEAR_INF
 
-try:
-    import torch
-except ImportError:
-    raise ImportError('Need to install Pytorch: go to pytorch.org')
-
-
-from torch import optim
 from collections import deque, namedtuple, Counter
-import json
-import random
-import math
 from operator import attrgetter
+
 
 """
 Batch is a namedtuple containing data being sent to an agent.

--- a/parlai/agents/tfidf_retriever/utils.py
+++ b/parlai/agents/tfidf_retriever/utils.py
@@ -7,15 +7,11 @@
 """Various retriever utilities."""
 
 import regex
+import torch
 import unicodedata
 import numpy as np
 import scipy.sparse as sp
 from sklearn.utils import murmurhash3_32
-
-try:
-    import torch
-except ImportError:
-    raise ImportError('Need to install Pytorch: go to pytorch.org')
 
 
 # ------------------------------------------------------------------------------

--- a/parlai/core/distributed_utils.py
+++ b/parlai/core/distributed_utils.py
@@ -15,6 +15,7 @@ in non-distributed mode.
 import builtins
 import pickle
 import contextlib
+from parlai.core.utils import check_torch_version
 
 try:
     import torch.version
@@ -31,11 +32,7 @@ def validate_params(opt):
 
     Raises exceptions if anything is wrong, otherwise returns None.
     """
-    if torch.__version__ < "1.1.0":
-        raise ImportError(
-            "Please upgrade to PyTorch >=1.1; "
-            "visit https://pytorch.org for instructions."
-        )
+    check_torch_version()
 
     if opt.get('no_cuda', False):
         raise ValueError('Distributed mode only makes sense when using GPUs.')

--- a/parlai/core/distributed_utils.py
+++ b/parlai/core/distributed_utils.py
@@ -17,13 +17,8 @@ import pickle
 import contextlib
 from parlai.core.utils import check_torch_version
 
-try:
-    import torch.version
-    import torch.distributed as dist
-
-    TORCH_AVAILABLE = True
-except ImportError:
-    TORCH_AVAILABLE = False
+check_torch_version()
+import torch.distributed as dist
 
 
 def validate_params(opt):
@@ -50,7 +45,7 @@ def validate_params(opt):
 
 def is_distributed():
     """Return if we are in distributed mode."""
-    return TORCH_AVAILABLE and dist.is_available() and dist.is_initialized()
+    return dist.is_available() and dist.is_initialized()
 
 
 def num_workers():

--- a/parlai/core/distributed_utils.py
+++ b/parlai/core/distributed_utils.py
@@ -31,9 +31,9 @@ def validate_params(opt):
 
     Raises exceptions if anything is wrong, otherwise returns None.
     """
-    if torch.version.__version__.startswith('0.'):
+    if torch.__version__ < "1.1.0":
         raise ImportError(
-            "Please upgrade to PyTorch >=1.0; "
+            "Please upgrade to PyTorch >=1.1; "
             "visit https://pytorch.org for instructions."
         )
 

--- a/parlai/core/distributed_utils.py
+++ b/parlai/core/distributed_utils.py
@@ -18,7 +18,8 @@ import contextlib
 from parlai.core.utils import check_torch_version
 
 check_torch_version()
-import torch.distributed as dist
+import torch  # noqa: E402
+import torch.distributed as dist  # noqa: E402
 
 
 def validate_params(opt):

--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -45,10 +45,7 @@ class ImageLoader:
                 )
 
     def _lazy_import_torch(self):
-        try:
-            import torch
-        except ImportError:
-            raise ImportError('Need to install Pytorch: go to pytorch.org')
+        import torch
         import torchvision
         import torchvision.transforms as transforms
         import torch.nn as nn

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -24,14 +24,14 @@ import os
 from functools import wraps
 import importlib
 from functools import lru_cache
-import torch  # noqa: F401
-from torch.utils.data import ConcatDataset, Dataset, DataLoader, sampler
-from torch.multiprocessing import Lock, Value
 import ctypes
 from threading import Thread, Condition, RLock
 
 # Perform Torch version check
 check_torch_version()
+import torch  # noqa: E402
+from torch.utils.data import ConcatDataset, Dataset, DataLoader, sampler  # noqa: E402
+from torch.multiprocessing import Lock, Value  # noqa: E402
 
 
 class BatchSortCache(object):

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -24,6 +24,7 @@ import os
 from functools import wraps
 import importlib
 from functools import lru_cache
+import torch  # noqa: F401
 from torch.utils.data import ConcatDataset, Dataset, DataLoader, sampler
 from torch.multiprocessing import Lock, Value
 import ctypes

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -13,6 +13,7 @@ http://parl.ai/docs/tutorial_worlds.html#multiprocessed-pytorch-dataloader
 
 from .teachers import FixedDialogTeacher
 from parlai.core.utils import warn_once
+from parlai.core.utils import check_torch_version
 from parlai.scripts.build_pytorch_data import build_data
 from .agents import get_agent_module
 import json
@@ -23,18 +24,13 @@ import os
 from functools import wraps
 import importlib
 from functools import lru_cache
-import torch  # noqa: F401
 from torch.utils.data import ConcatDataset, Dataset, DataLoader, sampler
 from torch.multiprocessing import Lock, Value
 import ctypes
 from threading import Thread, Condition, RLock
 
-
-if torch.__version__ < "1.1.0":
-    raise ImportError(
-        "Please upgrade to PyTorch >=1.1; "
-        "visit https://pytorch.org for instructions."
-    )
+# Perform Torch version check
+check_torch_version()
 
 
 class BatchSortCache(object):

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -23,20 +23,16 @@ import os
 from functools import wraps
 import importlib
 from functools import lru_cache
-
-try:
-    import torch  # noqa: F401
-except ImportError:
-    raise ImportError('Need to install Pytorch: go to pytorch.org')
+import torch  # noqa: F401
 from torch.utils.data import ConcatDataset, Dataset, DataLoader, sampler
 from torch.multiprocessing import Lock, Value
 import ctypes
 from threading import Thread, Condition, RLock
 
 
-if torch.version.__version__.startswith('0.'):
+if torch.__version__ < "1.1.0":
     raise ImportError(
-        "Please upgrade to PyTorch >=1.0; "
+        "Please upgrade to PyTorch >=1.1; "
         "visit https://pytorch.org for instructions."
     )
 

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -42,13 +42,9 @@ from parlai.core.utils import (
 )
 from parlai.core.distributed_utils import is_primary_worker
 
-try:
-    import torch
-except ImportError:
-    raise ImportError('Need to install Pytorch: go to pytorch.org')
-
 # Perform torch version check
 check_torch_version()
+import torch
 
 
 class Batch(AttrDict):

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -46,6 +46,12 @@ try:
 except ImportError:
     raise ImportError('Need to install Pytorch: go to pytorch.org')
 
+if torch.__version__ < "1.1.0":
+    raise ImportError(
+        "Please upgrade to PyTorch >=1.1; "
+        "visit https://pytorch.org for instructions."
+    )
+
 
 class Batch(AttrDict):
     """

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -38,7 +38,7 @@ from parlai.core.utils import (
     padded_tensor,
     warn_once,
     round_sigfigs,
-    check_torch_version
+    check_torch_version,
 )
 from parlai.core.distributed_utils import is_primary_worker
 

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -38,6 +38,7 @@ from parlai.core.utils import (
     padded_tensor,
     warn_once,
     round_sigfigs,
+    check_torch_version
 )
 from parlai.core.distributed_utils import is_primary_worker
 
@@ -46,11 +47,8 @@ try:
 except ImportError:
     raise ImportError('Need to install Pytorch: go to pytorch.org')
 
-if torch.__version__ < "1.1.0":
-    raise ImportError(
-        "Please upgrade to PyTorch >=1.1; "
-        "visit https://pytorch.org for instructions."
-    )
+# Perform torch version check
+check_torch_version()
 
 
 class Batch(AttrDict):

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -44,7 +44,7 @@ from parlai.core.distributed_utils import is_primary_worker
 
 # Perform torch version check
 check_torch_version()
-import torch
+import torch  # noqa: E402
 
 
 class Batch(AttrDict):

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -32,12 +32,14 @@ except ImportError:
     TORCH_LONG = None
     __TORCH_AVAILABLE = False
 
+
 def check_torch_version():
     if torch.__version__ < "1.1.0":
         raise ImportError(
             "Please upgrade to PyTorch >=1.1; "
             "visit https://pytorch.org for instructions."
         )
+
 
 """Near infinity, useful as a large penalty for scoring when inf is bad."""
 NEAR_INF = 1e20

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -20,8 +20,10 @@ import heapq
 
 from parlai.core.message import Message
 
+
 # some of the utility methods are helpful for Torch
 def check_torch_version():
+    """ Perform a central check for torch installation and version."""
     try:
         import torch
     except ImportError:
@@ -35,7 +37,7 @@ def check_torch_version():
 
 
 check_torch_version()
-import torch
+import torch  # noqa: E402
 
 TORCH_LONG = torch.long
 

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -21,25 +21,23 @@ import heapq
 from parlai.core.message import Message
 
 # some of the utility methods are helpful for Torch
-try:
-    import torch
-
-    # default type in padded3d needs to be protected if torch
-    # isn't installed.
-    TORCH_LONG = torch.long
-    __TORCH_AVAILABLE = True
-except ImportError:
-    TORCH_LONG = None
-    __TORCH_AVAILABLE = False
-
-
 def check_torch_version():
+    try:
+        import torch
+    except ImportError:
+        raise ImportError('Need to install Pytorch: go to pytorch.org')
+
     if torch.__version__ < "1.1.0":
         raise ImportError(
             "Please upgrade to PyTorch >=1.1; "
             "visit https://pytorch.org for instructions."
         )
 
+
+check_torch_version()
+import torch
+
+TORCH_LONG = torch.long
 
 """Near infinity, useful as a large penalty for scoring when inf is bad."""
 NEAR_INF = 1e20
@@ -1130,10 +1128,7 @@ def padded_tensor(
     :rtype: (Tensor[int64], list[int])
     """
     # hard fail if we don't have torch
-    if not __TORCH_AVAILABLE:
-        raise ImportError(
-            "Cannot use padded_tensor without torch; go to http://pytorch.org"
-        )
+    check_torch_version()
 
     # number of items
     n = len(items)
@@ -1237,7 +1232,7 @@ def argsort(keys, *lists, descending=False):
     output = []
     for lst in lists:
         # watch out in case we don't have torch installed
-        if __TORCH_AVAILABLE and isinstance(lst, torch.Tensor):
+        if isinstance(lst, torch.Tensor):
             output.append(lst[ind_sorted])
         else:
             output.append([lst[i] for i in ind_sorted])

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -39,8 +39,6 @@ def check_torch_version():
 check_torch_version()
 import torch  # noqa: E402
 
-TORCH_LONG = torch.long
-
 """Near infinity, useful as a large penalty for scoring when inf is bad."""
 NEAR_INF = 1e20
 NEAR_INF_FP16 = 65504
@@ -1172,7 +1170,7 @@ def padded_tensor(
     return output, lens
 
 
-def padded_3d(tensors, pad_idx=0, use_cuda=0, dtype=TORCH_LONG, fp16friendly=False):
+def padded_3d(tensors, pad_idx=0, use_cuda=0, dtype=torch.long, fp16friendly=False):
     """
     Make 3D padded tensor for list of lists of 1D tensors or lists.
 

--- a/parlai/core/utils.py
+++ b/parlai/core/utils.py
@@ -32,6 +32,12 @@ except ImportError:
     TORCH_LONG = None
     __TORCH_AVAILABLE = False
 
+def check_torch_version():
+    if torch.__version__ < "1.1.0":
+        raise ImportError(
+            "Please upgrade to PyTorch >=1.1; "
+            "visit https://pytorch.org for instructions."
+        )
 
 """Near infinity, useful as a large penalty for scoring when inf is bad."""
 NEAR_INF = 1e20

--- a/parlai/scripts/extract_image_feature.py
+++ b/parlai/scripts/extract_image_feature.py
@@ -111,17 +111,14 @@ def extract_feats(opt):
     elif opt.get('use_hdf5_extraction', False):
         # TODO Deprecate
         '''One can specify a Pytorch Dataset for custom image loading'''
+        import torch
+        from torch.utils.data import DataLoader
+
         nw = opt.get('numworkers', 1)
         im = opt.get('image_mode', 'raw')
         opt['batchsize'] = 1
         opt['extract_image'] = True
         bsz = 1
-        try:
-            import torch
-            from torch.utils.data import DataLoader
-        except ImportError:
-            raise ImportError('Need to install Pytorch: go to pytorch.org')
-
         dataset = get_dataset_class(opt)(opt)
         pre_image_path, _ = os.path.split(dataset.image_path)
         image_path = os.path.join(pre_image_path, opt.get('image_mode'))

--- a/parlai/tasks/coco_caption/agents.py
+++ b/parlai/tasks/coco_caption/agents.py
@@ -11,8 +11,6 @@ from .build_2014 import buildImage as buildImage_2014
 from .build_2017 import build as build_2017
 from .build_2017 import buildImage as buildImage_2017
 
-
-import torch  # noqa: F401
 from torch.utils.data import Dataset
 
 import os

--- a/parlai/tasks/coco_caption/agents.py
+++ b/parlai/tasks/coco_caption/agents.py
@@ -11,10 +11,8 @@ from .build_2014 import buildImage as buildImage_2014
 from .build_2017 import build as build_2017
 from .build_2017 import buildImage as buildImage_2017
 
-try:
-    import torch  # noqa: F401
-except ImportError:
-    raise ImportError('Need to install Pytorch: go to pytorch.org')
+
+import torch  # noqa: F401
 from torch.utils.data import Dataset
 
 import os

--- a/parlai/tasks/flickr30k/agents.py
+++ b/parlai/tasks/flickr30k/agents.py
@@ -8,8 +8,6 @@ from parlai.core.teachers import FixedDialogTeacher
 from parlai.core.image_featurizers import ImageLoader
 from .build import build
 
-
-import torch  # noqa: F401
 from torch.utils.data import Dataset
 from parlai.core.dict import DictionaryAgent
 

--- a/parlai/tasks/flickr30k/agents.py
+++ b/parlai/tasks/flickr30k/agents.py
@@ -8,10 +8,8 @@ from parlai.core.teachers import FixedDialogTeacher
 from parlai.core.image_featurizers import ImageLoader
 from .build import build
 
-try:
-    import torch  # noqa: F401
-except ImportError:
-    raise ImportError('Need to install Pytorch: go to pytorch.org')
+
+import torch  # noqa: F401
 from torch.utils.data import Dataset
 from parlai.core.dict import DictionaryAgent
 

--- a/parlai/tasks/vqa_v1/agents.py
+++ b/parlai/tasks/vqa_v1/agents.py
@@ -19,10 +19,7 @@ from .build import build
 from parlai.tasks.coco_caption.build_2014 import buildImage as buildImage_2014
 from parlai.tasks.coco_caption.build_2015 import buildImage as buildImage_2015
 
-try:
-    import torch
-except ImportError:
-    raise ImportError('Need to install Pytorch: go to pytorch.org')
+import torch
 from torch.utils.data import Dataset
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ scipy
 sh
 sphinx
 sphinx_rtd_theme
-torch>=1.1
 tqdm
 websocket-client
 websocket-server

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ scipy
 sh
 sphinx
 sphinx_rtd_theme
+torch>=1.1
 tqdm
 websocket-client
 websocket-server

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -130,6 +130,7 @@ class TestSeq2Seq(unittest.TestCase):
 
 
 class TestHogwildSeq2seq(unittest.TestCase):
+    # os_x tests: Hangs if using pip installation of pytorch; Succeeds if using conda installation
     @testing_utils.skipIfGPU
     def test_generation_multi(self):
         """This test uses a multi-turn task and multithreading."""


### PR DESCRIPTION
**Patch description**
 Deprecate Torch < 1.1. Fixes  [#1921 ](https://github.com/facebookresearch/ParlAI/issues/1921).

**Testing steps**
Follow instructions to install ParlAI. It should install a pytorch version >= 1.1 (since I added that in requirements.txt). The test case ```python tests/datatests/test_new_tasks.py``` should run without failure.

**Logs**
Truncated Output:
```
$ python setup.py test -s tests.suites.unittests -v
…
test_generation_multi (test_seq2seq.TestHogwildSeq2seq)
This test uses a multi-turn task and multithreading. ... ok
…
----------------------------------------------------------------------
Ran 127 tests in 658.747s

OK (skipped=6)
```
**A note on currently failing CircleCI tests**
- datatests: Couldn't run it locally since one (suspecting coco caption) or more of the tasks changed takes an enormous amount of time to download and train which my laptop isn't able to handle. 
- os_x tests: Strangely enough, on Circle CI the test hangs and never completes (even tried running locally for over 30 mins) for a pip installation of pytorch. Whereas if I install torch using conda, the tests pass locally (as can be seen in logs). I have added a comment above the test to mention this strange behavior.

To remedy os_x tests so that they do not spoil the current build when merged, I have modified circleci so that os_x tests use conda to install torch instead of pip