### PR TITLE
[Bug-fix] Fix Self-Feeding fixed-cands issue

### DIFF
--- a/projects/self_feeding/interactive.py
+++ b/projects/self_feeding/interactive.py
@@ -17,6 +17,7 @@ from parlai.core.params import ParlaiParser
 from parlai.core.agents import create_agent
 from parlai.core.worlds import create_task
 from parlai.agents.local_human.local_human import LocalHumanAgent
+from parlai.tasks.self_feeding.build import build
 from projects.self_feeding.self_feeding_agent import SelfFeedingAgent
 
 
@@ -40,6 +41,8 @@ def interactive(opt, print_parser=None):
         print('[ Deprecated Warning: interactive should be passed opt not Parser ]')
         opt = opt.parse_args()
 
+    opt['task'] = 'self_feeding'
+    build(opt)
     opt['task'] = 'parlai.agents.local_human.local_human:LocalHumanAgent'
     cand_file = os.path.join(opt['datapath'], 'self_feeding/convai2_cands.txt')
     # Set values to override when the opt dict for the saved model is loaded

--- a/projects/self_feeding/self_feeding_agent.py
+++ b/projects/self_feeding/self_feeding_agent.py
@@ -469,7 +469,6 @@ class SelfFeedingAgent(TransformerRankerAgent):
 
     def dialog_step(self, batch):
         batchsize = batch.text_vec.size(0)
