### PR TITLE
[Empathetic Dialogues] Emotion Classification task

### DIFF
--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -139,5 +139,64 @@ class EmpatheticDialogueTeacher(FixedDialogTeacher):
         return shared
 
 
+class EmotionClassificationTeacher(EmpatheticDialogueTeacher):
+    """
+    Class for detecting the emotion based on the utterance.
+    """
+    @staticmethod
+    def add_cmdline_args(parser):
+        parser = parser.add_argument_group('Emotion Classification Args')
+        parser.add_argument(
+            '--single-turn',
+            type='bool',
+            default=True,
+            help='Single turn classification task',
+        )
+
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
+        self.single_turn = opt['single_turn']
+        if not shared and self.single_turn:
+            self._make_single_turn()
+
+    def num_episodes(self):
+        return len(self.data)
+
+    def num_examples(self):
+        if not self.single_turn:
+            return super().num_examples()
+        return len(self.data)
+
+    def _make_single_turn(self):
+        new_data = []
+        for ep in self.data:
+            for ex in ep:
+                new_data.append(ex)
+        self.data = new_data
+
+    def get(self, episode_idx, entry_idx=0):
+        if not self.single_turn:
+            ep = self.data[episode_idx]
+            i = entry_idx * 2
+            ex = ep[i]
+            episode_done = i >= (len(ep) - 2)
+        else:
+            ex = self.data[episode_idx]
+            episode_done = True
+
+        return {
+            'situation': ex[3],
+            'labels': [ex[2]],
+            'text': ex[0],
+            'next_utt': ex[1],
+            'prepend_ctx': ex[6],
+            'prepend_cand': ex[7],
+            'deepmoji_ctx': ex[4],
+            'deepmoji_cand': ex[5],
+            'episode_done': episode_done,
+            'label_candidates': ex[8],
+        }
+
+
 class DefaultTeacher(EmpatheticDialogueTeacher):
     pass

--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -177,11 +177,14 @@ class EmotionClassificationTeacher(EmpatheticDialogueTeacher):
 
     def get(self, episode_idx, entry_idx=0):
         if not self.single_turn:
+            # get the specific episode from the example
             ep = self.data[episode_idx]
             i = entry_idx * 2
             ex = ep[i]
             episode_done = i >= (len(ep) - 2)
         else:
+            # each episode is a singular example, we use both sides of the
+            # conversation
             ex = self.data[episode_idx]
             episode_done = True
 

--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -143,6 +143,7 @@ class EmotionClassificationTeacher(EmpatheticDialogueTeacher):
     """
     Class for detecting the emotion based on the utterance.
     """
+
     @staticmethod
     def add_cmdline_args(parser):
         parser = parser.add_argument_group('Emotion Classification Args')


### PR DESCRIPTION
**Patch description**
Add task for emotion classification. I.e., classify the associated emotion based on the utterance. Option to make this single turn examples, with that being the default.

Example output from `python examples/display_data.py -t empathetic_dialogues:emotionClassification`

```
[situation]: I remember going to the fireworks with my best friend. There was a lot of people, but it only felt like us in the world.
[next_utt]: Was this a friend you were in love with, or just a best friend?
[prepend_ctx]: None
[prepend_cand]: None
[deepmoji_ctx]: None
[deepmoji_cand]: None
[empathetic_dialogues:emotionClassification]: I remember going to see the fireworks with my best friend. It was the first time we ever spent time alone together. Although there was a lot of people, we felt like the only people in the world.
[labels: sentimental]
- - - - - - - - - - - - - - - - - - - - -
~~
[situation]: I remember going to the fireworks with my best friend. There was a lot of people, but it only felt like us in the world.
[next_utt]: This was a best friend. I miss her.
[prepend_ctx]: None
[prepend_cand]: None
[deepmoji_ctx]: None
[deepmoji_cand]: None
[empathetic_dialogues:emotionClassification]: Was this a friend you were in love with, or just a best friend?
[labels: sentimental]
- - - - - - - - - - - - - - - - - - - - -
~~
[situation]: I remember going to the fireworks with my best friend. There was a lot of people, but it only felt like us in the world.
[next_utt]: Where has she gone?
[prepend_ctx]: None
[prepend_cand]: None
[deepmoji_ctx]: None
[deepmoji_cand]: None
[empathetic_dialogues:emotionClassification]: This was a best friend. I miss her.
[labels: sentimental]
- - - - - - - - - - - - - - - - - - - - -
```