### PR TITLE
Implements local browser chat service

### DIFF
--- a/parlai/chat_service/services/browser_chat/README.md
+++ b/parlai/chat_service/services/browser_chat/README.md
@@ -1,0 +1,18 @@
+## Terminal Chat
+This allows you to participate in a ParlAI world as an agent using the terminal.
+This extends the `websocket` chat service implementation to run a server locally,
+which you can send and receive messages from using the terminal.
+
+## Setup
+1. Run:
+
+ `python parlai/chat_service/services/terminal_chat/run.py --config-path path/to/config.yml --port PORT_NUMBER`
+
+  Example:
+
+   `python parlai/chat_service/services/terminal_chat/run.py --config-path parlai/chat_service/tasks/chatbot/config.yml --port 10001`
+
+2. Run: `python client.py --port PORT_NUMBER`
+3. Interact
+
+If no port number is specified in `--port` then the default port used will be `34596`. If specifying, ensure both port numbers match on client and server side.

--- a/parlai/chat_service/services/browser_chat/README.md
+++ b/parlai/chat_service/services/browser_chat/README.md
@@ -1,16 +1,16 @@
-## Terminal Chat
-This allows you to participate in a ParlAI world as an agent using the terminal.
+## Browser Chat
+This allows you to participate in a ParlAI world as an agent using a local browser.
 This extends the `websocket` chat service implementation to run a server locally,
-which you can send and receive messages from using the terminal.
+which you can send and receive messages using a browser.
 
 ## Setup
 1. Run:
 
- `python parlai/chat_service/services/terminal_chat/run.py --config-path path/to/config.yml --port PORT_NUMBER`
+ `python parlai/chat_service/services/browser_chat/run.py --config-path path/to/config.yml --port PORT_NUMBER`
 
   Example:
 
-   `python parlai/chat_service/services/terminal_chat/run.py --config-path parlai/chat_service/tasks/chatbot/config.yml --port 10001`
+   `python parlai/chat_service/services/browser_chat/run.py --config-path parlai/chat_service/tasks/chatbot/config.yml --port 10001`
 
 2. Run: `python client.py --port PORT_NUMBER`
 3. Interact

--- a/parlai/chat_service/services/browser_chat/__init__.py
+++ b/parlai/chat_service/services/browser_chat/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/parlai/chat_service/services/browser_chat/agents.py
+++ b/parlai/chat_service/services/browser_chat/agents.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from parlai.chat_service.services.websocket.agents import WebsocketAgent
+
+
+class BrowserAgent(WebsocketAgent):
+    pass

--- a/parlai/chat_service/services/browser_chat/browser_manager.py
+++ b/parlai/chat_service/services/browser_chat/browser_manager.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from parlai.chat_service.services.websocket.websocket_manager import WebsocketManager
+
+
+class BrowserManager(WebsocketManager):
+    """
+    Chat Service manager that runs chat service tasks using terminal to send and receive
+    messages.
+    """
+
+    pass

--- a/parlai/chat_service/services/browser_chat/browser_manager.py
+++ b/parlai/chat_service/services/browser_chat/browser_manager.py
@@ -9,8 +9,8 @@ from parlai.chat_service.services.websocket.websocket_manager import WebsocketMa
 
 class BrowserManager(WebsocketManager):
     """
-    Chat Service manager that runs chat service tasks using a local browser
-    to send and receive messages.
+    Chat Service manager that runs chat service tasks using a local browser to send and
+    receive messages.
     """
 
     pass

--- a/parlai/chat_service/services/browser_chat/browser_manager.py
+++ b/parlai/chat_service/services/browser_chat/browser_manager.py
@@ -9,8 +9,8 @@ from parlai.chat_service.services.websocket.websocket_manager import WebsocketMa
 
 class BrowserManager(WebsocketManager):
     """
-    Chat Service manager that runs chat service tasks using terminal to send and receive
-    messages.
+    Chat Service manager that runs chat service tasks using a local browser 
+    to send and receive messages.
     """
 
     pass

