### PR TITLE
Add initial WebSocket based chat service

### DIFF
--- a/parlai/chat_service/services/messenger/world_runner.py
+++ b/parlai/chat_service/services/messenger/world_runner.py
@@ -8,7 +8,7 @@
 The World Runner provides the manager with utility functions for running
 overworlds, onboard worlds, and task worlds.
 """
-import shared_utils as utils
+from . import shared_utils as utils
 import time
 import datetime
 from concurrent import futures

--- a/parlai/chat_service/services/websocket/agents.py
+++ b/parlai/chat_service/services/websocket/agents.py
@@ -38,10 +38,7 @@ class WebsocketAgent(Agent):
         if 'payload' in act:
             raise ValueError("Payload not supported yet by websockets")
         else:
-            if act['id'] != '':
-                msg = '{}: {}'.format(act['id'], act['text'])
-            else:
-                msg = act['text']
+            msg = act['text']
             resp = self.manager.observe_message(
                 self.id,
                 msg,

--- a/parlai/chat_service/services/websocket/agents.py
+++ b/parlai/chat_service/services/websocket/agents.py
@@ -39,18 +39,12 @@ class WebsocketAgent(Agent):
             raise ValueError("Payload not supported yet by websockets")
         else:
             msg = act['text']
-            resp = self.manager.observe_message(
-                self.id,
-                msg,
-            )
+            self.manager.observe_message(self.id, msg)
 
     def put_data(self, message):
         """Put data into the message queue if it hasn't already been seen"""
         logging.info(f"Received new message: {message}")
-        action = {
-            'episode_done': False,
-            'text': message,
-        }
+        action = {'episode_done': False, 'text': message}
         self.msg_queue.put(action)
 
     def get_new_act_message(self):
@@ -85,7 +79,6 @@ class WebsocketAgent(Agent):
             if msg is not None and self.message_request_time is not None:
                 self.message_request_time = None
         return msg
-
 
     def act_blocking(self, timeout=None):
         """Repeatedly loop until we retrieve a message from the queue"""

--- a/parlai/chat_service/services/websocket/agents.py
+++ b/parlai/chat_service/services/websocket/agents.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+from queue import Queue
+
+from parlai.core.agents import Agent
+
+
+class WebsocketAgent(Agent):
+    """Class for a person that can act in a ParlAI world via websockets"""
+
+    def __init__(self, opt, manager, task_id, socketID):
+        super().__init__(opt)
+        self.manager = manager
+        self.id = socketID
+
+        self.active = True
+        self.msg_queue = Queue()
+        self.stored_data = {}
+        self.set_stored_data()
+
+    def set_stored_data(self):
+        """Gets agent state data from manager"""
+        agent_state = self.manager.get_agent_state(self.id)
+        if agent_state is not None and hasattr(agent_state, 'stored_data'):
+            self.stored_data = agent_state.stored_data

--- a/parlai/chat_service/services/websocket/agents.py
+++ b/parlai/chat_service/services/websocket/agents.py
@@ -42,7 +42,7 @@ class WebsocketAgent(Agent):
             self.manager.observe_message(self.id, msg)
 
     def put_data(self, message):
-        """Put data into the message queue if it hasn't already been seen"""
+        """Put data into the message queue"""
         logging.info(f"Received new message: {message}")
         action = {'episode_done': False, 'text': message}
         self.msg_queue.put(action)
@@ -54,6 +54,11 @@ class WebsocketAgent(Agent):
             return self.msg_queue.get()
 
         return None
