### PR TITLE
[BUG FIX] Fix eval model with `train:evalmode`

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -152,7 +152,7 @@ class FixedDialogTeacher(Teacher):
         if not hasattr(self, 'random'):
             self.random = self.datatype == 'train'
         if not hasattr(self, 'training'):
-            self.training = self.datatype.startswith('train')
+            self.training = self.datatype.startswith('train') and 'evalmode' not in self.datatype
         if not hasattr(self, 'datafile'):
             self.datafile = opt.get('datafile', opt.get('pytorch_datafile'))
         # set up support for multithreaded data loading
@@ -462,7 +462,7 @@ class DialogTeacher(FixedDialogTeacher):
 
         self.startTime = time.time()
         self.datatype = opt['datatype']
-        self.training = self.datatype.startswith('train')
+        self.training = self.datatype.startswith('train') and 'evalmode' not in self.datatype
         self.stream = 'stream' in self.datatype.split(':')
 
         if not self.use_batch_act:

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -152,7 +152,9 @@ class FixedDialogTeacher(Teacher):
         if not hasattr(self, 'random'):
             self.random = self.datatype == 'train'
         if not hasattr(self, 'training'):
-            self.training = self.datatype.startswith('train') and 'evalmode' not in self.datatype
+            self.training = (
+                self.datatype.startswith('train') and 'evalmode' not in self.datatype
+            )
         if not hasattr(self, 'datafile'):
             self.datafile = opt.get('datafile', opt.get('pytorch_datafile'))
         # set up support for multithreaded data loading
@@ -462,7 +464,9 @@ class DialogTeacher(FixedDialogTeacher):
 
         self.startTime = time.time()
         self.datatype = opt['datatype']
-        self.training = self.datatype.startswith('train') and 'evalmode' not in self.datatype
+        self.training = (
+            self.datatype.startswith('train') and 'evalmode' not in self.datatype
+        )
         self.stream = 'stream' in self.datatype.split(':')
 
         if not self.use_batch_act:

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -23,7 +23,6 @@ import string
 import torch
 import json
 from abc import ABC
-from typing import TypeVar
 
 # default parameters
 VOCAB_SIZE = 7
@@ -124,12 +123,10 @@ class FixedDialogCandidateTeacher(CandidateBaseTeacher, FixedDialogTeacher):
     Useful if you'd like to test the FixedDialogTeacher
     """
 
-    def __init__(
-        self,
-        *args,
-        **kwargs
-    ):
-        """Override to build candidates."""
+    def __init__(self, *args, **kwargs):
+        """
+        Override to build candidates.
+        """
         super().__init__(*args, **kwargs)
         opt = args[0]
         if 'shared' not in kwargs:

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -36,6 +36,7 @@ class FixedDialogCandidateTeacher(FixedDialogTeacher):
 
     Useful if you'd like to test the FixedDialogTeacher
     """
+
     def __init__(
         self,
         opt,
@@ -139,7 +140,7 @@ class FixedDialogCandidateTeacher(FixedDialogTeacher):
             'text': self.corpus[episode_idx],
             'episode_done': True,
             'labels': [self.corpus[episode_idx]],
-            'label_candidates': self.cands[episode_idx]
+            'label_candidates': self.cands[episode_idx],
         }
 
 

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -246,7 +246,18 @@ def tempdir():
 
 
 @contextlib.contextmanager
-def timeout(time):
+def timeout(time: int = 30):
+    """
+    Raise a timeout if a function does not return in time `time`.
+
+    Use as a context manager, so that the signal class can reset it's alarm for
+    `SIGALARM`
+
+    :param int time:
+        Time in seconds to wait for timeout. Default is 30 seconds.
+    """
+    assert time >= 0, 'Time specified in timeout must be nonnegative.'
+
     def _handler(signum, frame):
         raise TimeoutError
 
@@ -332,33 +343,6 @@ def eval_model(opt, skip_valid=False, skip_test=False, valid_datatype=None):
         test = None if skip_test else ems.eval_model(popt)
 
     return (output.getvalue(), valid, test)
-
-
-def eval_model_timeout(
-    opt, skip_valid=False, skip_test=False, valid_datatype=None, timeout_seconds=None
-):
-    """
-    Run through evaluation loop, with timeout.
-
-    :param opt:
-        Any non-default options you wish to set.
-    :param bool skip_valid:
-        If true skips the valid evaluation, and the second return value will be None.
-    :param bool skip_test:
-        If true skips the test evaluation, and the third return value will be None.
-    :param str valid_datatype:
-        If custom datatype required for valid, e.g. train:evalmode, specify here
-    :param int timeout:
-        Seconds to wait before timeout. Fails if None
-
-    :return: (stdout, valid_results, test_results)
-    :rtype: (str, dict, dict)
-    """
-    if timeout_seconds is None or timeout_seconds <= 0:
-        raise TypeError('Timeout must be positive')
-
-    with timeout(timeout_seconds):
-        return eval_model(opt, skip_valid, skip_test, valid_datatype)
 
 
 def display_data(opt):

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -335,7 +335,7 @@ def eval_model(opt, skip_valid=False, skip_test=False, valid_datatype=None):
     return (output.getvalue(), valid, test)
 
 
