### PR TITLE
[Utils] Display Processed Images in display_data

### DIFF
--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -764,8 +764,8 @@ def display_messages(msgs, prettify=False, ignore_fields='', max_len=1000):
                 else:
                     line = '[' + key + ']: ' + clip_text(str(msg.get(key)), max_len)
                 lines.append(space + line)
-        if type(msg.get('image')) == str:
-            lines.append(msg['image'])
+        if type(msg.get('image')) in [str, torch.Tensor]:
+            lines.append(f'[ image ]: {msg["image"]}')
         if msg.get('text', ''):
             text = clip_text(msg['text'], max_len)
             ID = '[' + msg['id'] + ']: ' if 'id' in msg else ''


### PR DESCRIPTION
**Patch description**
When displaying data with images, I'd like to see the image features if they are present.

**Testing steps**
Use display data with `--image-mode` some form of `resnet_<>` or `resnext101_32x<>d_wsl`

**Logs**
```
$ python examples/display_data.py -t flickr30k --image-mode resnet152

. . .

~~
[image_id]: 1001545525
[ image ]: tensor([[[[0.7679]],

         [[0.4607]],

         [[0.6969]],

         ...,

         [[0.4178]],

         [[0.4143]],

         [[0.3745]]]], requires_grad=True)
[labels: Two men in Germany jumping over a rail at the same time without shirts.|Two youths are jumping over a roadside railing, at night.|Boys dancing on poles in the middle of the night.|Two men with no shirts jumping over a rail.|Two guys jumping over a gate together]
- - - - - - - - - - - - - - - - - - - - -
~~
[ loaded 29000 episodes with a total of 29000 examples ]
```
