### PR TITLE
Try again with the build website.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,15 +108,18 @@ setupcuda: &setupcuda
     command: |
       # download and install nvidia drivers, cuda, etc
       wget --no-clobber -P ~/nvidia-downloads 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.40.run'
-      wget --no-clobber -P ~/nvidia-downloads https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-ubuntu1604.pin
-      wget --no-clobber -P ~/nvidia-downloads http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda-repo-ubuntu1604-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
-      sudo cp ~/nvidia-downloads/cuda-ubuntu1604.pin /etc/apt/preferences.d/cuda-repository-pin-600
-      sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run -s --no-drm
-      sudo dpkg -i ~/nvidia-downloads/cuda-repo-ubuntu1604-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
-      sudo apt-key add /var/cuda-repo-10-2-local-10.2.89-440.33.01/7fa2af80.pub
-      sudo apt-get update
-      sudo apt-get -y install cuda
-      echo "Done installing."
+      wget --no-clobber -P ~/nvidia-downloads wget http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run
+      sudo sh ~/nvidia-downloads/cuda_10.2.89_440.33.01_linux.run
+      # old instructions
+      # wget --no-clobber -P ~/nvidia-downloads https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-ubuntu1604.pin
+      # wget --no-clobber -P ~/nvidia-downloads http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda-repo-ubuntu1604-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
+      # sudo cp ~/nvidia-downloads/cuda-ubuntu1604.pin /etc/apt/preferences.d/cuda-repository-pin-600
+      # sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run -s --no-drm
+      # sudo dpkg -i ~/nvidia-downloads/cuda-repo-ubuntu1604-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
+      # sudo apt-key add /var/cuda-repo-10-2-local-10.2.89-440.33.01/7fa2af80.pub
+      # sudo apt-get update
+      # sudo apt-get -y install cuda
+      echo "Done installing CUDA."
       pyenv versions
       nvidia-smi
       pyenv global 3.7.0
@@ -218,10 +221,10 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: nvidia-downloads-v1
+          key: nvidia-downloads-v2
       - <<: *setupcuda
       - save_cache:
-          key: nvidia-downloads-v1
+          key: nvidia-downloads-v2
           paths:
             - "~/nvidia-downloads/"
       - <<: *setup
@@ -245,10 +248,10 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: nvidia-downloads-v1
+          key: nvidia-downloads-v2
       - <<: *setupcuda
       - save_cache:
-          key: nvidia-downloads-v1
+          key: nvidia-downloads-v2
           paths:
             - "~/nvidia-downloads/"
       - <<: *setup
@@ -315,10 +318,10 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: nvidia-downloads-v1
+          key: nvidia-downloads-v2
       - <<: *setupcuda
       - save_cache:
-          key: nvidia-downloads-v1
+          key: nvidia-downloads-v2
           paths:
             - "~/nvidia-downloads/"
       - <<: *setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,11 @@ jobs:
             - "~/venv/lib"
       - <<: *installtorchcpu37
       - <<: *buildwebsite
-      - <<: *codecov
+      - run:
+          working_directory: ~/ParlAI/
+          name: temp check
+          command: |
+            pip install s3cmd
 
   copyright:
     <<: *standard_cpu37
@@ -392,11 +396,10 @@ jobs:
           working_directory: ~/ParlAI/
           name: Upload the website
           command: |
-            sudo apt-get install s3cmd
+            pip install s3cmd
             s3cmd --access_key="${S3_ACCESS_KEY}" --secret_key="${S3_SECRET_KEY}" sync -f --delete-removed website/build/ "s3://parl.ai/"
             s3cmd --access_key="${S3_ACCESS_KEY}" --secret_key="${S3_SECRET_KEY}" setacl --acl-public --recursive "s3://parl.ai/"
             s3cmd --access_key="${S3_ACCESS_KEY}" --secret_key="${S3_SECRET_KEY}" modify --add-header="Content-type:text/css" 's3://parl.ai/static/css/*' 's3://parl.ai/docs/_static/*.css' 's3://parl.ai/docs/_static/css/*.css'
