### PR TITLE
[Bug FIx]Rouge metrics are computed but not reported.

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -400,6 +400,13 @@ class Metrics(object):
                     m['f1'] = round_sigfigs(
                         self.metrics['f1'] / max(1, self.metrics['f1_cnt']), 4
                     )
+                if 'rouge' in self.metrics_list:
+                    for each_rouge in ROUGE_METRICS:
+                        m[each_rouge] = round_sigfigs(
+                            self.metrics[each_rouge]
+                            / max(1, self.metrics['{}_cnt'.format(each_rouge)]),
+                            4,
+                        )
             if self.flags['has_text_cands']:
                 for k in self.eval_pr:
                     m['hits@' + str(k)] = round_sigfigs(


### PR DESCRIPTION
**Patch description**
As stating in the title.
**Test**
Run any eval_model with --metrics all
