### PR TITLE
[Poly-encoder] Fixes for DSTC7 Task

### DIFF
--- a/parlai/tasks/dstc7/agents.py
+++ b/parlai/tasks/dstc7/agents.py
@@ -34,25 +34,28 @@ class DSTC7Teacher(FixedDialogTeacher):
         filepath = os.path.join(
             basedir, 'ubuntu_%s_subtask_1%s.json' % (self.split, self.get_suffix())
         )
-        with open(filepath, 'r') as f:
-            self.data = json.loads(f.read())
+        if shared is not None:
+            self.data = shared['data']
+        else:
+            with open(filepath, 'r') as f:
+                self.data = json.loads(f.read())
 
-        # special case of test set
-        if self.split == "test":
-            id_to_res = {}
-            with open(
-                os.path.join(basedir, "ubuntu_responses_subtask_1.tsv"), 'r'
-            ) as f:
-                for line in f:
-                    splited = line[0:-1].split("\t")
-                    id_ = splited[0]
-                    id_res = splited[1]
-                    res = splited[2]
-                    id_to_res[id_] = [{"candidate-id": id_res, "utterance": res}]
-            for sample in self.data:
-                sample["options-for-correct-answers"] = id_to_res[
-                    str(sample["example-id"])
-                ]
+            # special case of test set
+            if self.split == "test":
+                id_to_res = {}
+                with open(
+                    os.path.join(basedir, "ubuntu_responses_subtask_1.tsv"), 'r'
+                ) as f:
+                    for line in f:
+                        splited = line[0:-1].split("\t")
+                        id_ = splited[0]
+                        id_res = splited[1]
+                        res = splited[2]
+                        id_to_res[id_] = [{"candidate-id": id_res, "utterance": res}]
+                for sample in self.data:
+                    sample["options-for-correct-answers"] = id_to_res[
+                        str(sample["example-id"])
+                    ]
 
         super().__init__(opt, shared)
         self.reset()
@@ -96,6 +99,16 @@ class DSTC7Teacher(FixedDialogTeacher):
         return shared
 
 
+class DSTC7TeacherAugmented(DSTC7Teacher):
+    """ Augmented
+    """
+
+    def get_suffix(self):
+        if self.split != "train":
+            return ""
+        return "_augmented"
+
+
 class DSTC7TeacherAugmentedSampled(DSTC7Teacher):
     """
     The dev and test set are the same, but the training set has been augmented using the
@@ -107,7 +120,7 @@ class DSTC7TeacherAugmentedSampled(DSTC7Teacher):
     def get_suffix(self):
         if self.split != "train":
             return ""
-        return "_augmented"
+        return "_sampled"
 
     def get_nb_cands(self):
         return 16

--- a/parlai/tasks/dstc7/agents.py
+++ b/parlai/tasks/dstc7/agents.py
@@ -100,7 +100,8 @@ class DSTC7Teacher(FixedDialogTeacher):
 
 
 class DSTC7TeacherAugmented(DSTC7Teacher):
-    """ Augmented
+    """
+    Augmented.
     """
 
     def get_suffix(self):

--- a/parlai/tasks/dstc7/agents.py
+++ b/parlai/tasks/dstc7/agents.py
@@ -101,7 +101,27 @@ class DSTC7Teacher(FixedDialogTeacher):
 
 class DSTC7TeacherAugmented(DSTC7Teacher):
     """
-    Augmented.
+    Augmented Data.
+
+    To mimic the way ParlAI generally handles dialogue datasets, the data associated
+    with this teacher is presented in a format such that a single "episode" is split
+    across multiple entries.
+
+    I.e., suppose we have the following dialogue between speakers 1 and 2:
+    utterances: [A, B, C, D, E],
+    label: F
+
+    The data in this file is split such that we have the following episodes:
+
+    ep1:
+        utterances: [A],
+        label: B
+    ep2:
+        utterances [A, B, C]
+        label: D
+    ep3:
+        utterances: [A, B, C, D, E],
+        label: F
     """
 
     def get_suffix(self):

