### PR TITLE
Fixed a bug in MutliWOZ data setup

### DIFF
--- a/parlai/tasks/multiwoz/agents.py
+++ b/parlai/tasks/multiwoz/agents.py
@@ -56,21 +56,21 @@ class MultiWozTeacher(FixedDialogTeacher):
         valid_path = os.path.join(jsons_path, 'valListFile.json')
         if self.datatype.startswith('test'):
             with open(test_path) as f:
-                test_data = {self.messages[line] for line in f}
+                test_data = {line.strip(): self.messages[line] for line in f}
                 self.messages = test_data
         elif self.datatype.startswith('valid'):
             with open(valid_path) as f:
-                valid_data = {self.messages[line] for line in f}
+                valid_data = {line.strip(): self.messages[line.strip()] for line in f}
                 self.messages = valid_data
         else:
             with open(test_path) as f:
                 for line in f:
-                    if line in self.messages:
-                        del self.messages[line]
+                    if line.strip() in self.messages:
+                        del self.messages[line.strip()]
             with open(valid_path) as f:
                 for line in f:
-                    if line in self.messages:
-                        del self.messages[line]
+                    if line.strip() in self.messages:
+                        del self.messages[line.strip()]
         self.messages = list(self.messages.values())
 
     def num_examples(self):

--- a/parlai/tasks/multiwoz/agents.py
+++ b/parlai/tasks/multiwoz/agents.py
@@ -56,7 +56,7 @@ class MultiWozTeacher(FixedDialogTeacher):
         valid_path = os.path.join(jsons_path, 'valListFile.json')
         if self.datatype.startswith('test'):
             with open(test_path) as f:
-                test_data = {line.strip(): self.messages[line] for line in f}
+                test_data = {line.strip(): self.messages[line.strip()] for line in f}
                 self.messages = test_data
         elif self.datatype.startswith('valid'):
             with open(valid_path) as f:


### PR DESCRIPTION
**Patch description**
During data setup in MultiWozTeacher class, there was a KeyError due to having end-of-line token in the key. Previously, it wasn't loading the datasets properly.
Fixed by adding key.strip() to remove '\n'.

**Logs**
```
Traceback (most recent call last):
  File "examples/eval_model.py", line 17, in <module>
    eval_model(opt, print_parser=parser)
  File "/home/takatoy/ParlAI/parlai/scripts/eval_model.py", line 117, in eval_model
    task_report = _eval_single_world(opt, agent, task)
  File "/home/takatoy/ParlAI/parlai/scripts/eval_model.py", line 69, in _eval_single_world
    world = create_task(task_opt, agent)  # create worlds for tasks
  File "/home/takatoy/ParlAI/parlai/core/worlds.py", line 1214, in create_task
    world = create_task_world(opt, user_agents, default_world=default_world)
  File "/home/takatoy/ParlAI/parlai/core/worlds.py", line 1171, in create_task_world
    opt, user_agents, default_world=default_world
  File "/home/takatoy/ParlAI/parlai/core/worlds.py", line 1126, in _get_task_world
    task_agents = _create_task_agents(opt)
  File "/home/takatoy/ParlAI/parlai/core/worlds.py", line 1119, in _create_task_agents
    return create_task_agent_from_taskname(opt)
  File "/home/takatoy/ParlAI/parlai/core/agents.py", line 830, in create_task_agent_from_taskname
    task_agents = teacher_class(opt)
  File "/home/takatoy/ParlAI/parlai/tasks/multiwoz/agents.py", line 46, in __init__
    self._setup_data(opt['datafile'], jsons_path)
  File "/home/takatoy/ParlAI/parlai/tasks/multiwoz/agents.py", line 63, in _setup_data
    valid_data = {self.messages[line] for line in f}
  File "/home/takatoy/ParlAI/parlai/tasks/multiwoz/agents.py", line 63, in <setcomp>
    valid_data = {self.messages[line] for line in f}
KeyError: 'PMUL0698.json\n'
```