+
+    def mark_inactive(self):
+        # some kind of behavior to send a message when a user is marked as
+        # being inactive. Could be useful. Should return a message to be sent
+        pass
 
     def act(self, timeout=None):
         """Pulls a message from the message queue. If none exist returns None

--- a/parlai/chat_service/services/websocket/run.py
+++ b/parlai/chat_service/services/websocket/run.py
@@ -7,8 +7,6 @@
 from parlai.core.params import ParlaiParser
 from parlai.chat_service.services.websocket.websocket_manager import WebsocketManager
 from parlai.chat_service.services.messenger import shared_utils as utils
-import logging
-import sys
 
 
 def setup_args():
@@ -28,6 +26,7 @@ def run(opt):
         raise
     finally:
         manager.shutdown()
+
 
 if __name__ == '__main__':
     opt = setup_args()

--- a/parlai/chat_service/services/websocket/run.py
+++ b/parlai/chat_service/services/websocket/run.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Websocket Runner."""
+from parlai.core.params import ParlaiParser
+from parlai.chat_service.services.websocket.websocket_manager import WebsocketManager
+from parlai.chat_service.services.messenger import shared_utils as utils
+import logging
+import sys
+
+
+def setup_args():
+    """Set up args."""
+    parser = ParlaiParser(False, False)
+    parser.add_parlai_data_path()
+    parser.add_websockets_args()
+    return parser.parse_args()
+
+
+def run(opt):
+    """Run MessengerManager."""
+    manager = WebsocketManager(opt)
+    try:
+        manager.start_task()
+    except BaseException:
+        raise
+    finally:
+        manager.shutdown()
+
+if __name__ == '__main__':
+    opt = setup_args()
+    config_path = opt.get('config_path')
+    config = utils.parse_configuration_file(config_path)
+    opt.update(config['world_opt'])
+    opt['config'] = config
+    run(opt)

--- a/parlai/chat_service/services/websocket/sockets.py
+++ b/parlai/chat_service/services/websocket/sockets.py
@@ -17,9 +17,12 @@ class MessageSocketHandler(WebSocketHandler):
     subs = {}
 
     def __init__(self, *args, **kwargs):
-        self.message_callback = kwargs.pop('message_callback', None)
+        def _default_callback(message, socketID):
+            logging.warn(f"No callback defined for new WebSocket messages.")
+
+        self.message_callback = kwargs.pop('message_callback', _default_callback)
         self.sid = get_rand_id()
