### PR TITLE
Fix running Messenger chat service locally

### DIFF
--- a/parlai/chat_service/services/messenger/message_socket.py
+++ b/parlai/chat_service/services/messenger/message_socket.py
@@ -134,7 +134,7 @@ class MessageSocket:
             url_base_name = self.server_url.split('https://')[1]
             while self.keep_running:
                 try:
-                    sock_addr = "ws://{}/".format(url_base_name)
+                    sock_addr = "wss://{}/".format(url_base_name)
                     self.ws = websocket.WebSocketApp(
                         sock_addr,
                         on_message=on_message,

--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -173,11 +173,13 @@ class MessengerManager:
         self.task_configs = self.config['configs']
         self.max_workers = self.config['max_workers']
         self.opt['task'] = self.config['task_name']
+        #if not self.world_runner.world_initializing:
         # Deepcopy the opts so the manager opts aren't changed by the world runner
         runner_opt = copy.deepcopy(opt)
         self.world_runner = MessengerWorldRunner(
             runner_opt, self.world_path, self.max_workers, self, opt['is_debug']
         )
+        self._load_model(runner_opt)
         self.max_agents_for = {
             task: cfg.agents_required for task, cfg in self.task_configs.items()
         }
@@ -195,13 +197,10 @@ class MessengerManager:
         self.setup_socket()
         self.start_new_run()
 
-        if not self.world_runner.world_initializing:
-            self._load_model()
-
-    def _load_model(self):
+    def _load_model(self, runner_opt):
         """Load model if necessary."""
-        if 'model_file' in self.opt or 'model' in self.opt:
-            self.opt['shared_bot_params'] = create_agent(self.opt).share()
+        if 'model_file' in runner_opt or 'model' in runner_opt:
+            runner_opt['shared_bot_params'] = create_agent(runner_opt).share()
 
     def _init_logs(self):
         """Initialize logging settings from the opt."""

--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -16,6 +16,7 @@ import threading
 import time
 import traceback
 import datetime
+import copy
 
 from parlai.core.agents import create_agent
 from parlai.chat_service.services.messenger.agents import MessengerAgent
@@ -172,8 +173,10 @@ class MessengerManager:
         self.task_configs = self.config['configs']
         self.max_workers = self.config['max_workers']
         self.opt['task'] = self.config['task_name']
+        # Deepcopy the opts so the manager opts aren't changed by the world runner
+        runner_opt = copy.deepcopy(opt)
         self.world_runner = MessengerWorldRunner(
-            opt, self.world_path, self.max_workers, self, opt['is_debug']
+            runner_opt, self.world_path, self.max_workers, self, opt['is_debug']
         )
         self.max_agents_for = {
             task: cfg.agents_required for task, cfg in self.task_configs.items()
@@ -191,7 +194,9 @@ class MessengerManager:
         self.init_new_state()
         self.setup_socket()
         self.start_new_run()
-        self._load_model()
+
+        if not self.world_runner.world_initializing:
+            self._load_model()
 
     def _load_model(self):
         """Load model if necessary."""
@@ -380,6 +385,16 @@ class MessengerManager:
                 self._log_debug('{} returned with error {}'.format(task_id, repr(e)))
                 if self.debug:
                     raise e
+            else:
+                self.observe_message(agent_id, 'See you later!')
+                for world_type in self.agent_pool:
+                    agent_state = self.get_agent_state(agent_id)
+                    if agent_state in self.agent_pool[world_type]:
+                        self.agent_pool[world_type].remove(agent_state)
+                        self.remove_agent_from_pool(agent_state, world_type=world_type)
+                del self.messenger_agent_states[agent_id]
+                del self.agent_id_to_overworld_future[agent_id]
+
 
         future.add_done_callback(_done_callback)
         self.agent_id_to_overworld_future[agent_id] = future
@@ -398,6 +413,11 @@ class MessengerManager:
             message to put on queue
         """
         agent_id = message['sender']['id']
+        if not self.world_runner.is_initialized():
+            self.observe_message(
+                agent_id, 'Please wait while the worlds are initializing...'
+            )
+            self.world_runner.init_fut.result()
         if agent_id not in self.messenger_agent_states:
             self._on_first_message(message)
             return
@@ -570,8 +590,6 @@ class MessengerManager:
         # Set up receive
         if not self.bypass_server_setup:
             socket_use_url = self.server_url
-            if self.opt['local']:  # skip some hops for local stuff
-                socket_use_url = 'https://localhost'
             self.message_socket = MessageSocket(
                 socket_use_url, self.port, self._handle_webhook_event
             )

--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -173,7 +173,6 @@ class MessengerManager:
         self.task_configs = self.config['configs']
         self.max_workers = self.config['max_workers']
         self.opt['task'] = self.config['task_name']
-        #if not self.world_runner.world_initializing:
         # Deepcopy the opts so the manager opts aren't changed by the world runner
         runner_opt = copy.deepcopy(opt)
         self.world_runner = MessengerWorldRunner(

--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -395,7 +395,6 @@ class MessengerManager:
                 del self.messenger_agent_states[agent_id]
                 del self.agent_id_to_overworld_future[agent_id]
 
-
         future.add_done_callback(_done_callback)
         self.agent_id_to_overworld_future[agent_id] = future
 

--- a/parlai/chat_service/services/messenger/run.py
+++ b/parlai/chat_service/services/messenger/run.py
@@ -9,6 +9,9 @@ from parlai.chat_service.services.messenger.messenger_manager import MessengerMa
 import shared_utils as utils
 
 
+SERVICE_NAME = 'messenger'
+
+
 def setup_args():
     """Set up args."""
     parser = ParlaiParser(False, False)
@@ -19,6 +22,7 @@ def setup_args():
 
 def run(opt):
     """Run MessengerManager."""
+    opt['service'] = SERVICE_NAME
     manager = MessengerManager(opt)
     try:
         manager.start_task()

--- a/parlai/chat_service/services/messenger/server/server.js
+++ b/parlai/chat_service/services/messenger/server/server.js
@@ -8,12 +8,15 @@ const bodyParser = require('body-parser');
 const express = require('express');
 const fs = require('fs');
 const http = require('http');
+const https = require('https');
 const nunjucks = require('nunjucks');
 const WebSocket = require('ws');
 
 const task_directory_name = 'task';
 
 const PORT = process.env.PORT || 3000;
+const LOCAL_HTTPS = process.env.LOCAL_HTTPS || false;
+const HOME = process.env.HOME || '';
 
 // Initialize app
 const app = express();
@@ -33,7 +36,18 @@ nunjucks.configure(task_directory_name, {
 // ======================= <Socket> =======================
 
 // Start a socket to make a connection between the world and
-const server = http.createServer(app);
+let server;
+if (LOCAL_HTTPS) {
+  var options = {
+      ca: fs.readFileSync(HOME + '/.ssl/fullchain.pem'),
+      key: fs.readFileSync(HOME + '/.ssl/privkey.pem'),
+      cert: fs.readFileSync(HOME + '/.ssl/cert.pem'),
+  };
+
+  server = https.createServer(options, app);
+} else {
+  server = http.createServer(app);
+}
 const wss = new WebSocket.Server({ server });
 
 // Socket used for speaking to the world

--- a/parlai/chat_service/services/messenger/world_runner.py
+++ b/parlai/chat_service/services/messenger/world_runner.py
@@ -32,8 +32,16 @@ class MessengerWorldRunner:
         self.opt = opt
         self.tasks = {}  # task ID to task
         self.initialized = False
+        self.world_initializing = False
 
         def _is_done_initializing(fut):
+            e = fut.exception()
+            if e is not None:
+                self._log(
+                    '`module_initialize` returned with error {}'.format(repr(e))
+                )
+                if self.debug:
+                    raise e
             if fut.result():
                 print(fut.result())
             if self.debug:
@@ -41,6 +49,7 @@ class MessengerWorldRunner:
             self.initialized = True
 
         if hasattr(self._world_module, "module_initialize"):
+            self.world_initializing = True
             self._log("Initializing world module...")
             # perform any module intialization steps
             init_fn = self._world_module.module_initialize

--- a/parlai/chat_service/services/messenger/world_runner.py
+++ b/parlai/chat_service/services/messenger/world_runner.py
@@ -32,7 +32,6 @@ class MessengerWorldRunner:
         self.opt = opt
         self.tasks = {}  # task ID to task
         self.initialized = False
-        self.world_initializing = False
 
         def _is_done_initializing(fut):
             e = fut.exception()
@@ -47,7 +46,6 @@ class MessengerWorldRunner:
             self.initialized = True
 
         if hasattr(self._world_module, "module_initialize"):
-            self.world_initializing = True
             self._log("Initializing world module...")
             # perform any module intialization steps
             init_fn = self._world_module.module_initialize

--- a/parlai/chat_service/services/messenger/world_runner.py
+++ b/parlai/chat_service/services/messenger/world_runner.py
@@ -37,9 +37,7 @@ class MessengerWorldRunner:
         def _is_done_initializing(fut):
             e = fut.exception()
             if e is not None:
-                self._log(
-                    '`module_initialize` returned with error {}'.format(repr(e))
-                )
+                self._log('`module_initialize` returned with error {}'.format(repr(e)))
                 if self.debug:
                     raise e
             if fut.result():

--- a/parlai/chat_service/services/websocket/agents.py
+++ b/parlai/chat_service/services/websocket/agents.py
@@ -39,37 +39,10 @@ class WebsocketAgent(ChatServiceAgent):
         """
         logging.info(f"Sending new message: {act}")
         quick_replies = act.get('quick_replies', None)
-        attachment_msg = self._get_attachment_msg(act)
-        if attachment_msg is not None:
-            self.manager.observe_payload(self.id, attachment_msg, quick_replies)
+        if act.get('payload', None):
+            self.manager.observe_payload(self.id, act['payload'], quick_replies)
         else:
             self.manager.observe_message(self.id, act['text'], quick_replies)
-
-    def _get_attachment_msg(self, act):
-        """
-        Gets the message for an attachment given an act
-
-        Args:
-            act: dict. See `observe` for the structure of this dict
-
-        If the act does not have an attachment key, returns None. Otherwise,
-        returns the message for observe.
-        """
-        if not act.get('attachment'):
-            return None
-
-        attachment = act['attachment']
-        assert attachment['type'] == 'image', "Only image attachments supported"
-
-        if 'path' in attachment:
-            image = Image.open(attachment['path'])
-            msg = self._get_message_from_image(image)
-        elif 'data' in attachment:
-            msg = self._get_message_from_image(attachment['data'])
-        else:
-            raise ValueError("Invalid attachment format for type 'image'")
-
-        return msg
 
     def _get_message_from_image(self, image):
         """Gets the message dict for sending the provided image
@@ -97,7 +70,7 @@ class WebsocketAgent(ChatServiceAgent):
         action = {
             'episode_done': False,
             'text': message.get('text', ''),
-            'attachment': message.get('attachment'),
+            'payload': message.get('payload'),
         }
 
         self._queue_action(action, self.action_id)

--- a/parlai/chat_service/services/websocket/agents.py
+++ b/parlai/chat_service/services/websocket/agents.py
@@ -27,13 +27,13 @@ class WebsocketAgent(ChatServiceAgent):
         base 64 encoded image and `mime_type` which will be an image mime type.
 
         Args:
-            act: dict. If act contains an `attachment` key, then a dict should be
-                provided for the value in `attachment`. Otherwise, act should be
+            act: dict. If act contain an `payload` key, then a dict should be
+                provided for the value in `payload`. Otherwise, act should be
                 a dict with the key `text` for the message.
-                For the `attachment` dict, this agent expects a `type` key, which
+                For the `pyaload` dict, this agent expects a `type` key, which
                 specifies whether or not the attachment is an image. If the
-                attachment is an image, either a `path` key must be specified
-                for the path to the image, or a `data` key holding a PIL Image.
+                attachment is an image, a `data` key must be specified with a
+                base 64 encoded image.
                 A `quick_replies` key can be provided with a list of string quick
                 replies for any message
         """

--- a/parlai/chat_service/services/websocket/run.py
+++ b/parlai/chat_service/services/websocket/run.py
@@ -9,6 +9,9 @@ from parlai.chat_service.services.websocket.websocket_manager import WebsocketMa
 from parlai.chat_service.services.messenger import shared_utils as utils
 
 
+SERVICE_NAME = 'websocket'
+
+
 def setup_args():
     """Set up args."""
     parser = ParlaiParser(False, False)
@@ -19,6 +22,7 @@ def setup_args():
 
 def run(opt):
     """Run MessengerManager."""
+    opt['service'] = SERVICE_NAME
     manager = WebsocketManager(opt)
     try:
         manager.start_task()

--- a/parlai/chat_service/services/websocket/sockets.py
+++ b/parlai/chat_service/services/websocket/sockets.py
@@ -53,7 +53,7 @@ class MessageSocketHandler(WebSocketHandler):
         message = json.loads(message_text)
         message = {
             'text': message.get('text', ''),
-            'attachment': message.get('attachment'),
+            'payload': message.get('payload'),
             'sender': {'id': self.sid},
             'recipient': {'id': 0},
         }

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -255,12 +255,12 @@ class WebsocketManager(ChatServiceManager):
             (dict) payload to send through the socket. The keys should be:
                 'image': (True/False) whether the message is an image
                 'mime_type': str. Mime type of the message
-                'text': str. base64 encoded content
+                'data': str. base64 encoded content
 
         Returns a tornado future for tracking the `write_message` action.
         """
-        payload['text'] = payload['text'].replace('\n', '<br />')
-        message = {'text': '', 'attachment': payload, 'quick_replies': quick_replies}
+        payload['data'] = payload['data'].replace('\n', '<br />')
+        message = {'text': '', 'payload': payload, 'quick_replies': quick_replies}
         payload = json.dumps(message)
 
         asyncio.set_event_loop(asyncio.new_event_loop())


### PR DESCRIPTION
**Patch description**
This PR fixes the ability to run the FB Messenger chat service locally using `--local`. This functionality was previously not fully working because the port could not be customized and SSL certificates could not be provided (which Messenger requires).

If the `--local` flag is provided and the environment variable `LOCAL_HTTPS=true`, this change will accept SSL certificates in the `~/.ssl` directory under the names `privkey.pem`, `fullchain.pem`, and `cert.pem`. The `https://localhost` hostname is also no longer hardcoded, as this is customizable through the prompts anyways so removing it only improves flexibility. This is useful since trusted certs will not be for the `localhost` domain.

In addition, there are some minor changes to the WS message structure to improve its uniformity with the Messenger message structure.

The changes to the MessengerManager are primarily copied from the ChatServiceManager, while #2149 refactors the manager to use the base class.

**Testing steps**
After getting trusted SSL certificates, run `LOCAL_HTTPS=true python parlai/chat_service/services/messenger/run.py --local --config-path parlai/chat_service/tasks/chatbot/config.yml` and ensure the local server successfully works.

**Screenshots**
<img width="1259" alt="Screen Shot 2019-11-21 at 10 54 55 AM" src="https://user-images.githubusercontent.com/3749750/69354034-7bf6ac00-0c4d-11ea-96d8-b5c258c2a88c.png">
<img width="1260" alt="Screen Shot 2019-11-21 at 10 55 26 AM" src="https://user-images.githubusercontent.com/3749750/69354035-7bf6ac00-0c4d-11ea-8c7a-71d83023be1c.png">
