### PR TITLE
[Chat Services] WebSocket manager should check for non-existent socket before sending payload

### DIFF
--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -264,6 +264,9 @@ class WebsocketManager(ChatServiceManager):
         payload = json.dumps(message)
 
         asyncio.set_event_loop(asyncio.new_event_loop())
+        if socket_id not in MessageSocketHandler.subs:
+            self.agent_id_to_overworld_future[socket_id].cancel()
+            return
         return MessageSocketHandler.subs[socket_id].write_message(message)
 
     def restructure_message(self):


### PR DESCRIPTION
**Patch description**
This fixes the WebSocket manager to check that a socket ID exists before sending images. This check is already in place for sending text messages, but this PR includes it for images.

**Testing steps**
Reproducing this issue is very difficult, as it requires a situation where images are sent after the user is no longer subscribed to the websocket. This can happen sometimes when closing a tab before the game ends, which may cause the WebsocketManager to send an image before it knows the socket is no longer subscribed.
