### PR TITLE
[Zoo] Include Pre-trained Transformers in Model Zoo

### DIFF
--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -321,6 +321,10 @@ model_list = [
             "--poly-attention-type basic --dict-endtoken __start__ "
             "--model-file <YOUR MODEL FILE>"
         ),
+        "result": (
+            "(subject to some variance, you may see the following as a result of validation of the model)\n"
+            "{'exs': 7801, 'accuracy': 0.8942 ...}"
+        ),
     },
     {
         "title": "Poly-Encoder Transformer Wikipedia/Toronto Books Pretrained Model",
@@ -351,6 +355,10 @@ model_list = [
             "--learn-embeddings True --polyencoder-type codes --poly-n-codes 64 "
             "--poly-attention-type basic --dict-endtoken __start__ "
             "--model-file <YOUR MODEL FILE>"
+        ),
+        "result": (
+            "(subject to some variance, you may see the following as a result of validation of the model)\n"
+            "{'exs': 7801, 'accuracy': 0.861 ...}"
         ),
     },
     {
@@ -385,6 +393,10 @@ model_list = [
             "--share-word-embeddings False --dict-endtoken __start__ --fp16 True "
             "--model-file <YOUR MODEL FILE>"
         ),
+        "result": (
+            "(subject to some variance, you may see the following as a result of validation of the model)\n"
+            "{'exs': 7801, 'accuracy': 0.8686 ...}"
+        ),
     },
     {
         "title": "Bi-Encoder Transformer Wikipedia/Toronto Books Pretrained Model",
@@ -418,6 +430,10 @@ model_list = [
             "--share-word-embeddings False --dict-endtoken __start__ --fp16 True "
             "--model-file <YOUR MODEL FILE>"
         ),
+        "result": (
+            "(subject to some variance, you may see the following as a result of validation of the model)\n"
+            "{'exs': 7801, 'accuracy': 0.846 ...}"
+        ),
     },
     {
         "title": "Cross-Encoder Transformer Reddit Pretrained Model",
@@ -448,6 +464,10 @@ model_list = [
             "--learn-embeddings True --dict-endtoken __start__ "
             "--model-file <YOUR MODEL FILE>"
         ),
+        "result": (
+            "(subject to some variance, you may see the following as a result of validation of the model)\n"
+            "{'exs': 7801, 'accuracy': 0.903 ...}"
+        ),
     },
     {
         "title": "Cross-Encoder Transformer Wikipedia/Toronto Books Pretrained Model",
@@ -477,6 +497,10 @@ model_list = [
             "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
             "--learn-embeddings True --dict-endtoken __start__ "
             "--model-file <YOUR MODEL FILE>"
+        ),
+        "result": (
+            "(subject to some variance, you may see the following as a result of validation of the model)\n"
+            "{'exs': 7801, 'accuracy': 0.873 ...}"
         ),
     },
     {

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -305,12 +305,21 @@ model_list = [
         "example": (
             "python -u examples/train_model.py "
             "--init-model zoo:pretrained_transformers/poly_model_huge_reddit/model "
-            "-t convai2  --model transformer/polyencoder --n-positions 1024 "
+            "-pyt convai2 --shuffle true "
+            "--model transformer/polyencoder --batchsize 256 --eval-batchsize 10 "
+            "--warmup_updates 100 --lr-scheduler-patience 0 --lr-scheduler-decay 0.4 "
+            "-lr 5e-05 --data-parallel True --history-size 20 --label-truncate 72 "
+            "--text-truncate 360 --num-epochs 8.0 --max_train_time 200000 -veps 0.5 "
+            "-vme 8000 --validation-metric accuracy --validation-metric-mode max "
+            "--save-after-valid True --log_every_n_secs 20 --candidates batch --fp16 True "
+            "--dict-tokenizer bpe --dict-lower True --optimizer adamax --output-scaling 0.06 "
             "--variant xlm --reduction-type mean --share-encoders False "
             "--learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 "
+            "--attention-dropout 0.1 --relu-dropout 0.0 --dropout 0.1 --n-positions 1024 "
             "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
             "--learn-embeddings True --polyencoder-type codes --poly-n-codes 64 "
-            "--poly-attention-type basic --model-file <YOUR MODEL FILE> "
+            "--poly-attention-type basic --dict-endtoken __start__ "
+            "--model-file <YOUR MODEL FILE>"
         ),
     },
     {
@@ -327,12 +336,21 @@ model_list = [
         "example": (
             "python -u examples/train_model.py "
             "--init-model zoo:pretrained_transformers/poly_model_huge_wikito/model "
-            "-t convai2  --model transformer/polyencoder --n-positions 1024 "
+            "-pyt convai2 --shuffle true "
+            "--model transformer/polyencoder --batchsize 256 --eval-batchsize 10 "
+            "--warmup_updates 100 --lr-scheduler-patience 0 --lr-scheduler-decay 0.4 "
+            "-lr 5e-05 --data-parallel True --history-size 20 --label-truncate 72 "
+            "--text-truncate 360 --num-epochs 8.0 --max_train_time 200000 -veps 0.5 "
+            "-vme 8000 --validation-metric accuracy --validation-metric-mode max "
+            "--save-after-valid True --log_every_n_secs 20 --candidates batch --fp16 True "
+            "--dict-tokenizer bpe --dict-lower True --optimizer adamax --output-scaling 0.06 "
             "--variant xlm --reduction-type mean --share-encoders False "
             "--learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 "
+            "--attention-dropout 0.1 --relu-dropout 0.0 --dropout 0.1 --n-positions 1024 "
             "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
             "--learn-embeddings True --polyencoder-type codes --poly-n-codes 64 "
-            "--poly-attention-type basic --model-file <YOUR MODEL FILE> "
+            "--poly-attention-type basic --dict-endtoken __start__ "
+            "--model-file <YOUR MODEL FILE>"
         ),
     },
     {
@@ -349,11 +367,23 @@ model_list = [
         "example": (
             "python -u examples/train_model.py "
             "--init-model zoo:pretrained_transformers/bi_model_huge_reddit/model "
-            "-t convai2  --model transformer/biencoder --n-positions 1024 "
+            "--batchsize 512 -pyt convai2 "
+            "--shuffle true --model transformer/biencoder --eval-batchsize 6 "
+            "--warmup_updates 100 --lr-scheduler-patience 0 "
+            "--lr-scheduler-decay 0.4 -lr 5e-05 --data-parallel True "
+            "--history-size 20 --label-truncate 72 --text-truncate 360 "
+            "--num-epochs 10.0 --max_train_time 200000 -veps 0.5 -vme 8000 "
+            "--validation-metric accuracy --validation-metric-mode max "
+            "--save-after-valid True --log_every_n_secs 20 --candidates batch "
+            "--dict-tokenizer bpe --dict-lower True --optimizer adamax "
+            "--output-scaling 0.06 "
             "--variant xlm --reduction-type mean --share-encoders False "
-            "--learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 "
-            "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
-            "--learn-embeddings True --model-file <YOUR MODEL FILE> "
+            "--learn-positional-embeddings True --n-layers 12 --n-heads 12 "
+            "--ffn-size 3072 --attention-dropout 0.1 --relu-dropout 0.0 --dropout 0.1 "
+            "--n-positions 1024 --embedding-size 768 --activation gelu "
+            "--embeddings-scale False --n-segments 2 --learn-embeddings True "
+            "--share-word-embeddings False --dict-endtoken __start__ --fp16 True "
+            "--model-file <YOUR MODEL FILE>"
         ),
     },
     {
@@ -370,11 +400,23 @@ model_list = [
         "example": (
             "python -u examples/train_model.py "
             "--init-model zoo:pretrained_transformers/bi_model_huge_wikito/model "
-            "-t convai2  --model transformer/biencoder --n-positions 1024 "
+            "--batchsize 512 -pyt convai2 "
+            "--shuffle true --model transformer/biencoder --eval-batchsize 6 "
+            "--warmup_updates 100 --lr-scheduler-patience 0 "
+            "--lr-scheduler-decay 0.4 -lr 5e-05 --data-parallel True "
+            "--history-size 20 --label-truncate 72 --text-truncate 360 "
+            "--num-epochs 10.0 --max_train_time 200000 -veps 0.5 -vme 8000 "
+            "--validation-metric accuracy --validation-metric-mode max "
+            "--save-after-valid True --log_every_n_secs 20 --candidates batch "
+            "--dict-tokenizer bpe --dict-lower True --optimizer adamax "
+            "--output-scaling 0.06 "
             "--variant xlm --reduction-type mean --share-encoders False "
-            "--learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 "
-            "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
-            "--learn-embeddings True --model-file <YOUR MODEL FILE> "
+            "--learn-positional-embeddings True --n-layers 12 --n-heads 12 "
+            "--ffn-size 3072 --attention-dropout 0.1 --relu-dropout 0.0 --dropout 0.1 "
+            "--n-positions 1024 --embedding-size 768 --activation gelu "
+            "--embeddings-scale False --n-segments 2 --learn-embeddings True "
+            "--share-word-embeddings False --dict-endtoken __start__ --fp16 True "
+            "--model-file <YOUR MODEL FILE>"
         ),
     },
     {
@@ -391,11 +433,20 @@ model_list = [
         "example": (
             "python -u examples/train_model.py "
             "--init-model zoo:pretrained_transformers/cross_model_huge_reddit/model "
-            "-t convai2  --model transformer/crossencoder --n-positions 1024 "
-            "--variant xlm --reduction-type mean --share-encoders False "
+            "-pyt convai2 --shuffle true "
+            "--model transformer/crossencoder --batchsize 16 --eval-batchsize 10 "
+            "--warmup_updates 1000 --lr-scheduler-patience 0 --lr-scheduler-decay 0.4 "
+            "-lr 5e-05 --data-parallel True --history-size 20 --label-truncate 72 "
+            "--text-truncate 360 --num-epochs 12.0 --max_train_time 200000 -veps 0.5 "
+            "-vme 2500 --validation-metric accuracy --validation-metric-mode max "
+            "--save-after-valid True --log_every_n_secs 20 --candidates inline --fp16 True "
+            "--dict-tokenizer bpe --dict-lower True --optimizer adamax --output-scaling 0.06 "
+            "--variant xlm --reduction-type first --share-encoders False "
             "--learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 "
+            "--attention-dropout 0.1 --relu-dropout 0.0 --dropout 0.1 --n-positions 1024 "
             "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
-            "--learn-embeddings True --model-file <YOUR MODEL FILE> "
+            "--learn-embeddings True --dict-endtoken __start__ "
+            "--model-file <YOUR MODEL FILE>"
         ),
     },
     {
@@ -412,11 +463,20 @@ model_list = [
         "example": (
             "python -u examples/train_model.py "
             "--init-model zoo:pretrained_transformers/cross_model_huge_wikito/model "
-            "-t convai2  --model transformer/crossencoder --n-positions 1024 "
-            "--variant xlm --reduction-type mean --share-encoders False "
+            "-pyt convai2 --shuffle true "
+            "--model transformer/crossencoder --batchsize 16 --eval-batchsize 10 "
+            "--warmup_updates 1000 --lr-scheduler-patience 0 --lr-scheduler-decay 0.4 "
+            "-lr 5e-05 --data-parallel True --history-size 20 --label-truncate 72 "
+            "--text-truncate 360 --num-epochs 12.0 --max_train_time 200000 -veps 0.5 "
+            "-vme 2500 --validation-metric accuracy --validation-metric-mode max "
+            "--save-after-valid True --log_every_n_secs 20 --candidates inline --fp16 True "
+            "--dict-tokenizer bpe --dict-lower True --optimizer adamax --output-scaling 0.06 "
+            "--variant xlm --reduction-type first --share-encoders False "
             "--learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 "
+            "--attention-dropout 0.1 --relu-dropout 0.0 --dropout 0.1 --n-positions 1024 "
             "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
-            "--learn-embeddings True --model-file <YOUR MODEL FILE> "
+            "--learn-embeddings True --dict-endtoken __start__ "
+            "--model-file <YOUR MODEL FILE>"
         ),
     },
     {

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -295,7 +295,7 @@ model_list = [
         "title": "Poly-Encoder Transformer Reddit Pretrained Model",
         "id": "pretrained_transformers",
         "path": "zoo:pretrained_transformers/poly_model_huge_reddit",
-        "agent": "transformer/polyencoder",  # noqa: E501
+        "agent": "transformer/polyencoder",
         "task": "pretrained_transformers",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
@@ -326,7 +326,7 @@ model_list = [
         "title": "Poly-Encoder Transformer Wikipedia/Toronto Books Pretrained Model",
         "id": "pretrained_transformers",
         "path": "zoo:pretrained_transformers/poly_model_huge_wikito",
-        "agent": "transformer/polyencoder",  # noqa: E501
+        "agent": "transformer/polyencoder",
         "task": "pretrained_transformers",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
@@ -357,7 +357,7 @@ model_list = [
         "title": "Bi-Encoder Transformer Reddit Pretrained Model",
         "id": "pretrained_transformers",
         "path": "zoo:pretrained_transformers/poly_model_huge_reddit",
-        "agent": "transformer/biencoder",  # noqa: E501
+        "agent": "transformer/biencoder",
         "task": "pretrained_transformers",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
@@ -390,7 +390,7 @@ model_list = [
         "title": "Bi-Encoder Transformer Wikipedia/Toronto Books Pretrained Model",
         "id": "pretrained_transformers",
         "path": "zoo:pretrained_transformers/bi_model_huge_wikito",
-        "agent": "transformer/biencoder",  # noqa: E501
+        "agent": "transformer/biencoder",
         "task": "pretrained_transformers",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
@@ -423,7 +423,7 @@ model_list = [
         "title": "Cross-Encoder Transformer Reddit Pretrained Model",
         "id": "pretrained_transformers",
         "path": "zoo:pretrained_transformers/cross_model_huge_reddit",
-        "agent": "transformer/crossencoder",  # noqa: E501
+        "agent": "transformer/crossencoder",
         "task": "pretrained_transformers",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
@@ -453,7 +453,7 @@ model_list = [
         "title": "Cross-Encoder Transformer Wikipedia/Toronto Books Pretrained Model",
         "id": "pretrained_transformers",
         "path": "zoo:pretrained_transformers/cross_model_huge_wikito",
-        "agent": "transformer/crossencoder",  # noqa: E501
+        "agent": "transformer/crossencoder",
         "task": "pretrained_transformers",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
@@ -483,7 +483,7 @@ model_list = [
         "title": "Poly-Encoder Transformer ConvAI2 Model",
         "id": "pretrained_transformers",
         "path": "zoo:pretrained_transformers/model_poly",
-        "agent": "transformer/polyencoder",  # noqa: E501
+        "agent": "transformer/polyencoder",
         "task": "convai2",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
@@ -600,7 +600,7 @@ model_list = [
         "title": "Transformer Classifier Single-turn Dialogue Safety Model",
         "id": "dialogue_safety",
         "path": "zoo:dialogue_safety/single_turn/model",
-        "agent": "transformer/classifier",  # noqa: E501
+        "agent": "transformer/classifier",
         "task": "dialogue_safety:adversarial,dialogue_safety:standard",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/dialogue_safety",
         "description": (
@@ -618,7 +618,7 @@ model_list = [
         "title": "BERT Classifier Multi-turn Dialogue Safety Model",
         "id": "dialogue_safety",
         "path": "zoo:dialogue_safety/multi_turn/model",
-        "agent": "bert_classifier",  # noqa: E501
+        "agent": "bert_classifier",
         "task": "dialogue_safety:multiturn",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/dialogue_safety",
         "description": (

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -292,6 +292,134 @@ model_list = [
         ),
     },
     {
+        "title": "Poly-Encoder Transformer Reddit Pretrained Model",
+        "id": "pretrained_transformers",
+        "path": "zoo:pretrained_transformers/poly_model_huge_reddit",
+        "agent": "transformer/polyencoder",  # noqa: E501
+        "task": "pretrained_transformers",
+        "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
+        "description": (
+            "Poly-Encoder pretrained on Reddit. Use this model as an `--init-model` for a poly-encoder "
+            "when fine-tuning on another task. For more details on how to train, see the project page."
+        ),
+        "example": (
+            "python -u examples/train_model.py "
+            "--init-model zoo:pretrained_transformers/poly_model_huge_reddit/model "
+            "-t convai2  --model transformer/polyencoder --n-positions 1024 "
+            "--variant xlm --reduction-type mean --share-encoders False "
+            "--learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 "
+            "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
+            "--learn-embeddings True --polyencoder-type codes --poly-n-codes 64 "
+            "--poly-attention-type basic --model-file <YOUR MODEL FILE> "
+        ),
+    },
+    {
+        "title": "Poly-Encoder Transformer Wikipedia/Toronto Books Pretrained Model",
+        "id": "pretrained_transformers",
+        "path": "zoo:pretrained_transformers/poly_model_huge_wikito",
+        "agent": "transformer/polyencoder",  # noqa: E501
+        "task": "pretrained_transformers",
+        "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
+        "description": (
+            "Poly-Encoder pretrained on Wikipedia/Toronto Books. Use this model as an `--init-model` for a poly-encoder "
+            "when fine-tuning on another task. For more details on how to train, see the project page."
+        ),
+        "example": (
+            "python -u examples/train_model.py "
+            "--init-model zoo:pretrained_transformers/poly_model_huge_wikito/model "
+            "-t convai2  --model transformer/polyencoder --n-positions 1024 "
+            "--variant xlm --reduction-type mean --share-encoders False "
+            "--learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 "
+            "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
+            "--learn-embeddings True --polyencoder-type codes --poly-n-codes 64 "
+            "--poly-attention-type basic --model-file <YOUR MODEL FILE> "
+        ),
+    },
+    {
+        "title": "Bi-Encoder Transformer Reddit Pretrained Model",
+        "id": "pretrained_transformers",
+        "path": "zoo:pretrained_transformers/poly_model_huge_reddit",
+        "agent": "transformer/biencoder",  # noqa: E501
+        "task": "pretrained_transformers",
+        "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
+        "description": (
+            "Bi-Encoder pretrained on Reddit. Use this model as an `--init-model` for a bi-encoder "
+            "when fine-tuning on another task. For more details on how to train, see the project page."
+        ),
+        "example": (
+            "python -u examples/train_model.py "
+            "--init-model zoo:pretrained_transformers/bi_model_huge_reddit/model "
+            "-t convai2  --model transformer/biencoder --n-positions 1024 "
+            "--variant xlm --reduction-type mean --share-encoders False "
+            "--learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 "
+            "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
+            "--learn-embeddings True --model-file <YOUR MODEL FILE> "
+        ),
+    },
+    {
+        "title": "Bi-Encoder Transformer Wikipedia/Toronto Books Pretrained Model",
+        "id": "pretrained_transformers",
+        "path": "zoo:pretrained_transformers/bi_model_huge_wikito",
+        "agent": "transformer/biencoder",  # noqa: E501
+        "task": "pretrained_transformers",
+        "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
+        "description": (
+            "Bi-Encoder pretrained on Wikipedia/Toronto Books. Use this model as an `--init-model` for a poly-encoder "
+            "when fine-tuning on another task. For more details on how to train, see the project page."
+        ),
+        "example": (
+            "python -u examples/train_model.py "
+            "--init-model zoo:pretrained_transformers/bi_model_huge_wikito/model "
+            "-t convai2  --model transformer/biencoder --n-positions 1024 "
+            "--variant xlm --reduction-type mean --share-encoders False "
+            "--learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 "
+            "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
+            "--learn-embeddings True --model-file <YOUR MODEL FILE> "
+        ),
+    },
+    {
+        "title": "Cross-Encoder Transformer Reddit Pretrained Model",
+        "id": "pretrained_transformers",
+        "path": "zoo:pretrained_transformers/cross_model_huge_reddit",
+        "agent": "transformer/crossencoder",  # noqa: E501
+        "task": "pretrained_transformers",
+        "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
+        "description": (
+            "Cross-Encoder pretrained on Reddit. Use this model as an `--init-model` for a cross-encoder "
+            "when fine-tuning on another task. For more details on how to train, see the project page."
+        ),
+        "example": (
+            "python -u examples/train_model.py "
+            "--init-model zoo:pretrained_transformers/cross_model_huge_reddit/model "
+            "-t convai2  --model transformer/crossencoder --n-positions 1024 "
+            "--variant xlm --reduction-type mean --share-encoders False "
+            "--learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 "
+            "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
+            "--learn-embeddings True --model-file <YOUR MODEL FILE> "
+        ),
+    },
+    {
+        "title": "Cross-Encoder Transformer Wikipedia/Toronto Books Pretrained Model",
+        "id": "pretrained_transformers",
+        "path": "zoo:pretrained_transformers/cross_model_huge_wikito",
+        "agent": "transformer/crossencoder",  # noqa: E501
+        "task": "pretrained_transformers",
+        "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
+        "description": (
+            "Cross-Encoder pretrained on Wikipedia/Toronto Books. Use this model as an `--init-model` for a poly-encoder "
+            "when fine-tuning on another task. For more details on how to train, see the project page."
+        ),
+        "example": (
+            "python -u examples/train_model.py "
+            "--init-model zoo:pretrained_transformers/cross_model_huge_wikito/model "
+            "-t convai2  --model transformer/crossencoder --n-positions 1024 "
+            "--variant xlm --reduction-type mean --share-encoders False "
+            "--learn-positional-embeddings True --n-layers 12 --n-heads 12 --ffn-size 3072 "
+            "--embedding-size 768 --activation gelu --embeddings-scale False --n-segments 2 "
+            "--learn-embeddings True --model-file <YOUR MODEL FILE> "
+        ),
+    },
+    {
         "title": "Poly-Encoder Transformer ConvAI2 Model",
         "id": "pretrained_transformers",
         "path": "zoo:pretrained_transformers/model_poly",

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -299,7 +299,7 @@ model_list = [
         "task": "pretrained_transformers",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
-            "Poly-Encoder pretrained on Reddit. Use this model as an `--init-model` for a poly-encoder "
+            "Poly-Encoder pretrained on Reddit. Use this model as an ``--init-model`` for a poly-encoder "
             "when fine-tuning on another task. For more details on how to train, see the project page."
         ),
         "example": (
@@ -321,7 +321,7 @@ model_list = [
         "task": "pretrained_transformers",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
-            "Poly-Encoder pretrained on Wikipedia/Toronto Books. Use this model as an `--init-model` for a poly-encoder "
+            "Poly-Encoder pretrained on Wikipedia/Toronto Books. Use this model as an ``--init-model`` for a poly-encoder "
             "when fine-tuning on another task. For more details on how to train, see the project page."
         ),
         "example": (
@@ -343,7 +343,7 @@ model_list = [
         "task": "pretrained_transformers",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
-            "Bi-Encoder pretrained on Reddit. Use this model as an `--init-model` for a bi-encoder "
+            "Bi-Encoder pretrained on Reddit. Use this model as an ``--init-model`` for a bi-encoder "
             "when fine-tuning on another task. For more details on how to train, see the project page."
         ),
         "example": (
@@ -364,7 +364,7 @@ model_list = [
         "task": "pretrained_transformers",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
-            "Bi-Encoder pretrained on Wikipedia/Toronto Books. Use this model as an `--init-model` for a poly-encoder "
+            "Bi-Encoder pretrained on Wikipedia/Toronto Books. Use this model as an ``--init-model`` for a poly-encoder "
             "when fine-tuning on another task. For more details on how to train, see the project page."
         ),
         "example": (
@@ -385,7 +385,7 @@ model_list = [
         "task": "pretrained_transformers",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
-            "Cross-Encoder pretrained on Reddit. Use this model as an `--init-model` for a cross-encoder "
+            "Cross-Encoder pretrained on Reddit. Use this model as an ``--init-model`` for a cross-encoder "
             "when fine-tuning on another task. For more details on how to train, see the project page."
         ),
         "example": (
@@ -406,7 +406,7 @@ model_list = [
         "task": "pretrained_transformers",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
-            "Cross-Encoder pretrained on Wikipedia/Toronto Books. Use this model as an `--init-model` for a poly-encoder "
+            "Cross-Encoder pretrained on Wikipedia/Toronto Books. Use this model as an ``--init-model`` for a poly-encoder "
             "when fine-tuning on another task. For more details on how to train, see the project page."
         ),
         "example": (


### PR DESCRIPTION
**Patch description**
Include the pre-trained transformers from the [poly-encoder project](https://parl.ai/projects/polyencoder/) in the model zoo, with their example invocations.

**Testing steps**
This is mostly a cosmetic change, as these models already existed; as such, I am relying on `test_docs` and will share a screenshot below of what the docs look like with these models.

**Logs**
![Screenshot 2020-01-09 12 22 10](https://user-images.githubusercontent.com/8562788/72089930-04eba480-32db-11ea-9aaa-f506e167f30d.png)
