### PR TITLE
[WIP] Swap step order

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1823,8 +1823,6 @@ class TorchAgent(ABC, Agent):
             if self._is_lr_warming_up():
                 self.warmup_scheduler.step(epoch=self._number_training_updates)
 
-       
-
         if self.fp16:
             # we've been accumulating grads in fp16 and delaying the fp32 copy update.
             # finally time to perform the update.
@@ -1841,7 +1839,7 @@ class TorchAgent(ABC, Agent):
             self.metrics['clip'] += float(grad_norm > self.opt['gradient_clip'])
 
         self.metrics['updates'] += 1
-        
+
         if self.opt.get('lr_scheduler') == 'invsqrt' and not self._is_lr_warming_up():
             # training step scheduler
             self.scheduler.step(self._number_training_updates)

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1811,6 +1811,8 @@ class TorchAgent(ABC, Agent):
             if self._number_grad_accum != 0:
                 return
 
+        self.optimizer.step()
+
         # keep track up number of steps, compute warmup factor
         self._number_training_updates += 1
 
@@ -1839,7 +1841,6 @@ class TorchAgent(ABC, Agent):
             self.metrics['clip'] += float(grad_norm > self.opt['gradient_clip'])
 
         self.metrics['updates'] += 1
-        self.optimizer.step()
         
         if self.opt.get('lr_scheduler') == 'invsqrt' and not self._is_lr_warming_up():
             # training step scheduler

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1811,22 +1811,6 @@ class TorchAgent(ABC, Agent):
             if self._number_grad_accum != 0:
                 return
 
-        self.optimizer.step()
-
-        # keep track up number of steps, compute warmup factor
-        self._number_training_updates += 1
-
-        # compute warmup adjustment if needed
-        if self.opt.get('warmup_updates', -1) > 0:
-            if not hasattr(self, 'warmup_scheduler'):
-                raise RuntimeError('Looks like you forgot to call build_lr_scheduler')
-            if self._is_lr_warming_up():
-                self.warmup_scheduler.step(epoch=self._number_training_updates)
-
-        if self.opt.get('lr_scheduler') == 'invsqrt' and not self._is_lr_warming_up():
-            # training step scheduler
-            self.scheduler.step(self._number_training_updates)
-
         if self.fp16:
             # we've been accumulating grads in fp16 and delaying the fp32 copy update.
             # finally time to perform the update.
@@ -1843,6 +1827,21 @@ class TorchAgent(ABC, Agent):
             self.metrics['clip'] += float(grad_norm > self.opt['gradient_clip'])
 
         self.metrics['updates'] += 1
+        self.optimizer.step()
+
+        # keep track up number of steps, compute warmup factor
+        self._number_training_updates += 1
+
+        # compute warmup adjustment if needed
+        if self.opt.get('warmup_updates', -1) > 0:
+            if not hasattr(self, 'warmup_scheduler'):
+                raise RuntimeError('Looks like you forgot to call build_lr_scheduler')
+            if self._is_lr_warming_up():
+                self.warmup_scheduler.step(epoch=self._number_training_updates)
+
+        if self.opt.get('lr_scheduler') == 'invsqrt' and not self._is_lr_warming_up():
+            # training step scheduler
+            self.scheduler.step(self._number_training_updates)
 
     def zero_grad(self):
         """

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1823,6 +1823,10 @@ class TorchAgent(ABC, Agent):
             if self._is_lr_warming_up():
                 self.warmup_scheduler.step(epoch=self._number_training_updates)
 
+        if self.opt.get('lr_scheduler') == 'invsqrt' and not self._is_lr_warming_up():
+            # training step scheduler
+            self.scheduler.step(self._number_training_updates)
+
         if self.fp16:
             # we've been accumulating grads in fp16 and delaying the fp32 copy update.
             # finally time to perform the update.
@@ -1839,10 +1843,6 @@ class TorchAgent(ABC, Agent):
             self.metrics['clip'] += float(grad_norm > self.opt['gradient_clip'])
 
         self.metrics['updates'] += 1
-
-        if self.opt.get('lr_scheduler') == 'invsqrt' and not self._is_lr_warming_up():
-            # training step scheduler
-            self.scheduler.step(self._number_training_updates)
 
     def zero_grad(self):
         """

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1821,9 +1821,7 @@ class TorchAgent(ABC, Agent):
             if self._is_lr_warming_up():
                 self.warmup_scheduler.step(epoch=self._number_training_updates)
 
