### PR TITLE
Decrease runtime of quickstart test and move to nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,9 +182,6 @@ jobs:
       - run:
           name: Unit tests (GPU; pytorch 1.1)
           command: python setup.py test -s tests.suites.unittests -v
-      - run:
-          name: Quickstart unit tests (GPU; pytorch 1.1)
-          command: sh tests/test_quickstart.sh
 
   unittests_gpu12:
     <<: *gpu
@@ -199,9 +196,6 @@ jobs:
       - run:
           name: Unit tests (GPU; pytorch 1.2)
           command: python setup.py test -s tests.suites.unittests -v
-      - run:
-          name: Quickstart unit tests (GPU; pytorch 1.1)
-          command: sh tests/test_quickstart.sh
 
   black:
     <<: *standard_cpu36
@@ -260,6 +254,9 @@ jobs:
           name: Nightly GPU tests
           no_output_timeout: 60m
           command: python setup.py test -s tests.suites.nightly_gpu -v
+      - run:
+          name: Quickstart unit tests (GPU; pytorch 1.1)
+          command: sh tests/test_quickstart.sh
 
   mturk_tests:
     <<: *standard_cpu36

--- a/tests/test_quickstart.sh
+++ b/tests/test_quickstart.sh
@@ -13,7 +13,7 @@ python examples/display_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -ecands v
 # train a transformer on twitter
 pip3 install emoji unidecode
 python examples/display_data.py -t twitter
-python examples/train_model.py -t twitter -mf /tmp/tr_twitter -m transformer/ranker -bs 10 -vtim 3600 -cands batch -ecands batch --data-parallel True --num-epochs 0.001 -nl 1 --dict-tokenizer split -emb fasttext --ffn-size 128
+python examples/train_model.py -t twitter -mf /tmp/tr_twitter -m transformer/ranker -bs 10 -vtim 3600 -cands batch -ecands batch --data-parallel True --max-train-time 20 -nl 1 --dict-tokenizer split -emb fasttext --ffn-size 128
 python examples/eval_model.py -t twitter -bs 50 -m legacy:seq2seq:0 -mf models:convai2/seq2seq/convai2_self_seq2seq_model --num-examples 1
 python examples/display_model.py -t twitter -mf /tmp/tr_twitter -ecands batch
 

--- a/tests/test_quickstart.sh
+++ b/tests/test_quickstart.sh
@@ -13,8 +13,8 @@ python examples/display_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -ecands v
 # train a transformer on twitter
 pip3 install emoji unidecode
 python examples/display_data.py -t twitter
-python examples/train_model.py -t twitter -mf /tmp/tr_twitter -m transformer/ranker -bs 10 -vtim 3600 -cands batch -ecands batch --data-parallel True --num-epochs 0.01
-python examples/eval_model.py -t twitter -bs 50 -m legacy:seq2seq:0 -mf models:convai2/seq2seq/convai2_self_seq2seq_model
+python examples/train_model.py -t twitter -mf /tmp/tr_twitter -m transformer/ranker -bs 10 -vtim 3600 -cands batch -ecands batch --data-parallel True --num-epochs 0.01 -nl 1 --dict-tokenizer split -emb fasttext --ffn-size 128
+python examples/eval_model.py -t twitter -bs 50 -m legacy:seq2seq:0 -mf models:convai2/seq2seq/convai2_self_seq2seq_model --num-examples 1
 python examples/display_model.py -t twitter -mf /tmp/tr_twitter -ecands batch
 
 # add a simple model

--- a/tests/test_quickstart.sh
+++ b/tests/test_quickstart.sh
@@ -13,7 +13,7 @@ python examples/display_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -ecands v
 # train a transformer on twitter
 pip3 install emoji unidecode
 python examples/display_data.py -t twitter
-python examples/train_model.py -t twitter -mf /tmp/tr_twitter -m transformer/ranker -bs 10 -vtim 3600 -cands batch -ecands batch --data-parallel True --max-train-time 20 -nl 1 --dict-tokenizer split -emb fasttext --ffn-size 128
+python examples/train_model.py -t twitter -mf /tmp/tr_twitter -m transformer/ranker -bs 10 -vtim 3600 -cands batch -ecands batch --data-parallel True --max-train-time 20 -nl 1 --dict-tokenizer split -emb random --ffn-size 128
 python examples/eval_model.py -t twitter -bs 50 -m legacy:seq2seq:0 -mf models:convai2/seq2seq/convai2_self_seq2seq_model --num-examples 1
 python examples/display_model.py -t twitter -mf /tmp/tr_twitter -ecands batch
 

--- a/tests/test_quickstart.sh
+++ b/tests/test_quickstart.sh
@@ -13,7 +13,7 @@ python examples/display_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -ecands v
 # train a transformer on twitter
 pip3 install emoji unidecode
 python examples/display_data.py -t twitter
-python examples/train_model.py -t twitter -mf /tmp/tr_twitter -m transformer/ranker -bs 10 -vtim 3600 -cands batch -ecands batch --data-parallel True --num-epochs 0.01 -nl 1 --dict-tokenizer split -emb fasttext --ffn-size 128
+python examples/train_model.py -t twitter -mf /tmp/tr_twitter -m transformer/ranker -bs 10 -vtim 3600 -cands batch -ecands batch --data-parallel True --num-epochs 0.001 -nl 1 --dict-tokenizer split -emb fasttext --ffn-size 128
 python examples/eval_model.py -t twitter -bs 50 -m legacy:seq2seq:0 -mf models:convai2/seq2seq/convai2_self_seq2seq_model --num-examples 1
 python examples/display_model.py -t twitter -mf /tmp/tr_twitter -ecands batch
 


### PR DESCRIPTION
**Patch description**
As noted in #2075, `quickstart.sh` currently takes around [40 minutes](https://app.circleci.com/jobs/github/facebookresearch/ParlAI/14942) to run. 

This PR lowers the time to [20 minutes](https://app.circleci.com/jobs/github/facebookresearch/ParlAI/15206), a majority of which is accomplished by setting `num_epochs` to `0.01`.

**Testing steps**

CircleCI

**Logs**

N/A

**Other information**

The majority of time is now spent downloading the `twitter` dataset, so I think the main speedup would be from switching to a smaller dataset.

**Data tests (if applicable)**

N/A