### PR TITLE
Make WebSocket Manager use World Runner opts if loading models

### DIFF
--- a/parlai/chat_service/core/chat_service_manager.py
+++ b/parlai/chat_service/core/chat_service_manager.py
@@ -161,9 +161,9 @@ class ChatServiceManager(ABC):
         self.max_workers = self.config['max_workers']
         self.opt['task'] = self.config['task_name']
         # Deepcopy the opts so the manager opts aren't changed by the world runner
-        runner_opt = copy.deepcopy(opt)
+        self.runner_opt = copy.deepcopy(opt)
         self.world_runner = MessengerWorldRunner(
-            runner_opt, self.world_path, self.max_workers, self, opt['is_debug']
+            self.runner_opt, self.world_path, self.max_workers, self, opt['is_debug']
         )  # Replace with base runner
         self.max_agents_for = {
             task: cfg.agents_required for task, cfg in self.task_configs.items()

--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -174,11 +174,10 @@ class MessengerManager:
         self.max_workers = self.config['max_workers']
         self.opt['task'] = self.config['task_name']
         # Deepcopy the opts so the manager opts aren't changed by the world runner
-        runner_opt = copy.deepcopy(opt)
+        self.runner_opt = copy.deepcopy(opt)
         self.world_runner = MessengerWorldRunner(
-            runner_opt, self.world_path, self.max_workers, self, opt['is_debug']
+            self.runner_opt, self.world_path, self.max_workers, self, opt['is_debug']
         )
-        self._load_model(runner_opt)
         self.max_agents_for = {
             task: cfg.agents_required for task, cfg in self.task_configs.items()
         }
@@ -195,11 +194,12 @@ class MessengerManager:
         self.init_new_state()
         self.setup_socket()
         self.start_new_run()
+        self._load_model()
 
-    def _load_model(self, runner_opt):
+    def _load_model(self):
         """Load model if necessary."""
-        if 'model_file' in runner_opt or 'model' in runner_opt:
-            runner_opt['shared_bot_params'] = create_agent(runner_opt).share()
+        if 'model_file' in self.opt or 'model' in self.opt:
+            self.runner_opt['shared_bot_params'] = create_agent(self.runner_opt).share()
 
     def _init_logs(self):
         """Initialize logging settings from the opt."""

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -67,7 +67,7 @@ class WebsocketManager(ChatServiceManager):
     def _load_model(self):
         """Load model if necessary"""
         if 'model_file' in self.opt or 'model' in self.opt:
-            self.opt['shared_bot_params'] = create_agent(self.opt).share()
+            self.runner_opt['shared_bot_params'] = create_agent(self.runner_opt).share()
 
     def _handle_message_read(self, event):
         """Send read receipt back to user who sent message


### PR DESCRIPTION
**Patch description**
This PR ensures the WebSocket manager uses the World Runner opts if it is loading models so that individual worlds can use the shared bot params in the correct opts dict. This change has been made to the messenger manager but not the websocket manager.

Additionally, the check for whether to load the model must be on the original opts (self.opt) rather than the runner opts since the runner opts could be changed from the original configured value by `module_initialize`.

**Testing steps**
Tested the chatbot task on both the messenger and the websocket services to ensure the models are loaded correctly by the managers. Then tested an internal task that uses `module_initialize` on both of the messenger and the websocket services to make sure the managers do not attempt to load models for this task.
