### PR TITLE
Quiet false interactive mode warning.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1773,7 +1773,7 @@ class TorchAgent(ABC, Agent):
 
     def set_interactive_mode(self, mode, shared):
         """Set interactive mode on or off."""
-        if shared is None:
+        if shared is None and mode:
             # Only print in the non-shared version.
             print("[" + self.id + ': full interactive mode on.' + ']')
 


### PR DESCRIPTION
**Patch description**
I think someone pointed out to me the logic here was wrong so that we were falsely printing that interactive mode was on even when it wasn't. This fixes the false alarm.

**Testing steps**
yolo