### PR TITLE
[TRA tests] Speed up eval fixed cands test

### DIFF
--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -16,6 +16,7 @@ import tempfile
 import shutil
 import io
 import signal
+import time
 from typing import Tuple
 
 
@@ -131,6 +132,16 @@ class retry(object):
             return testfn(testself, *args, **kwargs)
 
         return _wrapper
+
+
+def print_test_time(func):
+    def _wrapper(*args, **kwargs):
+        start_time = time.time()
+        func(*args, **kwargs)
+        end_time = round(time.time() - start_time, 5)
+        print(f'\n[ Test {func.__name__} completed in {end_time}s ]')
+
+    return _wrapper
 
 
 def git_ls_files(root=None, skip_nonexisting=True):

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -16,7 +16,6 @@ import tempfile
 import shutil
 import io
 import signal
-import time
 from typing import Tuple
 
 
@@ -132,16 +131,6 @@ class retry(object):
             return testfn(testself, *args, **kwargs)
 
         return _wrapper
-
-
-def print_test_time(func):
-    def _wrapper(*args, **kwargs):
-        start_time = time.time()
-        func(*args, **kwargs)
-        end_time = round(time.time() - start_time, 5)
-        print(f'\n[ Test {func.__name__} completed in {end_time}s ]')
-
-    return _wrapper
 
 
 def git_ls_files(root=None, skip_nonexisting=True):

--- a/tests/test_tra.py
+++ b/tests/test_tra.py
@@ -157,7 +157,7 @@ class _AbstractTRATest(unittest.TestCase):
             args['fixed_candidates_path'] = tmp_cands_file
             args['encode_candidate_vecs'] = False  # don't encode before training
             args['ignore_bad_candidates'] = False
-            args['num_epochs'] = 20
+            args['num_epochs'] = 4
             stdout, valid, test = testing_utils.train_model(args)
             self.assertGreaterEqual(
                 valid['hits@100'],
@@ -251,7 +251,7 @@ class TestPolyRanker(_AbstractTRATest):
             args['ignore_bad_candidates'] = False
             args['model_file'] = os.path.join(tmpdir, 'model')
             args['dict_file'] = os.path.join(tmpdir, 'model.dict')
-            args['num_epochs'] = 20
+            args['num_epochs'] = 4
             # Train model where it has access to the candidate in labels
             stdout, valid, test = testing_utils.train_model(args)
             self.assertGreaterEqual(


### PR DESCRIPTION
**Patch description**
Decrease number of epochs that the eval_fixed_cands test runs for. As far as I can tell this doesn't affect whether or not the test passes usually. For the three models that run this test, the speedups are as follows:

**Before**
```
[ Test test_eval_fixed completed in 10.13738s ]
.
[ Test test_eval_fixed completed in 18.37439s ]
..
[ Test test_eval_fixed completed in 14.78047s ]
```

**After**
```
[ Test test_eval_fixed completed in 2.79047s ]
........
[ Test test_eval_fixed completed in 6.67095s ]
.........
[ Test test_eval_fixed completed in 5.17016s ]
```

I also added a decorator to be able to easily track this when you are debugging. Idk if generally useful, up to @stephenroller ...