### PR TITLE
Add OneCommon Dataset

### DIFF
--- a/parlai/tasks/onecommon/README.md
+++ b/parlai/tasks/onecommon/README.md
@@ -1,0 +1,7 @@
+Task: One Common
+======================
+Description: A collaborative referring task which requires advanced skills of common grounding under continuous and partially-observable context. This code also includes reference-resolution annotation from Udagawa and Aizawa '19.
+
+Link: https://arxiv.org/abs/1907.03399, https://arxiv.org/abs/1911.07588
+
+Tags: #OneCommon, #All, #CommonGrounding

--- a/parlai/tasks/onecommon/__init__.py
+++ b/parlai/tasks/onecommon/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/parlai/tasks/onecommon/agents.py
+++ b/parlai/tasks/onecommon/agents.py
@@ -13,6 +13,7 @@ EOS_TOKEN = '<eos>'
 SELECTION_TOKEN = '<selection>'
 YOU_TOKEN = 'YOU:'
 THEM_TOKEN = 'THEM:'
+SILENCE_TOKEN = '__SILENCE__'
 
 INPUT_TAG = 'input'
 DIALOGUE_TAG = 'dialogue'
@@ -73,7 +74,7 @@ class OneCommonTeacher(FixedDialogTeacher):
         super().reset()
 
     def num_examples(self):
