### PR TITLE
[TGA][fix] beam search producing same hypotheses

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -851,8 +851,6 @@ class TreeSearch(object):
                 logprobs[hyp_id][self.eos] = neginf(logprobs.dtype)
 
         if self.scores is None:
-            #  if t=0, only single hypothesis is expanded
-            logprobs = logprobs[0:1]
             self.scores = torch.zeros(1).type_as(logprobs).to(logprobs.device)
 
         hyp_ids, tok_ids, self.scores = self.select_paths(logprobs, self.scores)
@@ -1004,6 +1002,9 @@ class BeamSearch(TreeSearch):
 
     def select_paths(self, logprobs, prior_scores):
         """Select the next vocabulary item in these beams."""
+        if prior_scores.numel() == 1:
+            logprobs = logprobs[0:1]
+
         # beam search actually looks over all hypotheses together so we flatten
         beam_scores = logprobs + prior_scores.unsqueeze(1).expand_as(logprobs)
         flat_beam_scores = beam_scores.view(-1)

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -1002,6 +1002,7 @@ class BeamSearch(TreeSearch):
 
     def select_paths(self, logprobs, prior_scores):
         """Select the next vocabulary item in these beams."""
+        # if numel is 1, then this is the first time step, only one hyp is expanded
         if prior_scores.numel() == 1:
             logprobs = logprobs[0:1]
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -851,6 +851,8 @@ class TreeSearch(object):
                 logprobs[hyp_id][self.eos] = neginf(logprobs.dtype)
 
         if self.scores is None:
+            #  if t=0, only single hypothesis is expanded
+            logprobs = logprobs[0:1]
             self.scores = torch.zeros(1).type_as(logprobs).to(logprobs.device)
 
         hyp_ids, tok_ids, self.scores = self.select_paths(logprobs, self.scores)


### PR DESCRIPTION
beam fix: initially only a single hypothesis should be expanded, otherwise they… all will be same

This PR forces only a single starting hypothesis (with start token) to be expanded initially.

Otherwise same tokens will be selected after topk and effectively beam search is a greedy one.

# Reproduce:

To reproduce and see same beam.outputs, put this print statement in the end of `_generate` function:
`print([i.tolist() for i in beams[0].outputs])`

now run the following command (any model which is using TGA fits):
`python ParlAI/examples/eval_model.py -t convai2:self:none -mf b72/model --inference beam --beam-size 5 --skip-generation False -bs 1 -ne 1`

Output:
`[[1, 1, 1, 1, 1], [792, 792, 792, 792, 792], [6, 6, 6, 6, 6], [14, 14, 14, 14, 14], [8, 8, 8, 8, 8], [58, 58, 58, 58, 58], [1880, 1880, 1880, 1880, 1880], [12, 12, 12, 12, 12], [435, 435, 435, 435, 435], [5, 5, 5, 5, 5], [2, 2, 2, 2, 2]]`
the actual numbers are not important (depends on a particular model), the repetition is important.

Output after the fix:
`[[1, 1, 1, 1, 1], [792, 14, 880, 226, 69], [8, 6, 195, 37, 6], [58, 14, 14, 1880, 14], [1880, 8, 195, 8, 195], [58, 58, 12, 1390, 1880], [1089, 435, 1880, 267, 69], 
[12, 1880, 6, 12, 5], [169, 435, 12, 14, 14], [5, 6, 435, 5, 6], [2, 15, 102, 5, 102], [20, 72, 72, 5, 46], [2, 15, 15, 15, 5], [2, 20, 20, 20, 5]]`

As you see now it looks legit.

# Update
The first commit here pasted it in the main TreeSearch, however nucleus etc. uses it too.
Now the fix is located exactly in the BeamSearch.

