### PR TITLE
Suppress verbose tests and Make minor nits

### DIFF
--- a/parlai/agents/tfidf_retriever/build_db.py
+++ b/parlai/agents/tfidf_retriever/build_db.py
@@ -16,12 +16,10 @@ from tqdm import tqdm
 from collections import deque
 import random
 from parlai.core.agents import create_task_agent_from_taskname
-from parlai.utils.logging import ParlaiLogger, INFO
+from parlai.utils.logging import logger
 
 fmt = '%(asctime)s: [ %(message)s ]'
-logger = ParlaiLogger(
-    name=__name__, console_level=INFO, console_format=fmt, file_format=fmt
-)
+logger.set_format(fmt)
 
 # ------------------------------------------------------------------------------
 # Store corpus.

--- a/parlai/agents/tfidf_retriever/build_tfidf.py
+++ b/parlai/agents/tfidf_retriever/build_tfidf.py
@@ -23,12 +23,10 @@ from collections import Counter
 from . import utils
 from .doc_db import DocDB
 from . import tokenizers
-from parlai.utils.logging import ParlaiLogger, INFO
+from parlai.utils.logging import logger
 
 fmt = '%(asctime)s: [ %(message)s ]'
-logger = ParlaiLogger(
-    name=__name__, console_level=INFO, console_format=fmt, file_format=fmt
-)
+logger.set_format(fmt)
 # ------------------------------------------------------------------------------
 # Multiprocessing functions
 # ------------------------------------------------------------------------------

--- a/parlai/utils/distributed.py
+++ b/parlai/utils/distributed.py
@@ -16,7 +16,6 @@ import builtins
 import pickle
 import contextlib
 
-# from parlai.utils.logging import logger # TODO: Uncomment before completion of #2044
 try:
     import torch.version
     import torch.distributed as dist
@@ -105,37 +104,6 @@ def override_print(suppress=False, prefix=None):
     yield
     # bring it back at the end of the context
     builtins.print = builtin_print
-
-
-# # TODO: Replace override_print with this version before completing #2044
-# # TODO: Uncomment import statement at the top
-# # TODO: IDEA: Pass logger object as parameter to thi function
-# @contextlib.contextmanager
-# def override_print(suppress=False, prefix=None):
-#     """
-#     Context manager to override the logger to suppress or modify output.
-#
-#     Recommended usage is to call this with suppress=True for all non-primary workers,
-#     or call with a prefix of rank on all workers.
-#
-#     >>> with override_print(prefix="rank{}".format(rank)):
-#     ...     my_computation()
-#
-#     :param bool suppress:
-#         if true, all future log statements are noops.
-#     :param str prefix:
-#         if not None, this string is prefixed to all future log statements.
-#     """
-#     Alternative implementation: To be used when switched to all-logging
-#     if suppress:
-#         logger.disabled = True
-#     elif prefix:
-#         logger.add_format_prefix(prefix)
-#     else:
-#         pass  # do nothing
-#     yield
-#     logger.disabled = False
-#     logger.reset_formatters()
 
 
 def all_gather_list(data, max_size=16384):

--- a/parlai/utils/logging.py
+++ b/parlai/utils/logging.py
@@ -113,6 +113,12 @@ class ParlaiLogger(logging.Logger):
             updatedFileFormat = ':'.join(prevFileFormat)
             self.fileHandler.setFormatter(logging.Formatter(updatedFileFormat))
 
+    def set_format(self, fmt):
+        """Set format after instantiation"""
+        self.streamHandler.setFormatter(logging.Formatter(fmt))
+        if hasattr(self, 'fileHandler'):
+            self.fileHandler.setFormatter(logging.Formatter(fmt))
+
     def reset_formatters(self):
         """Resort back to initial formatting."""
         if hasattr(self, 'fileHandler'):

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -15,7 +15,6 @@ import shutil
 import io
 from typing import Tuple
 
-# from parlai.utils.logging import logger # TODO: Uncomment before completion of #2044
 
 try:
     import torch
@@ -187,29 +186,6 @@ def capture_output():
     sio = TeeStringIO()
     with contextlib.redirect_stdout(sio), contextlib.redirect_stderr(sio):
         yield sio
