### PR TITLE
add message_partners to chat_service agents

### DIFF
--- a/parlai/chat_service/core/agents.py
+++ b/parlai/chat_service/core/agents.py
@@ -26,6 +26,7 @@ class ChatServiceAgent(Agent, ABC):
         self.observed_packets = {}
         self.message_request_time = None
         self.stored_data = {}
+        self.message_partners = []
         # initialize stored data
         self.set_stored_data()
 


### PR DESCRIPTION
**Patch description**
`chat_service/core/manager.py` (functions `start_task`, `_handle_message_read`, and `_on_new_message`) relies on `ChatServiceAgent` in `chat_service/core/manager.py` to have a class variable `message_partners`. Currently it does not, so if an agent inherits `ChatServiceAgent` it needs to add that variable itself. This just adds the line initializing `message_partners` so inheriting agents don't need to.

**Testing steps**
Commented out `self.message_partners = []` in `WebsocketAgent`, and tested that the Terminal Chat Service (its agent extends `WebsocketAgent`) worked like it previously did

**Logs**
N/A

**Other information**
N/A

**Data tests (if applicable)**
N/A
