### PR TITLE
Always run all tests on master.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -440,6 +440,10 @@ workflows:
           filters:
             branches:
               only: master
+      - nightly_gpu_tests:
+          filters:
+            branches:
+              only: master
       - check_extra_tests:
           filters:
             branches:
@@ -455,20 +459,3 @@ workflows:
       - test_website:
           requires:
             - deploy_website
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 10 * * *" # 10am UTC is 5am NYC
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - unittests_36
-      - unittests_37
-      - unittests_gpu11
-      - unittests_gpu12
-      - unittests_osx
-      - mturk_tests
-      - nightly_gpu_tests
-      - test_website

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -83,6 +83,11 @@ class retry(object):
     """
     Decorator for flaky tests. Test is run up to ntries times, retrying on failure.
 
+    :param ntries:
+        the number of tries to attempt
+    :param log_retry:
+        if True, prints to stdout on retry to avoid being seen as "hanging"
+
     On the last time, the test will simply fail.
 
     >>> @retry(ntries=10)
@@ -91,8 +96,9 @@ class retry(object):
     ...     self.assertLess(0.5, random.random())
     """
 
-    def __init__(self, ntries=3):
+    def __init__(self, ntries=3, log_retry=False):
         self.ntries = ntries
+        self.log_retry = log_retry
 
     def __call__(self, testfn):
         """Call testfn(), possibly multiple times on failureException."""
@@ -104,7 +110,8 @@ class retry(object):
                 try:
                     return testfn(testself, *args, **kwargs)
                 except testself.failureException:
-                    pass
+                    if self.log_retry:
+                        print("Retrying {}".format(testfn))
             # last time, actually throw any errors there may be
             return testfn(testself, *args, **kwargs)
 

--- a/tests/nightly/gpu/test_bert.py
+++ b/tests/nightly/gpu/test_bert.py
@@ -17,6 +17,7 @@ class TestBertModel(unittest.TestCase):
     for about 100 samples on convai2
     """
 
+    @testing_utils.retry(ntries=3)
     def test_biencoder(self):
         stdout, valid, test = testing_utils.train_model(
             dict(
@@ -39,6 +40,7 @@ class TestBertModel(unittest.TestCase):
             'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
         )
 
+    @testing_utils.retry(ntries=3)
     def test_crossencoder(self):
         stdout, valid, test = testing_utils.train_model(
             dict(

--- a/tests/nightly/gpu/test_bert.py
+++ b/tests/nightly/gpu/test_bert.py
@@ -17,7 +17,7 @@ class TestBertModel(unittest.TestCase):
     for about 100 samples on convai2
     """
 
-    @testing_utils.retry(ntries=3)
+    @testing_utils.retry(ntries=3, log_retry=True)
     def test_biencoder(self):
         stdout, valid, test = testing_utils.train_model(
             dict(
@@ -40,7 +40,7 @@ class TestBertModel(unittest.TestCase):
             'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
         )
 
-    @testing_utils.retry(ntries=3)
+    @testing_utils.retry(ntries=3, log_retry=True)
     def test_crossencoder(self):
         stdout, valid, test = testing_utils.train_model(
             dict(


### PR DESCRIPTION
**Patch description**
Fixes #2178.

Always run GPU tests on every hit to master. After realizing how much that pytorch is using, there's absolutely no reason for us to moderate this to once a day.

Additionally, preemptively try to fix some of the potential flakiness of one test with retries.

Testing:
Run [long] here, will need to also run on master.