### PR TITLE
token-level loss debugging

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1542,12 +1542,11 @@ class TorchAgent(ABC, Agent):
         """
         if output is None:
             return batch_reply
-        if output.text is not None:
-            for i, response in zip(valid_inds, output.text):
-                batch_reply[i]['text'] = response
-        if output.text_candidates is not None:
-            for i, cands in zip(valid_inds, output.text_candidates):
-                batch_reply[i]['text_candidates'] = cands
+        for k, v in output.items():
+            if v is None:
+                continue
+            for i, sub_val in zip(valid_inds, v):
+                batch_reply[i][k] = sub_val
         return batch_reply
 
     def last_reply(self, use_reply='label'):

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -382,8 +382,7 @@ class TorchGeneratorAgent(TorchAgent):
         If overridden, this model should produce a sum that can be used for a per-token loss.
         """
         return torch.nn.CrossEntropyLoss(
-            ignore_index=self.NULL_IDX,
-            reduction='sum' if reduce else 'none',
+            ignore_index=self.NULL_IDX, reduction='sum' if reduce else 'none'
         )
 
     def _v2t(self, vec):
@@ -572,10 +571,14 @@ class TorchGeneratorAgent(TorchAgent):
         # Zip decoded tokens with losses
         token_losses = []
         for i, label in enumerate(labels):
-            token_losses.append(list(zip(
-                [self.dict[token] for token in label.tolist()],
-                losses[i].tolist(),
-            )))
+            token_losses.append(
+                list(
+                    zip(
+                        [self.dict[token] for token in label.tolist()],
+                        losses[i].tolist(),
+                    )
+                )
+            )
         return token_losses
 
     def eval_step(self, batch):
@@ -589,12 +592,13 @@ class TorchGeneratorAgent(TorchAgent):
 
         if batch.label_vec is not None:
             # calculate loss on targets with teacher forcing
-            loss, model_output = self.compute_loss(batch, return_output=True)  # noqa: F841  we need the side effects
+            loss, model_output = self.compute_loss(
+                batch, return_output=True
+            )  # noqa: F841  we need the side effects
             self.metrics['loss'] += loss.item()
             if self.output_token_losses:
                 token_losses = self._construct_token_losses(
-                    batch.label_vec,
-                    model_output,
+                    batch.label_vec, model_output
                 )
 
         preds = None

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -295,6 +295,12 @@ class TorchGeneratorAgent(TorchAgent):
         agent.add_argument(
             '--topp', type=float, default=0.9, help='p used in nucleus sampling'
         )
+        agent.add_argument(
+            '--output-token-losses',
+            action='store_true',
+            hidden=True,
+            help='Display per-token loss breakdown. Useful for debugging.',
+        )
 
         super(TorchGeneratorAgent, cls).add_cmdline_args(argparser)
         return agent
@@ -306,6 +312,7 @@ class TorchGeneratorAgent(TorchAgent):
         self.beam_size = opt.get('beam_size', 1)
         self.beam_min_length = opt.get('beam_min_length', 1)
         self.beam_block_ngram = opt.get('beam_block_ngram', -1)
+        self.output_token_losses = opt.get('output_token_losses', False)
 
         if shared:
             # set up shared properties
@@ -366,7 +373,7 @@ class TorchGeneratorAgent(TorchAgent):
 
         self.reset()
 
-    def build_criterion(self):
+    def build_criterion(self, reduce=True):
         """
         Construct and return the loss function.
 
@@ -374,7 +381,10 @@ class TorchGeneratorAgent(TorchAgent):
 
         If overridden, this model should produce a sum that can be used for a per-token loss.
         """
-        return torch.nn.CrossEntropyLoss(ignore_index=self.NULL_IDX, reduction='sum')
+        return torch.nn.CrossEntropyLoss(
+            ignore_index=self.NULL_IDX,
+            reduction='sum' if reduce else 'none',
+        )
 
     def _v2t(self, vec):
         """Convert token indices to string of tokens."""
@@ -550,6 +560,24 @@ class TorchGeneratorAgent(TorchAgent):
             else:
                 raise e
 
+    def _construct_token_losses(self, labels, model_output):
+        # Get non-aggregated losses
+        scores, _, _ = model_output
+        score_view = scores.view(-1, scores.size(-1))
+        criterion = self.build_criterion(reduce=False)
+        if self.use_cuda:
+            criterion.cuda()
+        losses = criterion(score_view, labels.view(-1)).view(len(labels), -1)
+
+        # Zip decoded tokens with losses
+        token_losses = []
+        for i, label in enumerate(labels):
+            token_losses.append(list(zip(
+                [self.dict[token] for token in label.tolist()],
+                losses[i].tolist(),
+            )))
+        return token_losses
+
     def eval_step(self, batch):
         """Evaluate a single batch of examples."""
         if batch.text_vec is None:
@@ -557,11 +585,17 @@ class TorchGeneratorAgent(TorchAgent):
         bsz = batch.text_vec.size(0)
         self.model.eval()
         cand_scores = None
+        token_losses = None
 
         if batch.label_vec is not None:
             # calculate loss on targets with teacher forcing
-            loss = self.compute_loss(batch)  # noqa: F841  we need the side effects
+            loss, model_output = self.compute_loss(batch, return_output=True)  # noqa: F841  we need the side effects
             self.metrics['loss'] += loss.item()
+            if self.output_token_losses:
+                token_losses = self._construct_token_losses(
+                    batch.label_vec,
+                    model_output,
+                )
 
         preds = None
         if self.skip_generation:
@@ -600,7 +634,7 @@ class TorchGeneratorAgent(TorchAgent):
                 cand_choices.append([batch.candidates[i][o] for o in ordering])
 
         text = [self._v2t(p) for p in preds] if preds is not None else None