-def eval_model_timeout(opt, skip_valid=False, skip_test=False, timeout_seconds=None, valid_datatype=None):
+def eval_model_timeout(opt, skip_valid=False, skip_test=False, valid_datatype=None, timeout_seconds=None):
     """
     Run through evaluation loop, with timeout.
 
@@ -345,6 +345,8 @@ def eval_model_timeout(opt, skip_valid=False, skip_test=False, timeout_seconds=N
         If true skips the valid evaluation, and the second return value will be None.
     :param bool skip_test:
         If true skips the test evaluation, and the third return value will be None.
+    :param str valid_datatype:
+        If custom datatype required for valid, e.g. train:evalmode, specify here
     :param int timeout:
         Seconds to wait before timeout. Fails if None
 

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -247,7 +247,6 @@ def tempdir():
 
 @contextlib.contextmanager
 def timeout(time):
-
     def _handler(signum, frame):
         raise TimeoutError
 
@@ -335,7 +334,9 @@ def eval_model(opt, skip_valid=False, skip_test=False, valid_datatype=None):
     return (output.getvalue(), valid, test)
 
 
-def eval_model_timeout(opt, skip_valid=False, skip_test=False, valid_datatype=None, timeout_seconds=None):
+def eval_model_timeout(
+    opt, skip_valid=False, skip_test=False, valid_datatype=None, timeout_seconds=None
+):
     """
     Run through evaluation loop, with timeout.
 

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -169,7 +169,7 @@ class TestEvalModel(unittest.TestCase):
             'datatype': 'train:evalmode',
         }
 
-        teachers = ['integration_tests:candidate_base', 'integration_tests']
+        teachers = ['integration_tests:fixed_dialog_candidate', 'integration_tests']
         batchsize = [1, 64]
         for bs in batchsize:
             for teacher in teachers:
@@ -178,7 +178,7 @@ class TestEvalModel(unittest.TestCase):
                 d['batchsize'] = bs
                 stdout, valid, test = testing_utils.eval_model_timeout(
                     d,
-                    valid_datatype=d['datatype']
+                    valid_datatype=d['datatype'],
                     timeout_seconds=20,
                 )
                 self.assertEqual(

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -160,6 +160,35 @@ class TestEvalModel(unittest.TestCase):
             'Task accuracy is averaged incorrectly',
         )
 