-        if self.opt.get('lr_scheduler') == 'invsqrt' and not self._is_lr_warming_up():
-            # training step scheduler
-            self.scheduler.step(self._number_training_updates)
+       
 
         if self.fp16:
             # we've been accumulating grads in fp16 and delaying the fp32 copy update.
@@ -1842,6 +1840,10 @@ class TorchAgent(ABC, Agent):
 
         self.metrics['updates'] += 1
         self.optimizer.step()
+        
+        if self.opt.get('lr_scheduler') == 'invsqrt' and not self._is_lr_warming_up():
+            # training step scheduler
+            self.scheduler.step(self._number_training_updates)
 
     def zero_grad(self):
         """

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -578,27 +578,25 @@ class TestLearningRateScheduler(unittest.TestCase):
             num_epochs=9 / 500,
         )
 
-        with testing_utils.tempdir() as tmpdir:
-            model_file = os.path.join(tmpdir, 'model')
-            args['num_epochs'] = 9 / 500
-            args['validation_every_n_epochs'] = 9 / 500
-            stdout1, valid1, test1 = testing_utils.train_model(args)
-            args['num_epochs'] = 16 / 500
-            args['validation_every_n_epochs'] = 16 / 500
-            stdout2, valid2, test2 = testing_utils.train_model(args)
+        args['num_epochs'] = 9 / 500
+        args['validation_every_n_epochs'] = 9 / 500
+        stdout1, valid1, test1 = testing_utils.train_model(args)
+        args['num_epochs'] = 16 / 500
+        args['validation_every_n_epochs'] = 16 / 500
+        stdout2, valid2, test2 = testing_utils.train_model(args)
 
-            self.assertAlmostEqual(
-                valid1['lr'],
-                1 / 3,
-                msg='Invsqrt LR {} was not 1/3 at step 9'.format(valid1['lr']),
-                delta=0.001,
-            )
-            self.assertAlmostEqual(
-                valid2['lr'],
-                1 / 4,
-                msg='Invsqrt LR {} was not 1/4 at step 16'.format(valid2['lr']),
-                delta=0.001,
-            )
+        self.assertAlmostEqual(
+            valid1['lr'],
+            1 / 3,
+            msg='Invsqrt LR {} was not 1/3 at step 9'.format(valid1['lr']),
+            delta=0.001,
+        )
+        self.assertAlmostEqual(
+            valid2['lr'],
+            1 / 4,
+            msg='Invsqrt LR {} was not 1/4 at step 16'.format(valid2['lr']),
+            delta=0.001,
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -567,6 +567,39 @@ class TestLearningRateScheduler(unittest.TestCase):
         )
         test_learning_rate_resuming(self, RANKER_ARGS)
 
+    def test_invsqrt_learning_rate(self):
+        args = dict(
+            task='integration_tests:candidate',
+            model='transformer/generator',
+            learningrate=1,
+            batchsize=1,
+            warmup_updates=1,
+            lr_scheduler='invsqrt',
+            num_epochs=9 / 500,
+        )
+
+        with testing_utils.tempdir() as tmpdir:
+            model_file = os.path.join(tmpdir, 'model')
+            args['num_epochs'] = 9 / 500
+            args['validation_every_n_epochs'] = 9 / 500
+            stdout1, valid1, test1 = testing_utils.train_model(args)
+            args['num_epochs'] = 16 / 500
+            args['validation_every_n_epochs'] = 16 / 500
+            stdout2, valid2, test2 = testing_utils.train_model(args)
+
+            self.assertAlmostEqual(
+                valid1['lr'],
+                1 / 3,
+                msg='Invsqrt LR {} was not 1/3 at step 9'.format(valid1['lr']),
+                delta=0.001,
+            )
+            self.assertAlmostEqual(
+                valid2['lr'],
+                1 / 4,
+                msg='Invsqrt LR {} was not 1/4 at step 16'.format(valid2['lr']),
+                delta=0.001,
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Patch description**
As in #2042, lr_scheduler.step() was being called before optimizer.step() causing a pytorch warning to appear.

**Testing steps**
Ran `python examples/train_model.py -t convai2 -m transformer/ranker -mf /tmp/tr0 --lr_scheduler invsqrt --warmup_updates 50` and expected to not see any warnings about optimizer.step() after lr_scheduler.step() or other new warnings. 

**Logs**
`python examples/train_model.py -t convai2 -m transformer/ranker -mf /tmp/tr0 --lr_scheduler invsqrt --warmup_updates 50`

Optional arguments output and rest of training omitted
Before changes:
```
[loading fbdialog data:/home/dom/Documents/ParlAI/data/ConvAI2/train_self_original.txt]
[ training... ]
/home/dom/Documents/ParlAI/parlai/core/torch_ranker_agent.py:599: UserWarning: [ Executing train mode with provided inline set of candidates ]
  ''.format(mode)
/home/dom/.local/lib/python3.6/site-packages/torch/optim/lr_scheduler.py:100: UserWarning: Detected call of `lr_scheduler.step()` before `optimizer.step()`. In PyTorch 1.1.0 and later, you should call them in the opposite order: `optimizer.step()` before `lr_scheduler.step()`.  Failure to do this will result in PyTorch skipping the first value of the learning rate schedule.See more details at https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate
  "https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate", UserWarning)
/home/dom/Documents/ParlAI/parlai/core/torch_ranker_agent.py:377: UserWarning: Some training metrics are omitted for speed. Set the flag `--train-predict` to calculate train metrics.
  "Some training metrics are omitted for speed. Set the flag "
[ time:2.0s total_exs:11 epochs:0.0 ] {'exs': 11, 'lr': 2.201e-05, 'total_train_updates': 11, 'gnorm': 86.16, 'clip': 1.0, 'examples': 11, 'loss': 40.24, 'mean_loss': 3.658}
[ time:4.0s total_exs:24 epochs:0.0 ] {'exs': 13, 'lr': 4.801e-05, 'total_train_updates': 24, 'gnorm': 73.73, 'clip': 1.0, 'examples': 13, 'loss': 47.29, 'mean_loss': 3.637}
[ time:6.0s total_exs:38 epochs:0.0 ] {'exs': 14, 'lr': 7.6e-05, 'total_train_updates': 38, 'gnorm': 79.09, 'clip': 1.0, 'examples': 14, 'loss': 48.48, 'mean_loss': 3.463}
```

After changes:
```
[loading fbdialog data:/home/dom/Documents/ParlAI/data/ConvAI2/train_self_original.txt]
[ training... ]
/home/dom/Documents/ParlAI/parlai/core/torch_ranker_agent.py:599: UserWarning: [ Executing train mode with provided inline set of candidates ]
  ''.format(mode)
/home/dom/Documents/ParlAI/parlai/core/torch_ranker_agent.py:377: UserWarning: Some training metrics are omitted for speed. Set the flag `--train-predict` to calculate train metrics.
  "Some training metrics are omitted for speed. Set the flag "
[ time:2.0s total_exs:10 epochs:0.0 ] {'exs': 10, 'lr': 2.001e-05, 'total_train_updates': 10, 'gnorm': 106.6, 'clip': 1.0, 'examples': 10, 'loss': 39.58, 'mean_loss': 3.958}
[ time:4.0s total_exs:24 epochs:0.0 ] {'exs': 14, 'lr': 4.801e-05, 'total_train_updates': 24, 'gnorm': 106.0, 'clip': 1.0, 'examples': 14, 'loss': 65.18, 'mean_loss': 4.655}
[ time:6.0s total_exs:38 epochs:0.0 ] {'exs': 14, 'lr': 7.6e-05, 'total_train_updates': 38, 'gnorm': 90.92, 'clip': 1.0, 'examples': 14, 'loss': 53.51, 'mean_loss': 3.822}


```

**Other information**
N/A

**Data tests (if applicable)**
N/A
