### PR TITLE
MTurk tests always run; OS X tests only run on master.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,9 +507,9 @@ workflows:
       - unittests_gpu12
       - unittests_37
       - unittests_36
-      - unittests_osx
       - copyright
-      - mturk_tests:
+      - mturk_tests
+      - unittests_osx:
           filters:
             branches:
               only: master

--- a/.circleci/triggers.py
+++ b/.circleci/triggers.py
@@ -26,6 +26,14 @@ def detect_all():
     return any(kw in testing_utils.git_commit_messages() for kw in ['[all]', '[long]'])
 
 
+def detect_osx():
+    """
+    Check if we should run OSX tests.
+    """
+    commit_msg = '[OSX]' in testing_utils.git_commit_messages()
+    return commit_msg or test_changed
+
+
 def detect_gpu():
     """
     Check if we should run GPU tests.
@@ -49,21 +57,10 @@ def detect_data():
     return commit_msg or test_changed
 
 
-def detect_mturk():
-    """
-    Check if we should run mturk tests.
-    """
-    commit_msg = '[mturk]' in testing_utils.git_commit_messages().lower()
-    mturk_changed = any(
-        'parlai/mturk' in fn for fn in testing_utils.git_changed_files()
-    )
-    return commit_msg or mturk_changed
-
-
 MAPPING = {
     'nightly_gpu_tests': detect_gpu,
     'datatests': detect_data,
-    'mturk_tests': detect_mturk,
+    'unittests_osx': detect_osx,
 }
 
 

--- a/.circleci/triggers.py
+++ b/.circleci/triggers.py
@@ -31,7 +31,7 @@ def detect_osx():
     Check if we should run OSX tests.
     """
     commit_msg = '[OSX]' in testing_utils.git_commit_messages()
-    return commit_msg or test_changed
+    return commit_msg
 
 
 def detect_gpu():


### PR DESCRIPTION
**Patch description**
Moves OSX tests to only run on the master branch, and changes mturk tests to run on all branches.

OSX tests take a long time, partly because the machines are slower, and partly because we have to spend a long time waiting to get the environment allocated to us. There is no reason for it to slow us down, which it rarely is a red flag. We can still run always on master to flag anytime it breaks quickly.

On the other hand, MTurk tests are the opposite. They take a very short amount of time, and we are only running them on master. That used to be because there was some flakiness and false positives, but I think most of those are gone. We can keep the coverage benefit then without it slowing us down.

**Testing**
CI