### PR TITLE
Escape emoji.

### DIFF
--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -25,7 +25,8 @@ class TestDictionary(unittest.TestCase):
         opt = Opt({'dict_tokenizer': 'gpt2', 'datapath': './data'})
         agent = DictionaryAgent(opt)
         self.assertEqual(
-            agent.gpt2_tokenize(u'Hello, ParlAI! 😀'),
+            # grinning face emoji
+            agent.gpt2_tokenize(u'Hello, ParlAI! \U0001f600'),
             [
                 'Hello',
                 ',',
@@ -50,7 +51,8 @@ class TestDictionary(unittest.TestCase):
                     r'\xc4\xa2',
                 ]
             ),
-            u'Hello, ParlAI! 😀',
+            # grinning face emoji
+            u'Hello, ParlAI! \U0001f600',
         )
 
     def test_space_tokenize(self):


### PR DESCRIPTION
**Patch description**
Unfortunately, due to a local configuration issue, my environment does not render the emoji, which is a little obnoxious. Rather than spend a day trying to fix the configuration of the jumphost, I'm requesting we just escape the unicode here.

**Testing steps**
tests/test_dict.py