### PR TITLE
Make shebang failure fatal.

### DIFF
--- a/parlai/agents/alice/__init__.py
+++ b/parlai/agents/alice/__init__.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/tests/check_copyright.py
+++ b/tests/check_copyright.py
@@ -47,6 +47,7 @@ def main():
 
         if fn.endswith('.py') and not src.startswith(PYTHON_SHEBANG):
             print(f'{fn}:1: Bad python3 shebang, use "{PYTHON_SHEBANG}"')
+            allgood = False
 
     if not allgood:
         sys.exit(1)


### PR DESCRIPTION
**Patch description**
Missed a line of code in #2260, causing CI to not notice a failure of shebangs.

**Testing steps**
Found something that slipped through the cracks.