### PR TITLE
Detect bad imports with the linter.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,6 @@ extend-ignore =
     E266
     W503
     F403
-    F401
     D202
 select = C,E,F,W,B,B950,D,RST
 


### PR DESCRIPTION
**Patch description**
#2030 had some imports that were unused. I expected the linter to detect these, but they weren't. Turns out, I had marked them as explicit ignores in the config file. Who knows? Maybe past Stephen but not current Stephen.

**Testing steps**
flaked parlai/core and found some unused imports. Let's see who gets them first ;)