### PR TITLE
Ignore .mypy_cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ heroku-cli-*
 
 # VSCode
 *.vscode
+
+# mypy cache
+.mypy_cache


### PR DESCRIPTION
**Patch description**
I've had a few small problems due to my experiments with mypy. This cache is in my source dir but not ignored by git, which is causing me headaches. In the future, when we actually use typing, this might be helpful. For now, it's a small thing.