--- a/parlai/chat_service/services/browser_chat/browser_manager.py
+++ b/parlai/chat_service/services/browser_chat/browser_manager.py
@@ -9,7 +9,7 @@ from parlai.chat_service.services.websocket.websocket_manager import WebsocketMa
 
 class BrowserManager(WebsocketManager):
     """
-    Chat Service manager that runs chat service tasks using a local browser 
+    Chat Service manager that runs chat service tasks using a local browser
     to send and receive messages.
     """
 

--- a/parlai/chat_service/services/browser_chat/client.py
+++ b/parlai/chat_service/services/browser_chat/client.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import uuid
+import websocket
+import time
+import threading
+import requests
+from parlai.core.params import ParlaiParser
+from parlai.scripts.interactive_web import (
+    HOST_NAME,
+    PORT,
+    WEB_HTML,
+    STYLE_SHEET,
+    FONT_AWESOME,
+)
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+SHARED = {}
+
+
+def setup_interactive(ws):
+    SHARED['ws'] = ws
+
+
+new_message = None
+message_available = threading.Event()
+
+
+class BrowserHandler(BaseHTTPRequestHandler):
+    """
+    Handle HTTP requests.
+    """
+
+    def _interactive_running(self, reply_text):
+        data = {}
+        data['text'] = reply_text.decode('utf-8')
+        if data['text'] == "[DONE]":
+            print('[ Closing socket... ]')
+            SHARED['ws'].close()
+            SHARED['wb'].shutdown()
+        json_data = json.dumps(data)
+        SHARED['ws'].send(json_data)
+
+    def do_HEAD(self):
+        """
+        Handle HEAD requests.
+        """
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_POST(self):
+        """
+        Handle POST request, especially replying to a chat message.
+        """
+        if self.path == '/interact':
+            content_length = int(self.headers['Content-Length'])
+            body = self.rfile.read(content_length)
+            self._interactive_running(body)
+            self.send_response(200)
+            self.send_header('Content-type', 'application/json')
+            self.end_headers()
+            model_response = {'id': 'Model', 'episode_done': False}
+            message_available.wait()
+            model_response['text'] = new_message
+            message_available.clear()
+            json_str = json.dumps(model_response)
+            self.wfile.write(bytes(json_str, 'utf-8'))
+        elif self.path == '/reset':
+            self.send_response(200)
+            self.send_header('Content-type', 'application/json')
+            self.end_headers()
+            self.wfile.write(bytes("{}", 'utf-8'))
+        else:
+            return self._respond({'status': 500})
+
+    def do_GET(self):
+        """
+        Respond to GET request, especially the initial load.
+        """
+        paths = {
+            '/': {'status': 200},
+            '/favicon.ico': {'status': 202},  # Need for chrome
+        }
+        if self.path in paths:
+            self._respond(paths[self.path])
+        else:
+            self._respond({'status': 500})
+
+    def _handle_http(self, status_code, path, text=None):
+        self.send_response(status_code)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        content = WEB_HTML.format(STYLE_SHEET, FONT_AWESOME)
+        return bytes(content, 'UTF-8')
+
+    def _respond(self, opts):
+        response = self._handle_http(opts['status'], self.path)
+        self.wfile.write(response)
+
+
+def on_message(ws, message):
+    """
+    Prints the incoming message from the server.
+
+    :param ws: a WebSocketApp
+    :param message: json with 'text' field to be printed
+    """
+    incoming_message = json.loads(message)
+    global new_message
+    new_message = incoming_message['text']
+    message_available.set()
+
+
+def on_error(ws, error):
+    """
+    Prints an error, if occurs.
+
+    :param ws: WebSocketApp
+    :param error: An error
+    """
+    print(error)
+
+
+def on_close(ws):
+    """
+    Cleanup before closing connection.
+
+    :param ws: WebSocketApp
+    """
+    # Reset color formatting if necessary
+    print("Connection closed")
+
+
+def _run_browser():
+    httpd = HTTPServer(('localhost', 8080), BrowserHandler)
+
+    print('Please connect to the link: http://{}:{}/'.format('localhost', 8080))
+
+    SHARED['wb'] = httpd
+
+    httpd.serve_forever()
+
+
+def on_open(ws):
+    """
+    Starts a new thread that loops, taking user input and sending it to the websocket.
+
+    :param ws: websocket.WebSocketApp that sends messages to a browser_manager
+    """
+    threading.Thread(target=_run_browser).start()
+
+
+def setup_args():
+    """
+    Set up args, specifically for the port number.
+
+    :return: A parser that parses the port from commandline arguments.
+    """
+    parser = ParlaiParser(False, False)
+    parser_grp = parser.add_argument_group('Browser Chat')
+    parser_grp.add_argument(
+        '--port', default=35496, type=int, help='Port to run the browser chat server'
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    opt = setup_args()
+    port = opt.get('port', 34596)
+    print("Connecting to port: ", port)
+    ws = websocket.WebSocketApp(
+        "ws://localhost:{}/websocket".format(port),
+        on_message=on_message,
+        on_error=on_error,
+        on_close=on_close,
+    )
+    ws.on_open = on_open
+    setup_interactive(ws)
+    ws.run_forever()

--- a/parlai/chat_service/services/browser_chat/client.py
+++ b/parlai/chat_service/services/browser_chat/client.py
@@ -9,8 +9,6 @@ import websocket
 import threading
 from parlai.core.params import ParlaiParser
 from parlai.scripts.interactive_web import (
-    HOST_NAME,
-    PORT,
     WEB_HTML,
     STYLE_SHEET,
     FONT_AWESOME,

--- a/parlai/chat_service/services/browser_chat/client.py
+++ b/parlai/chat_service/services/browser_chat/client.py
@@ -5,11 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import json
-import uuid
 import websocket
-import time
 import threading
-import requests
 from parlai.core.params import ParlaiParser
 from parlai.scripts.interactive_web import (
     HOST_NAME,

--- a/parlai/chat_service/services/browser_chat/client.py
+++ b/parlai/chat_service/services/browser_chat/client.py
@@ -8,11 +8,7 @@ import json
 import websocket
 import threading
 from parlai.core.params import ParlaiParser
-from parlai.scripts.interactive_web import (
-    WEB_HTML,
-    STYLE_SHEET,
-    FONT_AWESOME,
-)
+from parlai.scripts.interactive_web import WEB_HTML, STYLE_SHEET, FONT_AWESOME
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 

--- a/parlai/chat_service/services/browser_chat/run.py
+++ b/parlai/chat_service/services/browser_chat/run.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Browser Chat Runner.
+
+Used to run the browser chat server.
+"""
+
+from parlai.core.params import ParlaiParser
+from parlai.chat_service.services.browser_chat.browser_manager import BrowserManager
+from parlai.chat_service.services.messenger import shared_utils as utils
+
+
+SERVICE_NAME = 'browser'
+
+
+def setup_args():
+    """
+    Set up args.
+
+    :return: A parser that takes in command line arguments for chat services (debug, config-path, password), and a port.
+    """
+    parser = ParlaiParser(False, False)
+    parser.add_parlai_data_path()
+    parser.add_chatservice_args()
+    parser_grp = parser.add_argument_group('Browser Chat')
+    parser_grp.add_argument(
+        '--port', default=35496, type=int, help='Port to run the browser chat server'
+    )
+    return parser.parse_args()
+
+
+def run(opt):
+    """
+    Run BrowserManager.
+    """
+    opt['service'] = SERVICE_NAME
+    manager = BrowserManager(opt)
+    try:
+        manager.start_task()
+    finally:
+        manager.shutdown()
+
+
+if __name__ == '__main__':
+    opt = setup_args()
+    config_path = opt.get('config_path')
+    config = utils.parse_configuration_file(config_path)
+    opt.update(config['world_opt'])
+    opt['config'] = config
+    run(opt)

--- a/parlai/chat_service/services/browser_chat/run.py
+++ b/parlai/chat_service/services/browser_chat/run.py
@@ -14,7 +14,7 @@ from parlai.chat_service.services.browser_chat.browser_manager import BrowserMan
 from parlai.chat_service.services.messenger import shared_utils as utils
 
 
-SERVICE_NAME = 'browser'
+SERVICE_NAME = 'Browser'
 
 
 def setup_args():


### PR DESCRIPTION
**Patch description**
Using the websocket implementation, adds the local browser as a chat service.

**Testing steps**
```
parlai/chat_service/services/browser_chat/run.py --config-path parlai/chat_service/tasks/chatbot/config.yml --port 30003

python client.py --port 30003
```

**Logs**
```
(base) Juui-MacBook-Pro:parlai juuhnpark$ python parlai/chat_service/services/browser_chat/run.py --config-path parlai/chat_service/tasks/chatbot/config.yml --port 30003
[ optional arguments: ] 
[  datapath: /Users/juuhnpark/ParlAI/data ]
[ Chat Services: ] 
[  config_path: parlai/chat_service/tasks/chatbot/config.yml ]
[  is_debug: False ]
[  password: None ]
[ Browser Chat: ] 
[  port: 30003 ]
[ Current ParlAI commit: 1322cdf2bc194ccde851a6f3e209261dff652945 ]
[ warning: overriding opt['model'] to legacy:seq2seq:0 (previously: seq2seq )]
[ Loading existing model params from /Users/juuhnpark/ParlAI/data/models/convai2/seq2seq/convai2_self_seq2seq_model ]
Dictionary: loading dictionary from /Users/juuhnpark/ParlAI/data/models/convai2/seq2seq/convai2_self_seq2seq_model.dict
[ num words =  18803 ]
/anaconda3/lib/python3.7/site-packages/torch/nn/_reduction.py:46: UserWarning: size_average and reduce args will be deprecated, please use reduction='sum' instead.
  warnings.warn(warning.format(ret))
[I 191208 06:50:45 web:2162] 101 GET /websocket (::1) 1.06ms
[I 191208 06:50:45 sockets:35] Opened new socket from ip: ::1
[I 191208 06:50:45 sockets:36] Current subscribers: {'b7558fc7-956e-427e-b348-74ae75966c74': <parlai.chat_service.services.websocket.sockets.MessageSocketHandler object at 0x1a399c8860>}
[I 191208 06:50:59 sockets:55] websocket message from client: {"text": "Hi!"}
[I 191208 06:50:59 agents:40] Sending new message: {'id': 'Overworld', 'text': 'Welcome to the overworld for the ParlAI messenger chatbot demo. Please type "begin" to start.', 'quick_replies': ['begin']}
[I 191208 06:51:02 sockets:55] websocket message from client: {"text": "begin"}
[I 191208 06:51:02 agents:55] Received new message: {'text': 'begin', 'payload': None, 'sender': {'id': 'b7558fc7-956e-427e-b348-74ae75966c74'}, 'recipient': {'id': 0}}

... 

[  port: 10001 ]
[ Current ParlAI commit: 1322cdf2bc194ccde851a6f3e209261dff652945 ]
Connecting to port:  10001
Please connect to the link: http://localhost:8080/
127.0.0.1 - - [08/Dec/2019 06:38:59] "POST /interact HTTP/1.1" 200 -
on_message called
127.0.0.1 - - [08/Dec/2019 06:39:01] "POST /interact HTTP/1.1" 200 -
on_message called
127.0.0.1 - - [08/Dec/2019 06:39:06] "POST /interact HTTP/1.1" 200 -
on_message called

```

**Other information**

![Screen Shot 2019-12-08 at 6 51 12 AM](https://user-images.githubusercontent.com/25288463/70389038-21b55500-1988-11ea-9b29-97f28217321d.png)
Screenshot from Safari

![Screen Shot 2019-12-08 at 6 52 00 AM](https://user-images.githubusercontent.com/25288463/70389041-34c82500-1988-11ea-8a12-686ce1e55f82.png)
Screenshot from Chrome