### PR TITLE
Skip img_seq2seq tests until pytorch 1.4 release.

### DIFF
--- a/tests/test_image_seq2seq.py
+++ b/tests/test_image_seq2seq.py
@@ -60,7 +60,8 @@ EVAL_ARGS = {
     'compute_tokenized_bleu': True,
 }
 
-
+# TODO: need pytorch 1.4 release, https://github.com/pytorch/vision/issues/1712
+@unittest.skip
 @unittest.skipUnless(TORCH_AVAILABLE, 'Must use torch 1.2 or above')
 class TestImageSeq2Seq(unittest.TestCase):
     """

--- a/tests/test_image_seq2seq.py
+++ b/tests/test_image_seq2seq.py
@@ -10,7 +10,7 @@ import parlai.utils.testing as testing_utils
 try:
     import torch
 
-    version = float('.'.join(torch.__version__.split('.')[:2]))
+    version = float('.'.join(torch.__version__.split('.')[:2]))  # type: ignore
     TORCH_AVAILABLE = version >= 1.2
 except ImportError:
     TORCH_AVAILABLE = False
@@ -45,7 +45,7 @@ IMAGE_ARGS = {
 }
 
 MULTITASK_ARGS = {
-    'task': ','.join([m['task'] for m in [IMAGE_ARGS, TEXT_ARGS]]),
+    'task': ','.join([m['task'] for m in [IMAGE_ARGS, TEXT_ARGS]]),  # type: ignore
     'num_epochs': 10,
     'multitask_weights': [1, 50],
     'image_mode': 'resnet152',
@@ -60,8 +60,10 @@ EVAL_ARGS = {
     'compute_tokenized_bleu': True,
 }
 
-# TODO: need pytorch 1.4 release, https://github.com/pytorch/vision/issues/1712
-@unittest.skip
+#
+@unittest.skip(
+    "need pytorch 1.4 release, https://github.com/pytorch/vision/issues/1712"
+)
 @unittest.skipUnless(TORCH_AVAILABLE, 'Must use torch 1.2 or above')
 class TestImageSeq2Seq(unittest.TestCase):
     """

--- a/tests/test_image_seq2seq.py
+++ b/tests/test_image_seq2seq.py
@@ -60,7 +60,7 @@ EVAL_ARGS = {
     'compute_tokenized_bleu': True,
 }
 
-#
+
 @unittest.skip(
     "need pytorch 1.4 release, https://github.com/pytorch/vision/issues/1712"
 )

--- a/tests/test_teachers.py
+++ b/tests/test_teachers.py
@@ -48,6 +48,8 @@ class TestAbstractImageTeacher(unittest.TestCase):
         """
         self._test_display_output('no_image_model')
 
+    # TODO: need pytorch 1.4 release, https://github.com/pytorch/vision/issues/1712
+    @unittest.skip
     @testing_utils.skipUnlessTorch
     @testing_utils.skipUnlessGPU
     def test_display_data_resnet(self):


### PR DESCRIPTION
**Patch description**
Skip the the img_seq2seq tests until until pytorch/vision#1712 is resolved and pytorch 1.4 is released.

**Testing steps**
CI