### PR TITLE
Move copyright check away from unit tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,7 @@ jobs:
       - <<: *buildwebsite
       - <<: *codecov
 
-  build_website:
+  copyright:
     <<: *standard_cpu37
     working_directory: ~/ParlAI
     steps:
@@ -368,7 +368,7 @@ jobs:
             - "~/venv/lib"
       - run:
           working_directory: ~/ParlAI/
-          name: Upload the website
+          name: Check copyrights
           command: |
               python tests/check_copyright.py
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,6 +352,26 @@ jobs:
       - <<: *buildwebsite
       - <<: *codecov
 
+  build_website:
+    <<: *standard_cpu37
+    working_directory: ~/ParlAI
+    steps:
+      - checkout
+      - <<: *fixgit
+      - <<: *setup
+      - restore_cache:
+          key: deps-bw-v3{{ checksum "requirements.txt" }}
+      - <<: *installdeps
+      - save_cache:
+          key: deps-bw-v3{{ checksum "requirements.txt" }}
+          paths:
+            - "~/venv/lib"
+      - run:
+          working_directory: ~/ParlAI/
+          name: Upload the website
+          command: |
+              python tests/check_copyright.py
+
   deploy_website:
     <<: *standard_cpu36
     working_directory: ~/ParlAI
@@ -436,6 +456,7 @@ workflows:
       - unittests_37
       - unittests_36
       - unittests_osx
+      - copyright
       - mturk_tests:
           filters:
             branches:

--- a/tests/check_copyright.py
+++ b/tests/check_copyright.py
@@ -9,10 +9,7 @@ import re
 import parlai.utils.testing as testing_utils
 
 FILENAME_EXTENSIONS = r'.*\.(rst|py|sh|js|css)$'
-WHITELIST_PHRASES = [
-    'Moscow Institute of Physics and Technology.',
-    'https://github.com/fartashf/vsepp',
-]
+WHITELIST_PHRASES = ['Moscow Institute of Physics and Technology.']
 COPYRIGHT = [
     "Copyright (c) Facebook, Inc. and its affiliates.",
     "This source code is licensed under the MIT license found in the",

--- a/tests/check_copyright.py
+++ b/tests/check_copyright.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+import re
+import parlai.utils.testing as testing_utils
+
+FILENAME_EXTENSIONS = r'.*\.(rst|py|sh|js|css)$'
+WHITELIST_PHRASES = [
+    'Moscow Institute of Physics and Technology.',
+    'https://github.com/fartashf/vsepp',
+]
+COPYRIGHT = [
+    "Copyright (c) Facebook, Inc. and its affiliates.",
+    "This source code is licensed under the MIT license found in the",
+    "LICENSE file in the root directory of this source tree.",
+]
+
+
+def main():
+    allgood = True
+    for fn in testing_utils.git_ls_files():
+        # only check source files
+        if not re.match(FILENAME_EXTENSIONS, fn):
+            continue
+
+        with open(fn, 'r') as f:
+            src = f.read(512)  # only need the beginning
+
+        if not src.strip():
+            # skip empty files
+            continue
+
+        if any(wl in src for wl in WHITELIST_PHRASES):
+            # skip a few things we don't have the copyright on
+            continue
+
+        for i, msg in enumerate(COPYRIGHT):
+            if "mlb_vqa" in fn and i < 2:
+                # very special exception for mlb_vqa
+                continue
+
+            if msg not in src:
+                print('{} missing copyright "{}"'.format(fn, msg))
+                allgood = False
+
+    if not allgood:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -10,47 +10,7 @@ Unit tests for general checks of code quality.
 
 import unittest
 import os
-import re
 import parlai.utils.testing as testing_utils
-
-FILENAME_EXTENSIONS = r'.*\.(rst|py|sh|js|css)$'
-WHITELIST_PHRASES = [
-    'Moscow Institute of Physics and Technology.',
-    'https://github.com/fartashf/vsepp',
-]
-COPYRIGHT = [
-    "Copyright (c) Facebook, Inc. and its affiliates.",
-    "This source code is licensed under the MIT license found in the",
-    "LICENSE file in the root directory of this source tree.",
-]
-
-
-class TestCopyright(unittest.TestCase):
-    """Make sure all files have the right copyright."""
-
-    def test_copyright(self):
-        for fn in testing_utils.git_ls_files():
-            # only check source files
-            if not re.match(FILENAME_EXTENSIONS, fn):
-                continue
-
-            with open(fn, 'r') as f:
-                src = f.read(512)  # only need the beginning
-
-            if not src.strip():
-                # skip empty files
-                continue
-
-            if any(wl in src for wl in WHITELIST_PHRASES):
-                # skip a few things we don't have the copyright on
-                continue
-
-            for i, msg in enumerate(COPYRIGHT):
-                if "mlb_vqa" in fn and i < 2:
-                    # very special exception for mlb_vqa
-                    continue
-
-                self.assertTrue(msg in src, '{} missing copyright "{}"'.format(fn, msg))
 
 
 class TestInit(unittest.TestCase):


### PR DESCRIPTION
**Patch description**
Move the copyright check out of the unit tests, so that we don't see some otherwise strange failures.