### PR TITLE
Update NVIDIA drivers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,9 +99,9 @@ setupcuda: &setupcuda
     working_directory: ~/
     command: |
       # download and install nvidia drivers, cuda, etc
-      wget -q 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.50.run'
-      sudo /bin/bash ./NVIDIA-Linux-x86_64-430.50.run -s --no-drm
-      wget -q https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-ubuntu1404-10-1-local-10.1.243-418.87.00_1.0-1_amd64.deb
+      wget -q 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.40.run'
+      sudo /bin/bash ./NVIDIA-Linux-x86_64-430.40.run -s --no-drm
+      wget -q https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-ubuntu1404-10-1-local-10.1.243-418.87.00_1.0-1_amd64.deb
       sudo dpkg -i cuda-repo-ubuntu1404-10-1-local-10.1.243-418.87.00_1.0-1_amd64.deb
       sudo apt-key add /var/cuda-repo-10-1-local-10.1.243-418.87.00/7fa2af80.pub
       nvidia-smi
@@ -197,7 +197,7 @@ jobs:
       - <<: *installdeps
       - <<: *installtorchgpu12
       - run:
-          name: Unit tests (GPU; pytorch 1.2)
+          name: Unit tests (GPU; pytorch >= 1.2)
           command: python setup.py test -s tests.suites.unittests -v
       - run:
           name: Quickstart unit tests (GPU; pytorch 1.1)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ installtorchgpu12: &installtorchgpu12
   run:
     name: Install torch GPU and dependencies
     command: |
-      pip3 install --progress-bar off https://download.pytorch.org/whl/cu100/torch-1.3.0%2Bcu100-cp36-cp36m-linux_x86_64.whl
+      pip3 install --progress-bar off 'torch>=1.2.0'
       pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off torchtext
@@ -99,11 +99,11 @@ setupcuda: &setupcuda
     working_directory: ~/
     command: |
       # download and install nvidia drivers, cuda, etc
-      wget -q 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-410.79.run'
-      sudo /bin/bash ./NVIDIA-Linux-x86_64-410.79.run -s --no-drm
-      wget -q https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-ubuntu1404-10-1-local-10.1.105-418.39_1.0-1_amd64.deb
-      sudo dpkg -i cuda-repo-ubuntu1404-10-1-local-10.1.105-418.39_1.0-1_amd64.deb
-      sudo apt-key add /var/cuda-repo-10-1-local-10.1.105-418.39/7fa2af80.pub
+      wget -q 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.50.run'
+      sudo /bin/bash ./NVIDIA-Linux-x86_64-430.50.run -s --no-drm
+      wget http://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-ubuntu1404-10-1-local-10.1.243-418.87.00_1.0-1_amd64.deb
+      sudo dpkg -i cuda-repo-ubuntu1404-10-1-local-10.1.243-418.87.00_1.0-1_amd64.deb
+      sudo apt-key add /var/cuda-repo-10-1-local-10.1.243-418.87.00/7fa2af80.pub
       nvidia-smi
       pyenv global 3.6.5
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ setupcuda: &setupcuda
       # download and install nvidia drivers, cuda, etc
       wget -q 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.50.run'
       sudo /bin/bash ./NVIDIA-Linux-x86_64-430.50.run -s --no-drm
-      wget http://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-ubuntu1404-10-1-local-10.1.243-418.87.00_1.0-1_amd64.deb
+      wget -q https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-ubuntu1404-10-1-local-10.1.243-418.87.00_1.0-1_amd64.deb
       sudo dpkg -i cuda-repo-ubuntu1404-10-1-local-10.1.243-418.87.00_1.0-1_amd64.deb
       sudo apt-key add /var/cuda-repo-10-1-local-10.1.243-418.87.00/7fa2af80.pub
       nvidia-smi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ installtorchgpu12: &installtorchgpu12
   run:
     name: Install torch GPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch>=1.2.0'
+      pip3 install --progress-bar off https://download.pytorch.org/whl/cu100/torch-1.3.0%2Bcu100-cp36-cp36m-linux_x86_64.whl
       pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off torchtext


### PR DESCRIPTION
**Patch description**
As mentioned in #2080 CUDA is not being properly installed with the existing ```installtorchgpu12``` command. This has occurred since the release of pytorch 1.3.

~~In this PR I have included a fix/workaround for that by specifying the exact link for the cuda installation file rather than just pip install torch. But maybe there is a better solution to that.~~

Further discussion on this PR revealed that stale GPU drivers maybe the problem and turns out that indeed that was the case. Updated the drivers to install the latest one available for a linux distribution (430.40) and looks like things are working as normal again.

 Looping in @EricMichaelSmith on this PR as requested by stephen.

**Testing steps**
gpu12 and nightly tests should work as expected

**Logs**
N/A

**Other information**
N/A

**Data tests (if applicable)**
N/A