### PR TITLE
[TA] rename num_updates report key to total_train_updates.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -999,7 +999,7 @@ class TorchAgent(ABC, Agent):
         if hasattr(self, 'scheduler') and self.scheduler is not None:
             current_lr = round_sigfigs(self.optimizer.param_groups[0]['lr'], 4)
             metrics['lr'] = round_sigfigs(current_lr, 4)
-        metrics['num_updates'] = self._number_training_updates
+        metrics['total_train_updates'] = self._number_training_updates
 
         steps = self.metrics['updates']
         if steps > 0 and self.opt.get('gradient_clip', -1) > 0:

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -39,7 +39,6 @@ from parlai.core.utils import (
     warn_once,
     round_sigfigs,
 )
-from parlai.core.distributed_utils import is_primary_worker
 
 try:
     import torch
@@ -1013,7 +1012,7 @@ class TorchAgent(ABC, Agent):
 
     def _gpu_usage(self):
         """
-        Computes GPU memory usage.
+        Compute GPU memory usage.
 
         Includes both allocated and cached memory; this should be close to the
         output of nvidia-smi, but not reflect of how much is currently demanded

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -248,7 +248,7 @@ model_list = [
             "-mf zoo:light/biranker_dialogue/model"
         ),
         "result": "{'exs': 6623, 'accuracy': 0.7586, 'f1': 0.7802, 'hits@1': 0.759, 'hits@5': 0.965,"  # noqa: E501
-        "'hits@10': 0.994, 'hits@100': 1.0, 'bleu': 0.7255, 'lr': 5e-05, 'num_updates': 15050,"  # noqa: E501
+        "'hits@10': 0.994, 'hits@100': 1.0, 'bleu': 0.7255, 'lr': 5e-05, 'total_train_updates': 15050,"  # noqa: E501
         "'examples': 6623, 'loss': 5307.0, 'mean_loss': 0.8013, 'mean_rank': 1.599, 'train_accuracy': 0}",  # noqa: E501
     },
     {
@@ -318,7 +318,7 @@ model_list = [
         ),
         "result2": (
             "[ Finished evaluating tasks ['convai2'] using datatype valid ]\n"
-            "{'exs': 7801, 'accuracy': 0.8942, 'f1': 0.9065, 'hits@1': 0.894, 'hits@5': 0.99, 'hits@10': 0.997, 'hits@100': 1.0, 'bleu': 0.8941, 'lr': 5e-09, 'num_updates': 0, 'examples': 7801, 'loss': 3004.0, 'mean_loss': 0.385, 'mean_rank': 1.234, 'mrr': 0.9359}"
+            "{'exs': 7801, 'accuracy': 0.8942, 'f1': 0.9065, 'hits@1': 0.894, 'hits@5': 0.99, 'hits@10': 0.997, 'hits@100': 1.0, 'bleu': 0.8941, 'lr': 5e-09, 'total_train_updates': 0, 'examples': 7801, 'loss': 3004.0, 'mean_loss': 0.385, 'mean_rank': 1.234, 'mrr': 0.9359}"
         ),
     },
     {
@@ -348,7 +348,7 @@ model_list = [
         ),
         "result2": (
             "[ Finished evaluating tasks ['convai2'] using datatype valid ]\n"
-            "{'exs': 7801, 'accuracy': 0.8686, 'f1': 0.8833, 'hits@1': 0.869, 'hits@5': 0.987, 'hits@10': 0.996, 'hits@100': 1.0, 'bleu': 0.8685, 'lr': 5e-09, 'num_updates': 0, 'examples': 7801, 'loss': 28.77, 'mean_loss': 0.003688, 'mean_rank': 1.301, 'mrr': 0.9197}"
+            "{'exs': 7801, 'accuracy': 0.8686, 'f1': 0.8833, 'hits@1': 0.869, 'hits@5': 0.987, 'hits@10': 0.996, 'hits@100': 1.0, 'bleu': 0.8685, 'lr': 5e-09, 'total_train_updates': 0, 'examples': 7801, 'loss': 28.77, 'mean_loss': 0.003688, 'mean_rank': 1.301, 'mrr': 0.9197}"
         ),
     },
     {
@@ -423,7 +423,7 @@ model_list = [
             "--round 3 -dt test -mf zoo:dialogue_safety/single_turn/model -bs 40"
         ),
         "result": (
-            "{'exs': 3000, 'accuracy': 0.9627, 'f1': 0.9627, 'bleu': 9.627e-10, 'lr': 5e-09, 'num_updates': 0, 'examples': 3000, 'mean_loss': 0.005441, 'class___notok___recall': 0.7833, 'class___notok___prec': 0.8333, 'class___notok___f1': 0.8076, 'class___ok___recall': 0.9826, 'class___ok___prec': 0.9761, 'class___ok___f1': 0.9793, 'weighted_f1': 0.9621}"
+            "{'exs': 3000, 'accuracy': 0.9627, 'f1': 0.9627, 'bleu': 9.627e-10, 'lr': 5e-09, 'total_train_updates': 0, 'examples': 3000, 'mean_loss': 0.005441, 'class___notok___recall': 0.7833, 'class___notok___prec': 0.8333, 'class___notok___f1': 0.8076, 'class___ok___recall': 0.9826, 'class___ok___prec': 0.9761, 'class___ok___f1': 0.9793, 'weighted_f1': 0.9621}"
         ),
     },
     {
@@ -440,7 +440,7 @@ model_list = [
             "python examples/eval_model.py -t dialogue_safety:multiturn -dt test -mf zoo:dialogue_safety/multi_turn/model --split-lines True -bs 40"
         ),
         "result": (
-            "{'exs': 3000, 'accuracy': 0.9317, 'f1': 0.9317, 'bleu': 9.317e-10, 'lr': 5e-09, 'num_updates': 0, 'examples': 3000, 'mean_loss': 0.008921, 'class___notok___recall': 0.7067, 'class___notok___prec': 0.6444, 'class___notok___f1': 0.6741, 'class___ok___recall': 0.9567, 'class___ok___prec': 0.9671, 'class___ok___f1': 0.9618, 'weighted_f1': 0.9331}"
+            "{'exs': 3000, 'accuracy': 0.9317, 'f1': 0.9317, 'bleu': 9.317e-10, 'lr': 5e-09, 'total_train_updates': 0, 'examples': 3000, 'mean_loss': 0.008921, 'class___notok___recall': 0.7067, 'class___notok___prec': 0.6444, 'class___notok___f1': 0.6741, 'class___ok___recall': 0.9567, 'class___ok___prec': 0.9671, 'class___ok___f1': 0.9618, 'weighted_f1': 0.9331}"
         ),
     },
 ]

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -80,8 +80,8 @@ class TestTransformerRanker(unittest.TestCase):
             )
             # make sure the number of updates is being tracked correctly
             self.assertGreater(
-                valid2['num_updates'],
-                valid1['num_updates'],
+                valid2['total_train_updates'],
+                valid1['total_train_updates'],
                 'Number of updates is not increasing',
             )
             # make sure the learning rate is decreasing
@@ -476,8 +476,8 @@ def test_learning_rate_resuming(self, args):
         )
         # make sure the number of updates is being tracked correctly
         self.assertGreater(
-            valid2['num_updates'],
-            valid1['num_updates'],
+            valid2['total_train_updates'],
+            valid1['total_train_updates'],
             '({}) Number of updates is not increasing'.format(mdl),
         )
         # make sure the learning rate is decreasing
@@ -497,9 +497,10 @@ def test_learning_rate_resuming(self, args):
             )
         )
         self.assertEqual(
-            valid3['num_updates'],
-            valid1['num_updates'],
-            '({}) Finetuning LR scheduler reset failed ' '(num_updates).'.format(mdl),
+            valid3['total_train_updates'],
+            valid1['total_train_updates'],
+            '({}) Finetuning LR scheduler reset failed '
+            '(total_train_updates).'.format(mdl),
         )
         self.assertEqual(
             valid3['lr'],
@@ -516,9 +517,9 @@ def test_learning_rate_resuming(self, args):
             )
         )
         self.assertEqual(
-            valid4['num_updates'],
-            valid1['num_updates'],
-            '({}) LR scheduler change reset failed (num_updates).'
+            valid4['total_train_updates'],
+            valid1['total_train_updates'],
+            '({}) LR scheduler change reset failed (total_train_updates).'
             '\n{}'.format(mdl, stdout4),
         )
         self.assertEqual(


### PR DESCRIPTION
**Patch description**
Fixes #2046. Renames the report `num_updates` to `total_train_updates` to lower the risk of user confusion.

**Testing steps**
CircleCI.