### PR TITLE
Empty/None string bugs fixed for cornell_movie DoubleTeacher.

### DIFF
--- a/parlai/tasks/cornell_movie/agents.py
+++ b/parlai/tasks/cornell_movie/agents.py
@@ -41,20 +41,15 @@ class DoubleTeacher(DefaultTeacher):
 
         Creates the additional dialog:
 
-        '' x1
         y1 x2
         y2 x3
 
-        And if a y3 was available in response to x3, also would have added:
-
-        y3
         """
 
         def rebuild(entries):
+
             new_list = []
             if len(entries) > 0:
-                # prepend silent input => x_0
-                new_list.append(('', [entries[0][0]]))
 
                 # add all ( y_t => x_(t+1) ) pairs
                 new_list.extend(
@@ -63,20 +58,25 @@ class DoubleTeacher(DefaultTeacher):
                         for i in range(len(entries) - 1)
                     ]
                 )
-                if len(entries[-1]) > 1 and entries[-1][1]:
-                    # add y_n => '', if last y avail
-                    new_list.append((entries[-1][1][0], None))
             return new_list
+
+        def is_valid(entry):
+            if entry[0] == '' or entry[1] is None:
+                return False
+            return True
 
         # this shows conversations in both directions
         alternate = []
         for entry, new in super().setup_data(path):
             if new:
                 for i, e in enumerate(rebuild(alternate)):
-                    yield e, i == 0
+                    if is_valid(e):
+                        yield e, i == 0
                 alternate.clear()
             alternate.append(entry)
-            yield entry, new
+            if is_valid(entry):
+                yield entry, new
         if alternate:
             for i, e in enumerate(rebuild(alternate)):
-                yield e, i == 0
+                if is_valid(e):
+                    yield e, i == 0

--- a/parlai/tasks/cornell_movie/agents.py
+++ b/parlai/tasks/cornell_movie/agents.py
@@ -31,6 +31,23 @@ class DoubleTeacher(DefaultTeacher):
     speakers.
     """
 
+    def _rebuild(self, entries):
+        new_list = []
+        if len(entries) > 0:
+            # add all ( y_t => x_(t+1) ) pairs
+            new_list.extend(
+                [
+                    (entries[i][1][0], [entries[i + 1][0]])
+                    for i in range(len(entries) - 1)
+                ]
+            )
+        return new_list
+
+    def _is_valid(self, entry):
+        if entry[0] == '' or entry[1] is None:
+            return False
+        return True
+
     def setup_data(self, path):
         """Adds additional perspectives.
         For example, in the conversation:
@@ -45,38 +62,18 @@ class DoubleTeacher(DefaultTeacher):
         y2 x3
 
         """
-
-        def rebuild(entries):
-
-            new_list = []
-            if len(entries) > 0:
-
-                # add all ( y_t => x_(t+1) ) pairs
-                new_list.extend(
-                    [
-                        (entries[i][1][0], [entries[i + 1][0]])
-                        for i in range(len(entries) - 1)
-                    ]
-                )
-            return new_list
-
-        def is_valid(entry):
-            if entry[0] == '' or entry[1] is None:
-                return False
-            return True
-
         # this shows conversations in both directions
         alternate = []
         for entry, new in super().setup_data(path):
             if new:
-                for i, e in enumerate(rebuild(alternate)):
-                    if is_valid(e):
+                for i, e in enumerate(self._rebuild(alternate)):
+                    if self._is_valid(e):
                         yield e, i == 0
                 alternate.clear()
             alternate.append(entry)
-            if is_valid(entry):
+            if self._is_valid(entry):
                 yield entry, new
         if alternate:
-            for i, e in enumerate(rebuild(alternate)):
-                if is_valid(e):
+            for i, e in enumerate(self._rebuild(alternate)):
+                if self._is_valid(e):
                     yield e, i == 0


### PR DESCRIPTION
**Patch description**
For a dialogue as follows:
```
x1 y1
x2 y2
x3
```
The `DoubleTeacher` will create two problematic training pairs. These problems is especially obvious when using `batch_size = 1`.
The first is `['', x1]`. With an empty source sequence, the program crashes due to `batch.text_vec` and `batch.label_vec` are both `None`.
The second is `[x3, None]`. When this happens, `eval_step` function is called even when `model.training == True`.

Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here.

**Testing steps**
No

**Logs**
No

**Other information**
No

