### PR TITLE
Make test_invsqrt_learning_rate run much faster

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -712,7 +712,8 @@ class TestLearningRateScheduler(unittest.TestCase):
             batchsize=1,
             warmup_updates=1,
             lr_scheduler='invsqrt',
-            num_epochs=9 / 500,
+            n_layers=1,
+            n_heads=1,
         )
 
         args['num_epochs'] = 9 / 500


### PR DESCRIPTION
**Patch description**
The `test_invsqrt_learning` rate test was timing out on tests for some builds. I updated it so it runs faster.

**Testing steps**
I ran the test alone and use `time.time()` to time it. It took around 11 seconds.