### PR TITLE
[TA] Fixed Torch Agent Dict Saving

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1689,7 +1689,9 @@ class TorchAgent(ABC, Agent):
 
         if path:
             model_dict_path = path + '.dict'
-            if hasattr(self, 'dict') and not os.path.exists(model_dict_path):  # force save dictionary
+            if hasattr(self, 'dict') and not os.path.exists(
+                model_dict_path
+            ):  # force save dictionary
                 # TODO: Look into possibly overriding opt('dict_file') with new path
                 self.dict.save(model_dict_path, sort=False)
             states = self.state_dict()

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1688,9 +1688,10 @@ class TorchAgent(ABC, Agent):
         path = self.opt.get('model_file', None) if path is None else path
 
         if path:
-            if hasattr(self, 'dict'):  # force save dictionary
+            model_dict_path = path + '.dict'
+            if hasattr(self, 'dict') and not os.path.exists(model_dict_path):  # force save dictionary
                 # TODO: Look into possibly overriding opt('dict_file') with new path
-                self.dict.save(path + '.dict', sort=False)
+                self.dict.save(model_dict_path, sort=False)
             states = self.state_dict()
             if states:  # anything found to save?
                 with open(path, 'wb') as write:


### PR DESCRIPTION
**Patch description**
We should not keep saving the dictionary during every `agent.save()` operation. This PR fixes to ensure that the dict is only saved one time. This is especially impactful when using `--save-after-valid true` 

**Testing steps**
Train any torch agent, observe after eval whether the dictionary continues to be saved.

**Logs**
Before Change
```
$ python examples/train_model.py -t empathetic_dialogues -m transformer/generator -mf /tmp/model_file_train -df /tmp/model_file.dict -vtim 5 -vme 5 --save-after-valid true

. . .

valid:{'exs': 5, 'accuracy': 0, 'f1': 0.06667, 'bleu-4': 3.663e-12, 'lr': 1, 'total_train_updates': 189, 'gpu_mem_percent': 0.00794, 'loss': 33.78, 'token_acc': 0.1132, 'nll_loss': 6.808, 'ppl': 904.9}
[ saving model checkpoint: /tmp/model_file_train.checkpoint ]
Dictionary: saving dictionary to /tmp/model_file_train.checkpoint.dict
[ new best accuracy: 0 ]
[ saving best valid model: /tmp/model_file_train ]
Dictionary: saving dictionary to /tmp/model_file_train.dict
[ saving best valid metric: /tmp/model_file_train.best_valid ]

. . .
valid:{'exs': 5, 'accuracy': 0, 'f1': 0.04, 'bleu-4': 6.043e-11, 'lr': 1, 'total_train_updates': 386, 'gpu_mem_percent': 0.00794, 'loss': 31.4, 'token_acc': 0.1509, 'nll_loss': 6.234, 'ppl': 509.6}
[ saving model checkpoint: /tmp/model_file_train.checkpoint ]
Dictionary: saving dictionary to /tmp/model_file_train.checkpoint.dict
[ did not beat best accuracy: 0 impatience: 1 ]
```


After Change
```
$ python examples/train_model.py -t empathetic_dialogues -m transformer/generator -mf /tmp/model_file_train -df /tmp/model_file.dict -vtim 5 -vme 5 --save-after-valid true
. . .
Dictionary: loading dictionary from /tmp/model_file_train.dict
. . .

valid:{'exs': 5, 'accuracy': 0, 'f1': 0.05, 'bleu-4': 6.561e-11, 'lr': 1, 'total_train_updates': 192, 'gpu_mem_percent': 0.00794, 'loss': 33.08, 'token_acc': 0.1132, 'nll_loss': 6.648, 'ppl': 771.2}
[ saving model checkpoint: /tmp/model_file_train.checkpoint ]
Dictionary: saving dictionary to /tmp/model_file_train.checkpoint.dict
[ new best accuracy: 0 ]
[ saving best valid model: /tmp/model_file_train ]
Dictionary: saving dictionary to /tmp/model_file_train.dict
[ saving best valid metric: /tmp/model_file_train.best_valid ]

. . .

valid:{'exs': 5, 'accuracy': 0, 'f1': 0, 'bleu-4': 0, 'lr': 1, 'total_train_updates': 386, 'gpu_mem_percent': 0.00806, 'loss': 31.53, 'token_acc': 0.1509, 'nll_loss': 6.321, 'ppl': 555.9}
[ saving model checkpoint: /tmp/model_file_train.checkpoint ]
[ did not beat best accuracy: 0 impatience: 1 ]
. . .
```

