### PR TITLE
Fix sync issue when using pretrained embeddings.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1172,10 +1172,6 @@ class TorchAgent(ABC, Agent):
         :param emb_type:
             pretrained embedding type
         """
-        if not is_primary_worker():
-            # we're in distributed mode, copying embeddings in the workers
-            # slows things down considerably
-            return
         embs, name = self._get_embtype(emb_type)
         cnt = 0
         for w, i in self.dict.tok2ind.items():


### PR DESCRIPTION
**Patch description**
Had previously prevented loading embeddings on other workers because I thought setting parameters involved network transfer. That was false, and the mistake is caught by  `check_synced_parameters`, so that's a nice assert.

Fixes #2028.

**Testing steps**
```
$ python -m parlai.scripts.multiprocessing_train -t convai2 -m transformer/generator -emb fasttext_cc -mf ./tmp/tg_fasttext_2gpu -df /checkpoint/parlai/dicts/20190222_bpelower_ost+toronto+wiki/dict --dict-tokenizer bpe
...
[ time:2.0s total_exs:122 epochs:0.0 ] {'exs': 122, 'lr': 1, 'num_updates': 61, 'gnorm': 19.42, 'clip': 1.0, 'gpu_mem_percent': 0.04185, 'loss': 496.4, 'token_acc': 0.03632, 'nll_loss': 8.282, 'ppl': 4276.0}
[ time:4.0s total_exs:260 epochs:0.0 ] {'exs': 138, 'lr': 1, 'num_updates': 130, 'gnorm': 11.72, 'clip': 1.0, 'gpu_mem_percent': 0.0419, 'loss': 448.8, 'token_acc': 0.07512, 'nll_loss': 6.571, 'ppl': 733.2}
[ time:6.0s total_exs:396 epochs:0.0 ] {'exs': 136, 'lr': 1, 'num_updates': 198, 'gnorm': 10.3, 'clip': 1.0, 'gpu_mem_percent': 0.0419, 'loss': 420.8, 'token_acc': 0.08432, 'nll_loss': 6.292, 'ppl': 540.2}

```