### PR TITLE
[Chat Service] Add support for a backup task in case of pool timeouts

### DIFF
--- a/parlai/chat_service/core/chat_service_manager.py
+++ b/parlai/chat_service/core/chat_service_manager.py
@@ -416,9 +416,7 @@ class ChatServiceManager(ABC):
                 if mark_removed:
                     agent.stored_data['removed_from_pool'] = True
                     if self.service_reference_id is not None:
-                        self.mark_removed(
-                            agent.service_id, self.service_reference_id
-                        )
+                        self.mark_removed(agent.service_id, self.service_reference_id)
 
     def _create_agent(self, task_id, agent_id):
         """Initialize an agent and return it.
@@ -487,7 +485,7 @@ class ChatServiceManager(ABC):
         self.task_group_id = '{}_{}'.format(self.opt['task'], self.run_id)
 
     def check_timeout_in_pool(
-        self, world_type, agent_pool, max_time_in_pool, backup_task=None,
+        self, world_type, agent_pool, max_time_in_pool, backup_task=None
     ):
         """Check for timed-out agents in pool.
 
@@ -579,7 +577,9 @@ class ChatServiceManager(ABC):
                     world_config = self.task_configs[world_type]
                     if world_config.max_time_in_pool is not None:
                         self.check_timeout_in_pool(
-                            world_type, agent_pool, world_config.max_time_in_pool,
+                            world_type,
+                            agent_pool,
+                            world_config.max_time_in_pool,
                             world_config.backup_task,
                         )
 

--- a/parlai/chat_service/core/chat_service_manager.py
+++ b/parlai/chat_service/core/chat_service_manager.py
@@ -417,7 +417,7 @@ class ChatServiceManager(ABC):
                     agent.stored_data['removed_from_pool'] = True
                     if self.service_reference_id is not None:
                         self.mark_removed(
-                            int(agent.service_id), int(self.service_reference_id)
+                            agent.service_id, self.service_reference_id
                         )
 
     def _create_agent(self, task_id, agent_id):
@@ -486,7 +486,9 @@ class ChatServiceManager(ABC):
         self.run_id = str(int(time.time()))
         self.task_group_id = '{}_{}'.format(self.opt['task'], self.run_id)
 
-    def check_timeout_in_pool(self, world_type, agent_pool, max_time_in_pool):
+    def check_timeout_in_pool(
+        self, world_type, agent_pool, max_time_in_pool, backup_task=None,
+    ):
         """Check for timed-out agents in pool.
 
         :param world_type:
@@ -495,6 +497,8 @@ class ChatServiceManager(ABC):
             list of ``AgentState``s
         :param max_time_in_pool:
             int maximum time allowed for agent to be in pool
+        :param backup_task:
+            string backup_task to start if we reach a timeout in the original pool
         """
         for agent_state in agent_pool:
             time_in_pool = agent_state.time_in_pool.get(world_type)
@@ -506,6 +510,9 @@ class ChatServiceManager(ABC):
 
                 agent_state.stored_data['removed_after_timeout'] = True
                 self.after_agent_removed(agent_state.service_id)
+
+                if backup_task is not None:
+                    self.add_agent_to_pool(agent_state, backup_task)
 
                 # reset wait message state
                 agent_state.stored_data['seen_wait_message'] = False
@@ -572,7 +579,8 @@ class ChatServiceManager(ABC):
                     world_config = self.task_configs[world_type]
                     if world_config.max_time_in_pool is not None:
                         self.check_timeout_in_pool(
-                            world_type, agent_pool, world_config.max_time_in_pool
+                            world_type, agent_pool, world_config.max_time_in_pool,
+                            world_config.backup_task,
                         )
 
                     needed_agents = self.max_agents_for[world_type]

--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -609,7 +609,9 @@ class MessengerManager:
         self.run_id = str(int(time.time()))
         self.task_group_id = '{}_{}'.format(self.opt['task'], self.run_id)
 
-    def check_timeout_in_pool(self, world_type, agent_pool, max_time_in_pool):
+    def check_timeout_in_pool(
+        self, world_type, agent_pool, max_time_in_pool, backup_task=None,
+    ):
         """Check for timed-out agents in pool.
 
         :param world_type:
@@ -618,6 +620,8 @@ class MessengerManager:
             list of ``AgentState``s
         :param max_time_in_pool:
             int maximum time allowed for agent to be in pool
+        :param backup_task:
+            string backup_task to start if we reach a timeout in the original pool
         """
         for agent_state in agent_pool:
             time_in_pool = agent_state.time_in_pool.get(world_type)
@@ -629,6 +633,9 @@ class MessengerManager:
 
                 agent_state.stored_data['removed_after_timeout'] = True
                 self.after_agent_removed(agent_state.messenger_id)
+
+                if backup_task is not None:
+                    self.add_agent_to_pool(agent_state, backup_task)
 
                 # reset wait message state
                 agent_state.stored_data['seen_wait_message'] = False
@@ -695,7 +702,8 @@ class MessengerManager:
                     world_config = self.task_configs[world_type]
                     if world_config.max_time_in_pool is not None:
                         self.check_timeout_in_pool(
-                            world_type, agent_pool, world_config.max_time_in_pool
+                            world_type, agent_pool, world_config.max_time_in_pool,
+                            world_config.backup_task,
                         )
 
                     needed_agents = self.max_agents_for[world_type]

--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -610,7 +610,7 @@ class MessengerManager:
         self.task_group_id = '{}_{}'.format(self.opt['task'], self.run_id)
 
     def check_timeout_in_pool(
-        self, world_type, agent_pool, max_time_in_pool, backup_task=None,
+        self, world_type, agent_pool, max_time_in_pool, backup_task=None
     ):
         """Check for timed-out agents in pool.
 
@@ -702,7 +702,9 @@ class MessengerManager:
                     world_config = self.task_configs[world_type]
                     if world_config.max_time_in_pool is not None:
                         self.check_timeout_in_pool(
-                            world_type, agent_pool, world_config.max_time_in_pool,
+                            world_type,
+                            agent_pool,
+                            world_config.max_time_in_pool,
                             world_config.backup_task,
                         )
 

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -115,7 +115,8 @@ class WebsocketManager(ChatServiceManager):
                 world_config = self.task_configs[world_type]
                 if world_config.max_time_in_pool is not None:
                     self.check_timeout_in_pool(
-                        world_type, agent_pool, world_config.max_time_in_pool
+                        world_type, agent_pool, world_config.max_time_in_pool,
+                        world_config.backup_task,
                     )
 
                 needed_agents = self.max_agents_for[world_type]

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -115,7 +115,9 @@ class WebsocketManager(ChatServiceManager):
                 world_config = self.task_configs[world_type]
                 if world_config.max_time_in_pool is not None:
                     self.check_timeout_in_pool(
-                        world_type, agent_pool, world_config.max_time_in_pool,
+                        world_type,
+                        agent_pool,
+                        world_config.max_time_in_pool,
                         world_config.backup_task,
                     )
 


### PR DESCRIPTION
**Patch description**
This PR adds support for backup tasks in case of timeouts in task pools. The ability to provide them in `config.yml` was already there, but they never were processed by the managers. To use this, simply add a `backup_task` field in a task's `config.yml`, where the value is another task name.

**Testing steps**
Add a backup task as described above and wait until a timeout occurs to make sure it transfers to the new task world.