-        cand_encs = None
         if self.model.training:
             cands, cand_vecs, label_inds = self._build_candidates(
                 batch, source=self.opt['candidates'], mode='train'
@@ -485,12 +484,12 @@ class SelfFeedingAgent(TransformerRankerAgent):
                 # if we cached candidate encodings for a fixed list of candidates,
                 # pass those into the score_candidates function
                 if self.eval_candidates == 'fixed':
-                    cand_encs = self.fixed_candidate_encs
+                    cand_vecs = self.fixed_candidate_encs
                 elif self.eval_candidates == 'vocab':
-                    cand_encs = self.vocab_candidate_encs
+                    cand_vecs = self.vocab_candidate_encs
 
         scores = self.model.score_dialog(
-            batch.text_vec, cand_encs if cand_encs is not None else cand_vecs
+            batch.text_vec, cand_vecs
         )
         _, ranks = scores.sort(1, descending=True)
 

--- a/projects/self_feeding/self_feeding_agent.py
+++ b/projects/self_feeding/self_feeding_agent.py
@@ -488,9 +488,7 @@ class SelfFeedingAgent(TransformerRankerAgent):
                 elif self.eval_candidates == 'vocab':
                     cand_vecs = self.vocab_candidate_encs
 
-        scores = self.model.score_dialog(
-            batch.text_vec, cand_vecs
-        )
+        scores = self.model.score_dialog(batch.text_vec, cand_vecs)
         _, ranks = scores.sort(1, descending=True)
 
         if self.model.training:

--- a/projects/self_feeding/self_feeding_agent.py
+++ b/projects/self_feeding/self_feeding_agent.py
@@ -469,6 +469,7 @@ class SelfFeedingAgent(TransformerRankerAgent):
 
     def dialog_step(self, batch):
         batchsize = batch.text_vec.size(0)
+        cand_encs = None
         if self.model.training:
             cands, cand_vecs, label_inds = self._build_candidates(
                 batch, source=self.opt['candidates'], mode='train'
@@ -477,8 +478,18 @@ class SelfFeedingAgent(TransformerRankerAgent):
             cands, cand_vecs, label_inds = self._build_candidates(
                 batch, source=self.opt['eval_candidates'], mode='eval'
             )
+            if self.encode_candidate_vecs and self.eval_candidates in ['fixed', 'vocab']:
+                # if we cached candidate encodings for a fixed list of candidates,
+                # pass those into the score_candidates function
+                if self.eval_candidates == 'fixed':
+                    cand_encs = self.fixed_candidate_encs
+                elif self.eval_candidates == 'vocab':
+                    cand_encs = self.vocab_candidate_encs
 
-        scores = self.model.score_dialog(batch.text_vec, cand_vecs)
+        scores = self.model.score_dialog(
+            batch.text_vec,
+            cand_encs if cand_encs is not None else cand_vecs
+        )
         _, ranks = scores.sort(1, descending=True)
 
         if self.model.training:

--- a/projects/self_feeding/self_feeding_agent.py
+++ b/projects/self_feeding/self_feeding_agent.py
@@ -478,7 +478,10 @@ class SelfFeedingAgent(TransformerRankerAgent):
             cands, cand_vecs, label_inds = self._build_candidates(
                 batch, source=self.opt['eval_candidates'], mode='eval'
             )
-            if self.encode_candidate_vecs and self.eval_candidates in ['fixed', 'vocab']:
+            if self.encode_candidate_vecs and self.eval_candidates in [
+                'fixed',
+                'vocab',
+            ]:
                 # if we cached candidate encodings for a fixed list of candidates,
                 # pass those into the score_candidates function
                 if self.eval_candidates == 'fixed':
@@ -487,8 +490,7 @@ class SelfFeedingAgent(TransformerRankerAgent):
                     cand_encs = self.vocab_candidate_encs
 
         scores = self.model.score_dialog(
-            batch.text_vec,
-            cand_encs if cand_encs is not None else cand_vecs
+            batch.text_vec, cand_encs if cand_encs is not None else cand_vecs
         )
         _, ranks = scores.sort(1, descending=True)
 


### PR DESCRIPTION
**Patch description**
Previously, while using the self-feeding agent with fixed candidates, the self-feeding agent would re-encode candidate vecs (and essentially ignore the `self.fixed_candidate_encs` attribute).

On GPU/powerful machines, this is not as easily noticeable; however, on cpu-only machines (e.g. a laptop), memory usage spikes and the bot appears to hang while it recomputes it's candidate encodings for 100k+ candidates (see #1980).

This issue is fixed in this PR. Additionally, a call to `build` is included so that the model has access to the fixed cands set.

**Logs**
After the change, running `python projects/self_feeding/interactive.py --model-file zoo:self_feeding/hh131k_hb60k_fb60k_st1k/model --no-cuda -bs 1 --request-feedback true` yields the following:
```
$ python projects/self_feeding/interactive.py --model-file zoo:self_feeding/hh131k_hb60k_fb60k_st1k/model --no-cuda -bs 1 --request-feedback true
/Users/kshuster/ParlAI/parlai/agents/transformer/modules.py:32: UserWarning: Installing APEX can give a significant speed boost.
  warn_once("Installing APEX can give a significant speed boost.")
[building data: /Users/kshuster/ParlAI/data/models/self_feeding/hh131k_hb60k_fb60k_st1k_v1.tar.gz]
[ downloading: http://parl.ai/downloads/_models/self_feeding/hh131k_hb60k_fb60k_st1k_v1.tar.gz to /Users/kshuster/ParlAI/data/models/self_feeding/hh131k_hb60k_fb60k_st1k_v1.tar.gz ]

...

[building data: /Users/kshuster/ParlAI/data/self_feeding]
[ downloading: http://parl.ai/downloads/self_feeding/self_feeding_v031.tar.gz to /Users/kshuster/ParlAI/data/self_feeding/self_feeding_v031.tar.gz ]

...

[ Loading fixed candidate set from /Users/kshuster/ParlAI/data/self_feeding/convai2_cands.txt ]
[ Vectorizing fixed candidate set (250 batch(es) of up to 512) ]

...

[ Saving fixed candidate set vectors to /Users/kshuster/ParlAI/data/models/self_feeding/hh131k_hb60k_fb60k_st1k/model.convai2_cands.vecs ]
[ Encoding fixed candidates set from (499 batch(es) of up to 256) ]

...

[ Saving fixed candidate set encodings to /Users/kshuster/ParlAI/data/models/self_feeding/hh131k_hb60k_fb60k_st1k/model.convai2_cands.encs ]
/Users/kshuster/anaconda3/lib/python3.6/site-packages/torch/nn/_reduction.py:49: UserWarning: size_average and reduce args will be deprecated, please use reduction='sum' instead.
  warnings.warn(warning.format(ret))
[creating task(s): parlai.agents.local_human.local_human:LocalHumanAgent]
Enter [DONE] if you want to end the episode.

...

Enter Your Message: hey what's going on
/Users/kshuster/ParlAI/parlai/core/torch_ranker_agent.py:649: UserWarning: [ Executing eval mode with a common set of fixed candidates (n = 127712). ]
  "(n = {}). ]".format(mode, len(self.fixed_candidates))
[SelfFeeding]: chillin to van halen . wearing my purple jump suit . what you up to ?
Enter Your Message:
```