### PR TITLE
Bad inputs for vec2txt for GPT-2 dictionary.

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -722,7 +722,7 @@ class DictionaryAgent(Agent):
         separated by the delimiter (default ``' '``).
         """
         if self.tokenizer == 'gpt2' and not self.opt.get('bpe_debug', False):
-            return self.gpt2_bpe.decode(vector)
+            return self.gpt2_bpe.decode(self[int(idx)] for idx in vector)
         # if we want to debug into this gpt2 bpe, you will get next line
         text = delimiter.join(self[int(idx)] for idx in vector)
         # if we used a BPE tokenizer we need to rejoin the encodings

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -39,7 +39,8 @@ class TestDictionary(unittest.TestCase):
         )
         self.assertEqual(
             agent.vec2txt(
-                [
+                agent.tok2ind[w]
+                for w in [
                     'Hello',
                     ',',
                     r'\xc4\xa0Par',


### PR DESCRIPTION
**Patch description**
vec2txt was assuming words in, instead of IDs as is actually used.