### PR TITLE
Add WandbLogger

### DIFF
--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -23,6 +23,11 @@ try:
 except ImportError:
     SummaryWriter = None
 
+try:
+    import wandb
+except ImportError:
+    wandb = None
+
 
 class TensorboardLogger(object):
     """Log objects to tensorboard."""
@@ -66,3 +71,60 @@ class TensorboardLogger(object):
                 self.writer.add_scalar(f'{setting}/{k}', v, global_step=step)
             else:
                 print(f'k {k} v {v} is not a number')
+
+
+class WandbLogger(object):
+    """Log objects to Weights & Biases."""
+
+    @staticmethod
+    def add_cmdline_args(argparser):
+        """Add wandb CLI args."""
+        logger = argparser.add_argument_group('W&B Arguments')
+        logger.add_argument(
+            '-wblog',
+            '--wandb-log',
+            type='bool',
+            default=False,
+            help="W&B logging of metrics, default is %(default)s",
+            hidden=False,
+        )
+
+    def __init__(self, opt):
+        if wandb is None:
+            raise ImportError('Please run `pip install wandb`.')
+
+        wandb.init(anonymous="allow")
+
+    def log_model(self, model):
+        """
+        Log model's gradients and parameters.
+
+        :param model:
+            The model to log
+        """
+        wandb.watch(model, log="all")
+
+    def log_parameters(self, params):
+        """
+        Log the parameters used to train a model.
+
+        :param params:
+            The training parameters
+        """
+        wandb.config.update(params)
+
+    def log_metrics(self, settings, step, report):
+        """
+        Log a report to W&B.
+
+        :param settings:
+            One of train/valid/test. Will be prepended to the metrics reported.
+        :param step:
+            Number of parleys
+        :param report:
+            The report to log
+        """
+        annotated_report = {}
+        for k, v in report.items():
+            annotated_report[f'{settings}_{k}'] = v
+        wandb.log(annotated_report, step=step)

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -18,7 +18,7 @@ Examples
 
 from parlai.core.params import ParlaiParser, print_announcements
 from parlai.core.agents import create_agent
-from parlai.core.logs import TensorboardLogger
+from parlai.core.logs import TensorboardLogger, WandbLogger
 from parlai.core.metrics import aggregate_task_reports
 from parlai.core.worlds import create_task
 from parlai.core.utils import TimeLogger
@@ -54,6 +54,7 @@ def setup_args(parser=None):
         'the rouge metrics will be computed as rouge-1, rouge-2 and rouge-l',
     )
     TensorboardLogger.add_cmdline_args(parser)
+    WandbLogger.add_cmdline_args(parser)
     parser.set_defaults(datatype='valid')
     return parser
 

--- a/parlai/scripts/eval_wordstat.py
+++ b/parlai/scripts/eval_wordstat.py
@@ -35,7 +35,7 @@ from parlai.core.agents import create_agent
 from parlai.core.worlds import create_task
 from parlai.core.utils import TimeLogger
 from parlai.core.metrics import normalize_answer
-from parlai.core.logs import TensorboardLogger
+from parlai.core.logs import TensorboardLogger, WandbLogger
 from collections import Counter
 
 import copy
@@ -81,6 +81,7 @@ def setup_args(parser=None):
     )
     parser.set_defaults(datatype='valid', model='repeat_label')
     TensorboardLogger.add_cmdline_args(parser)
+    WandbLogger.add_cmdline_args(parser)
     return parser
 
 


### PR DESCRIPTION
**Patch description**
This PR adds a new logger implementation that tracks metrics using https://www.wandb.com/. I found the [dashboards](https://app.wandb.ai/annirudh/parlai) and automatic parameter tracking useful when training models.

I intended `WandbLogger` to be a drop-in replacement the `Tensorboard` logger.

**Testing steps**
- Running `train_model.py` does not require `wandb` pip package when `-wblog` is not specified.
- Running `train_model.py` with `-wblog` correctly sends metrics to W&B
- Using both `-wblog` and `tblog` works, with metrics tracked in both Tensorboard and W&B.

**Logs**
```
python examples/train_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -bs 1 -nt 4 -eps 5 -m memnn -wblog true
```