-
-
-# # TODO: Replace capture_output with this version before completing #2044
-# # TODO: Uncomment import statement at the top
-# # TODO: IDEA: Pass logger object as parameter to thi function
-# @contextlib.contextmanager
-# def capture_output():
-#     """
-#     Suppress all logging output into a single buffer.
-#
-#     Use as a context manager.
-#
-#     >>> with capture_output() as output:
-#     ...     logger.info('hello')
-#     >>> output.getvalue()
-#     'hello'
-#     """
-#     sio = TeeStringIO()
-#     previous_level = logger.mute()  # Stop logging to stdout
-#     logger.redirect_out(sio)  # Instead log to sio (to preserve output for later)
-#     yield sio
-#     logger.stop_redirect_out()  # Stop redirecting [Removes handler]
-#     logger.unmute(previous_level)  # From now on log to stdout
 
 
 @contextlib.contextmanager

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -22,8 +22,9 @@ class TestDictionary(unittest.TestCase):
     """Basic tests on the built-in parlai Dictionary."""
 
     def test_gpt2_bpe_tokenize(self):
-        opt = Opt({'dict_tokenizer': 'gpt2', 'datapath': './data'})
-        agent = DictionaryAgent(opt)
+        with testing_utils.capture_output():
+            opt = Opt({'dict_tokenizer': 'gpt2', 'datapath': './data'})
+            agent = DictionaryAgent(opt)
         self.assertEqual(
             agent.gpt2_tokenize(u'Hello, ParlAI! 😀'),
             [

--- a/tests/test_tfidf_retriever.py
+++ b/tests/test_tfidf_retriever.py
@@ -7,12 +7,12 @@
 from parlai.core.params import ParlaiParser
 from parlai.core.agents import create_agent
 from parlai.core.worlds import create_task
+from parlai.utils.logging import logger, ERROR
 
 import os
 import unittest
 import contextlib
 import io
-import logging
 
 SKIP_TESTS = False
 try:
@@ -32,8 +32,7 @@ class TestTfidfRetriever(unittest.TestCase):
         DB_PATH = '/tmp/tmp_test_babi.db'
         TFIDF_PATH = '/tmp/tmp_test_babi.tfidf'
         # keep things quiet
-        logger = logging.getLogger('parlai.agents.tfidf_retriever.build_tfidf')
-        logger.setLevel(logging.ERROR)
+        logger.setLevel(ERROR)
         try:
             parser = ParlaiParser(True, True)
             parser.set_defaults(

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -985,23 +985,24 @@ class TestTorchAgent(unittest.TestCase):
 class TestLegacyVersioning(unittest.TestCase):
     def test_legacy_version(self):
         # simply tries to load and run some models with versioning attached
-        with self.assertRaises(RuntimeError):
+        with capture_output():
+            with self.assertRaises(RuntimeError):
+                testing_utils.display_model(
+                    {
+                        'model_file': 'models:convai2/seq2seq/convai2_self_seq2seq_model',
+                        'task': 'convai2',
+                        'no_cuda': True,
+                    }
+                )
+
             testing_utils.display_model(
                 {
+                    'model': 'legacy:seq2seq:0',
                     'model_file': 'models:convai2/seq2seq/convai2_self_seq2seq_model',
                     'task': 'convai2',
                     'no_cuda': True,
                 }
             )
-
-        testing_utils.display_model(
-            {
-                'model': 'legacy:seq2seq:0',
-                'model_file': 'models:convai2/seq2seq/convai2_self_seq2seq_model',
-                'task': 'convai2',
-                'no_cuda': True,
-            }
-        )
 
 
 if __name__ == '__main__':

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -8,7 +8,7 @@
 
 import os
 import unittest
-from parlai.core.agents import Agent, create_agent_from_shared
+from parlai.core.agents import create_agent_from_shared
 from parlai.utils.testing import capture_output, tempdir
 from parlai.utils.misc import Message
 import parlai.utils.testing as testing_utils


### PR DESCRIPTION
**Patch description**
While working on another branch I realized that Circle CI tests were being verbose in some cases. This PR is to fix that and other stuff needed to do that:
- tfidf_retriever test had some issue related to logging which was resulting in it not properly suppressing output during the circle CI run, fixed that
- legacy versioning was also quite verbose, added a capture_output around that. I assumed here that we do not want any output in the tests and hence did that, let me know if I was wrong in doing so.
- A gpt-2 test was also spitting out output, so silenced that as well
- Since I was making a PR regarding these small nits, I thought might as well remove the comments you asked me not to be there @stephenroller in testing_utils and distributed_utils.

**Testing steps**
Run the unit tests. None of them should be verbose, i.e. all contain just the name of the test and an 'ok' once completed.

**Logs**
N/A

**Other information**
One thing that **still remains** that I found was that the quickstart test recently added by is also quite verbose. Refer to #2075 for further details.

**Data tests (if applicable)**
N/A
