### PR TITLE
Enhance conversation renderring

### DIFF
--- a/parlai/scripts/convo_render.py
+++ b/parlai/scripts/convo_render.py
@@ -4,12 +4,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 import sys
 import json
 import random
 import argparse
 import tempfile
+import subprocess
 
 # Constants
 END_OF_CONVO = "EOC"
@@ -17,6 +17,7 @@ CHROME_PATH = r'/Applications/Google\ Chrome.app/Contents/MacOS//Google\ Chrome'
 
 ALT_EMOJI_IMG = "https://pbs.twimg.com/media/DUzY3TpWkAAOi34.png"
 HUMAN_EMOJI_IMG = "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/160/apple/76/woman_1f469.png"
+
 
 def gen_convo_ul(conversations):
     """
@@ -250,5 +251,7 @@ if __name__ == "__main__":
                     cmd = f"{CHROME_PATH} --headless --crash-dumps-dir=/tmp --print-to-pdf=\"{output_file}\" {fname}"
                 else:
                     cmd = f"{CHROME_PATH} --headless --crash-dumps-dir=/tmp --screenshot=\"{output_file}\" {fname}"
-                os.system(cmd)
+                subprocess.run(
+                    cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+                )
                 file_handle.close()

--- a/parlai/scripts/convo_render.py
+++ b/parlai/scripts/convo_render.py
@@ -258,7 +258,7 @@ def check_icon_arg(src, default):
             if os.path.isabs(src):
                 src = "file://" + src
             else:
-                raise Exception(
+                raise IOError(
                     f"Please provide a valid URL or valid *absolute* path to icon: {src}"
                 )
     return src
@@ -272,7 +272,7 @@ def validate_args(args):
     :return: Returns extension of output file. None if no output file
     """
     if not os.path.exists(args.input):
-        raise Exception("Input File does not exist")
+        raise IOError("Input File does not exist")
     if args.output is None:
         return None
     extension = args.output.split(".")[-1]

--- a/parlai/scripts/convo_render.py
+++ b/parlai/scripts/convo_render.py
@@ -15,6 +15,8 @@ import tempfile
 END_OF_CONVO = "EOC"
 CHROME_PATH = r'/Applications/Google\ Chrome.app/Contents/MacOS//Google\ Chrome'
 
