### PR TITLE
Fix interactive end2end wizard of wikipedia

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -18,6 +18,7 @@ literature (BERT and XLM; https://arxiv.org/abs/1901.07291).
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.nn import LayerNorm
 
 import math
 import numpy as np
@@ -25,12 +26,6 @@ import numpy as np
 from parlai.core.torch_generator_agent import TorchGeneratorModel
 from parlai.core.utils import warn_once
 from parlai.core.utils import neginf
-
-try:
-    from apex.normalization.fused_layer_norm import FusedLayerNorm as LayerNorm
-except ImportError:
-    warn_once("Installing APEX can give a significant speed boost.")
-    from torch.nn import LayerNorm
 
 LAYER_NORM_EPS = 1e-5  # Epsilon for layer norm.
 

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -18,7 +18,6 @@ literature (BERT and XLM; https://arxiv.org/abs/1901.07291).
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.nn import LayerNorm
 
 import math
 import numpy as np
@@ -26,6 +25,12 @@ import numpy as np
 from parlai.core.torch_generator_agent import TorchGeneratorModel
 from parlai.core.utils import warn_once
 from parlai.core.utils import neginf
+
+try:
+    from apex.normalization.fused_layer_norm import FusedLayerNorm as LayerNorm
+except ImportError:
+    warn_once("Installing APEX can give a significant speed boost.")
+    from torch.nn import LayerNorm
 
 LAYER_NORM_EPS = 1e-5  # Epsilon for layer norm.
 

--- a/projects/wizard_of_wikipedia/interactive_end2end/interactive_end2end.py
+++ b/projects/wizard_of_wikipedia/interactive_end2end/interactive_end2end.py
@@ -250,7 +250,7 @@ class InteractiveEnd2endAgent(Agent):
         responder_act = self.responder.act()
         if self.debug:
             print('DEBUG: Responder is acting:\n{}'.format(responder_act))
-        responder_act['id'] = 'WizardEnd2EndInteractiveAgent'
+        responder_act.force_set('id', 'WizardEnd2EndInteractiveAgent')
         return responder_act
 
     def share(self):


### PR DESCRIPTION
**Patch description**
Fix failure when running an example from https://github.com/facebookresearch/ParlAI/tree/master/projects/wizard_of_wikipedia#end-to-end-generative: `python examples/interactive.py -m projects:wizard_of_wikipedia:interactive_end2end -t wizard_of_wikipedia`

The issue is on this line: https://github.com/facebookresearch/ParlAI/blob/b59079d70689a41f624c4be981772e588395b6a4/projects/wizard_of_wikipedia/interactive_end2end/interactive_end2end.py#L253
`responder_act['id']` is already set to `'End2End'`.

