### PR TITLE
[Polyencoders] Fix dict file in READMEs

### DIFF
--- a/parlai/zoo/pretrained_transformers/README.md
+++ b/parlai/zoo/pretrained_transformers/README.md
@@ -74,7 +74,6 @@ python -u examples/train_model.py \
   --text-truncate 360 --num-epochs 8.0 --max_train_time 200000 -veps 0.5 \
   -vme 8000 --validation-metric accuracy --validation-metric-mode max \
   --save-after-valid True --log_every_n_secs 20 --candidates batch --fp16 True \
-  --dict-file ./data/models/pretrained_transformers/model_bi.dict \
   --dict-tokenizer bpe --dict-lower True --optimizer adamax --output-scaling 0.06 \
   --variant xlm --reduction-type mean --share-encoders False \
   --learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 \

--- a/projects/polyencoder/README.md
+++ b/projects/polyencoder/README.md
@@ -88,7 +88,6 @@ python -u examples/train_model.py \
   --text-truncate 360 --num-epochs 8.0 --max_train_time 200000 -veps 0.5 \
   -vme 8000 --validation-metric accuracy --validation-metric-mode max \
   --save-after-valid True --log_every_n_secs 20 --candidates batch --fp16 True \
-  --dict-file ./data/models/pretrained_transformers/model_bi.dict \
   --dict-tokenizer bpe --dict-lower True --optimizer adamax --output-scaling 0.06 \
   --variant xlm --reduction-type mean --share-encoders False \
   --learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 \


### PR DESCRIPTION
**Patch description**
Get rid of path to dict file. All dict files should automatically be loaded from `<path to model>.dict`. 

I forgot to get rid of this line in #1847.