-        return Output(text, cand_choices)
+        return Output(text, cand_choices, token_losses=token_losses)
 
     def _treesearch_factory(self, device):
         method = self.opt.get('inference', 'greedy')

--- a/parlai/scripts/display_model.py
+++ b/parlai/scripts/display_model.py
@@ -26,6 +26,13 @@ def setup_args():
     parser = ParlaiParser(True, True, 'Display model predictions.')
     parser.add_argument('-n', '-ne', '--num-examples', default=10)
     parser.add_argument('--display-ignore-fields', type=str, default='')
+    parser.add_argument(
+        '--verbose',
+        type='bool',
+        default=False,
+        hidden=True,
+        help='Display additional debug info, e.g. the per-token loss breakdown for generative models.',
+    )
     # by default we want to display info about the validation set
     parser.set_defaults(datatype='valid')
     return parser

--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -680,7 +680,7 @@ def display_messages(msgs, prettify=False, ignore_fields='', max_len=1000):
     ) -> str:
         """
         Displays the loss associated with each token. Can be used for debugging generative models.
-        
+
         See TorchGeneratorAgent._construct_token_losses for an example implementation.
         """
         key = 'token_losses'

--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -48,6 +48,7 @@ DISPLAY_MESSAGE_DEFAULT_FIELDS = {
     'eval_labels_vec',
     'text_vec',
     'label_candidates_vecs',
+    'token_losses',
 }
 
 
@@ -705,11 +706,26 @@ def display_messages(msgs, prettify=False, ignore_fields='', max_len=1000):
         for field in {'labels', 'eval_labels', 'label_candidates', 'text_candidates'}:
             if msg.get(field) and field not in ignore_fields:
                 lines.append('{}[{}: {}]'.format(space, field, _ellipse(msg[field])))
+        token_loss_line = _token_losses_line(msg, ignore_fields, space)
+        if token_loss_line:
+            lines.append(token_loss_line)
 
     if episode_done:
         lines.append('- - - - - - - - - - - - - - - - - - - - -')
 
     return '\n'.join(lines)
+
+
+def _token_losses_line(msg, ignore_fields, space) -> str:
+    key = 'token_losses'
+    token_losses = msg.get(key, None)
+    if key in ignore_fields or not token_losses:
+        return None
+    # Reduce losses to 4 significant figures
+    formatted_tl = ' | '.join(
+        [f"{tl[0]} {float('{:.4g}'.format(tl[1]))}" for tl in token_losses]
+    )
+    return f'{space}[{key}]: {formatted_tl}'
 
 
 def str_to_msg(txt, ignore_fields=''):

--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -13,6 +13,7 @@ import pickle
 import random
 import time
 import traceback
+from typing import Any, Dict, List
 import warnings
 
 from parlai.core.message import Message
@@ -673,6 +674,25 @@ def display_messages(msgs, prettify=False, ignore_fields='', max_len=1000):
     ignore_fields provides a list of fields in the msgs which should not be
     displayed.
     """
+
+    def _token_losses_line(
+        msg: Dict[str, Any], ignore_fields: List[str], space: str
+    ) -> str:
+        """
+        Displays the loss associated with each token. Can be used for debugging generative models.
+        
+        See TorchGeneratorAgent._construct_token_losses for an example implementation.
+        """
+        key = 'token_losses'
+        token_losses = msg.get(key, None)
+        if key in ignore_fields or not token_losses:
+            return None
+        # Reduce losses to 4 significant figures
+        formatted_tl = ' | '.join(
+            [f"{tl[0]} {float('{:.4g}'.format(tl[1]))}" for tl in token_losses]
+        )
+        return f'{space}[{key}]: {formatted_tl}'
+
     lines = []
     episode_done = False
     ignore_fields = ignore_fields.split(',')
@@ -706,6 +726,7 @@ def display_messages(msgs, prettify=False, ignore_fields='', max_len=1000):
         for field in {'labels', 'eval_labels', 'label_candidates', 'text_candidates'}:
             if msg.get(field) and field not in ignore_fields:
                 lines.append('{}[{}: {}]'.format(space, field, _ellipse(msg[field])))
+        # Handling this separately since we need to clean up the raw output before displaying.
         token_loss_line = _token_losses_line(msg, ignore_fields, space)
         if token_loss_line:
             lines.append(token_loss_line)
@@ -714,18 +735,6 @@ def display_messages(msgs, prettify=False, ignore_fields='', max_len=1000):
         lines.append('- - - - - - - - - - - - - - - - - - - - -')
 
     return '\n'.join(lines)
-
-
-def _token_losses_line(msg, ignore_fields, space) -> str:
-    key = 'token_losses'
-    token_losses = msg.get(key, None)
-    if key in ignore_fields or not token_losses:
-        return None
-    # Reduce losses to 4 significant figures
-    formatted_tl = ' | '.join(
-        [f"{tl[0]} {float('{:.4g}'.format(tl[1]))}" for tl in token_losses]
-    )
-    return f'{space}[{key}]: {formatted_tl}'
 
 
 def str_to_msg(txt, ignore_fields=''):


### PR DESCRIPTION
**Patch description**
When evaluating models on new datasets, I found it useful to look at the per-token losses to understand where the model was getting confused.
This change adds that functionality when invoking the verbose option.

**Testing steps**
Test with flag:
`python examples/display_model.py -t twitter -mf /path/to/model -m transformer/generator --verbose True`
https://gist.github.com/spencerp/385182ede285ed241e1ec37ee4801b3f

Test without flag:
`python examples/display_model.py -t twitter -mf /path/to/model -m transformer/generator`
https://gist.github.com/spencerp/066c3e5e45613b91798da1b69069dd8a

