### PR TITLE
Cap max examples in eval_model

### DIFF
--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -75,7 +75,7 @@ def _eval_single_world(opt, agent, task):
     log_time = TimeLogger()
 
     # max number of examples to evaluate
-    max_cnt = opt['num_examples'] if opt['num_examples'] > 0 else float('inf')
+    max_cnt = opt['num_examples'] if opt['num_examples'] > 0 else world.num_examples()
     cnt = 0
 
     while not world.epoch_done() and cnt < max_cnt:

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -75,7 +75,11 @@ def _eval_single_world(opt, agent, task):
     log_time = TimeLogger()
 
     # max number of examples to evaluate
-    max_cnt = opt['num_examples'] if opt['num_examples'] > 0 else world.num_examples()
+    max_cnt = float('inf')
+    if opt['num_examples'] > 0:
+        max_cnt = opt['num_examples']
+    elif world.num_examples() > 0:
+        max_cnt = world.num_examples()
     cnt = 0
 
     while not world.epoch_done() and cnt < max_cnt:


### PR DESCRIPTION
**Patch description**
This is probably a bug with a world somewhere, but figured I'd add this in as I've had this change locally for a long time now.

I ran into an issue where eval would not stop after all the examples because a world's `epoch_done()` method was not correctly implemented (I don't remember the command unfortunately). When we're evaluating a model, I don't think it makes sense to evaluate beyond the number of examples in a world; so why not cap `max_cnt` at that instead of `float('inf')`? 

**Testing steps**
Run `eval_model.py` for any model. Also unit tests