**Data tests (if applicable)**
```
running test
Searching for Unidecode==1.1.1
Best match: Unidecode 1.1.1
Processing Unidecode-1.1.1-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/Unidecode-1.1.1-py3.7.egg
Searching for tqdm==4.36.1
Best match: tqdm 4.36.1
Processing tqdm-4.36.1-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/tqdm-4.36.1-py3.7.egg
Searching for Sphinx==2.2.0
Best match: Sphinx 2.2.0
Processing Sphinx-2.2.0-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/Sphinx-2.2.0-py3.7.egg
Searching for scipy==1.3.1
Best match: scipy 1.3.1
Processing scipy-1.3.1-py3.7-macosx-10.7-x86_64.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/scipy-1.3.1-py3.7-macosx-10.7-x86_64.egg
Searching for scikit-learn==0.21.3
Best match: scikit-learn 0.21.3
Processing scikit_learn-0.21.3-py3.7-macosx-10.7-x86_64.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/scikit_learn-0.21.3-py3.7-macosx-10.7-x86_64.egg
Searching for requests-mock==1.7.0
Best match: requests-mock 1.7.0
Processing requests_mock-1.7.0-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/requests_mock-1.7.0-py3.7.egg
Searching for requests==2.22.0
Best match: requests 2.22.0
Processing requests-2.22.0-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/requests-2.22.0-py3.7.egg
Searching for regex==2019.8.19
Best match: regex 2019.8.19
Processing regex-2019.8.19-py3.7-macosx-10.7-x86_64.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/regex-2019.8.19-py3.7-macosx-10.7-x86_64.egg
Searching for pyzmq==18.1.0
Best match: pyzmq 18.1.0
Processing pyzmq-18.1.0-py3.7-macosx-10.7-x86_64.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/pyzmq-18.1.0-py3.7-macosx-10.7-x86_64.egg
Searching for pre-commit==1.18.3
Best match: pre-commit 1.18.3
Processing pre_commit-1.18.3-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/pre_commit-1.18.3-py3.7.egg
Searching for Pillow==6.2.0
Best match: Pillow 6.2.0
Processing Pillow-6.2.0-py3.7-macosx-10.7-x86_64.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/Pillow-6.2.0-py3.7-macosx-10.7-x86_64.egg
Searching for pexpect==4.7.0
Best match: pexpect 4.7.0
Processing pexpect-4.7.0-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/pexpect-4.7.0-py3.7.egg
Searching for numpy==1.17.2
Best match: numpy 1.17.2
Processing numpy-1.17.2-py3.7-macosx-10.7-x86_64.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/numpy-1.17.2-py3.7-macosx-10.7-x86_64.egg
Searching for nltk==3.4.5
Best match: nltk 3.4.5
Processing nltk-3.4.5-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/nltk-3.4.5-py3.7.egg
Searching for joblib==0.14.0
Best match: joblib 0.14.0
Processing joblib-0.14.0-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/joblib-0.14.0-py3.7.egg
Searching for h5py==2.10.0
Best match: h5py 2.10.0
Processing h5py-2.10.0-py3.7-macosx-10.7-x86_64.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/h5py-2.10.0-py3.7-macosx-10.7-x86_64.egg
Searching for GitPython==3.0.3
Best match: GitPython 3.0.3
Processing GitPython-3.0.3-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/GitPython-3.0.3-py3.7.egg
Searching for flake8-rst-docstrings==0.0.11
Best match: flake8-rst-docstrings 0.0.11
Processing flake8_rst_docstrings-0.0.11-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/flake8_rst_docstrings-0.0.11-py3.7.egg
Searching for flake8-docstrings==1.5.0
Best match: flake8-docstrings 1.5.0
Processing flake8_docstrings-1.5.0-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/flake8_docstrings-1.5.0-py3.7.egg
Searching for flake8-bugbear==19.8.0
Best match: flake8-bugbear 19.8.0
Processing flake8_bugbear-19.8.0-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/flake8_bugbear-19.8.0-py3.7.egg
Searching for emoji==0.5.4
Best match: emoji 0.5.4
Processing emoji-0.5.4-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/emoji-0.5.4-py3.7.egg
Searching for botocore==1.12.246
Best match: botocore 1.12.246
Processing botocore-1.12.246-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/botocore-1.12.246-py3.7.egg
Searching for boto3==1.9.246
Best match: boto3 1.9.246
Processing boto3-1.9.246-py3.7.egg

Using /Users/shaojie/src/ParlAI-1/.eggs/boto3-1.9.246-py3.7.egg
Searching for entrypoints<0.4.0,>=0.3.0
Best match: entrypoints 0.3
Processing entrypoints-0.3-py3.7.egg

Using /Users/shaojie/anaconda3/envs/newparlai/lib/python3.7/site-packages/entrypoints-0.3-py3.7.egg
running egg_info
writing parlai.egg-info/PKG-INFO
writing dependency_links to parlai.egg-info/dependency_links.txt
writing requirements to parlai.egg-info/requires.txt
writing top-level names to parlai.egg-info/top_level.txt
reading manifest file 'parlai.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'parlai.egg-info/SOURCES.txt'
running build_ext
test_verify_data (test_new_tasks.TestNewTasks) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.714s

OK
```