-        num_exs = sum(len(episode['dialogue']) for episode in self.episodes)
+        num_exs = sum(len(episode['dialogue']) // 2 for episode in self.episodes)
         return num_exs
 
     def num_episodes(self):
@@ -140,7 +141,7 @@ class OneCommonTeacher(FixedDialogTeacher):
         # Fill in teacher's message (THEM)
         sentence = dialogue[entry_idx]
         if sentence is None:
-            action['text'] = None
+            action['text'] = SILENCE_TOKEN
         else:
             action['text'] = ' '.join(sentence[1:])
 

--- a/parlai/tasks/onecommon/agents.py
+++ b/parlai/tasks/onecommon/agents.py
@@ -8,9 +8,6 @@ from parlai.core.teachers import FixedDialogTeacher
 from .build import build
 
 import os
-import random
-
-WELCOME_MESSAGE = ''
 
 EOS_TOKEN = '<eos>'
 SELECTION_TOKEN = '<selection>'
@@ -32,15 +29,18 @@ N_OBJECT = 7
 
 
 def get_tag(tokens, tag):
-    """Extracts the value inside the given tag."""
+    """
+    Extracts the value inside the given tag.
+    """
     start = tokens.index('<' + tag + '>') + 1
     stop = tokens.index('</' + tag + '>')
     return tokens[start:stop]
 
 
 class OneCommonTeacher(FixedDialogTeacher):
-    """OneCommon teacher that loads the data from
-    https://github.com/Alab-NII/Reference-Resolution.
+    """
+    OneCommon teacher that loads the data from https://github.com/Alab-NII/Reference-
+    Resolution.
     """
 
     def __init__(self, opt, shared=None):
@@ -227,11 +227,10 @@ class OneCommonTeacher(FixedDialogTeacher):
         """
         Split the referents.
 
-        The first 3 values are begin idx, end idx, and eos idx
-        The next N_OBJECT values are booleans of if the object is referred
-        e.g. 3 4 10 0 1 0 0 0 0 0
-             means idx 3 to 4 is a markable of the utterance
-             that has <eos> at idx 10, and it refers to the 2nd dot
+        The first 3 values are begin idx, end idx, and eos idx The next N_OBJECT values
+        are booleans of if the object is referred e.g. 3 4 10 0 1 0 0 0 0 0 means idx 3
+        to 4 is a markable of an utterance with <eos> at idx 10, and it refers to the
+        2nd dot
         """
 
         referent_len = 3 + N_OBJECT

--- a/parlai/tasks/onecommon/agents.py
+++ b/parlai/tasks/onecommon/agents.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from parlai.core.teachers import FixedDialogTeacher
+from .build import build
+
+import os
+import random
+
+WELCOME_MESSAGE = ''
+
+EOS_TOKEN = '<eos>'
+SELECTION_TOKEN = '<selection>'
+YOU_TOKEN = 'YOU:'
+THEM_TOKEN = 'THEM:'
+
+INPUT_TAG = 'input'
+DIALOGUE_TAG = 'dialogue'
+REFERENTS_TAG = 'referents'
+OUTPUT_TAG = 'output'
+REAL_IDS_TAG = 'real_ids'
+
+REF_BEGIN_IDX = 0
+REF_END_IDX = 1
+REF_EOS_IDX = 2
+REF_BEGIN_TARGET_IDX = 3
+
+N_OBJECT = 7
+
+
+def get_tag(tokens, tag):
+    """Extracts the value inside the given tag."""
+    start = tokens.index('<' + tag + '>') + 1
+    stop = tokens.index('</' + tag + '>')
+    return tokens[start:stop]
+
+
+class OneCommonTeacher(FixedDialogTeacher):
+    """OneCommon teacher that loads the data from
+    https://github.com/Alab-NII/Reference-Resolution.
+    """
+
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
+        self.datatype = opt['datatype'].split(':')[0]
+        build(opt)
+
+        data_path = os.path.join(
+            opt['datapath'],
+            'onecommon',
+            'onecommon-master',
+            'aaai2020',
+            'experiments',
+            'data',
+            'onecommon',
+            self.datatype + '_reference_0.txt',
+        )
+
+        if shared and 'episodes' in shared:
+            self.episodes = shared['episodes']
+        else:
+            self._setup_data(data_path)
+
+        self.expected = {}
+
+        self.reset()
+
+    def reset(self):
+        self.expected = {}
+        super().reset()
+
+    def num_examples(self):
+        num_exs = sum(len(episode['dialogue']) for episode in self.episodes)
+        return num_exs
+
+    def num_episodes(self):
+        return len(self.episodes)
+
+    def share(self):
+        shared = super().share()
+        shared['episodes'] = self.episodes
+        return shared
+
+    def observe(self, observation):
+        if 'metrics' not in observation:
+            observation['metrics'] = {}
+
+        # Selection accuracy
+        if (
+            'output' in observation
+            and observation['output'] is not None
+            and 'output' in self.expected
+            and self.expected['output'] is not None
+        ):
+            obs_out = int(observation['output'])
+            exp_out = int(self.expected['output'])
+            observation['metrics']['target_sel_accuracy'] = float(obs_out == exp_out)
+
+        # Reference accuracy
+        if (
+            'referents' in observation
+            and observation['referents'] is not None
+            and len(observation['referents']) > 0
+            and 'referents' in self.expected
+            and self.expected['referents'] is not None
+            and len(self.expected['referents']) > 0
+        ):
+            obs_refs = observation['referents']
+            exp_refs = self.expected['referents']
+            assert len(obs_refs) == len(exp_refs)
+
+            exact_match = 0.0
+            equal_cnt = total_cnt = 0.0
+            for obs_ref, exp_ref in zip(obs_refs, exp_refs):
+                for obs_tgt, exp_tgt in zip(obs_ref['target'], exp_ref['target']):
+                    # Expected sorted referents
+                    equal_cnt += float(int(obs_tgt) == int(exp_tgt))
+                    total_cnt += 1.0
+                if equal_cnt == total_cnt:
+                    exact_match += 1.0
+
+            observation['metrics']['referent_exact_match'] = exact_match / len(exp_refs)
+            observation['metrics']['referent_accuracy'] = equal_cnt / total_cnt
+
+        return super().observe(observation)
+
+    def get(self, episode_idx, entry_idx):
+        episode = self.episodes[episode_idx]
+        dialogue = episode['dialogue']
+        referents = episode['referents']
+
+        entry_idx *= 2  # Every two utterance is an entry
+
+        action = {}
+        action['context'] = episode['context']
+
+        # Fill in teacher's message (THEM)
+        sentence = dialogue[entry_idx]
+        if sentence is None:
+            action['text'] = None
+        else:
+            action['text'] = ' '.join(sentence[1:])
+
+        # Fill in learner's response (YOU)
+        entry_idx += 1
+        sentence = dialogue[entry_idx]
+        if sentence is None:
+            action['labels'] = [SELECTION_TOKEN]
+            action['referents'] = []
+        else:
+            action['labels'] = [' '.join(sentence[1:])]
+            action['referents'] = referents[entry_idx]
+        self.expected['referents'] = action['referents']
+
+        # Fill in output at end of dialogue
+        if entry_idx < len(dialogue) - 1:
+            action['output'] = None
+            action['episode_done'] = False
+        else:
+            action['output'] = episode['output']
+            action['episode_done'] = True
+            self.expected['output'] = action['output']
+
+        return action
+
+    def _setup_data(self, data_path):
+        print('loading: ' + data_path)
+        with open(data_path) as data_file:
+            raw_data = data_file.readlines()
+
+        self.episodes = []
+        for data in raw_data:
+            words = data.strip().split()
+            context = list(map(float, get_tag(words, INPUT_TAG)))
+            dialogue, spans = self._split_dialogue(get_tag(words, DIALOGUE_TAG))
+            referents = self._split_referents(get_tag(words, REFERENTS_TAG), spans)
+            output = int(get_tag(words, OUTPUT_TAG)[0])
+            self.episodes.append(
+                {
+                    'context': context,
+                    'dialogue': dialogue,
+                    'referents': referents,
+                    'output': output,
+                }
+            )
+
+    def _split_dialogue(self, words, separator=EOS_TOKEN):
+        sentences = []
+        spans = []
+        start = 0
+        for stop in range(len(words)):
+            if words[stop] == separator:
+                sentences.append(words[start:stop])
+                spans.append((start, stop))
+                start = stop + 1
+        if stop >= start:
+            sentences.append(words[start:])
+            spans.append((start, len(words) - 1))
+
+        # Dataset contains consecutive turn
+        # concatenate utterances for those cases
+        dialogue = []
+        utterance = sentences[0]
+        for i in range(1, len(sentences)):
+            if sentences[i - 1][0] == sentences[i][0]:
+                utterance += sentences[i][1:]
+            else:
+                dialogue.append(utterance)
+                utterance = sentences[i]
+        dialogue.append(utterance)
+
+        if dialogue[0][0] == YOU_TOKEN:
+            # Dialogue starts with YOU
+            dialogue.insert(0, None)
+            spans.insert(0, None)
+        if dialogue[-1][0] == THEM_TOKEN:
+            # Dialogue starts with THEM
+            dialogue.append(None)
+            spans.append(None)
+
+        return dialogue, spans
+
+    def _split_referents(self, raw_referents, spans):
+        """
+        Split the referents.
+
+        The first 3 values are begin idx, end idx, and eos idx
+        The next N_OBJECT values are booleans of if the object is referred
+        e.g. 3 4 10 0 1 0 0 0 0 0
+             means idx 3 to 4 is a markable of the utterance
+             that has <eos> at idx 10, and it refers to the 2nd dot
+        """
+
+        referent_len = 3 + N_OBJECT
+        splitted_referents = []
+        for i in range(len(raw_referents) // referent_len):
+            val = raw_referents[i * referent_len : (i + 1) * referent_len]
+            splitted_referents.append(list(map(int, val)))
+
+        referents = []
+        idx = 0
+        for span in spans:
+            if span is None:
+                referents.append(None)
+                continue
+
+            # span is a (bos index, eos index) of an utterance
+            refs = []
+            while idx < len(splitted_referents):
+                if splitted_referents[idx][REF_EOS_IDX] == span[1]:
+                    ref = {
+                        'begin': splitted_referents[idx][REF_BEGIN_IDX] - (span[0] + 1),
+                        'end': splitted_referents[idx][REF_END_IDX] - (span[0] + 1),
+                        'target': splitted_referents[idx][REF_BEGIN_TARGET_IDX:],
+                    }
+                    refs.append(ref)
+                    idx += 1
+                else:
+                    break
+            referents.append(refs)
+
+        return referents
+
+
+class DefaultTeacher(OneCommonTeacher):
+    pass

--- a/parlai/tasks/onecommon/build.py
+++ b/parlai/tasks/onecommon/build.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import parlai.core.build_data as build_data
+import os
+from parlai.core.build_data import DownloadableFile
+
+RESOURCES = [
+    DownloadableFile(
+        'https://github.com/Alab-NII/onecommon/archive/master.zip',
+        'onecommon.zip',
+        'a07eb871653e5d5d53c554b85e1824f8ae1493e4472c60a54c634c2a2d7d5626',
+    )
+]
+
+
+def build(opt):
+    dpath = os.path.join(opt['datapath'], 'onecommon')
+    version = None
+
+    if not build_data.built(dpath, version_string=version):
+        print('[building data: ' + dpath + ']')
+
+        # make a clean directory if needed
+        if build_data.built(dpath):
+            # an older version exists, so remove these outdated files.
+            build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # Download the data.
+        for downloadable_file in RESOURCES:
+            downloadable_file.download_file(dpath)
+
+        # Mark as done
+        build_data.mark_done(dpath, version_string=version)

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -1053,4 +1053,16 @@ task_list = [
             " for more information). "
         ),
     },
+    {
+        "id": "OneCommon",
+        "display_name": "OneCommon",
+        "task": "onecommon",
+        "tags": ["All", "CommonGrounding"],
+        "description": (
+            "A collaborative referring task which requires advanced skills "
+            "of common grounding under continuous and partially-observable context. "
+            "This code also includes reference-resolution annotation "
+            "from Udagawa and Aizawa '19."
+        ),
+    },
 ]

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -1057,12 +1057,12 @@ task_list = [
         "id": "OneCommon",
         "display_name": "OneCommon",
         "task": "onecommon",
-        "tags": ["All", "CommonGrounding"],
+        "tags": ["All", "Goal"],
         "description": (
             "A collaborative referring task which requires advanced skills "
             "of common grounding under continuous and partially-observable context. "
             "This code also includes reference-resolution annotation "
-            "from Udagawa and Aizawa '19."
+            "from Udagawa and Aizawa '19. Link: https://github.com/Alab-NII/onecommon"
         ),
     },
 ]


### PR DESCRIPTION
**Patch description**
Adds the OneCommon dataset to the tasks.
AAAI 19 Paper: https://aaai.org/ojs/index.php/AAAI/article/view/4694
AAAI 20 Paper: https://arxiv.org/abs/1911.07588

**Testing steps**
```
python examples/display_data.py -t onecommon -dt train
python examples/display_data.py -t onecommon -dt valid
python examples/display_data.py -t onecommon -dt test
```

**Logs**
```
python examples/display_data.py -t onecommon -dt train
.
- - - - - - - - - - - - - - - - - - - - -
~~
[context]:
  0.46
  0.81
  -0.3333333333333333
  -0.5333333333333333
  -0.835
  ...and 23 more
[referents]:
  {'begin': 3, 'end': 7, 'target': [0, 0, 0, 1, 0, 0, 0]}
  {'begin': 9, 'end': 12, 'target': [0, 0, 0, 0, 1, 0, 0]}
  {'begin': 16, 'end': 16, 'target': [0, 0, 0, 1, 0, 0, 0]}
  {'begin': 19, 'end': 19, 'target': [0, 0, 0, 1, 0, 0, 0]}
[output]: None
[labels: do you have a black kinda small one with a very smaller one lighter directly to it 's right/below it ?]
~~
[context]:
  0.46
  0.81
  -0.3333333333333333
  -0.5333333333333333
  -0.835
  ...and 23 more
[referents]:
  {'begin': 1, 'end': 2, 'target': [1, 0, 0, 0, 0, 1, 0]}
  {'begin': 7, 'end': 10, 'target': [0, 1, 1, 0, 0, 0, 1]}
  {'begin': 21, 'end': 21, 'target': [1, 0, 0, 0, 0, 1, 0]}
  {'begin': 26, 'end': 29, 'target': [0, 0, 0, 0, 0, 1, 0]}
  {'begin': 31, 'end': 33, 'target': [1, 0, 0, 0, 0, 0, 0]}
[output]: None
[onecommon]: hmm i think the lower one is cut out for me . is there a very light grey dot up and to the left of the black one ?
[labels: ok that 's toward the bottom ? most of the others run in a line up and to the left above them ? if so pick the really light one above the black one]
~~
[context]:
  0.46
  0.81
  -0.3333333333333333
  -0.5333333333333333
  -0.835
  ...and 23 more
[referents]:
  {'begin': 6, 'end': 10, 'target': [0, 0, 0, 0, 0, 0, 1]}
[output]: 6
[onecommon]: no i 'm confused . do you have a large med grey dot with a smaller light grey dot down to its right ?
[labels: lol yes . let 's choose the large med grey one then , ty <selection>]
- - - - - - - - - - - - - - - - - - - - -
~~
[context]:
  -0.135
  -0.78
  0.3333333333333333
  -1.0
  0.64
  ...and 23 more
[referents]:
  {'begin': 2, 'end': 5, 'target': [1, 0, 0, 0, 0, 0, 0]}
  {'begin': 7, 'end': 7, 'target': [1, 0, 0, 0, 0, 0, 0]}
[output]: None
[labels: i have 1 pure black dot . it is largish in size]
~~
[context]:
  -0.135
  -0.78
  0.3333333333333333
  -1.0
  0.64
  ...and 23 more
[referents]:
  {'begin': 3, 'end': 4, 'target': [1, 0, 0, 0, 0, 0, 0]}
[output]: 0
[onecommon]: is it at the top ? there is a similar size grey one below it , with a line of 3 or 4 below that going from left to right upward ?
[labels: exactly . click the black <selection>]
- - - - - - - - - - - - - - - - - - - - -
~~
[ loaded 8304 episodes with a total of 46258 examples ]
```

```
python examples/display_data.py -t onecommon -dt valid
.
[ loaded 1038 episodes with a total of 5888 examples ]
```

```
python examples/display_data.py -t onecommon -dt test
.
[ loaded 1038 episodes with a total of 5710 examples ]
```

**Data tests (if applicable)**
```
Using /Users/takato/lab/project/ParlAI/.eggs/untokenize-0.1.1-py3.6.egg
running egg_info
writing parlai.egg-info/PKG-INFO
writing dependency_links to parlai.egg-info/dependency_links.txt
writing requirements to parlai.egg-info/requires.txt
writing top-level names to parlai.egg-info/top_level.txt
reading manifest file 'parlai.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'parlai.egg-info/SOURCES.txt'
running build_ext
test_verify_data (test_new_tasks.TestNewTasks) ... ok

----------------------------------------------------------------------
Ran 1 test in 43.219s

OK
```