+    def test_train_evalmode(self):
+        """
+        Test that evaluating a model with train:evalmode completes an epoch.
+        """
+        base_dict = {
+            'model': 'repeat_label',
+            'datatype': 'train:evalmode',
+        }
+
+        teachers = ['integration_tests:candidate_base', 'integration_tests']
+        batchsize = [1, 64]
+        for bs in batchsize:
+            for teacher in teachers:
+                d = base_dict.copy()
+                d['task'] = teacher
+                d['batchsize'] = bs
+                stdout, valid, test = testing_utils.eval_model_timeout(
+                    d,
+                    timeout_seconds=20,
+                    valid_datatype=d['datatype']
+                )
+                self.assertEqual(
+                    int(valid['exs']),
+                    500,
+                    f'train:evalmode failed with bs {bs} and teacher {teacher}'
+                    f' stdout: {stdout}'
+                )
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -178,8 +178,8 @@ class TestEvalModel(unittest.TestCase):
                 d['batchsize'] = bs
                 stdout, valid, test = testing_utils.eval_model_timeout(
                     d,
-                    timeout_seconds=20,
                     valid_datatype=d['datatype']
+                    timeout_seconds=20,
                 )
                 self.assertEqual(
                     int(valid['exs']),

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -173,9 +173,10 @@ class TestEvalModel(unittest.TestCase):
                 d = base_dict.copy()
                 d['task'] = teacher
                 d['batchsize'] = bs
-                stdout, valid, test = testing_utils.eval_model_timeout(
-                    d, valid_datatype=d['datatype'], timeout_seconds=20
-                )
+                with testing_utils.timeout(time=20):
+                    stdout, valid, test = testing_utils.eval_model(
+                        d, valid_datatype=d['datatype'],
+                    )
                 self.assertEqual(
                     int(valid['exs']),
                     500,

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -175,7 +175,7 @@ class TestEvalModel(unittest.TestCase):
                 d['batchsize'] = bs
                 with testing_utils.timeout(time=20):
                     stdout, valid, test = testing_utils.eval_model(
-                        d, valid_datatype=d['datatype'],
+                        d, valid_datatype=d['datatype']
                     )
                 self.assertEqual(
                     int(valid['exs']),

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -164,10 +164,7 @@ class TestEvalModel(unittest.TestCase):
         """
         Test that evaluating a model with train:evalmode completes an epoch.
         """
-        base_dict = {
-            'model': 'repeat_label',
-            'datatype': 'train:evalmode',
-        }
+        base_dict = {'model': 'repeat_label', 'datatype': 'train:evalmode'}
 
         teachers = ['integration_tests:fixed_dialog_candidate', 'integration_tests']
         batchsize = [1, 64]
@@ -177,17 +174,14 @@ class TestEvalModel(unittest.TestCase):
                 d['task'] = teacher
                 d['batchsize'] = bs
                 stdout, valid, test = testing_utils.eval_model_timeout(
-                    d,
-                    valid_datatype=d['datatype'],
-                    timeout_seconds=20,
+                    d, valid_datatype=d['datatype'], timeout_seconds=20
                 )
                 self.assertEqual(
                     int(valid['exs']),
                     500,
                     f'train:evalmode failed with bs {bs} and teacher {teacher}'
-                    f' stdout: {stdout}'
+                    f' stdout: {stdout}',
                 )
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Patch description**
Fixes an issue where evaluating a model with `-bs` > 1 and `-dt train:evalmode` would result in looping forever.

**Testing steps**
Manual testing with below commands. Also added my own lovely test.

**Logs**
Before fix:

```
$ python examples/eval_model.py -t convai2 -m repeat_label -dt train:evalmode -bs 128
.
.
.
20s elapsed: {'exs': 110464, '%done': '84.04%', 'time_left': '3s', 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 0.9954}
22s elapsed: {'exs': 121216, '%done': '92.22%', 'time_left': '1s', 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 0.9955}
24s elapsed: {'exs': 132864, '%done': '101.08%', 'time_left': '0s', 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 0.9954}
26s elapsed: {'exs': 144000, '%done': '109.56%', 'time_left': '-2s', 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 0.9954}
.
.
.

------------------------------------------------------
$ python examples/eval_model.py -t integration_tests:CandidateBase -dt train:evalmode -m repeat_label -bs 128
.
.
.
2s elapsed: {'exs': 11904, '%done': '2380.80%', 'time_left': '-1s', 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 1.0}
[ Finished evaluating tasks ['integration_tests:CandidateBase'] using datatype train:evalmode ]
{'exs': 16000, 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 1.0}

------------------------------------------------------
$ python examples/eval_model.py -t integration_tests -dt train:evalmode -m repeat_label -bs 128
.
.
.
2s elapsed: {'exs': 11776, '%done': '2355.20%', 'time_left': '-1s', 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 1.0}
[ Finished evaluating tasks ['integration_tests'] using datatype train:evalmode ]
{'exs': 16000, 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 1.0}
```

After fix:

```
$ python examples/eval_model.py -t convai2 -m repeat_label -dt train:evalmode -bs 128
.
.
.
20s elapsed: {'exs': 87680, '%done': '66.71%', 'time_left': '10s', 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 0.9956}
22s elapsed: {'exs': 96768, '%done': '73.62%', 'time_left': '7s', 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 0.9955}
24s elapsed: {'exs': 105984, '%done': '80.63%', 'time_left': '5s', 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 0.9954}
26s elapsed: {'exs': 115200, '%done': '87.65%', 'time_left': '3s', 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 0.9955}
28s elapsed: {'exs': 124288, '%done': '94.56%', 'time_left': '1s', 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 0.9955}
[ Finished evaluating tasks ['convai2'] using datatype train:evalmode ]
{'exs': 131438, 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 0.9954}

------------------------------------------------------------------
$ python examples/eval_model.py -t integration_tests -dt train:evalmode -m repeat_label -bs 128
.
.
.
[ Finished evaluating tasks ['integration_tests'] using datatype train:evalmode ]
{'exs': 500, 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 1.0}

-------------------------------------------------------------------
$ python examples/eval_model.py -t integration_tests:CandidateBase -dt train:evalmode -m repeat_label -bs 128
.
.
.
[ Finished evaluating tasks ['integration_tests:CandidateBase'] using datatype train:evalmode ]
{'exs': 500, 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 1.0}
```
**Other information**
I cannot guarantee this is comprehensive, but this is what I found from first glance. 

