### PR TITLE
UI Changes to interactive_web.py

### DIFF
--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -29,7 +29,7 @@ WEB_HTML = """
         <div class="columns" style="height: 100%">
             <div class="column is-three-fifths is-offset-one-fifth">
               <section class="hero is-info is-large has-background-light has-text-grey-dark" style="height: 100%">
-                <div id="parent" class="hero-body">
+                <div id="parent" class="hero-body" style="overflow: auto; height: calc(100% - 76px); padding-top: 1em; padding-bottom: 0;">
                     <article class="media">
                       <figure class="media-left">
                         <span class="icon is-large">
@@ -47,7 +47,7 @@ WEB_HTML = """
                       </div>
                     </article>
                 </div>
-                <div class="hero-foot column is-three-fifths is-offset-one-fifth">
+                <div class="hero-foot column is-three-fifths is-offset-one-fifth" style="height: 76px">
                   <form id = "interact">
                       <div class="field is-grouped">
                         <p class="control is-expanded">
@@ -129,7 +129,7 @@ WEB_HTML = """
 
                     // Change info for Model response
                     parDiv.append(createChatRow("Model", data.text));
-                    window.scrollTo(0,document.body.scrollHeight);
+                    parDiv.scrollTo(0, parDiv.scrollHeight);
                 }})
             }});
             document.getElementById("interact").addEventListener("reset", function(event){{
@@ -147,7 +147,7 @@ WEB_HTML = """
 
                     parDiv.innerHTML = '';
                     parDiv.append(createChatRow("Model", "Enter a message, and the model will respond interactively."));
-                    window.scrollTo(0,document.body.scrollHeight);
+                    parDiv.scrollTo(0, parDiv.scrollHeight);
                 }})
             }});
         </script>

--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -31,15 +31,10 @@ WEB_HTML = """
               <section class="hero is-info is-large has-background-light has-text-grey-dark" style="height: 100%">
                 <div id="parent" class="hero-body" style="overflow: auto; height: calc(100% - 76px); padding-top: 1em; padding-bottom: 0;">
                     <article class="media">
-                      <figure class="media-left">
-                        <span class="icon is-large">
-                          <i class="fas fa-robot fas fa-2x"></i>
-                        </span>
-                      </figure>
                       <div class="media-content">
                         <div class="content">
                           <p>
-                            <strong>Model</strong>
+                            <strong>Instructions</strong>
                             <br>
                             Enter a message, and the model will respond interactively.
                           </p>
@@ -106,7 +101,10 @@ WEB_HTML = """
                 span.appendChild(icon);
                 figure.appendChild(span);
 
-                article.appendChild(figure);
+                if (agent !== "Instructions") {{
+                    article.appendChild(figure);
+                }};
+
                 article.appendChild(media);
 
                 return article;
@@ -146,7 +144,7 @@ WEB_HTML = """
                     var parDiv = document.getElementById("parent");
 
                     parDiv.innerHTML = '';
-                    parDiv.append(createChatRow("Model", "Enter a message, and the model will respond interactively."));
+                    parDiv.append(createChatRow("Instructions", "Enter a message, and the model will respond interactively."));
                     parDiv.scrollTo(0, parDiv.scrollHeight);
                 }})
             }});

--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -26,9 +26,9 @@ WEB_HTML = """
     <script defer src={}></script>
     <head><title> Interactive Run </title></head>
     <body>
-        <div class="columns">
+        <div class="columns" style="height: 100%">
             <div class="column is-three-fifths is-offset-one-fifth">
-              <section class="hero is-info is-large has-background-light has-text-grey-dark">
+              <section class="hero is-info is-large has-background-light has-text-grey-dark" style="height: 100%">
                 <div id="parent" class="hero-body">
                     <article class="media">
                       <figure class="media-left">


### PR DESCRIPTION
**Patch description**

Made a number of UI changes, as requested in #2063. These include:

- Setting the height of the page to 100%
- Making the div with text scrollable, and scrolling to the bottom of the div on new messages
- Changing instructions to not come from the Model
- Removing padding from the top of the div

**Testing steps**

Tested with `python parlai/scripts/interactive_web.py -m legacy:seq2seq:0`.

**Other information**

New view upon opening the page, or upon pressing "Restart Conversation" (screenshot of the entire page)

<img width="1404" alt="image" src="https://user-images.githubusercontent.com/8889311/69919240-db706b00-1448-11ea-92de-d74262bce047.png">

View upon filling the entire div:

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/8889311/69919256-fb079380-1448-11ea-897f-a35e5c6c95f8.png">