+ALT_EMOJI_IMG = "https://pbs.twimg.com/media/DUzY3TpWkAAOi34.png"
+HUMAN_EMOJI_IMG = "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/160/apple/76/woman_1f469.png"
 
 def gen_convo_ul(conversations):
     """
@@ -26,9 +28,19 @@ def gen_convo_ul(conversations):
     ul_str = f"\t<ul>\n"
     for speaker, speech in conversations:
         if speaker == END_OF_CONVO:
-            ul_str += f"\t\t<li class=\"breaker\"><hr/></li>\n"
+            ul_str += f"\n\t  <li class=\"breaker\"><hr/></li>\n"
         else:
-            ul_str += f"\t\t<li class=\"{speaker}\">{speech}</li>\n"
+            ul_str += f"""
+    <li>
+        <div class="{speaker}_img_div">
+            <img class="{speaker}_img">
+        </div>
+        <div class="{speaker}_p_div">
+            <p class="{speaker}">{speech}</p>
+        </div>
+        <div class="clear"></div>
+    </li>
+    """
     ul_str += "\t</ul>"
 
     return ul_str
@@ -61,17 +73,40 @@ def gen_html(conversations, height, width, title, other_speaker, human_speaker):
             @page{{ margin: 0; size: {str(width)}in {str(height)}in; }}
         }}
         ul{{
-            list-style: none;
-            margin: 0;
-            padding: 0;
+          list-style: none;
         }}
-        ul li{{
-            display:inline-block;
+        .{other_speaker}_img_div{{
+          display: inline-block;
+          float: left;
+          margin: 18px 5px 0px -25px;
+        }}
+        .{human_speaker}_img_div{{
+          display: inline-block;
+          float: right;
+          margin: 18px 15px 5px 5px;
+        }}
+        .{other_speaker}_img{{
+            content:url({ALT_EMOJI_IMG});
+        }}
+        .{human_speaker}_img{{
+            content:url({HUMAN_EMOJI_IMG});
+        }}
+        .{other_speaker}_p_div{{
+          float: left;
+        }}
+        .{human_speaker}_p_div{{
+          float:right;
+        }}
+        p{{
+          display:inline-block;
+          overflow-wrap: break-word;
+          border-radius: 30px;
+          padding: 10px 10px 10px 10px;
+          font-family: Helvetica, Arial, sans-serif;
+        }}
+        .clear{{
+            float: none;
             clear: both;
-            padding: 20px;
-            border-radius: 30px;
-            margin-bottom: 2px;
-            font-family: Helvetica, Arial, sans-serif;
         }}
         .{other_speaker}{{
                 background: #eee;
@@ -89,6 +124,11 @@ def gen_html(conversations, height, width, title, other_speaker, human_speaker):
             margin: 20px 20px 20px 20px;
             text-align: center;
             text-transform: uppercase;
+        }}
+        img{{
+          border-radius: 50px;
+          width: 30;
+          height: 30;
         }}
     </style>
 </head>

--- a/parlai/scripts/convo_render.py
+++ b/parlai/scripts/convo_render.py
@@ -216,6 +216,13 @@ if __name__ == "__main__":
         type=int,
         default=10,
     )
+    parser.add_argument(
+        "--window-size",
+        "-ws",
+        help="Window Size for screenshot",
+        nargs='+',
+        default=[800, 480],
+    )
 
     args = parser.parse_args()
     input_file, output_file = args.input, args.output
@@ -250,7 +257,16 @@ if __name__ == "__main__":
                 if extension == "pdf":
                     cmd = f"{CHROME_PATH} --headless --crash-dumps-dir=/tmp --print-to-pdf=\"{output_file}\" {fname}"
                 else:
-                    cmd = f"{CHROME_PATH} --headless --crash-dumps-dir=/tmp --screenshot=\"{output_file}\" {fname}"
+                    if len(args.window_size) != 2:
+                        raise Exception("Invalid window size provided")
+                    if (
+                        not args.window_size[0].isdigit()
+                        or not args.window_size[1].isdigit()
+                    ):
+                        raise ValueError(
+                            "Please provide integer values for window size"
+                        )
+                    cmd = f"{CHROME_PATH} --headless --crash-dumps-dir=/tmp --window-size={args.window_size[0]},{args.window_size[1]} --screenshot=\"{output_file}\" {fname}"
                 subprocess.run(
                     cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
                 )

--- a/parlai/scripts/convo_render.py
+++ b/parlai/scripts/convo_render.py
@@ -325,7 +325,8 @@ if __name__ == "__main__":
                     cmd = f"{CHROME_PATH} --headless --crash-dumps-dir=/tmp \
                      --print-to-pdf=\"{output_file}\" {fname}"
                 else:
-                    cmd = f"{CHROME_PATH} --headless --crash-dumps-dir=/tmp \
+                    cmd = f"{CHROME_PATH} --headless --hide-scrollbars \
+                    --crash-dumps-dir=/tmp \
                      --window-size={args.width * 100},{args.height * 100} \
                       --screenshot=\"{output_file}\" {fname}"
                 subprocess.run(


### PR DESCRIPTION
**Patch description**
Builds upon #2035 in order to complete other tasks remaining in #2021 
In this PR:
- Add images to the conversation
- Add CL argument to control size for screenshots
- Mute headless logging

**Testing steps**
Assuming the jsonl file is created already, the following command can be used to generate a screenshot of dimensions 800 X 590
```bash
python convo_render.py inquisitive_model_ct_setting10.jsonl -o out.png -ws 800 590
```

**Logs**
out.png from the previous command:
![amb](https://user-images.githubusercontent.com/18496064/66248059-81755280-e6f0-11e9-922e-56571cb426cf.png)


**Other information**
Following up on other tasks:
- I tried researching but couldn't find a way to make the background transparent using headless chrome, if you know of a way please let me know!
- Window size seems to be useful only for screenshots, the PDF size is predetermined by the height and width parameter of the HTML page (already have args for these)
- Currently in a screenshot one can see the scroller on the top right. Minor issue but not sure how to get rid of that, just the way headless works.
- @klshuster could you elaborate on the image and captioning task and how you want it to look like ? Maybe even provide a sample dataset that can be considered to be the standard going ahead.