--- a/parlai/tasks/dstc7/build.py
+++ b/parlai/tasks/dstc7/build.py
@@ -10,16 +10,16 @@ import parlai.core.build_data as build_data
 
 RESOURCES = [
     DownloadableFile(
-        'http://parl.ai/downloads/dstc7/dstc7.tar.gz',
-        'dstc7.tar.gz',
-        'aa3acec0aedb660f1549cdd802f01e5bc9c5b9dc06f10764c5e20686aa4d5571',
+        'http://parl.ai/downloads/dstc7/dstc7_v2.tgz',
+        'dstc7_v2.tgz',
+        'cc8fd830f9894768ab4f7b104cddd4105456812ab614041337ec12c5a3a56685',
     )
 ]
 
 
 def build(opt):
     dpath = os.path.join(opt['datapath'], 'dstc7')
-    version = None
+    version = '2.0'
 
     if not build_data.built(dpath, version_string=version):
         print('[building data: ' + dpath + ']')


### PR DESCRIPTION
**Patch description**
The DSTC7 Augmented Sampled teacher was using a different train set than the one we used in the Poly-encoder paper; this PR fixes that.

Also a small fix to use the data in `shared`.

Fix for #2306 

**Testing steps**
I trained a poly-encoder model and got similar results to those in the paper.

**Logs**
```
$ python examples/train_model.py -m transformer/poly_encoder -t dstc7:UbuntuDSTC7TeacherAugmentedSampled --init-model zoo:pretrained_transformers/poly_model_huge_reddit/model  --batchsize 256   --model transformer/polyencoder  --warmup_updates 100  --lr-scheduler-patience 0  --lr-scheduler-decay 0.4  -lr 5e-05  --data-parallel True  --history-size 20  --label-truncate 72  --text-truncate 360  -vp 5  -veps 0.5  --validation-metric accuracy  --validation-metric-mode max  --save-after-valid True  --log_every_n_secs 20  --candidates batch  --dict-tokenizer bpe   --dict-lower True  --optimizer adamax  --output-scaling 0.06  --variant xlm  --reduction_type mean  --share-encoders False  --learn-positional-embeddings True  --n-layers 12  --n-heads 12  --ffn-size 3072  --attention-dropout 0.1  --relu-dropout 0.0  --dropout 0.1  --n-positions 1024  --embedding-size 768  --activation gelu  --embeddings-scale False  --n-segments 2  --learn-embeddings True  --share-word-embeddings False  --dict-endtoken __start__  --fp16 True  --polyencoder-type codes  --codes-attention-type basic  --poly-n-codes 64  --poly-attention-type basic  --polyencoder-attention-keys context --eval-batchsize 10 --model-file /tmp/test_model --dict-file data/models/pretrained_transformers/poly_model_huge_reddit/model.dict

.
.
.
[creating task(s): dstc7:DSTC7TeacherAugmentedSampled]
[ running eval: valid ]
[ eval completed in 282.11s ]
valid:{'exs': 5000, 'accuracy': 0.6068, 'f1': 0.6216, 'hits@1': 0.607, 'hits@5': 0.81, 'hits@10': 0.883, 'hits@100': 1.0, 'bleu-4': 0.5299, 'lr': 2e-05, 'total_train_updates': 3537, 'gpu_mem_percent': 0.419, 'examples': 5000, 'loss': 9024.0, 'mean_loss': 1.805, 'mean_rank': 5.001, 'mrr': 0.6998}
[creating task(s): dstc7:DSTC7TeacherAugmentedSampled]
[ running eval: test ]
[ eval completed in 56.18s ]
test:{'exs': 1000, 'accuracy': 0.696, 'f1': 0.7125, 'hits@1': 0.696, 'hits@5': 0.864, 'hits@10': 0.905, 'hits@100': 1.0, 'bleu-4': 0.666, 'lr': 2e-05, 'total_train_updates': 3537, 'gpu_mem_percent': 0.419, 'examples': 1000, 'loss': 1358.0, 'mean_loss': 1.358, 'mean_rank': 3.936, 'mrr': 0.7736}
```