-        super(MessageSocketHandler, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def open(self):
         """

--- a/parlai/chat_service/services/websocket/sockets.py
+++ b/parlai/chat_service/services/websocket/sockets.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from tornado.websocket import WebSocketHandler
+import uuid
+import logging
+
+def get_rand_id():
+    return str(uuid.uuid4())
+
+
+class MessageSocketHandler(WebSocketHandler):
+    subs = {}
+
+    def __init__(self, *args, **kwargs):
+        self.message_callback = kwargs.pop('message_callback', None)
+        self.sid = get_rand_id()
+        super(MessageSocketHandler, self).__init__(*args, **kwargs)
+
+    def open(self):
+        """
+        Opens a websocket and assigns a random UUID that is stored in the class-level
+        `subs` variable
+        """
+        if self.sid not in self.subs.values():
+            self.subs[self.sid] = self
+            logging.info(
+                f"Opened new socket from ip: {self.request.remote_ip}"
+            )
+            logging.info(
+                f"Current subscribers: {self.subs}",
+            )
+
+    def on_close(self):
+        """Runs when a socket is closed"""
+        del self.subs[self.sid]
+
+    def on_message(self, message):
+        """Callback that runs when a new message is received from a client"""
+        logging.info('websocket message from client: {}'.format(message))
+        self.message_callback(message, self.sid)
+
+    def check_origin(self, origin):
+        return True

--- a/parlai/chat_service/services/websocket/sockets.py
+++ b/parlai/chat_service/services/websocket/sockets.py
@@ -8,6 +8,7 @@ from tornado.websocket import WebSocketHandler
 import uuid
 import logging
 
+
 def get_rand_id():
     return str(uuid.uuid4())
 
@@ -27,12 +28,8 @@ class MessageSocketHandler(WebSocketHandler):
         """
         if self.sid not in self.subs.values():
             self.subs[self.sid] = self
-            logging.info(
-                f"Opened new socket from ip: {self.request.remote_ip}"
-            )
-            logging.info(
-                f"Current subscribers: {self.subs}",
-            )
+            logging.info(f"Opened new socket from ip: {self.request.remote_ip}")
+            logging.info(f"Current subscribers: {self.subs}")
 
     def on_close(self):
         """Runs when a socket is closed"""

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -28,8 +28,6 @@ from agents import WebsocketAgent
 import tornado
 from tornado.options import options
 
-PORT = 35496
-
 
 class WebsocketManager:
     """
@@ -40,7 +38,7 @@ class WebsocketManager:
     def __init__(self, opt):
         """Create a WebsocketManager using the given setup options"""
         self.subs = []
-        self.port = opt.get('port', PORT)
+        self.port = opt.get('port')
         self.opt = opt
         self.app = None
         self.debug = opt.get('debug', True)

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -334,9 +334,9 @@ class WebsocketManager:
         self.app = self._make_app()
         self.app.listen(self.port)
         # Must use a tornado callback to run the main loop
-        callack_time = shared_utils.THREAD_MEDIUM_SLEEP * 1000
+        callback_time = shared_utils.THREAD_MEDIUM_SLEEP * 1000
         tornado.ioloop.PeriodicCallback(
-            callback=self._manager_loop_fn, callback_time=callack_time
+            callback=self._manager_loop_fn, callback_time=callback_time
         ).start()
         tornado.ioloop.IOLoop.current().start()
 
@@ -344,7 +344,7 @@ class WebsocketManager:
         """Defined to shutown the tornado application"""
         tornado.ioloop.IOLoop.current().stop()
 
-    def _new_message(self, message, socketID):
+    def _on_new_message(self, message, socketID):
         """Callback when a new message is received
         Args:
             message: string. Message from client
@@ -426,7 +426,7 @@ class WebsocketManager:
         """
         Starts the tornado application
         """
-        message_callback = self._new_message
+        message_callback = self._on_new_message
 
         options['log_to_stderr'] = True
         tornado.options.parse_command_line([])

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -10,10 +10,13 @@ websockets
 
 import time
 import logging
+# TODO: Use a generalized AgentState module (Issue #2079)
+from parlai.chat_service.services.messenger.messenger_manager import AgentState
 import parlai.chat_service.services.messenger.shared_utils as shared_utils
 from parlai.chat_service.services.websocket.sockets import (
     MessageSocketHandler,
 )
+from agents import WebsocketAgent
 import tornado
 from tornado.options import define, options
 
@@ -32,6 +35,13 @@ class WebsocketManager:
         self.opt = opt
         self.app = None
         self.debug = opt.get('debug', True)
+        # TODO: Rename when using a generalized AgentState module (Issue #2079)
+        self.messenger_agent_states = {}
+        self._parse_config(opt)
+
+    def _parse_config(self, opt):
+        """Parse config for task."""
+        self.config = opt['config']
 
     def start_task(self):
         """Begin handling task.
@@ -46,13 +56,44 @@ class WebsocketManager:
         """Defined to shutown the tornado application"""
         tornado.ioloop.IOLoop.current().stop()
 
-    def _new_message(self, message, senderId):
+    def _new_message(self, message, socketID):
         """Callback when a new message is received
         Args:
             message: string. Message from client
-            senderId: UUID. UUID of message sender
+            socketID: UUID. UUID of message sender socket
         """
         logging.info("Manager got new message!")
+        if socketID not in self.messenger_agent_states:
+            self._on_first_message(message)
+            return
+
+    def _on_first_message(self, message, socketID):
+        """Handle first message from player.
+
+        Run when a socketID is given that is not paired with any assignment yet.
+        Launch an overworld, complete onboarding, etc.
+
+        :param message:
+            string message sent from agent
+        :param socketID:
+            int socket ID of the message sender
+        """
+        task_id = 'overworld-{}-{}'.format(socketID, time.time())
+        agent = self._create_agent(task_id, socketID)
+        agent_state = AgentState(socketID, agent)
+        self.messenger_agent_states[socketID] = agent_state
+
+    def _create_agent(self, task_id, socketID):
+        """Initialize an agent and return it.
+
+        Called each time an agent is placed into a new task.
+
+        :param task_id:
+            string task identifier
+        :param agent_id:
+            int agent id
+        """
+        return WebsocketAgent(self.opt, self, task_id, socketID)
 
     def _make_app(self):
         """

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Websocket Manager Module
+Contains implementation of the WebsocketManager which helps run ParlAI via
+websockets
+"""
+
+import time
+import logging
+import parlai.chat_service.services.messenger.shared_utils as shared_utils
+from parlai.chat_service.services.websocket.sockets import (
+    MessageSocketHandler,
+)
+import tornado
+from tornado.options import define, options
+
+PORT = 35496
+
+
+class WebsocketManager:
+    """
+    Manages interactions between agents on a websocket as well as direct interactions
+    between agents and an overworld.
+    """
+    def __init__(self, opt):
+        """Create a WebsocketManager using the given setup options"""
+        self.subs = []
+        self.port = opt.get('port', PORT)
+        self.opt = opt
+        self.app = None
+        self.debug = opt.get('debug', True)
+
+    def start_task(self):
+        """Begin handling task.
+        """
+        self.running = True
+        logger = logging.getLogger("MainLogger")
+        self.app = self._make_app()
+        self.app.listen(self.port)
+        tornado.ioloop.IOLoop.current().start()
+
+    def shutdown(self):
+        """Defined to shutown the tornado application"""
+        tornado.ioloop.IOLoop.current().stop()
+
+    def _new_message(self, message, senderId):
+        """Callback when a new message is received
+        Args:
+            message: string. Message from client
+            senderId: UUID. UUID of message sender
+        """
+        logging.info("Manager got new message!")
+
+    def _make_app(self):
+        """
+        Starts the tornado application
+        """
+        message_callback = self._new_message
+
+        options['log_to_stderr'] = True
+        tornado.options.parse_command_line([])
+
+        return tornado.web.Application([
+            (r"/websocket", MessageSocketHandler, {'message_callback': message_callback}),
+        ], debug=self.debug)

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -8,10 +8,16 @@ Contains implementation of the WebsocketManager which helps run ParlAI via
 websockets
 """
 
+import asyncio
 import time
+import datetime
 import logging
-# TODO: Use a generalized AgentState module (Issue #2079)
+import threading
+from parlai.core.agents import create_agent
+# TODO: Use generalized module (Issue #2079)
 from parlai.chat_service.services.messenger.messenger_manager import AgentState
+# TODO: Use a generalized World Runner module (Issue #2079)
+from parlai.chat_service.services.messenger.world_runner import MessengerWorldRunner
 import parlai.chat_service.services.messenger.shared_utils as shared_utils
 from parlai.chat_service.services.websocket.sockets import (
     MessageSocketHandler,
@@ -36,12 +42,288 @@ class WebsocketManager:
         self.app = None
         self.debug = opt.get('debug', True)
         # TODO: Rename when using a generalized AgentState module (Issue #2079)
+        self.agent_pool = {}
         self.messenger_agent_states = {}
+        self.agent_id_to_overworld_future = {}
+        self.task_to_agent_ids = {}
+        self.conversation_index = 0
+        self.shutting_down = False
+        self.agent_pool_change_condition = threading.Condition()
+        self.active_worlds = {}
         self._parse_config(opt)
+        self._complete_setup()
 
     def _parse_config(self, opt):
         """Parse config for task."""
         self.config = opt['config']
+        self.overworld = self.config['overworld']
+        self.world_path = self.config['world_path']
+        self.world_module = shared_utils.get_world_module(self.world_path)
+        self.max_workers = self.config['max_workers']
+        self.task_configs = self.config['configs']
+        self.opt['task'] = self.config['task_name']
+        self.world_runner = MessengerWorldRunner(
+            opt, self.world_path, self.max_workers, self, opt['is_debug']
+        )
+        self.max_agents_for = {
+            task: cfg.agents_required for task, cfg in self.task_configs.items()
+        }
+        self.onboard_map = {
+            task: cfg.onboarding_name for task, cfg in self.task_configs.items()
+        }
+        self.taskworld_map = {
+            task: cfg.task_name for task, cfg in self.task_configs.items()
+        }
+
+
+    def check_timeout_in_pool(self, world_type, agent_pool, max_time_in_pool):
+        """Check for timed-out agents in pool.
+
+        :param world_type:
+            string world type
+        :param agent_pool:
+            list of ``AgentState``s
+        :param max_time_in_pool:
+            int maximum time allowed for agent to be in pool
+        """
+        for agent_state in agent_pool:
+            time_in_pool = agent_state.time_in_pool.get(world_type)
+            if time_in_pool and time.time() - time_in_pool > max_time_in_pool:
+                # remove agent from agent_pool
+                self.remove_agent_from_pool(agent_state, world_type)
+                # put agent back in overworld
+                agent_state.set_active_agent(agent_state.get_overworld_agent())
+
+                agent_state.stored_data['removed_after_timeout'] = True
+
+                # reset wait message state
+                agent_state.stored_data['seen_wait_message'] = False
+
+            elif time_in_pool and time.time() - time_in_pool > 30:
+                # tell agent that a match is taking longer than
+                # expected
+                if (
+                    not agent_state.stored_data.get('seen_wait_message')
+                    or not agent_state.stored_data['seen_wait_message']
+                ):
+                    self.observe_message(
+                        agent_state.messenger_id,
+                        'Pairing is taking longer than expected. '
+                        'If you wish to exit, type *EXIT*.',
+                    )
+                    agent_state.stored_data['seen_wait_message'] = True
+
+    def remove_agent_from_pool(self, agent, world_type='default', mark_removed=True):
+        """Remove agent from the pool.
+
+        :param agent:
+            MessengerAgent object
+        :param world_type:
+            string, world name
+        :param mark_removed:
+            bool, whether to mark an agent as removed from the pool
+        """
+        with self.agent_pool_change_condition:
+            self._log_debug('Removing agent {} from pool...'.format(agent.messenger_id))
+            if world_type in self.agent_pool and agent in self.agent_pool[world_type]:
+                self.agent_pool[world_type].remove(agent)
+                # reset agent's time_in_pool
+                if world_type in agent.time_in_pool:
+                    del agent.time_in_pool[world_type]
+                # maybe mark agent as removed
+                if mark_removed:
+                    agent.stored_data['removed_from_pool'] = True
+                    if self.page_id is not None:
+                        self.mark_removed(int(agent.messenger_id), int(self.page_id))
+
+    def add_agent_to_pool(self, agent, world_type='default'):
+        """Add the agent to pool.
+
+        :param agent:
+            MessengerAgent object
+        :param world_type:
+            Name of world whose pool should now contain agent
+        """
+        with self.agent_pool_change_condition:
+            self._log_debug('Adding agent {} to pool...'.format(agent.messenger_id))
+            # time agent entered agent_pool
+            agent.time_in_pool.setdefault(world_type, time.time())
+            # add agent to pool
+            self.agent_pool.setdefault(world_type, []).append(agent)
+
+    def _expire_all_conversations(self):
+        """Iterate through all sub-worlds and shut them down."""
+        self.running = False
+        for agent_id, overworld_fut in self.agent_id_to_overworld_future.items():
+            self.observe_message(
+                agent_id,
+                'System: The conversation bot going to go offline soon, '
+                'finish any active conversations in the next 5 minutes.',
+            )
+            overworld_fut.cancel()
+
+        # 5 minute grace period for conversations to finish
+        time_passed = 0
+        while time_passed < 5 * 60:
+            any_alive = False
+            for task_fut in self.active_worlds.values():
+                if task_fut is not None:
+                    any_alive = any_alive or task_fut.running()
+            if not any_alive:
+                break
+            time.sleep(1)
+
+        # Tell the worlds that they should be shutting down at this point,
+        # agents will refer to this value
+        self.shutting_down = True
+
+    def _get_unique_pool(self):
+        """Return unique pool.
+
+        Returns a filtered version of the agent pool where each agent is
+        only listed a maximum of one time.
+
+        :return:
+            a dictionary mapping world_types to agent pools
+        """
+        valid_pools = {}
+        for world_type, agent_pool in self.agent_pool.items():
+            eligibility_function = shared_utils.get_eligibility_fn(
+                self.world_module, world_type
+            )
+            if eligibility_function is not None:
+                valid_pools[world_type] = [
+                    w for w in agent_pool if eligibility_function(w)
+                ]
+            else:
+                valid_pools[world_type] = self.agent_pool[world_type]
+        return valid_pools
+
+    def get_agent_state(self, agent_id):
+        """Return agent state.
+
+        :param agent_id:
+            int agent identifier
+
+        :return:
+            AgentState object if agent_id is being tracked, else None
+        """
+        if agent_id in self.messenger_agent_states:
+            return self.messenger_agent_states[agent_id]
+        return None
+
+    def _get_agent(self, agent_id, task_id):
+        """Return agent object for given agent ID and task ID.
+
+        :param agent_id:
+            int agent identifier
+        :param task_id:
+            string task name
+
+        :return:
+            MessengerAgent object associated with given agent ID and task ID if
+            possible, else None
+        """
+        agent_state = self.get_agent_state(agent_id)
+        if agent_state is not None:
+            if agent_state.has_task(task_id):
+                return agent_state.get_agent_for_task(task_id)
+        return None
+
+    def _complete_setup(self):
+        """Complete necessary setup items."""
+        self._load_model()
+
+    def _load_model(self):
+        """Load model if necessary"""
+        if 'model_file' in self.opt or 'model' in self.opt:
+            self.opt['shared_bot_params'] = create_agent(self.opt).share()
+
+    def _manager_iteration(self):
+        def _done_callback(fut):
+            """Log and raise exception of task world, if there is one.
+
+            Additionally, set active agent to overworld agent.
+            """
+            e = fut.exception()
+            if e is not None:
+                shared_utils.print_and_log(
+                    logging.ERROR,
+                    'World {} had error {}'.format(world_type, repr(e)),
+                    should_print=True,
+                )
+                traceback.print_exc(file=sys.stdout)
+                for agent in agents:
+                    self.observe_message(
+                        agent.id, 'Sorry, this world closed. Returning to overworld.'
+                    )
+            else:
+                shared_utils.print_and_log(
+                    logging.INFO,
+                    'World {} had no error'.format(world_type),
+                    should_print=True,
+                )
+            self.active_worlds[task_id] = None
+            for agent in agents:
+                agent_state = self.get_agent_state(agent.id)
+                agent_state.set_active_agent(agent_state.get_overworld_agent())
+
+        with self.agent_pool_change_condition:
+            valid_pools = self._get_unique_pool()
+            for world_type, agent_pool in valid_pools.items():
+                # check if agent has exceeded max time in pool
+                world_config = self.task_configs[world_type]
+                if world_config.max_time_in_pool is not None:
+                    self.check_timeout_in_pool(
+                        world_type, agent_pool, world_config.max_time_in_pool
+                    )
+
+                needed_agents = self.max_agents_for[world_type]
+                if len(agent_pool) >= needed_agents:
+                    shared_utils.print_and_log(
+                        logging.INFO, 'starting pool', should_print=True
+                    )
+                    # enough agents in pool to start new conversation
+                    self.conversation_index += 1
+                    task_id = 't_{}'.format(self.conversation_index)
+
+                    # Add the required number of valid agents to the conv
+                    agent_states = [w for w in agent_pool[:needed_agents]]
+                    agents = []
+                    for state in agent_states:
+                        agent = self._create_agent(task_id, state.get_id())
+                        agent.onboard_data = state.onboard_data
+                        state.assign_agent_to_task(agent, task_id)
+                        state.set_active_agent(agent)
+                        agents.append(agent)
+                        # reset wait message state
+                        state.stored_data['seen_wait_message'] = False
+                    assign_role_function = shared_utils.get_assign_roles_fn(
+                        self.world_module, self.taskworld_map[world_type]
+                    )
+                    if assign_role_function is None:
+                        assign_role_function = shared_utils.default_assign_roles_fn
+                    assign_role_function(agents)
+                    # Allow task creator to filter out workers and run
+                    # versions of the task that require fewer agents
+                    agents = [a for a in agents if a.disp_id is not None]
+                    for a in agents:
+                        # Remove selected workers from the agent pool
+                        self.remove_agent_from_pool(
+                            self.get_agent_state(a.id),
+                            world_type=world_type,
+                            mark_removed=False,
+                        )
+                    for a in agents:
+                        partner_list = agents.copy()
+                        partner_list.remove(a)
+                        a.message_partners = partner_list
+                    # launch task world.
+                    future = self.world_runner.launch_task_world(
+                        task_id, self.taskworld_map[world_type], agents
+                    )
+                    future.add_done_callback(_done_callback)
+                    self.active_worlds[task_id] = future
 
     def start_task(self):
         """Begin handling task.
@@ -50,6 +332,10 @@ class WebsocketManager:
         logger = logging.getLogger("MainLogger")
         self.app = self._make_app()
         self.app.listen(self.port)
+        callack_time = shared_utils.THREAD_MEDIUM_SLEEP * 1000
+        tornado.ioloop.PeriodicCallback(
+            callback=self._manager_iteration, callback_time=callack_time
+        ).start()
         tornado.ioloop.IOLoop.current().start()
 
     def shutdown(self):
@@ -64,8 +350,35 @@ class WebsocketManager:
         """
         logging.info("Manager got new message!")
         if socketID not in self.messenger_agent_states:
-            self._on_first_message(message)
+            self._on_first_message(message, socketID)
             return
+
+        agent_state = self.get_agent_state(socketID)
+        if agent_state.get_active_agent() is None:
+            # return agent to overworld
+            if (
+                'text' in message['message']
+                and message['message']['text'].upper() == 'EXIT'
+            ):
+                # remove agent from agent_pool
+                to_remove = []
+                for world_type, _time in agent_state.time_in_pool.items():
+                    to_remove.append(world_type)
+                for world_type in to_remove:
+                    self.remove_agent_from_pool(
+                        agent_state, world_type, mark_removed=False
+                    )
+                agent_state.set_active_agent(agent_state.get_overworld_agent())
+            else:
+                self.observe_message(
+                    socketID,
+                    'Please wait while we pair you with another person. '
+                    'If you wish to exit, type *EXIT*.',
+                )
+        else:
+            agent = agent_state.get_active_agent()
+            agent.put_data(message)
+
 
     def _on_first_message(self, message, socketID):
         """Handle first message from player.
@@ -82,6 +395,21 @@ class WebsocketManager:
         agent = self._create_agent(task_id, socketID)
         agent_state = AgentState(socketID, agent)
         self.messenger_agent_states[socketID] = agent_state
+
+        future = self.world_runner.launch_overworld(
+            task_id, self.overworld, self.onboard_map, agent,
+        )
+
+        def _done_callback(fut):
+            """Log and raise exception of overworld (if there is one)."""
+            e = fut.exception()
+            if e is not None:
+                self._log_debug('{} returned with error {}'.format(task_id, repr(e)))
+                if self.debug:
+                    raise e
+
+        future.add_done_callback(_done_callback)
+        self.agent_id_to_overworld_future[socketID] = future
 
     def _create_agent(self, task_id, socketID):
         """Initialize an agent and return it.
@@ -107,3 +435,20 @@ class WebsocketManager:
         return tornado.web.Application([
             (r"/websocket", MessageSocketHandler, {'message_callback': message_callback}),
         ], debug=self.debug)
+
+    def observe_message(self, socket_id, text):
+        """Send a message through the message manager.
+
+        :param socket_id:
+            int identifier for agent socket to send message to
+        :param text:
+            string text to send
+        """
+        asyncio.set_event_loop(asyncio.new_event_loop())
+        return MessageSocketHandler.subs[socket_id].write_message(
+            text
+        )
+
+    def _log_debug(self, text):
+        time = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        shared_utils.print_and_log(logging.DEBUG, f'{time}: {text}', should_print=True)

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -455,6 +455,9 @@ class ParlaiParser(argparse.ArgumentParser):
             type=str,
             help='/path/to/config/file for a given task.',
         )
+        websockets.add_argument(
+            '--port', default=35496, type=int, help='Port to run the websocket handler'
+        )
 
     def add_messenger_args(self):
         """Add Facebook Messenger arguments."""

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -440,6 +440,22 @@ class ParlaiParser(argparse.ArgumentParser):
         mturk.set_defaults(is_debug=False)
         mturk.set_defaults(verbose=False)
 
+    def add_websockets_args(self):
+        """Add websocket arguments."""
+        websockets = self.add_argument_group('Websockets')
+        websockets.add_argument(
+            '--debug',
+            dest='is_debug',
+            action='store_true',
+            help='print and log all server interactions and messages',
+        )
+        websockets.add_argument(
+            '--config-path',
+            default=None,
+            type=str,
+            help='/path/to/config/file for a given task.',
+        )
+
     def add_messenger_args(self):
         """Add Facebook Messenger arguments."""
         messenger = self.add_argument_group('Facebook Messenger')


### PR DESCRIPTION
**Patch description**
This PR is the initial implementation of a WebSocket based chat service. Much of this code is identical or very similar to the messenger chat service, which will be generalized in #2079. This service is simplified from the messenger service, and does not yet include display names, attachments (stickers, images, etc.), or quick replies.

**Testing steps**
Ran the service using `run.py` similar to the Messenger service and provided first the `chatbot` example task and then the `overworld_demo`. Then connected via the internal WebSocket based web-app and began chatting. Tested pairing in `overworld_demo` as well as singleplayer in `chatbot`.

Example server run command (for chatbot task): `./parlai/chat_service/services/websocket/run.py --config-path parlai/chat_service/tasks/chatbot/config.yml`
To customize the listening port, specify the `--port` flag (defaults to 35496).

Connect via WebSocket at `ws://<YOUR DOMAIN>:<PORT>/websocket`. Example websocket frontend JS:
```
var ws = new WebSocket("ws://localhost:35496/websocket");
ws.onmessage = function(msg) {
    console.log("Received Message: " + msg.data)
}
ws.send("Hey");
```
Sample output from above: 
```
Received Message: Welcome to the overworld for the ParlAI messenger chatbot demo. Please type "begin" to start.
```

Components that could be generalized in #2079:

**In agents.py:**
- `set_stored_data`
- `get_new_act_message`
- `act_blocking`
- `episode_done`
- `mark_inactive`
- `act`, `observe`, and `put_data` could be generalized with small changes such as ensuring messenger specific fields such as quick_replies are not required.

**In websocket_manager.py**:
- `MessengerWorldRunner` import
- `AgentState` import
- `shared_utils` import
- most of `parse_config` is identical, the rest of it can be overridden (such as page_id for messenger)
- `check_timeout_in_pool`
- most of `remove_agent_from_pool` with some post-removal done by messenger
- `add_agent_to_pool`
- `_expire_all_conversations`
- `_get_unique_pool`
- `get_agent_state`
- `_get_agent`
- part of `_complete_setup`
- `_load_model`
-  In, `start_task` the loop body and the `_done_callback` are mostly identical. However, the `while self.running` part is not identical because the WebSocket implementation uses a periodic tornado callback rather than a while loop. The following line is only relevant to messenger:
      `agents = [a for a in agents if a.disp_id is not None]`
- `_on_new_message`, except the message format would need to be consistent. Messenger also has `typing_on` and `handle_bot_read` calls which are irrelevant to WebSockets.
- `_log_debug`