### PR TITLE
[WebSockets Service] Set debug based on the is_debug flag

### DIFF
--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -44,7 +44,7 @@ class WebsocketManager(ChatServiceManager):
         self.subs = []
 
         self.app = None
-        self.debug = opt.get('debug', True)
+        self.debug = opt.get('is_debug', False)
 
         self.message_sender = WebsocketManager.MessageSender()
 


### PR DESCRIPTION
**Patch description**
This patch sets the debug flag based on the `is_debug` parameter in the ParlaiParser which is the actual name of the debug param. Also, sets the default to False since code autoreloading reduces tornado speed significantly.

**Testing steps**
Ran `python ~/ParlAI/parlai/chat_service/services/websocket/run.py --config-path <path to config>` without the `--debug` flag and with `--debug` and checked whether debugging is working by testing autoreloading (should be on in the latter case).
