### PR TITLE
[tensorboard] only use tensorboard in primary worker.

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -427,7 +427,7 @@ class TrainLoop:
                 self.impatience = obj.get('impatience', 0)
                 self.valid_reports = obj.get('valid_reports', [])
 
-        if opt['tensorboard_log'] is True:
+        if opt['tensorboard_log'] and is_primary_worker():
             self.tb_logger = TensorboardLogger(opt)
 
     def save_model(self, suffix=None):


### PR DESCRIPTION
**Patch description**
Every worker was trying to create a tblog file in distributed mode, which was creating some crashes. This ensures only the primary worker does this.

**Testing steps**
Distributed training using tensorboard.