### PR TITLE
Attempt to fix the website building process due to deprecated debian.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@ version: 2
 # -------------------------------------------------------------------------------------
 standard_cpu37: &standard_cpu37
   docker:
-    - image: circleci/python:3.7.5-buster
+    - image: circleci/python:3.7.5-buster-node
 
 standard_cpu36: &standard_cpu36
   docker:
-    - image: circleci/python:3.6.9-buster
+    - image: circleci/python:3.6.9-buster-node
 
 osx_cpu37: &osx_cpu37
   macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@ version: 2
 # -------------------------------------------------------------------------------------
 standard_cpu37: &standard_cpu37
   docker:
-    - image: circleci/python:3.7.1
+    - image: circleci/python:3.7.5-buster
 
 standard_cpu36: &standard_cpu36
   docker:
-    - image: circleci/python:3.6.5-node
+    - image: circleci/python:3.6.9-buster
 
 osx_cpu37: &osx_cpu37
   macos:
@@ -316,7 +316,7 @@ jobs:
       - <<: *codecov
 
   mturk_tests:
-    <<: *standard_cpu36
+    <<: *standard_cpu37
     working_directory: ~/ParlAI
     steps:
       - checkout
@@ -335,7 +335,7 @@ jobs:
       - <<: *codecov
 
   build_website:
-    <<: *standard_cpu36
+    <<: *standard_cpu37
     working_directory: ~/ParlAI
     steps:
       - checkout
@@ -353,7 +353,7 @@ jobs:
       - <<: *codecov
 
   deploy_website:
-    <<: *standard_cpu36
+    <<: *standard_cpu37
     working_directory: ~/ParlAI
     steps:
       - checkout
@@ -376,6 +376,7 @@ jobs:
             s3cmd --access_key="${S3_ACCESS_KEY}" --secret_key="${S3_SECRET_KEY}" sync -f --delete-removed website/build/ "s3://parl.ai/"
             s3cmd --access_key="${S3_ACCESS_KEY}" --secret_key="${S3_SECRET_KEY}" setacl --acl-public --recursive "s3://parl.ai/"
             s3cmd --access_key="${S3_ACCESS_KEY}" --secret_key="${S3_SECRET_KEY}" modify --add-header="Content-type:text/css" 's3://parl.ai/static/css/*' 's3://parl.ai/docs/_static/*.css' 's3://parl.ai/docs/_static/css/*.css'
+            sudo apt-get install s3cmd
 
   test_website:
     <<: *standard_cpu36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ buildwebsite: &buildwebsite
 # -------------------------------------------------------------------------------------
 jobs:
   datatests:
-    <<: *standard_cpu36
+    <<: *standard_cpu37
     working_directory: ~/ParlAI
     steps:
       - checkout
@@ -139,7 +139,7 @@ jobs:
           key: deps-dt-v3{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
-      - <<: *installtorchcpu36
+      - <<: *installtorchcpu37
       - run:
           name: Data tests
           command: coverage run setup.py test -s tests.suites.datatests -v
@@ -248,7 +248,7 @@ jobs:
       - <<: *codecov
 
   black:
-    <<: *standard_cpu36
+    <<: *standard_cpu37
     working_directory: ~/ParlAI
     steps:
       - checkout
@@ -266,7 +266,7 @@ jobs:
             bash ./tests/lint_changed.sh -b
 
   lint:
-    <<: *standard_cpu36
+    <<: *standard_cpu37
     working_directory: ~/ParlAI
     steps:
       - checkout
@@ -348,7 +348,7 @@ jobs:
           key: deps-bw-v3{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
-      - <<: *installtorchcpu36
+      - <<: *installtorchcpu37
       - <<: *buildwebsite
       - <<: *codecov
 
@@ -366,7 +366,7 @@ jobs:
           key: deps-dw-v3{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
-      - <<: *installtorchcpu36
+      - <<: *installtorchcpu37
       - <<: *buildwebsite
       - run:
           working_directory: ~/ParlAI/
@@ -379,7 +379,7 @@ jobs:
             sudo apt-get install s3cmd
 
   test_website:
-    <<: *standard_cpu36
+    <<: *standard_cpu37
     working_directory: ~/
     steps:
       - run:
@@ -399,7 +399,7 @@ jobs:
             curl -f -i 'https://parl.ai/docs/_static/css/parlai_theme.css'
 
   check_extra_tests:
-    <<: *standard_cpu36
+    <<: *standard_cpu37
     working_directory: ~/ParlAI
     steps:
       - checkout


### PR DESCRIPTION
**Patch description**
Fixes #2203. Debian stretch is no longer supported I guess, so upgrade to buster.

Also upgrades most of the environments to python 3.7.