### PR TITLE
Fix one syntax error. Reword 'Task: " to " models".

### DIFF
--- a/docs/source/generate_zoo_list.py
+++ b/docs/source/generate_zoo_list.py
@@ -67,7 +67,7 @@ def model_text(model_dict, fout):
 fout = open('zoo_list.inc', 'w')
 
 for task_name in category_zoo_list:
-    s = 'Task: ' + task_name.capitalize() + '\n'
+    s = task_name.title().replace('_', ' ') + ' models\n'
     fout.write(s)
     fout.write('-' * len(s) + '\n\n')
 

--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -437,20 +437,27 @@ def download_multiprocess(
     urls, path, num_processes=32, chunk_size=100, dest_filenames=None, error_path=None
 ):
     """
-    Download items in parallel (e.g. for an image + dialogue task)
+    Download items in parallel (e.g. for an image + dialogue task).
 
-    Note: "of threading, multiprocess and pytorch.multiprocessing pick two".
-    These three don't all play well together. On OS X, may hang upon successful finish.
+    WARNING: may have issues with OS X.
 
-    :param urls: Array of urls to download
-    :param path: directory to save items in
-    :param num_processes: number of processes to use
-    :param chunk_size: chunk size to use
-    :param dest_filenames: optional array of same length as url with filenames.
-     Images will be saved as path + dest_filename
-    :param error_path: where to save error logs
-    :return: array of tuples of (destination filename, http status code, error
-    message if any). Note that upon failure, file may not actually be created.
+    :param urls:
+        Array of urls to download
+    :param path:
+        directory to save items in
+    :param num_processes:
+        number of processes to use
+    :param chunk_size:
+        chunk size to use
+    :param dest_filenames:
+        optional array of same length as url with filenames.  Images will be
+        saved as path + dest_filename
+    :param error_path:
+        where to save error logs
+    :return:
+        array of tuples of (destination filename, http status code, error
+        message if any). Note that upon failure, file may not actually be
+        created.
     """
 
     pbar = tqdm.tqdm(total=len(urls), position=0)


### PR DESCRIPTION
**Patch description**
- Small change to one docstring to prevent compile errors.
- Small rewording of a word on teh docs page.