-            sudo apt-get install s3cmd
 
   test_website:
     <<: *standard_cpu37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ setupcuda: &setupcuda
       sudo dpkg -i cuda-repo-ubuntu1404-10-1-local-10.1.243-418.87.00_1.0-1_amd64.deb
       sudo apt-key add /var/cuda-repo-10-1-local-10.1.243-418.87.00/7fa2af80.pub
       nvidia-smi
-      pyenv global 3.6.5
+      pyenv global 3.7.5
 
 buildwebsite: &buildwebsite
   run:
@@ -133,10 +133,10 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-dt-v3{{ checksum "requirements.txt" }}
+          key: deps-dt-v4{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-dt-v3{{ checksum "requirements.txt" }}
+          key: deps-dt-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *installtorchcpu37
@@ -153,10 +153,10 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-osx-v3{{ checksum "requirements.txt" }}
+          key: deps-osx-v4{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-osx-v3{{ checksum "requirements.txt" }}
+          key: deps-osx-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *installtorchcpuosx
@@ -173,10 +173,10 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-ut36-v3{{ checksum "requirements.txt" }}
+          key: deps-ut36-v4{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-ut36-v3{{ checksum "requirements.txt" }}
+          key: deps-ut36-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *installtorchcpu36
@@ -193,10 +193,10 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-ut37-v3{{ checksum "requirements.txt" }}
+          key: deps-ut37-v4{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-ut37-v3{{ checksum "requirements.txt" }}
+          key: deps-ut37-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *installtorchcpu37
@@ -214,10 +214,10 @@ jobs:
       - <<: *setupcuda
       - <<: *setup
       - restore_cache:
-          key: deps-gpu11-v3{{ checksum "requirements.txt" }}
+          key: deps-gpu11-v4{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-gpu11-v3{{ checksum "requirements.txt" }}
+          key: deps-gpu11-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *installtorchgpu11
@@ -235,10 +235,10 @@ jobs:
       - <<: *setupcuda
       - <<: *setup
       - restore_cache:
-          key: deps-gpu12-v3{{ checksum "requirements.txt" }}
+          key: deps-gpu12-v4{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-gpu12-v3{{ checksum "requirements.txt" }}
+          key: deps-gpu12-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *installtorchgpu12
@@ -299,10 +299,10 @@ jobs:
       - <<: *setupcuda
       - <<: *setup
       - restore_cache:
-          key: deps-nightly-v3{{ checksum "requirements.txt" }}
+          key: deps-nightly-v4{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-nightly-v3{{ checksum "requirements.txt" }}
+          key: deps-nightly-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *installtorchgpu12
@@ -323,10 +323,10 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-mturk-v3{{ checksum "requirements.txt" }}
+          key: deps-mturk-v4{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-mturk-v3{{ checksum "requirements.txt" }}
+          key: deps-mturk-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -342,10 +342,10 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-bw-v3{{ checksum "requirements.txt" }}
+          key: deps-bw-v4{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-bw-v3{{ checksum "requirements.txt" }}
+          key: deps-bw-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *installtorchcpu37
@@ -364,10 +364,10 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-bw-v3{{ checksum "requirements.txt" }}
+          key: deps-bw-v4{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-bw-v3{{ checksum "requirements.txt" }}
+          key: deps-bw-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -384,10 +384,10 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-dw-v3{{ checksum "requirements.txt" }}
+          key: deps-dw-v4{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-dw-v3{{ checksum "requirements.txt" }}
+          key: deps-dw-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *installtorchcpu37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ osx_cpu37: &osx_cpu37
 
 gpu: &gpu
   environment:
-    CUDA_VERSION: "10.0"
+    CUDA_VERSION: "10.2"
   machine:
     image: ubuntu-1604:201903-01
   resource_class: gpu.medium # tesla m60
@@ -107,13 +107,19 @@ setupcuda: &setupcuda
     working_directory: ~/
     command: |
       # download and install nvidia drivers, cuda, etc
-      wget 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.40.run'
-      sudo /bin/bash ./NVIDIA-Linux-x86_64-430.40.run -s --no-drm
-      wget https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-ubuntu1404-10-1-local-10.1.243-418.87.00_1.0-1_amd64.deb
-      sudo dpkg -i cuda-repo-ubuntu1404-10-1-local-10.1.243-418.87.00_1.0-1_amd64.deb
-      sudo apt-key add /var/cuda-repo-10-1-local-10.1.243-418.87.00/7fa2af80.pub
+      wget --no-clobber -P ~/nvidia-downloads 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.40.run'
+      wget --no-clobber -P ~/nvidia-downloads https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-ubuntu1604.pin
+      wget --no-clobber -P ~/nvidia-downloads http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda-repo-ubuntu1604-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
+      sudo cp cuda-ubuntu1604.pin /etc/apt/preferences.d/cuda-repository-pin-600
+      sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run -s --no-drm
+      sudo dpkg -i ~/nvidia-downloads/cuda-repo-ubuntu1604-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
+      sudo apt-key add sudo apt-key add /var/cuda-repo-10-2-local-10.2.89-440.33.01/7fa2af80.pub
+      sudo apt-get update
+      sudo apt-get -y install cuda
+      echo "Done installing."
+      pyenv versions
       nvidia-smi
-      pyenv global 3.7.5
+      pyenv global 3.7.0
 
 buildwebsite: &buildwebsite
   run:
@@ -211,7 +217,13 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
+      - restore_cache:
+          key: nvidia-downloads-v1
       - <<: *setupcuda
+      - save_cache:
+          key: nvidia-downloads-v1
+          paths:
+            - "~/nvidia-downloads/"
       - <<: *setup
       - restore_cache:
           key: deps-gpu11-v4{{ checksum "requirements.txt" }}
@@ -232,7 +244,13 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
+      - restore_cache:
+          key: nvidia-downloads-v1
       - <<: *setupcuda
+      - save_cache:
+          key: nvidia-downloads-v1
+          paths:
+            - "~/nvidia-downloads/"
       - <<: *setup
       - restore_cache:
           key: deps-gpu12-v4{{ checksum "requirements.txt" }}
@@ -296,7 +314,13 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
+      - restore_cache:
+          key: nvidia-downloads-v1
       - <<: *setupcuda
+      - save_cache:
+          key: nvidia-downloads-v1
+          paths:
+            - "~/nvidia-downloads/"
       - <<: *setup
       - restore_cache:
           key: deps-nightly-v4{{ checksum "requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ gpu: &gpu
   environment:
     CUDA_VERSION: "10.0"
   machine:
-    image: default
+    image: ubuntu-1604:201903-01
   resource_class: gpu.medium # tesla m60
 # -------------------------------------------------------------------------------------
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ setupcuda: &setupcuda
       wget --no-clobber -P ~/nvidia-downloads 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.40.run'
       wget --no-clobber -P ~/nvidia-downloads https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-ubuntu1604.pin
       wget --no-clobber -P ~/nvidia-downloads http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda-repo-ubuntu1604-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
-      sudo cp cuda-ubuntu1604.pin /etc/apt/preferences.d/cuda-repository-pin-600
+      sudo cp ~/nvidia-downloads/cuda-ubuntu1604.pin /etc/apt/preferences.d/cuda-repository-pin-600
       sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run -s --no-drm
       sudo dpkg -i ~/nvidia-downloads/cuda-repo-ubuntu1604-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
       sudo apt-key add sudo apt-key add /var/cuda-repo-10-2-local-10.2.89-440.33.01/7fa2af80.pub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,8 +110,8 @@ setupcuda: &setupcuda
       # download and install nvidia drivers, cuda, etc
       wget --no-clobber -P ~/nvidia-downloads 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.40.run'
       wget --no-clobber -P ~/nvidia-downloads http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run
-      sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run -s --no-drm
-      sudo sh ~/nvidia-downloads/cuda_10.2.89_440.33.01_linux.run
+      sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run --no-drm -q
+      sudo sh ~/nvidia-downloads/cuda_10.2.89_440.33.01_linux.run --silent
       # old instructions
       # wget --no-clobber -P ~/nvidia-downloads https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-ubuntu1604.pin
       # wget --no-clobber -P ~/nvidia-downloads http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda-repo-ubuntu1604-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ setupcuda: &setupcuda
       # download and install nvidia drivers, cuda, etc
       wget --no-clobber -P ~/nvidia-downloads 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.40.run'
       wget --no-clobber -P ~/nvidia-downloads http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run
-      sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run --no-drm -q
+      sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run --no-drm -q --ui=none
       sudo sh ~/nvidia-downloads/cuda_10.2.89_440.33.01_linux.run --silent
       # old instructions
       # wget --no-clobber -P ~/nvidia-downloads https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-ubuntu1604.pin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ setupcuda: &setupcuda
     command: |
       # download and install nvidia drivers, cuda, etc
       wget --no-clobber -P ~/nvidia-downloads 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.40.run'
-      wget --no-clobber -P ~/nvidia-downloads wget http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run
+      wget --no-clobber -P ~/nvidia-downloads http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run
       sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run -s --no-drm
       sudo sh ~/nvidia-downloads/cuda_10.2.89_440.33.01_linux.run
       # old instructions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ setupcuda: &setupcuda
       sudo cp ~/nvidia-downloads/cuda-ubuntu1604.pin /etc/apt/preferences.d/cuda-repository-pin-600
       sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run -s --no-drm
       sudo dpkg -i ~/nvidia-downloads/cuda-repo-ubuntu1604-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
-      sudo apt-key add sudo apt-key add /var/cuda-repo-10-2-local-10.2.89-440.33.01/7fa2af80.pub
+      sudo apt-key add /var/cuda-repo-10-2-local-10.2.89-440.33.01/7fa2af80.pub
       sudo apt-get update
       sudo apt-get -y install cuda
       echo "Done installing."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ installdeps: &installdeps
   run:
     name: Installs basic dependencies
     command: |
+      pip install -r requirements.txt
       python setup.py develop
       python -c "import nltk; nltk.download('punkt')"
 
@@ -109,6 +110,7 @@ setupcuda: &setupcuda
       # download and install nvidia drivers, cuda, etc
       wget --no-clobber -P ~/nvidia-downloads 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.40.run'
       wget --no-clobber -P ~/nvidia-downloads wget http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run
+      sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run -s --no-drm
       sudo sh ~/nvidia-downloads/cuda_10.2.89_440.33.01_linux.run
       # old instructions
       # wget --no-clobber -P ~/nvidia-downloads https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-ubuntu1604.pin

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ GitPython==3.0.3
 h5py==2.10.0
 joblib==0.14.0
 nltk==3.4.5
-numpy==1.17.2
 pexpect==4.7.0
 Pillow==6.2.0
 pre-commit==1.18.3
@@ -22,6 +21,7 @@ requests==2.22.0
 requests-mock==1.7.0
 scikit-learn==0.21.3
 scipy==1.3.1
+numpy==1.17.2
 sh==1.12.14
 Sphinx==2.2.0
 sphinx_rtd_theme==0.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,11 @@ flake8-docstrings==1.5.0
 flake8-rst-docstrings==0.0.11
 GitPython==3.0.3
 h5py==2.10.0
-joblib==0.14.0
+joblib>=0.14.0
 nltk==3.4.5
+numpy>=1.16.0
 pexpect==4.7.0
-Pillow==6.2.0
+Pillow>=6.2.0
 pre-commit==1.18.3
 py-gfm==0.1.4
 py-rouge==1.1
@@ -19,9 +20,8 @@ pyzmq==18.1.0
 regex==2019.8.19
 requests==2.22.0
 requests-mock==1.7.0
-scikit-learn==0.21.3
-scipy==1.3.1
-numpy==1.17.2
+scikit-learn>=0.21.0
+scipy>=1.3.0
 sh==1.12.14
 Sphinx==2.2.0
 sphinx_rtd_theme==0.4.3


### PR DESCRIPTION
**Patch description**
Still trying to get all of the kinks worked out of CircleCI. Changing to `>=` for some key dependencies managed to fix things.

Thought there were some problems with the GPU setup, so I ended up also upgrading the distribution of linux we're running GPU jobs on, and adding caching to the nvidia downloads.

Changes:
- Add a `pip install -r requirements.txt`
- Change some key dependencies to `>=` allowing pip to sort things out a bit better
- Upgrade linux distribution in GPU tests so we can use python 3.7. This mandated upgrading the NVIDIA/CUDA installation as well.
- Add caching to nvidia downloads
- Bumped the cache on all the dependencies for safety.

**Testing steps**
CircleCI long finally passes.