### PR TITLE
self-chat logs:  label->labels bug

### DIFF
--- a/parlai/utils/world_logging.py
+++ b/parlai/utils/world_logging.py
@@ -62,7 +62,7 @@ class WorldLogger:
                     {
                         'id': msgs[0].get('id'),
                         'text': text,
-                        'label': label,
+                        'labels': [ label ],
                         'episode_done': False,
                     }
                 )

--- a/parlai/utils/world_logging.py
+++ b/parlai/utils/world_logging.py
@@ -62,7 +62,7 @@ class WorldLogger:
                     {
                         'id': msgs[0].get('id'),
                         'text': text,
-                        'labels': [ label ],
+                        'labels': [label],
                         'episode_done': False,
                     }
                 )


### PR DESCRIPTION
Currently saves out the data, but the label is in the wrongly named field.