### PR TITLE
Remove`capture_output`, rely on pytests.

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -449,7 +449,7 @@ class Metrics(object):
                 for i in range(3):
                     weights = [1 / (i + 1) for _ in range(i + 1)]
                     bleu_scores[f'bleu-{i + 1}'] = _bleu(prediction, labels, weights)
-            if 'rouge-L' in self.metrics_list:
+            if 'rouge-L' in self._print_metrics_list:
                 rouge1, rouge2, rougeL = _rouge(prediction, labels)
             with self._lock():
                 if 'f1' in self.metrics:

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -46,9 +46,6 @@ except ImportError:
     BPE_INSTALLED = False
 
 
-DEBUG = False  # change this to true to print to stdout anyway
-
-
 def is_this_circleci():
     """
     Return if we are currently running in CircleCI.
@@ -191,29 +188,6 @@ def is_new_task_filename(filename):
     )
 
 
-class TeeStringIO(io.StringIO):
-    """
-    StringIO which also prints to stdout.
-
-    Used in case of DEBUG=False to make sure we get verbose output.
-    """
-
-    def __init__(self, *args):
-        self.stream = sys.stdout
-        super().__init__(*args)
-
-    def write(self, data):
-        """
-        Write data to stdout and the buffer.
-        """
-        if DEBUG and self.stream:
-            self.stream.write(data)
-        super().write(data)
-
-    def __str__(self):
-        return self.getvalue()
-
-
 @contextlib.contextmanager
 def capture_output():
     """
@@ -226,7 +200,7 @@ def capture_output():
     >>> output.getvalue()
     'hello'
     """
-    sio = TeeStringIO()
+    sio = io.StringIO()
     with contextlib.redirect_stdout(sio), contextlib.redirect_stderr(sio):
         yield sio
 

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -273,7 +273,7 @@ def timeout(time: int = 30):
         signal.signal(signal.SIGALRM, signal.SIG_IGN)
 
 
-def train_model(opt: Opt) -> (Dict[str, Any], Dict[str, Any]):
+def train_model(opt: Opt) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """
     Run through a TrainLoop.
 
@@ -336,13 +336,12 @@ def eval_model(opt, skip_valid=False, skip_test=False, valid_datatype=None):
     if popt.get('model_file') and not popt.get('dict_file'):
         popt['dict_file'] = popt['model_file'] + '.dict'
 
-    with capture_output() as output:
-        popt['datatype'] = 'valid' if valid_datatype is None else valid_datatype
-        valid = None if skip_valid else ems.eval_model(popt)
-        popt['datatype'] = 'test'
-        test = None if skip_test else ems.eval_model(popt)
+    popt['datatype'] = 'valid' if valid_datatype is None else valid_datatype
+    valid = None if skip_valid else ems.eval_model(popt)
+    popt['datatype'] = 'test'
+    test = None if skip_test else ems.eval_model(popt)
 
-    return (output.getvalue(), valid, test)
+    return valid, test
 
 
 def display_data(opt):

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -8,7 +8,6 @@
 General utilities for helping writing ParlAI unit and integration tests.
 """
 
-import sys
 import os
 import unittest
 import contextlib

--- a/tests/datatests/test_new_tasks.py
+++ b/tests/datatests/test_new_tasks.py
@@ -58,8 +58,7 @@ class TestNewTasks(unittest.TestCase):
                 opt = parser.parse_args(args=['--task', subt], print_args=False)
                 opt['task'] = subt
                 try:
-                    with testing_utils.capture_output():
-                        text, log = verify(opt, print_parser=False)
+                    text, log = verify(opt, print_parser=False)
                 except Exception:
                     found_errors = True
                     traceback.print_exc()

--- a/tests/nightly/cpu/test_alice.py
+++ b/tests/nightly/cpu/test_alice.py
@@ -14,13 +14,8 @@ class TestAlice(unittest.TestCase):
         """
         Test that the ALICE agent is stable over time.
         """
-        stdout, valid, test = testing_utils.eval_model(
-            dict(task='convai2', model='alice')
-        )
-
-        self.assertEqual(
-            valid['f1'], 0.01397, "valid f1 = {}\nLOG:\n{}".format(valid['f1'], stdout)
-        )
+        valid, test = testing_utils.eval_model(dict(task='convai2', model='alice'))
+        self.assertEqual(valid['f1'], 0.01397, "valid f1 = {}".format(valid['f1']))
 
 
 if __name__ == '__main__':

--- a/tests/nightly/cpu/test_alice.py
+++ b/tests/nightly/cpu/test_alice.py
@@ -15,7 +15,7 @@ class TestAlice(unittest.TestCase):
         Test that the ALICE agent is stable over time.
         """
         valid, test = testing_utils.eval_model(dict(task='convai2', model='alice'))
-        self.assertEqual(valid['f1'], 0.01397, "valid f1 = {}".format(valid['f1']))
+        self.assertEqual(valid['f1'], 0.01397)
 
 
 if __name__ == '__main__':

--- a/tests/nightly/cpu/test_convai2_cpu.py
+++ b/tests/nightly/cpu/test_convai2_cpu.py
@@ -26,13 +26,11 @@ class TestConvai2KVMemnn(unittest.TestCase):
     def test_kvmemnn_hits1(self):
         import projects.convai2.baselines.kvmemnn.eval_hits as eval_hits
 
-        with testing_utils.capture_output() as stdout:
-            report = eval_hits.main(args=[])
-        self.assertEqual(report['hits@1'], 0.5510, str(stdout))
+        report = eval_hits.main(args=[])
+        self.assertEqual(report['hits@1'], 0.5510)
 
     def test_kvmemnn_f1(self):
         import projects.convai2.baselines.kvmemnn.eval_f1 as eval_f1
 
-        with testing_utils.capture_output() as stdout:
-            report = eval_f1.main(args=[])
-        self.assertAlmostEqual(report['f1'], 0.1173, delta=0.0002, msg=str(stdout))
+        report = eval_f1.main(args=[])
+        self.assertAlmostEqual(report['f1'], 0.1173, delta=0.0002)

--- a/tests/nightly/cpu/test_urls.py
+++ b/tests/nightly/cpu/test_urls.py
@@ -26,28 +26,23 @@ class TestUtils(unittest.TestCase):
             for task in task_list
         )
         for task in sorted(tasks):
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", ResourceWarning)
-                warnings.simplefilter("ignore", DeprecationWarning)
-                if task in SPECIFIC_BUILDS:
-                    for build in SPECIFIC_BUILDS[task]:
-                        mod = importlib.import_module(
-                            ('parlai.tasks.' + task + '.' + build)
-                        )
-                        for f in mod.RESOURCES:
-                            with self.subTest(f"{task}: {f.url}"):
-                                f.check_header()
-                else:
-                    try:
-                        mod = importlib.import_module(
-                            ('parlai.tasks.' + task + '.build')
-                        )
-                        file_list = mod.RESOURCES
-                    except (ModuleNotFoundError, AttributeError):
-                        continue
-                    for f in file_list:
+            if task in SPECIFIC_BUILDS:
+                for build in SPECIFIC_BUILDS[task]:
+                    mod = importlib.import_module(
+                        ('parlai.tasks.' + task + '.' + build)
+                    )
+                    for f in mod.RESOURCES:
                         with self.subTest(f"{task}: {f.url}"):
                             f.check_header()
+            else:
+                try:
+                    mod = importlib.import_module(('parlai.tasks.' + task + '.build'))
+                    file_list = mod.RESOURCES
+                except (ModuleNotFoundError, AttributeError):
+                    continue
+                for f in file_list:
+                    with self.subTest(f"{task}: {f.url}"):
+                        f.check_header()
 
 
 if __name__ == '__main__':

--- a/tests/nightly/cpu/test_urls.py
+++ b/tests/nightly/cpu/test_urls.py
@@ -7,7 +7,6 @@
 
 import unittest
 import importlib
-import warnings
 from parlai.tasks.task_list import task_list
 
 SPECIFIC_BUILDS = {

--- a/tests/nightly/gpu/test_bert.py
+++ b/tests/nightly/gpu/test_bert.py
@@ -19,7 +19,7 @@ class TestBertModel(unittest.TestCase):
 
     @testing_utils.retry(ntries=3, log_retry=True)
     def test_biencoder(self):
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='convai2',
                 model='bert_ranker/bi_encoder_ranker',
@@ -37,12 +37,12 @@ class TestBertModel(unittest.TestCase):
         self.assertLessEqual(
             test['accuracy'],
             0.5,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
+            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy']),
         )
 
     @testing_utils.retry(ntries=3, log_retry=True)
     def test_crossencoder(self):
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='convai2',
                 model='bert_ranker/cross_encoder_ranker',
@@ -63,12 +63,12 @@ class TestBertModel(unittest.TestCase):
         self.assertGreaterEqual(
             test['accuracy'],
             0.03,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
+            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy']),
         )
         self.assertLessEqual(
             test['accuracy'],
             0.8,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
+            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy']),
         )
 
 

--- a/tests/nightly/gpu/test_bert.py
+++ b/tests/nightly/gpu/test_bert.py
@@ -34,11 +34,7 @@ class TestBertModel(unittest.TestCase):
         # can't conclude much from the biencoder after that little iterations.
         # this test will just make sure it hasn't crashed and the accuracy isn't
         # too high
-        self.assertLessEqual(
-            test['accuracy'],
-            0.5,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy']),
-        )
+        self.assertLessEqual(test['accuracy'], 0.5)
 
     @testing_utils.retry(ntries=3, log_retry=True)
     def test_crossencoder(self):
@@ -60,16 +56,8 @@ class TestBertModel(unittest.TestCase):
         # The cross encoder reaches an interesting state MUCH faster
         # accuracy should be present and somewhere between 0.2 and 0.8
         # (large interval so that it doesn't flake.)
-        self.assertGreaterEqual(
-            test['accuracy'],
-            0.03,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy']),
-        )
-        self.assertLessEqual(
-            test['accuracy'],
-            0.8,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy']),
-        )
+        self.assertGreaterEqual(test['accuracy'], 0.03)
+        self.assertLessEqual(test['accuracy'], 0.8)
 
 
 if __name__ == '__main__':

--- a/tests/nightly/gpu/test_controllable.py
+++ b/tests/nightly/gpu/test_controllable.py
@@ -58,9 +58,8 @@ class TestControllableDialogue(unittest.TestCase):
             truncate=32,
             short_final_eval=True,
         )
-        with testing_utils.capture_output():
-            opt = parser.parse_args([])
-            tcs2s.TrainLoop(opt).train()
+        opt = parser.parse_args([])
+        tcs2s.TrainLoop(opt).train()
 
     def test_convai2_finetuned_greedy(self):
         """

--- a/tests/nightly/gpu/test_controllable.py
+++ b/tests/nightly/gpu/test_controllable.py
@@ -65,7 +65,7 @@ class TestControllableDialogue(unittest.TestCase):
         """
         Check the greedy model produces correct results.
         """
-        _, valid, _ = testing_utils.eval_model(
+        valid, _ = testing_utils.eval_model(
             {
                 'model_file': 'zoo:controllable_dialogue/convai2_finetuned_baseline',
                 'task': 'projects.controllable_dialogue.tasks.agents',
@@ -82,7 +82,7 @@ class TestControllableDialogue(unittest.TestCase):
         """
         Check the beamsearch baseline produces correct results.
         """
-        _, valid, _ = testing_utils.eval_model(
+        valid, _ = testing_utils.eval_model(
             {
                 'model_file': 'zoo:controllable_dialogue/convai2_finetuned_baseline',
                 'task': 'projects.controllable_dialogue.tasks.agents',
@@ -105,7 +105,7 @@ class TestControllableDialogue(unittest.TestCase):
         """
         Checks the finetuned model with repetition blocking produces correct results.
         """
-        _, valid, _ = testing_utils.eval_model(
+        valid, _ = testing_utils.eval_model(
             {
                 'model_file': 'zoo:controllable_dialogue/convai2_finetuned_baseline',
                 'task': 'projects.controllable_dialogue.tasks.agents',
@@ -130,7 +130,7 @@ class TestControllableDialogue(unittest.TestCase):
         """
         Checks the question-controlled model (z=7) produces correct results.
         """
-        _, valid, _ = testing_utils.eval_model(
+        valid, _ = testing_utils.eval_model(
             {
                 # b11e10 stands for 11 buckets, embedding size 10
                 'model_file': 'zoo:controllable_dialogue/control_questionb11e10',
@@ -157,7 +157,7 @@ class TestControllableDialogue(unittest.TestCase):
         """
         Checks the question-controlled model (z=10 boost) produces correct results.
         """
-        _, valid, _ = testing_utils.eval_model(
+        valid, _ = testing_utils.eval_model(
             {
                 'model_file': 'zoo:controllable_dialogue/control_questionb11e10',
                 'task': 'projects.controllable_dialogue.tasks.agents',
@@ -184,7 +184,7 @@ class TestControllableDialogue(unittest.TestCase):
         """
         Checks the specificity-CT model (z=7) produces correct results.
         """
-        _, valid, _ = testing_utils.eval_model(
+        valid, _ = testing_utils.eval_model(
             {
                 'model_file': 'zoo:controllable_dialogue/control_avgnidf10b10e',
                 'task': 'projects.controllable_dialogue.tasks.agents',
@@ -210,7 +210,7 @@ class TestControllableDialogue(unittest.TestCase):
         """
         Checks the specificity-weighted decoding model produces correct results.
         """
-        _, valid, _ = testing_utils.eval_model(
+        valid, _ = testing_utils.eval_model(
             {
                 'model_file': 'zoo:controllable_dialogue/convai2_finetuned_baseline',
                 'task': 'projects.controllable_dialogue.tasks.agents',
@@ -235,7 +235,7 @@ class TestControllableDialogue(unittest.TestCase):
         """
         Checks the responsiveness-weighted decoding model produces correct results.
         """
-        _, valid, _ = testing_utils.eval_model(
+        valid, _ = testing_utils.eval_model(
             {
                 'model_file': 'zoo:controllable_dialogue/convai2_finetuned_baseline',
                 'task': 'projects.controllable_dialogue.tasks.agents',

--- a/tests/nightly/gpu/test_convai2.py
+++ b/tests/nightly/gpu/test_convai2.py
@@ -26,16 +26,14 @@ class TestConvai2Seq2Seq(unittest.TestCase):
     def test_seq2seq_hits1(self):
         import projects.convai2.baselines.seq2seq.eval_hits as eval_hits
 
-        with testing_utils.capture_output() as stdout:
-            report = eval_hits.main(args=[])
-        self.assertEqual(report['hits@1'], 0.1250, str(stdout))
+        report = eval_hits.main(args=[])
+        self.assertEqual(report['hits@1'], 0.1250)
 
     def test_seq2seq_f1(self):
         import projects.convai2.baselines.seq2seq.eval_f1 as eval_f1
 
-        with testing_utils.capture_output() as stdout:
-            report = eval_f1.main(args=[])
-        self.assertEqual(report['f1'], 0.1682, str(stdout))
+        report = eval_f1.main(args=[])
+        self.assertEqual(report['f1'], 0.1682)
 
 
 @testing_utils.skipUnlessGPU
@@ -47,9 +45,8 @@ class TestConvai2LanguageModel(unittest.TestCase):
     def test_languagemodel_f1(self):
         import projects.convai2.baselines.language_model.eval_f1 as eval_f1
 
-        with testing_utils.capture_output() as stdout:
-            report = eval_f1.main(args=[])
-        self.assertEqual(report['f1'], 0.1531, str(stdout))
+        report = eval_f1.main(args=[])
+        self.assertEqual(report['f1'], 0.1531)
 
 
 class TestLegacyVersioning(unittest.TestCase):

--- a/tests/nightly/gpu/test_drqa.py
+++ b/tests/nightly/gpu/test_drqa.py
@@ -15,16 +15,16 @@ class TestDrQAModel(unittest.TestCase):
     """
 
     def test_pretrained(self):
-        stdout, _, test = testing_utils.eval_model(
+        _, test = testing_utils.eval_model(
             dict(task='squad:index', model_file='zoo:drqa/squad/model')
         )
         self.assertGreaterEqual(
             test['accuracy'],
             0.68,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
+            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy']),
         )
         self.assertGreaterEqual(
-            test['f1'], 0.78, 'test f1 = {}\nLOG:\n{}'.format(test['f1'], stdout)
+            test['f1'], 0.78, 'test f1 = {}\nLOG:\n{}'.format(test['f1'])
         )
 
 

--- a/tests/nightly/gpu/test_drqa.py
+++ b/tests/nightly/gpu/test_drqa.py
@@ -18,14 +18,8 @@ class TestDrQAModel(unittest.TestCase):
         _, test = testing_utils.eval_model(
             dict(task='squad:index', model_file='zoo:drqa/squad/model')
         )
-        self.assertGreaterEqual(
-            test['accuracy'],
-            0.68,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy']),
-        )
-        self.assertGreaterEqual(
-            test['f1'], 0.78, 'test f1 = {}\nLOG:\n{}'.format(test['f1'])
-        )
+        self.assertGreaterEqual(test['accuracy'], 0.68)
+        self.assertGreaterEqual(test['f1'], 0.78)
 
 
 if __name__ == '__main__':

--- a/tests/nightly/gpu/test_self_feeding.py
+++ b/tests/nightly/gpu/test_self_feeding.py
@@ -52,13 +52,13 @@ class TestSelffeeding(unittest.TestCase):
             'batchsize': 32,
             'embeddings_scale': False,
         }
-        _, _, _ = testing_utils.train_model(opt)
+        testing_utils.train_model(opt)
 
     def test_released_model(self):
         """
         Check the pretrained model produces correct results.
         """
-        _, _, test = testing_utils.eval_model(
+        _, test = testing_utils.eval_model(
             {
                 'model_file': 'zoo:self_feeding/hh131k_hb60k_fb60k_st1k/model',
                 'task': 'self_feeding:all',

--- a/tests/nightly/gpu/test_transresnet.py
+++ b/tests/nightly/gpu/test_transresnet.py
@@ -43,18 +43,10 @@ class TestTransresnet(unittest.TestCase):
         Test pretrained model.
         """
         stdout, _, test = testing_utils.eval_model(MODEL_OPTIONS, skip_valid=True)
-        self.assertEqual(
-            test['accuracy'], 0.4, 'test accuracy = {}'.format(test['accuracy']),
-        )
-        self.assertEqual(
-            test['hits@5'], 0.9, 'test hits@5 = {}'.format(test['hits@5']),
-        )
-        self.assertEqual(
-            test['hits@10'], 0.9, 'test hits@10 = {}'.format(test['hits@10']),
-        )
-        self.assertEqual(
-            test['med_rank'], 2.0, 'test med_rank = {}'.format(test['med_rank']),
-        )
+        self.assertEqual(test['accuracy'], 0.4)
+        self.assertEqual(test['hits@5'], 0.9)
+        self.assertEqual(test['hits@10'], 0.9)
+        self.assertEqual(test['med_rank'], 2.0)
 
 
 if __name__ == '__main__':

--- a/tests/nightly/gpu/test_transresnet.py
+++ b/tests/nightly/gpu/test_transresnet.py
@@ -44,24 +44,16 @@ class TestTransresnet(unittest.TestCase):
         """
         stdout, _, test = testing_utils.eval_model(MODEL_OPTIONS, skip_valid=True)
         self.assertEqual(
-            test['accuracy'],
-            0.4,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
+            test['accuracy'], 0.4, 'test accuracy = {}'.format(test['accuracy']),
         )
         self.assertEqual(
-            test['hits@5'],
-            0.9,
-            'test hits@5 = {}\nLOG:\n{}'.format(test['hits@5'], stdout),
+            test['hits@5'], 0.9, 'test hits@5 = {}'.format(test['hits@5']),
         )
         self.assertEqual(
-            test['hits@10'],
-            0.9,
-            'test hits@10 = {}\nLOG:\n{}'.format(test['hits@10'], stdout),
+            test['hits@10'], 0.9, 'test hits@10 = {}'.format(test['hits@10']),
         )
         self.assertEqual(
-            test['med_rank'],
-            2.0,
-            'test med_rank = {}\nLOG:\n{}'.format(test['med_rank'], stdout),
+            test['med_rank'], 2.0, 'test med_rank = {}'.format(test['med_rank']),
         )
 
 

--- a/tests/nightly/gpu/test_transresnet.py
+++ b/tests/nightly/gpu/test_transresnet.py
@@ -32,12 +32,11 @@ class TestTransresnet(unittest.TestCase):
         """
         Set up the test by downloading the model/data.
         """
-        with testing_utils.capture_output():
-            parser = display_data.setup_args()
-            parser.set_defaults(**MODEL_OPTIONS)
-            opt = parser.parse_args([], print_args=False)
-            opt['num_examples'] = 1
-            display_data.display_data(opt)
+        parser = display_data.setup_args()
+        parser.set_defaults(**MODEL_OPTIONS)
+        opt = parser.parse_args([], print_args=False)
+        opt['num_examples'] = 1
+        display_data.display_data(opt)
 
     def test_transresnet(self):
         """

--- a/tests/nightly/gpu/test_transresnet_multimodal.py
+++ b/tests/nightly/gpu/test_transresnet_multimodal.py
@@ -41,31 +41,25 @@ class TestTransresnet(unittest.TestCase):
         """
         Test pretrained model.
         """
-        stdout, _, test = testing_utils.eval_model(MODEL_OPTIONS, skip_valid=True)
+        _, test = testing_utils.eval_model(MODEL_OPTIONS, skip_valid=True)
 
         # Overall
         self.assertEqual(
-            test['accuracy'],
-            0.3667,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
+            test['accuracy'], 0.3667, 'test accuracy = {}'.format(test['accuracy']),
         )
         self.assertEqual(
-            test['hits@5'],
-            0.633,
-            'test hits@5 = {}\nLOG:\n{}'.format(test['hits@5'], stdout),
+            test['hits@5'], 0.633, 'test hits@5 = {}'.format(test['hits@5']),
         )
         self.assertEqual(
-            test['hits@10'],
-            0.767,
-            'test hits@10 = {}\nLOG:\n{}'.format(test['hits@10'], stdout),
+            test['hits@10'], 0.767, 'test hits@10 = {}'.format(test['hits@10']),
         )
 
         # First round
         self.assertEqual(
             test['first_round']['hits@1/100'],
             0.2,
-            'test first round hits@1/100 = {}\nLOG:\n{}'.format(
-                test['first_round']['hits@1/100'], stdout
+            'test first round hits@1/100 = {}'.format(
+                test['first_round']['hits@1/100']
             ),
         )
 
@@ -73,8 +67,8 @@ class TestTransresnet(unittest.TestCase):
         self.assertEqual(
             test['second_round']['hits@1/100'],
             0.5,
-            'test second round hits@1/100 = {}\nLOG:\n{}'.format(
-                test['second_round']['hits@1/100'], stdout
+            'test second round hits@1/100 = {}'.format(
+                test['second_round']['hits@1/100']
             ),
         )
 
@@ -82,8 +76,8 @@ class TestTransresnet(unittest.TestCase):
         self.assertEqual(
             test['third_round+']['hits@1/100'],
             0.4,
-            'test third round hits@1/100 = {}\nLOG:\n{}'.format(
-                test['third_round+']['hits@1/100'], stdout
+            'test third round hits@1/100 = {}'.format(
+                test['third_round+']['hits@1/100']
             ),
         )
 

--- a/tests/nightly/gpu/test_transresnet_multimodal.py
+++ b/tests/nightly/gpu/test_transresnet_multimodal.py
@@ -31,12 +31,11 @@ class TestTransresnet(unittest.TestCase):
         """
         Set up the test by downloading the model/data.
         """
-        with testing_utils.capture_output():
-            parser = display_data.setup_args()
-            parser.set_defaults(**MODEL_OPTIONS)
-            opt = parser.parse_args([], print_args=False)
-            opt['num_examples'] = 1
-            display_data.display_data(opt)
+        parser = display_data.setup_args()
+        parser.set_defaults(**MODEL_OPTIONS)
+        opt = parser.parse_args([], print_args=False)
+        opt['num_examples'] = 1
+        display_data.display_data(opt)
 
     def test_transresnet(self):
         """

--- a/tests/nightly/gpu/test_wizard.py
+++ b/tests/nightly/gpu/test_wizard.py
@@ -46,12 +46,11 @@ class TestWizardModel(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # go ahead and download things here
-        with testing_utils.capture_output():
-            parser = display_data.setup_args()
-            parser.set_defaults(**END2END_OPTIONS)
-            opt = parser.parse_args([], print_args=False)
-            opt['num_examples'] = 1
-            display_data.display_data(opt)
+        parser = display_data.setup_args()
+        parser.set_defaults(**END2END_OPTIONS)
+        opt = parser.parse_args([], print_args=False)
+        opt['num_examples'] = 1
+        display_data.display_data(opt)
 
     def test_end2end(self):
         stdout, valid, _ = testing_utils.eval_model(END2END_OPTIONS)

--- a/tests/nightly/gpu/test_wizard.py
+++ b/tests/nightly/gpu/test_wizard.py
@@ -54,34 +54,22 @@ class TestWizardModel(unittest.TestCase):
 
     def test_end2end(self):
         stdout, valid, _ = testing_utils.eval_model(END2END_OPTIONS)
-        self.assertEqual(
-            valid['ppl'], 61.21, 'valid ppl = {}\nLOG:\n{}'.format(valid['ppl'], stdout)
-        )
-        self.assertEqual(
-            valid['f1'], 0.1717, 'valid f1 = {}\nLOG:\n{}'.format(valid['f1'], stdout)
-        )
+        self.assertEqual(valid['ppl'], 61.21, 'valid ppl = {}'.format(valid['ppl']))
+        self.assertEqual(valid['f1'], 0.1717, 'valid f1 = {}'.format(valid['f1']))
         self.assertGreaterEqual(
-            valid['know_acc'],
-            0.2201,
-            'valid know_acc = {}\nLOG:\n{}'.format(valid['know_acc'], stdout),
+            valid['know_acc'], 0.2201, 'valid know_acc = {}'.format(valid['know_acc']),
         )
 
     def test_retrieval(self):
         stdout, _, test = testing_utils.eval_model(RETRIEVAL_OPTIONS)
         self.assertGreaterEqual(
-            test['accuracy'],
-            0.86,
-            'test acc = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
+            test['accuracy'], 0.86, 'test acc = {}'.format(test['accuracy']),
         )
         self.assertGreaterEqual(
-            test['hits@5'],
-            0.98,
-            'test hits@5 = {}\nLOG:\n{}'.format(test['hits@5'], stdout),
+            test['hits@5'], 0.98, 'test hits@5 = {}'.format(test['hits@5']),
         )
         self.assertGreaterEqual(
-            test['hits@10'],
-            0.99,
-            'test hits@10 = {}\nLOG:\n{}'.format(test['hits@10'], stdout),
+            test['hits@10'], 0.99, 'test hits@10 = {}'.format(test['hits@10']),
         )
 
 

--- a/tests/nightly/gpu/test_wizard.py
+++ b/tests/nightly/gpu/test_wizard.py
@@ -54,23 +54,15 @@ class TestWizardModel(unittest.TestCase):
 
     def test_end2end(self):
         stdout, valid, _ = testing_utils.eval_model(END2END_OPTIONS)
-        self.assertEqual(valid['ppl'], 61.21, 'valid ppl = {}'.format(valid['ppl']))
-        self.assertEqual(valid['f1'], 0.1717, 'valid f1 = {}'.format(valid['f1']))
-        self.assertGreaterEqual(
-            valid['know_acc'], 0.2201, 'valid know_acc = {}'.format(valid['know_acc']),
-        )
+        self.assertEqual(valid['ppl'], 61.21)
+        self.assertEqual(valid['f1'], 0.1717)
+        self.assertGreaterEqual(valid['know_acc'], 0.2201)
 
     def test_retrieval(self):
         stdout, _, test = testing_utils.eval_model(RETRIEVAL_OPTIONS)
-        self.assertGreaterEqual(
-            test['accuracy'], 0.86, 'test acc = {}'.format(test['accuracy']),
-        )
-        self.assertGreaterEqual(
-            test['hits@5'], 0.98, 'test hits@5 = {}'.format(test['hits@5']),
-        )
-        self.assertGreaterEqual(
-            test['hits@10'], 0.99, 'test hits@10 = {}'.format(test['hits@10']),
-        )
+        self.assertGreaterEqual(test['accuracy'], 0.86)
+        self.assertGreaterEqual(test['hits@5'], 0.98)
+        self.assertGreaterEqual(test['hits@10'], 0.99)
 
 
 class TestKnowledgeRetriever(unittest.TestCase):

--- a/tests/tasks/test_wizard_of_wikipedia.py
+++ b/tests/tasks/test_wizard_of_wikipedia.py
@@ -8,7 +8,6 @@ from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
 from parlai.core.worlds import create_task
 
 import unittest
-import io
 import itertools
 import parlai.utils.testing as testing_utils
 

--- a/tests/tasks/test_wizard_of_wikipedia.py
+++ b/tests/tasks/test_wizard_of_wikipedia.py
@@ -10,7 +10,7 @@ from parlai.core.worlds import create_task
 import unittest
 import io
 import itertools
-from contextlib import redirect_stdout
+import parlai.utils.testing as testing_utils
 
 
 def product_dict(dictionary):
@@ -67,16 +67,15 @@ class TestWoW(unittest.TestCase):
                     task_args = variant_args[task_var]
                     if len(task_args) == 0:
                         print('Testing {} with args {}'.format(task_name, opt_defaults))
-                        self.run_display_test(opt_defaults)
+                        self._run_display_test(opt_defaults)
                     else:
                         for combo in product_dict(task_args):
                             args = {**opt_defaults, **combo}
                             print('Testing {} with args {}'.format(task_name, args))
-                            self.run_display_test(args)
+                            self._run_display_test(args)
 
-    def run_display_test(self, kwargs):
-        f = io.StringIO()
-        with redirect_stdout(f):
+    def _run_display_test(self, kwargs):
+        with testing_utils.capture_output() as stdout:
             parser = setup_args()
             parser.set_defaults(**kwargs)
             opt = parser.parse_args([])
@@ -84,7 +83,7 @@ class TestWoW(unittest.TestCase):
             world = create_task(opt, agent)
             display(opt)
 
-        str_output = f.getvalue()
+        str_output = stdout.getvalue()
         self.assertTrue(
             '[ loaded {} episodes with a total of {} examples ]'.format(
                 world.num_episodes(), world.num_examples()

--- a/tests/test_build_data.py
+++ b/tests/test_build_data.py
@@ -38,22 +38,16 @@ class TestBuildData(unittest.TestCase):
             'https://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
         ]
 
-        with testing_utils.capture_output() as stdout:
-            download_results = build_data.download_multiprocess(
-                urls, self.datapath, dest_filenames=self.dest_filenames
-            )
-        stdout = stdout.getvalue()
+        download_results = build_data.download_multiprocess(
+            urls, self.datapath, dest_filenames=self.dest_filenames
+        )
 
         output_filenames, output_statuses, output_errors = zip(*download_results)
         self.assertEqual(
-            output_filenames,
-            self.dest_filenames,
-            f'output filenames not correct\n{stdout}',
+            output_filenames, self.dest_filenames, 'output filenames not correct',
         )
         self.assertEqual(
-            output_statuses,
-            (200, 403, 403),
-            f'output http statuses not correct\n{stdout}',
+            output_statuses, (200, 403, 403), 'output http statuses not correct',
         )
 
     def test_download_multiprocess_chunks(self):
@@ -64,19 +58,17 @@ class TestBuildData(unittest.TestCase):
             'https://parl.ai/downloads/mnist/mnist.tar.gz.BAD',
         ]
 
-        with testing_utils.capture_output() as stdout:
-            download_results = build_data.download_multiprocess(
-                urls, self.datapath, dest_filenames=self.dest_filenames, chunk_size=1
-            )
-        stdout = stdout.getvalue()
+        download_results = build_data.download_multiprocess(
+            urls, self.datapath, dest_filenames=self.dest_filenames, chunk_size=1
+        )
 
         output_filenames, output_statuses, output_errors = zip(*download_results)
 
-        self.assertIn('mnist0.tar.gz', output_filenames, f'missing file:\n{stdout}')
-        self.assertIn('mnist1.tar.gz', output_filenames, f'missing file:\n{stdout}')
-        self.assertIn('mnist2.tar.gz', output_filenames, f'missing file:\n{stdout}')
-        self.assertIn(200, output_statuses, f'unexpected error code:\n{stdout}')
-        self.assertIn(403, output_statuses, f'unexpected error code:\n{stdout}')
+        self.assertIn('mnist0.tar.gz', output_filenames, 'missing file mnist0.tar.gz')
+        self.assertIn('mnist1.tar.gz', output_filenames, 'missing file mnist1.tar.gz')
+        self.assertIn('mnist2.tar.gz', output_filenames, 'missing file mnist2.tar.gz')
+        self.assertIn(200, output_statuses, 'unexpected error code')
+        self.assertIn(403, output_statuses, 'unexpected error code')
 
 
 if __name__ == '__main__':

--- a/tests/test_build_data.py
+++ b/tests/test_build_data.py
@@ -64,9 +64,9 @@ class TestBuildData(unittest.TestCase):
 
         output_filenames, output_statuses, output_errors = zip(*download_results)
 
-        self.assertIn('mnist0.tar.gz', output_filenames, 'missing file mnist0.tar.gz')
-        self.assertIn('mnist1.tar.gz', output_filenames, 'missing file mnist1.tar.gz')
-        self.assertIn('mnist2.tar.gz', output_filenames, 'missing file mnist2.tar.gz')
+        self.assertIn('mnist0.tar.gz', output_filenames)
+        self.assertIn('mnist1.tar.gz', output_filenames)
+        self.assertIn('mnist2.tar.gz', output_filenames)
         self.assertIn(200, output_statuses, 'unexpected error code')
         self.assertIn(403, output_statuses, 'unexpected error code')
 

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -26,9 +26,8 @@ class TestDictionary(unittest.TestCase):
     """
 
     def test_gpt2_bpe_tokenize(self):
-        with testing_utils.capture_output():
-            opt = Opt({'dict_tokenizer': 'gpt2', 'datapath': './data'})
-            agent = DictionaryAgent(opt)
+        opt = Opt({'dict_tokenizer': 'gpt2', 'datapath': './data'})
+        agent = DictionaryAgent(opt)
         self.assertEqual(
             # grinning face emoji
             agent.gpt2_tokenize(u'Hello, ParlAI! \U0001f600'),
@@ -157,12 +156,11 @@ class TestDictionary(unittest.TestCase):
         """
         import parlai.scripts.train_model as tms
 
-        with testing_utils.capture_output():
-            parser = tms.setup_args()
-            parser.set_params(task='babi:task1k:1', model='seq2seq')
-            popt = parser.parse_args([], print_args=False)
-            with self.assertRaises(RuntimeError):
-                tms.TrainLoop(popt)
+        parser = tms.setup_args()
+        parser.set_params(task='babi:task1k:1', model='seq2seq')
+        popt = parser.parse_args([], print_args=False)
+        with self.assertRaises(RuntimeError):
+            tms.TrainLoop(popt)
 
 
 if __name__ == '__main__':

--- a/tests/test_display_data.py
+++ b/tests/test_display_data.py
@@ -3,7 +3,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from examples.display_data import display_data
 from parlai.core.params import ParlaiParser
 import unittest
 import parlai.utils.testing as testing_utils

--- a/tests/test_display_data.py
+++ b/tests/test_display_data.py
@@ -18,13 +18,10 @@ class TestDisplayData(unittest.TestCase):
         """
         Does display_data reach the end of the loop?
         """
-        with testing_utils.capture_output() as stdout:
-            parser = ParlaiParser()
-            opt = parser.parse_args(['--task', 'babi:task1k:1'], print_args=False)
-            opt['num_examples'] = 1
-            display_data(opt)
+        str_output, _, _ = testing_utils.display_data(
+            {'num_examples': 1, 'task': 'babi:task1k:1',}
+        )
 
-        str_output = stdout.getvalue()
         self.assertGreater(len(str_output), 0, "Output is empty")
         self.assertIn("[babi:task1k:1]:", str_output, "Babi task did not print")
         self.assertIn("~~", str_output, "Example output did not complete")

--- a/tests/test_display_data.py
+++ b/tests/test_display_data.py
@@ -3,7 +3,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from parlai.core.params import ParlaiParser
 import unittest
 import parlai.utils.testing as testing_utils
 
@@ -18,7 +17,7 @@ class TestDisplayData(unittest.TestCase):
         Does display_data reach the end of the loop?
         """
         str_output, _, _ = testing_utils.display_data(
-            {'num_examples': 1, 'task': 'babi:task1k:1',}
+            {'num_examples': 1, 'task': 'babi:task1k:1'}
         )
 
         self.assertGreater(len(str_output), 0, "Output is empty")

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -67,14 +67,10 @@ class TestDistributed(unittest.TestCase):
             )
         )
 
-        self.assertLessEqual(valid['ppl'], 1.20, "valid ppl = {}".format(valid['ppl']))
-        self.assertGreaterEqual(
-            valid['bleu-4'], 0.95, "valid blue = {}".format(valid['bleu-4']),
-        )
-        self.assertLessEqual(test['ppl'], 1.20, "test ppl = {}".format(test['ppl']))
-        self.assertGreaterEqual(
-            test['bleu-4'], 0.95, "test bleu = {}".format(test['bleu-4']),
-        )
+        self.assertLessEqual(valid['ppl'], 1.20)
+        self.assertGreaterEqual(valid['bleu-4'], 0.95)
+        self.assertLessEqual(test['ppl'], 1.20)
+        self.assertGreaterEqual(test['bleu-4'], 0.95)
 
 
 if __name__ == '__main__':

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -27,23 +27,22 @@ def _forced_parse(parser, opt):
 @testing_utils.skipUnlessGPU
 class TestDistributed(unittest.TestCase):
     def _distributed_train_model(self, opt):
-        with testing_utils.capture_output() as output:
-            with testing_utils.tempdir() as tmpdir:
-                if 'model_file' not in opt:
-                    opt['model_file'] = os.path.join(tmpdir, 'model')
-                if 'dict_file' not in opt:
-                    opt['dict_file'] = os.path.join(tmpdir, 'model.dict')
+        with testing_utils.tempdir() as tmpdir:
+            if 'model_file' not in opt:
+                opt['model_file'] = os.path.join(tmpdir, 'model')
+            if 'dict_file' not in opt:
+                opt['dict_file'] = os.path.join(tmpdir, 'model.dict')
 
-                parser = mp_train.setup_args()
-                popt = _forced_parse(parser, opt)
+            parser = mp_train.setup_args()
+            popt = _forced_parse(parser, opt)
 
-                # we need a prebuilt dictionary
-                parser = build_dict.setup_args()
-                build_dict.build_dict(popt)
+            # we need a prebuilt dictionary
+            parser = build_dict.setup_args()
+            build_dict.build_dict(popt)
 
-                valid, test = mp_train.launch_and_train(popt, 31337)
+            valid, test = mp_train.launch_and_train(popt, 31337)
 
-        return (output.getvalue(), valid, test)
+        return (valid, test)
 
     def tearDown(self):
         # we need to de-initialize the distributed world, otherwise other
@@ -51,7 +50,7 @@ class TestDistributed(unittest.TestCase):
         dist.destroy_process_group()
 
     def test_generator_distributed(self):
-        stdout, valid, test = self._distributed_train_model(
+        valid, test = self._distributed_train_model(
             dict(
                 task='integration_tests:nocandidate',
                 model='transformer/generator',
@@ -68,21 +67,13 @@ class TestDistributed(unittest.TestCase):
             )
         )
 
-        self.assertLessEqual(
-            valid['ppl'], 1.20, "valid ppl = {}\nLOG:\n{}".format(valid['ppl'], stdout)
-        )
+        self.assertLessEqual(valid['ppl'], 1.20, "valid ppl = {}".format(valid['ppl']))
         self.assertGreaterEqual(
-            valid['bleu-4'],
-            0.95,
-            "valid blue = {}\nLOG:\n{}".format(valid['bleu-4'], stdout),
+            valid['bleu-4'], 0.95, "valid blue = {}".format(valid['bleu-4']),
         )
-        self.assertLessEqual(
-            test['ppl'], 1.20, "test ppl = {}\nLOG:\n{}".format(test['ppl'], stdout)
-        )
+        self.assertLessEqual(test['ppl'], 1.20, "test ppl = {}".format(test['ppl']))
         self.assertGreaterEqual(
-            test['bleu-4'],
-            0.95,
-            "test bleu = {}\nLOG:\n{}".format(test['bleu-4'], stdout),
+            test['bleu-4'], 0.95, "test bleu = {}".format(test['bleu-4']),
         )
 
 

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -48,24 +48,12 @@ class TestEvalModel(unittest.TestCase):
         )
 
         opt = parser.parse_args([], print_args=False)
-        str_output, valid, test = testing_utils.eval_model(opt)
-        self.assertGreater(len(str_output), 0, "Output is empty")
+        valid, test = testing_utils.eval_model(opt)
 
-        # decode the output
-        scores = str_output.split("\n---\n")
-
-        for i in range(1, len(scores)):
-            score = ast.literal_eval(scores[i])
-            # check totals
-            self.assertEqual(score['exs'], i, "Total is incorrect")
-            # accuracy should be one
-            self.assertEqual(
-                'accuracy' in score, True, "Accuracy is missing from default"
-            )
-            self.assertEqual(score['accuracy'], 1, "Accuracy != 1")
-            self.assertEqual(
-                'rouge-1' in score, False, "Rouge is in the default metrics"
-            )
+        self.assertEqual(valid['accuracy'], 1)
+        self.assertEqual(test['accuracy'], 1)
+        self.assertNotIn('rouge-L', valid)
+        self.assertNotIn('rouge-L', test)
 
     def test_metrics_all(self):
         """
@@ -82,23 +70,16 @@ class TestEvalModel(unittest.TestCase):
         )
 
         opt = parser.parse_args([], print_args=False)
-        str_output, valid, test = testing_utils.eval_model(opt)
-        self.assertGreater(len(str_output), 0, "Output is empty")
+        valid, test = testing_utils.eval_model(opt)
 
-        # decode the output
-        scores = str_output.split("\n---\n")
-
-        for i in range(1, len(scores)):
-            score = ast.literal_eval(scores[i])
-            # check totals
-            self.assertEqual(score['exs'], i, "Total is incorrect")
-            # accuracy should be one
-            self.assertEqual('accuracy' in score, True, "Accuracy is missing from all")
-            self.assertEqual(score['accuracy'], 1, "Accuracy != 1")
-            self.assertEqual('rouge-1' in score, True, "Rouge is missing from all")
-            self.assertEqual(score['rouge-1'], 1, 'rouge1 != 1')
-            self.assertEqual(score['rouge-2'], 1, 'rouge-2 != 1')
-            self.assertEqual(score['rouge-L'], 1, 'rouge-L != 1')
+        self.assertEqual(valid['accuracy'], 1)
+        self.assertEqual(valid['rouge-L'], 1)
+        self.assertEqual(valid['rouge-1'], 1)
+        self.assertEqual(valid['rouge-2'], 1)
+        self.assertEqual(test['accuracy'], 1)
+        self.assertEqual(test['rouge-L'], 1)
+        self.assertEqual(test['rouge-1'], 1)
+        self.assertEqual(test['rouge-2'], 1)
 
     def test_metrics_select(self):
         """
@@ -115,30 +96,22 @@ class TestEvalModel(unittest.TestCase):
         )
 
         opt = parser.parse_args([], print_args=False)
-        str_output, valid, test = testing_utils.eval_model(opt)
-        self.assertGreater(len(str_output), 0, "Output is empty")
+        valid, test = testing_utils.eval_model(opt)
 
-        # decode the output
-        scores = str_output.split("\n---\n")
+        self.assertEqual(valid['accuracy'], 1)
+        self.assertEqual(valid['rouge-L'], 1)
+        self.assertEqual(valid['rouge-1'], 1)
+        self.assertEqual(valid['rouge-2'], 1)
+        self.assertEqual(test['accuracy'], 1)
+        self.assertEqual(test['rouge-L'], 1)
+        self.assertEqual(test['rouge-1'], 1)
+        self.assertEqual(test['rouge-2'], 1)
 
-        for i in range(1, len(scores)):
-            score = ast.literal_eval(scores[i])
-            # check totals
-            self.assertEqual(score['exs'], i, "Total is incorrect")
-            # accuracy should be one
-            self.assertEqual(
-                'accuracy' in score, True, "Accuracy is missing from selection"
-            )
-            self.assertEqual(score['accuracy'], 1, "Accuracy != 1")
-            self.assertEqual(
-                'rouge-1' in score, True, "Rouge is missing from selection"
-            )
-            self.assertEqual(score['rouge-1'], 1, 'rouge1 != 1')
-            self.assertEqual(score['rouge-2'], 1, 'rouge-2 != 1')
-            self.assertEqual(score['rouge-L'], 1, 'rouge-L != 1')
+        self.assertNotIn('bleu-4', valid)
+        self.assertNotIn('bleu-4', test)
 
     def test_multitasking_metrics(self):
-        stdout, valid, test = testing_utils.eval_model(
+        valid, test = testing_utils.eval_model(
             {
                 'task': 'integration_tests:candidate,'
                 'integration_tests:multiturnCandidate',
@@ -159,7 +132,7 @@ class TestEvalModel(unittest.TestCase):
             'Task accuracy is averaged incorrectly',
         )
 
-        stdout, valid, test = testing_utils.eval_model(
+        valid, test = testing_utils.eval_model(
             {
                 'task': 'integration_tests:candidate,'
                 'integration_tests:multiturnCandidate',
@@ -193,14 +166,13 @@ class TestEvalModel(unittest.TestCase):
                 d['task'] = teacher
                 d['batchsize'] = bs
                 with testing_utils.timeout(time=20):
-                    stdout, valid, test = testing_utils.eval_model(
+                    valid, test = testing_utils.eval_model(
                         d, valid_datatype=d['datatype']
                     )
                 self.assertEqual(
                     int(valid['exs']),
                     500,
-                    f'train:evalmode failed with bs {bs} and teacher {teacher}'
-                    f' stdout: {stdout}',
+                    f'train:evalmode failed with bs {bs} and teacher {teacher}',
                 )
 
 

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 from examples.eval_model import setup_args
 
-import ast
 import unittest
 import parlai.utils.testing as testing_utils
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -41,7 +41,7 @@ class TestExampleSeq2Seq(unittest.TestCase):
         """
         Test a simple TRA based bag-of-words model.
         """
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='integration_tests',
                 model='examples/tra',

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -50,19 +50,9 @@ class TestExampleSeq2Seq(unittest.TestCase):
             )
         )
 
-        self.assertTrue(
-            valid['accuracy'] > 0.8,
-            "valid accuracy = {}\nLOG:\n{}".format(valid['accuracy'], stdout),
-        )
-        self.assertTrue(
-            test['accuracy'] > 0.8,
-            "test accuracy = {}\nLOG:\n{}".format(test['accuracy'], stdout),
-        )
-        self.assertEqual(
-            test['exs'],
-            100,
-            'test examples = {}\nLOG:\n{}'.format(valid['exs'], stdout),
-        )
+        self.assertGreater(valid['accuracy'], 0.8)
+        self.assertGreater(test['accuracy'], 0.8)
+        self.assertEqual(test['exs'], 100)
 
 
 if __name__ == '__main__':

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -33,12 +33,8 @@ class TestExampleSeq2Seq(unittest.TestCase):
             )
         )
 
-        self.assertTrue(
-            valid['token_acc'] > 0.8, "valid token_acc = {}".format(valid['token_acc']),
-        )
-        self.assertTrue(
-            test['token_acc'] > 0.8, "test token_acc = {}".format(test['token_acc']),
-        )
+        self.assertGreater(valid['token_acc'], 0.8)
+        self.assertGreater(test['token_acc'], 0.8)
 
     @testing_utils.retry(ntries=3)
     def test_repeater(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -19,7 +19,7 @@ class TestExampleSeq2Seq(unittest.TestCase):
 
     @testing_utils.retry(ntries=3)
     def test_generation(self):
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='integration_tests:nocandidate',
                 model='examples/seq2seq',
@@ -34,12 +34,10 @@ class TestExampleSeq2Seq(unittest.TestCase):
         )
 
         self.assertTrue(
-            valid['token_acc'] > 0.8,
-            "valid token_acc = {}\nLOG:\n{}".format(valid['token_acc'], stdout),
+            valid['token_acc'] > 0.8, "valid token_acc = {}".format(valid['token_acc']),
         )
         self.assertTrue(
-            test['token_acc'] > 0.8,
-            "test token_acc = {}\nLOG:\n{}".format(test['token_acc'], stdout),
+            test['token_acc'] > 0.8, "test token_acc = {}".format(test['token_acc']),
         )
 
     @testing_utils.retry(ntries=3)

--- a/tests/test_hogwild.py
+++ b/tests/test_hogwild.py
@@ -36,9 +36,9 @@ class TestHogwild(unittest.TestCase):
                 opt['num_threads'] = nt
                 opt['batchsize'] = bs
 
-                stdout, valid, test = testing_utils.train_model(opt)
-                self.assertEqual(valid['exs'], NUM_EXS, 'LOG:\n{}'.format(stdout))
-                self.assertEqual(test['exs'], NUM_EXS, 'LOG:\n{}'.format(stdout))
+                valid, test = testing_utils.train_model(opt)
+                self.assertEqual(valid['exs'], NUM_EXS)
+                self.assertEqual(test['exs'], NUM_EXS)
 
     def test_hogwild_eval(self):
         """
@@ -52,9 +52,9 @@ class TestHogwild(unittest.TestCase):
                 opt['num_threads'] = nt
                 opt['batchsize'] = bs
 
-                stdout, valid, test = testing_utils.eval_model(opt)
-                self.assertEqual(valid['exs'], NUM_EXS, 'LOG:\n{}'.format(stdout))
-                self.assertEqual(test['exs'], NUM_EXS, 'LOG:\n{}'.format(stdout))
+                valid, test = testing_utils.eval_model(opt)
+                self.assertEqual(valid['exs'], NUM_EXS)
+                self.assertEqual(test['exs'], NUM_EXS)
 
 
 if __name__ == '__main__':

--- a/tests/test_image_seq2seq.py
+++ b/tests/test_image_seq2seq.py
@@ -79,9 +79,9 @@ class TestImageSeq2Seq(unittest.TestCase):
         """
         args = BASE_ARGS.copy()
         args.update(TEXT_ARGS)
-        stdout, valid, test = testing_utils.train_model(args)
+        valid, test = testing_utils.train_model(args)
         self.assertLessEqual(
-            valid['ppl'], 1.5, f'failed to train image_seq2seq on text task: {stdout}'
+            valid['ppl'], 1.5, f'failed to train image_seq2seq on text task'
         )
 
     @testing_utils.retry(ntries=3)
@@ -96,9 +96,9 @@ class TestImageSeq2Seq(unittest.TestCase):
         args = BASE_ARGS.copy()
         args.update(IMAGE_ARGS)
 
-        stdout, valid, test = testing_utils.train_model(args)
+        valid, test = testing_utils.train_model(args)
         self.assertLessEqual(
-            valid['ppl'], 6.6, f'failed to train image_seq2seq on image task: {stdout}'
+            valid['ppl'], 6.6, f'failed to train image_seq2seq on image task'
         )
 
     @testing_utils.retry(ntries=3)
@@ -111,11 +111,9 @@ class TestImageSeq2Seq(unittest.TestCase):
         args = BASE_ARGS.copy()
         args.update(MULTITASK_ARGS)
 
-        stdout, valid, test = testing_utils.train_model(args)
+        valid, test = testing_utils.train_model(args)
         self.assertLessEqual(
-            valid['ppl'],
-            5.0,
-            f'failed to train image_seq2seq on image+text task: {stdout}',
+            valid['ppl'], 5.0, f'failed to train image_seq2seq on image+text task',
         )
 
     def test_compute_tokenized_bleu(self):
@@ -125,7 +123,7 @@ class TestImageSeq2Seq(unittest.TestCase):
         args = BASE_ARGS.copy()
         args.update(EVAL_ARGS)
 
-        stdout, valid, _ = testing_utils.eval_model(args, skip_test=True)
+        valid, _ = testing_utils.eval_model(args, skip_test=True)
         self.assertIn('fairseq_bleu', valid)
         self.assertIn('nltk_bleu_unnormalized', valid)
 

--- a/tests/test_memnn.py
+++ b/tests/test_memnn.py
@@ -23,7 +23,7 @@ class TestMemnn(unittest.TestCase):
         This test uses a single-turn task, so doesn't test memories.
         """
 
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='integration_tests:candidate',
                 model='memnn',
@@ -43,12 +43,10 @@ class TestMemnn(unittest.TestCase):
         )
 
         self.assertTrue(
-            valid['hits@1'] > 0.95,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@1'] > 0.95, "valid hits@1 = {}".format(valid['hits@1']),
         )
         self.assertTrue(
-            test['hits@1'] > 0.95,
-            "test hits@1 = {}\nLOG:\n{}".format(test['hits@1'], stdout),
+            test['hits@1'] > 0.95, "test hits@1 = {}".format(test['hits@1']),
         )
 
     @testing_utils.skipIfGPU
@@ -57,7 +55,7 @@ class TestMemnn(unittest.TestCase):
         """
         This test uses a multi-turn task and multithreading.
         """
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='integration_tests:multiturn_candidate',
                 model='memnn',
@@ -77,19 +75,17 @@ class TestMemnn(unittest.TestCase):
         )
 
         self.assertTrue(
-            valid['hits@1'] > 0.95,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@1'] > 0.95, "valid hits@1 = {}".format(valid['hits@1']),
         )
         self.assertTrue(
-            test['hits@1'] > 0.95,
-            "test hits@1 = {}\nLOG:\n{}".format(test['hits@1'], stdout),
+            test['hits@1'] > 0.95, "test hits@1 = {}".format(test['hits@1']),
         )
 
     def test_backcomp(self):
         """
         Tests that the memnn model files continue to works over time.
         """
-        stdout, valid, test = testing_utils.eval_model(
+        valid, test = testing_utils.eval_model(
             dict(
                 task='integration_tests',
                 model='memnn',
@@ -100,21 +96,13 @@ class TestMemnn(unittest.TestCase):
         )
 
         self.assertGreaterEqual(
-            valid['accuracy'],
-            0.88,
-            'valid accuracy = {}\nLOG:\n{}'.format(valid['accuracy'], stdout),
+            valid['accuracy'], 0.88, 'valid accuracy = {}'.format(valid['accuracy']),
         )
+        self.assertGreaterEqual(valid['f1'], 0.999, 'valid f1 = {}'.format(valid['f1']))
         self.assertGreaterEqual(
-            valid['f1'], 0.999, 'valid f1 = {}\nLOG:\n{}'.format(valid['f1'], stdout)
+            test['accuracy'], 0.84, 'test accuracy = {}'.format(test['accuracy']),
         )
-        self.assertGreaterEqual(
-            test['accuracy'],
-            0.84,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
-        )
-        self.assertGreaterEqual(
-            test['f1'], 0.999, 'test f1 = {}\nLOG:\n{}'.format(test['f1'], stdout)
-        )
+        self.assertGreaterEqual(test['f1'], 0.999, 'test f1 = {}'.format(test['f1']))
 
 
 if __name__ == '__main__':

--- a/tests/test_memnn.py
+++ b/tests/test_memnn.py
@@ -42,12 +42,8 @@ class TestMemnn(unittest.TestCase):
             )
         )
 
-        self.assertTrue(
-            valid['hits@1'] > 0.95, "valid hits@1 = {}".format(valid['hits@1']),
-        )
-        self.assertTrue(
-            test['hits@1'] > 0.95, "test hits@1 = {}".format(test['hits@1']),
-        )
+        self.assertGreater(valid['hits@1'], 0.95)
+        self.assertGreater(test['hits@1'], 0.95)
 
     @testing_utils.skipIfGPU
     @testing_utils.retry()
@@ -74,12 +70,8 @@ class TestMemnn(unittest.TestCase):
             )
         )
 
-        self.assertTrue(
-            valid['hits@1'] > 0.95, "valid hits@1 = {}".format(valid['hits@1']),
-        )
-        self.assertTrue(
-            test['hits@1'] > 0.95, "test hits@1 = {}".format(test['hits@1']),
-        )
+        self.assertGreater(valid['hits@1'], 0.95)
+        self.assertGreater(test['hits@1'], 0.95)
 
     def test_backcomp(self):
         """
@@ -95,14 +87,10 @@ class TestMemnn(unittest.TestCase):
             )
         )
 
-        self.assertGreaterEqual(
-            valid['accuracy'], 0.88, 'valid accuracy = {}'.format(valid['accuracy']),
-        )
-        self.assertGreaterEqual(valid['f1'], 0.999, 'valid f1 = {}'.format(valid['f1']))
-        self.assertGreaterEqual(
-            test['accuracy'], 0.84, 'test accuracy = {}'.format(test['accuracy']),
-        )
-        self.assertGreaterEqual(test['f1'], 0.999, 'test f1 = {}'.format(test['f1']))
+        self.assertGreaterEqual(valid['accuracy'], 0.88)
+        self.assertGreaterEqual(valid['f1'], 0.999)
+        self.assertGreaterEqual(test['accuracy'], 0.84)
+        self.assertGreaterEqual(test['f1'], 0.999)
 
 
 if __name__ == '__main__':

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -41,22 +41,21 @@ class TestParlaiParser(unittest.TestCase):
         Test whether upgrade_opt works.
         """
         with testing_utils.tempdir() as tmp:
-            with testing_utils.capture_output() as _:
-                modfn = os.path.join(tmp, 'model')
-                with open(modfn, 'w') as f:
-                    f.write('Test.')
-                optfn = modfn + '.opt'
-                base_opt = {
-                    'model': 'tests.test_params:_ExampleUpgradeOptAgent',
-                    'dict_file': modfn + '.dict',
-                    'model_file': modfn,
-                }
-                with open(optfn, 'w') as f:
-                    json.dump(base_opt, f)
+            modfn = os.path.join(tmp, 'model')
+            with open(modfn, 'w') as f:
+                f.write('Test.')
+            optfn = modfn + '.opt'
+            base_opt = {
+                'model': 'tests.test_params:_ExampleUpgradeOptAgent',
+                'dict_file': modfn + '.dict',
+                'model_file': modfn,
+            }
+            with open(optfn, 'w') as f:
+                json.dump(base_opt, f)
 
-                pp = ParlaiParser(True, True)
-                opt = pp.parse_args(['--model-file', modfn])
-                agents.create_agent(opt)
+            pp = ParlaiParser(True, True)
+            opt = pp.parse_args(['--model-file', modfn])
+            agents.create_agent(opt)
 
     def test_recommendations_single(self):
         """
@@ -72,8 +71,7 @@ class TestParlaiParser(unittest.TestCase):
             recommended="10",
         )
 
-        with testing_utils.capture_output() as _:
-            parser.parse_args([])
+        parser.parse_args([])
         help_str = parser.format_help()
         assert re.search(r'--batchsize[^\n]*\n[^\n]*\(recommended: 10\)', help_str)
 
@@ -91,8 +89,7 @@ class TestParlaiParser(unittest.TestCase):
             help='batch size for minibatch training schemes',
             recommended=[5, 10, 15],
         )
-        with testing_utils.capture_output() as _:
-            parser.parse_args([])
+        parser.parse_args([])
 
         help_str = parser.format_help()
         assert re.search(r'Test Group:\n', help_str)

--- a/tests/test_pytorch_data_teacher.py
+++ b/tests/test_pytorch_data_teacher.py
@@ -49,7 +49,7 @@ integration_test_parser_defaults = {
 }
 
 
-def solved_task(str_output, valid, test):
+def solved_task(valid, test):
     return (
         valid['ppl'] < 1.3
         and test['ppl'] < 1.3
@@ -295,12 +295,10 @@ class TestPytorchDataTeacher(unittest.TestCase):
         defaults = integration_test_parser_defaults.copy()
         defaults['datatype'] = datatype
         defaults['shuffle'] = True  # for train:stream
-        str_output, valid, test = testing_utils.train_model(defaults)
+        valid, test = testing_utils.train_model(defaults)
         self.assertTrue(
-            solved_task(str_output, valid, test),
-            'Teacher could not teach seq2seq with args: {}; here is str_output: {}'.format(
-                defaults, str_output
-            ),
+            solved_task(valid, test),
+            'Teacher could not teach seq2seq with args: {}'.format(defaults),
         )
 
     @testing_utils.retry()
@@ -327,12 +325,10 @@ class TestPytorchDataTeacher(unittest.TestCase):
         defaults = integration_test_parser_defaults.copy()
         defaults['datatype'] = 'train'
         defaults['pytorch_preprocess'] = True
-        str_output, valid, test = testing_utils.train_model(defaults)
+        valid, test = testing_utils.train_model(defaults)
         self.assertTrue(
-            solved_task(str_output, valid, test),
-            'Teacher could not teach seq2seq with preprocessed obs, output: {}'.format(
-                str_output
-            ),
+            solved_task(valid, test),
+            'Teacher could not teach seq2seq with preprocessed obs',
         )
 
     def _pyt_batchsort_train(self, datatype, preprocess):
@@ -350,11 +346,11 @@ class TestPytorchDataTeacher(unittest.TestCase):
         defaults['pytorch_teacher_batch_sort'] = True
         if preprocess:
             defaults['batch_sort_field'] = 'text_vec'
-        str_output, valid, test = testing_utils.train_model(defaults)
+        valid, test = testing_utils.train_model(defaults)
         self.assertTrue(
-            solved_task(str_output, valid, test),
+            solved_task(valid, test),
             'Teacher could not teach seq2seq with batch sort '
-            'and args {} and output {}'.format((datatype, preprocess), str_output),
+            'and args {}'.format((datatype, preprocess)),
         )
 
     @testing_utils.retry()
@@ -424,7 +420,8 @@ class TestPytorchDataTeacher(unittest.TestCase):
             parser = display_setup_args()
             parser.set_defaults(**defaults)
             opt = parser.parse_args([])
-            display_data(opt)
+            with testing_utils.capture_output() as f:
+                display_data(opt)
             str_output = f.getvalue()
             self.assertTrue(
                 '[ loaded {} episodes with a total of {} examples ]'.format(

--- a/tests/test_pytorch_data_teacher.py
+++ b/tests/test_pytorch_data_teacher.py
@@ -85,27 +85,26 @@ class TestPytorchDataTeacher(unittest.TestCase):
                         'datatype': datatype,
                         'shuffle': shuffle,
                     }
-                    with testing_utils.capture_output() as _:
-                        parser = display_setup_args()
-                        parser.set_defaults(**opt_defaults)
-                        opt = parser.parse_args([])
-                        teacher = create_task_agent_from_taskname(opt)[0]
-                        if (
-                            'ordered' in datatype
-                            or ('stream' in datatype and not opt.get('shuffle'))
-                            or 'train' not in datatype
-                        ):
-                            self.assertIsInstance(
-                                teacher.pytorch_dataloader.sampler,
-                                Sequential,
-                                'PytorchDataTeacher failed with args: {}'.format(opt),
-                            )
-                        else:
-                            self.assertIsInstance(
-                                teacher.pytorch_dataloader.sampler,
-                                RandomSampler,
-                                'PytorchDataTeacher failed with args: {}'.format(opt),
-                            )
+                    parser = display_setup_args()
+                    parser.set_defaults(**opt_defaults)
+                    opt = parser.parse_args([])
+                    teacher = create_task_agent_from_taskname(opt)[0]
+                    if (
+                        'ordered' in datatype
+                        or ('stream' in datatype and not opt.get('shuffle'))
+                        or 'train' not in datatype
+                    ):
+                        self.assertIsInstance(
+                            teacher.pytorch_dataloader.sampler,
+                            Sequential,
+                            'PytorchDataTeacher failed with args: {}'.format(opt),
+                        )
+                    else:
+                        self.assertIsInstance(
+                            teacher.pytorch_dataloader.sampler,
+                            RandomSampler,
+                            'PytorchDataTeacher failed with args: {}'.format(opt),
+                        )
 
     def test_pyt_preprocess(self):
         """
@@ -121,15 +120,14 @@ class TestPytorchDataTeacher(unittest.TestCase):
             parser.set_defaults(**defaults)
             opt = parser.parse_args([])
             build_dict(opt)
-            with testing_utils.capture_output() as _:
-                teacher = create_task_agent_from_taskname(opt)[0]
+            teacher = create_task_agent_from_taskname(opt)[0]
             agent = create_agent(opt)
             act = teacher.act()
             if teacher_processed:
                 return act, agent
             return agent.observe(act), agent
 
-        with testing_utils.capture_output() as _, testing_utils.tempdir() as tmpdir:
+        with testing_utils.tempdir() as tmpdir:
             defaults = unit_test_parser_defaults.copy()
             defaults['batch_size'] = 1
             defaults['datatype'] = 'train:stream:ordered'
@@ -208,7 +206,7 @@ class TestPytorchDataTeacher(unittest.TestCase):
         defaults['datatype'] = 'train:stream:ordered'
         defaults['pytorch_teacher_batch_sort'] = True
 
-        with testing_utils.capture_output() as _, testing_utils.tempdir() as tmpdir:
+        with testing_utils.tempdir() as tmpdir:
             # Get processed act from agent
             defaults['pytorch_teacher_task'] = 'babi:task1k:1'
             defaults['batch_sort_cache_type'] = 'index'
@@ -241,7 +239,7 @@ class TestPytorchDataTeacher(unittest.TestCase):
         max_range = defaults['batch_length_range']
 
         def verify_batch_lengths(defaults):
-            with testing_utils.capture_output() as _, testing_utils.tempdir() as tmpdir:
+            with testing_utils.tempdir() as tmpdir:
                 # Get processed act from agent
                 parser = train_setup_args()
                 defaults['model_file'] = os.path.join(tmpdir, 'model')
@@ -379,23 +377,22 @@ class TestPytorchDataTeacher(unittest.TestCase):
         defaults['datatype'] = 'train:stream'
         defaults['image_mode'] = 'ascii'
 
-        with testing_utils.capture_output():
-            # Get processed act from agent
-            parser = display_setup_args()
-            defaults['pytorch_teacher_dataset'] = 'integration_tests'
-            del defaults['pytorch_teacher_task']
-            parser.set_defaults(**defaults)
-            opt = parser.parse_args([])
-            teacher = create_task_agent_from_taskname(opt)[0]
-            pytorch_teacher_act = teacher.act()
+        # Get processed act from agent
+        parser = display_setup_args()
+        defaults['pytorch_teacher_dataset'] = 'integration_tests'
+        del defaults['pytorch_teacher_task']
+        parser.set_defaults(**defaults)
+        opt = parser.parse_args([])
+        teacher = create_task_agent_from_taskname(opt)[0]
+        pytorch_teacher_act = teacher.act()
 
-            parser = display_setup_args()
-            defaults['task'] = 'integration_tests'
-            del defaults['pytorch_teacher_dataset']
-            parser.set_defaults(**defaults)
-            opt = parser.parse_args([])
-            teacher = create_task_agent_from_taskname(opt)[0]
-            regular_teacher_act = teacher.act()
+        parser = display_setup_args()
+        defaults['task'] = 'integration_tests'
+        del defaults['pytorch_teacher_dataset']
+        parser.set_defaults(**defaults)
+        opt = parser.parse_args([])
+        teacher = create_task_agent_from_taskname(opt)[0]
+        regular_teacher_act = teacher.act()
 
         keys = set(pytorch_teacher_act.keys()).intersection(
             set(regular_teacher_act.keys())
@@ -424,11 +421,10 @@ class TestPytorchDataTeacher(unittest.TestCase):
         """
 
         def run_display_test(defaults, ep_and_ex_counts):
-            with testing_utils.capture_output() as f:
-                parser = display_setup_args()
-                parser.set_defaults(**defaults)
-                opt = parser.parse_args([])
-                display_data(opt)
+            parser = display_setup_args()
+            parser.set_defaults(**defaults)
+            opt = parser.parse_args([])
+            display_data(opt)
             str_output = f.getvalue()
             self.assertTrue(
                 '[ loaded {} episodes with a total of {} examples ]'.format(

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -19,7 +19,7 @@ class TestSeq2Seq(unittest.TestCase):
 
     @testing_utils.retry(ntries=3)
     def test_ranking(self):
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='integration_tests:candidate',
                 model='seq2seq',
@@ -38,15 +38,14 @@ class TestSeq2Seq(unittest.TestCase):
             )
         )
         self.assertTrue(
-            valid['hits@1'] >= 0.95,
-            "hits@1 = {}\nLOG:\n{}".format(valid['ppl'], stdout),
+            valid['hits@1'] >= 0.95, "hits@1 = {}".format(valid['ppl']),
         )
 
     def test_generation(self):
         """
         This test uses a single-turn sequence repitition task.
         """
-        stdout, valid, test = testing_utils.eval_model(
+        valid, test = testing_utils.eval_model(
             dict(
                 task='integration_tests:multiturn_nocandidate',
                 model='seq2seq',
@@ -59,18 +58,14 @@ class TestSeq2Seq(unittest.TestCase):
             )
         )
 
-        self.assertTrue(
-            valid['ppl'] < 1.2, "valid ppl = {}\nLOG:\n{}".format(valid['ppl'], stdout)
-        )
-        self.assertTrue(
-            test['ppl'] < 1.2, "test ppl = {}\nLOG:\n{}".format(test['ppl'], stdout)
-        )
+        self.assertTrue(valid['ppl'] < 1.2, "valid ppl = {}".format(valid['ppl']))
+        self.assertTrue(test['ppl'] < 1.2, "test ppl = {}".format(test['ppl']))
 
     def test_beamsearch(self):
         """
         Ensures beam search can generate the correct response.
         """
-        stdout, valid, test = testing_utils.eval_model(
+        valid, test = testing_utils.eval_model(
             dict(
                 task='integration_tests:multiturn_nocandidate',
                 model='seq2seq',
@@ -82,19 +77,17 @@ class TestSeq2Seq(unittest.TestCase):
             )
         )
         self.assertTrue(
-            valid['accuracy'] > 0.95,
-            "valid accuracy = {}\nLOG:\n{}".format(valid['accuracy'], stdout),
+            valid['accuracy'] > 0.95, "valid accuracy = {}".format(valid['accuracy']),
         )
         self.assertTrue(
-            test['accuracy'] > 0.95,
-            "test accuracy = {}\nLOG:\n{}".format(test['accuracy'], stdout),
+            test['accuracy'] > 0.95, "test accuracy = {}".format(test['accuracy']),
         )
 
     def test_badinput(self):
         """
         Ensures model doesn't crash on malformed inputs.
         """
-        stdout, _, _ = testing_utils.train_model(
+        testing_utils.train_model(
             dict(
                 task='integration_tests:bad_example',
                 model='seq2seq',
@@ -108,8 +101,6 @@ class TestSeq2Seq(unittest.TestCase):
                 inference='greedy',
             )
         )
-        self.assertIn('valid:{', stdout)
-        self.assertIn('test:{', stdout)
 
 
 class TestHogwildSeq2seq(unittest.TestCase):
@@ -118,7 +109,7 @@ class TestHogwildSeq2seq(unittest.TestCase):
         """
         This test uses a multi-turn task and multithreading.
         """
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='integration_tests:multiturn_nocandidate',
                 model='seq2seq',
@@ -137,12 +128,8 @@ class TestHogwildSeq2seq(unittest.TestCase):
             )
         )
 
-        self.assertTrue(
-            valid['ppl'] < 1.2, "valid ppl = {}\nLOG:\n{}".format(valid['ppl'], stdout)
-        )
-        self.assertTrue(
-            test['ppl'] < 1.2, "test ppl = {}\nLOG:\n{}".format(test['ppl'], stdout)
-        )
+        self.assertTrue(valid['ppl'] < 1.2, "valid ppl = {}".format(valid['ppl']))
+        self.assertTrue(test['ppl'] < 1.2, "test ppl = {}".format(test['ppl']))
 
 
 class TestBackwardsCompatibility(unittest.TestCase):
@@ -151,7 +138,7 @@ class TestBackwardsCompatibility(unittest.TestCase):
     """
 
     def test_backwards_compatibility(self):
-        stdout, valid, test = testing_utils.eval_model(
+        valid, test = testing_utils.eval_model(
             dict(
                 task='integration_tests:multiturn_candidate',
                 model='seq2seq',
@@ -160,28 +147,16 @@ class TestBackwardsCompatibility(unittest.TestCase):
             )
         )
 
-        self.assertLessEqual(
-            valid['ppl'], 1.01, 'valid ppl = {}\nLOG:\n{}'.format(valid['ppl'], stdout)
-        )
+        self.assertLessEqual(valid['ppl'], 1.01, 'valid ppl = {}'.format(valid['ppl']))
         self.assertGreaterEqual(
-            valid['accuracy'],
-            0.999,
-            'valid accuracy = {}\nLOG:\n{}'.format(valid['accuracy'], stdout),
+            valid['accuracy'], 0.999, 'valid accuracy = {}'.format(valid['accuracy']),
         )
+        self.assertGreaterEqual(valid['f1'], 0.999, 'valid f1 = {}'.format(valid['f1']))
+        self.assertLessEqual(test['ppl'], 1.01, 'test ppl = {}'.format(test['ppl']))
         self.assertGreaterEqual(
-            valid['f1'], 0.999, 'valid f1 = {}\nLOG:\n{}'.format(valid['f1'], stdout)
+            test['accuracy'], 0.999, 'test accuracy = {}'.format(test['accuracy']),
         )
-        self.assertLessEqual(
-            test['ppl'], 1.01, 'test ppl = {}\nLOG:\n{}'.format(test['ppl'], stdout)
-        )
-        self.assertGreaterEqual(
-            test['accuracy'],
-            0.999,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
-        )
-        self.assertGreaterEqual(
-            test['f1'], 0.999, 'test f1 = {}\nLOG:\n{}'.format(test['f1'], stdout)
-        )
+        self.assertGreaterEqual(test['f1'], 0.999, 'test f1 = {}'.format(test['f1']))
 
 
 if __name__ == '__main__':

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -58,8 +58,8 @@ class TestSeq2Seq(unittest.TestCase):
             )
         )
 
-        self.assertTrue(valid['ppl'] < 1.2, "valid ppl = {}".format(valid['ppl']))
-        self.assertTrue(test['ppl'] < 1.2, "test ppl = {}".format(test['ppl']))
+        self.assertLess(valid['ppl'], 1.2)
+        self.assertLess(test['ppl'], 1.2)
 
     def test_beamsearch(self):
         """
@@ -76,12 +76,8 @@ class TestSeq2Seq(unittest.TestCase):
                 beam_size=5,
             )
         )
-        self.assertTrue(
-            valid['accuracy'] > 0.95, "valid accuracy = {}".format(valid['accuracy']),
-        )
-        self.assertTrue(
-            test['accuracy'] > 0.95, "test accuracy = {}".format(test['accuracy']),
-        )
+        self.assertGreater(valid['accuracy'], 0.95)
+        self.assertGreater(test['accuracy'], 0.95)
 
     def test_badinput(self):
         """
@@ -128,8 +124,8 @@ class TestHogwildSeq2seq(unittest.TestCase):
             )
         )
 
-        self.assertTrue(valid['ppl'] < 1.2, "valid ppl = {}".format(valid['ppl']))
-        self.assertTrue(test['ppl'] < 1.2, "test ppl = {}".format(test['ppl']))
+        self.assertLess(valid['ppl'], 1.2)
+        self.assertLess(test['ppl'], 1.2)
 
 
 class TestBackwardsCompatibility(unittest.TestCase):
@@ -147,16 +143,12 @@ class TestBackwardsCompatibility(unittest.TestCase):
             )
         )
 
-        self.assertLessEqual(valid['ppl'], 1.01, 'valid ppl = {}'.format(valid['ppl']))
-        self.assertGreaterEqual(
-            valid['accuracy'], 0.999, 'valid accuracy = {}'.format(valid['accuracy']),
-        )
-        self.assertGreaterEqual(valid['f1'], 0.999, 'valid f1 = {}'.format(valid['f1']))
-        self.assertLessEqual(test['ppl'], 1.01, 'test ppl = {}'.format(test['ppl']))
-        self.assertGreaterEqual(
-            test['accuracy'], 0.999, 'test accuracy = {}'.format(test['accuracy']),
-        )
-        self.assertGreaterEqual(test['f1'], 0.999, 'test f1 = {}'.format(test['f1']))
+        self.assertLessEqual(valid['ppl'], 1.01)
+        self.assertGreaterEqual(valid['accuracy'], 0.999)
+        self.assertGreaterEqual(valid['f1'], 0.999)
+        self.assertLessEqual(test['ppl'], 1.01)
+        self.assertGreaterEqual(test['accuracy'], 0.999)
+        self.assertGreaterEqual(test['f1'], 0.999)
 
 
 if __name__ == '__main__':

--- a/tests/test_tfidf_retriever.py
+++ b/tests/test_tfidf_retriever.py
@@ -47,9 +47,8 @@ class TestTfidfRetriever(unittest.TestCase):
                 num_epochs=1,
             )
             opt = parser.parse_args([], print_args=False)
-            with contextlib.redirect_stdout(io.StringIO()):
-                agent = create_agent(opt)
-                train_world = create_task(opt, agent)
+            agent = create_agent(opt)
+            train_world = create_task(opt, agent)
             # pass examples to dictionary
             while not train_world.epoch_done():
                 train_world.parley()

--- a/tests/test_tfidf_retriever.py
+++ b/tests/test_tfidf_retriever.py
@@ -11,8 +11,6 @@ from parlai.utils.logging import logger, ERROR
 
 import os
 import unittest
-import contextlib
-import io
 
 SKIP_TESTS = False
 try:

--- a/tests/test_tga.py
+++ b/tests/test_tga.py
@@ -23,12 +23,11 @@ class TestUpgradeOpt(unittest.TestCase):
         """
         Test --inference with simple options.
         """
-        with testing_utils.capture_output():
-            upgraded = TorchGeneratorAgent.upgrade_opt({'beam_size': 1})
-            self.assertEqual(upgraded['inference'], 'greedy')
+        upgraded = TorchGeneratorAgent.upgrade_opt({'beam_size': 1})
+        self.assertEqual(upgraded['inference'], 'greedy')
 
-            upgraded = TorchGeneratorAgent.upgrade_opt({'beam_size': 5})
-            self.assertEqual(upgraded['inference'], 'beam')
+        upgraded = TorchGeneratorAgent.upgrade_opt({'beam_size': 5})
+        self.assertEqual(upgraded['inference'], 'beam')
 
     def test_no_greedy_largebeam(self):
         """
@@ -59,27 +58,25 @@ class TestUpgradeOpt(unittest.TestCase):
         """
         Test --inference with older model files.
         """
-        with testing_utils.capture_output():
-            pp = ParlaiParser(True, True)
-            opt = pp.parse_args(
-                ['--model-file', 'zoo:unittest/transformer_generator2/model']
-            )
-            agent = create_agent(opt, True)
-            self.assertEqual(agent.opt['inference'], 'greedy')
+        pp = ParlaiParser(True, True)
+        opt = pp.parse_args(
+            ['--model-file', 'zoo:unittest/transformer_generator2/model']
+        )
+        agent = create_agent(opt, True)
+        self.assertEqual(agent.opt['inference'], 'greedy')
 
-        with testing_utils.capture_output():
-            pp = ParlaiParser(True, True)
-            opt = pp.parse_args(
-                [
-                    '--model-file',
-                    'zoo:unittest/transformer_generator2/model',
-                    '--beam-size',
-                    '5',
-                ],
-                print_args=False,
-            )
-            agent = create_agent(opt, True)
-            self.assertEqual(agent.opt['inference'], 'beam')
+        pp = ParlaiParser(True, True)
+        opt = pp.parse_args(
+            [
+                '--model-file',
+                'zoo:unittest/transformer_generator2/model',
+                '--beam-size',
+                '5',
+            ],
+            print_args=False,
+        )
+        agent = create_agent(opt, True)
+        self.assertEqual(agent.opt['inference'], 'beam')
 
 
 if __name__ == '__main__':

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -11,7 +11,7 @@ Unit tests for TorchAgent.
 import os
 import unittest
 from parlai.core.agents import create_agent_from_shared
-from parlai.utils.testing import capture_output, tempdir
+from parlai.utils.testing import tempdir
 from parlai.utils.misc import Message
 import parlai.utils.testing as testing_utils
 
@@ -40,8 +40,7 @@ def get_agent(**kwargs):
     MockTorchAgent.add_cmdline_args(parser)
     parser.set_params(**kwargs)
     opt = parser.parse_args([], print_args=False)
-    with testing_utils.capture_output():
-        return MockTorchAgent(opt)
+    return MockTorchAgent(opt)
 
 
 @unittest.skipIf(SKIP_TESTS, "Torch not installed.")
@@ -993,26 +992,25 @@ class TestTorchAgent(unittest.TestCase):
                 'log_every_n_secs': 10,
             }
 
-        with capture_output():
-            with tempdir() as tmpdir:
-                # First train model with init_model path set
-                mf = os.path.join(tmpdir, 'model')
-                init_mf = os.path.join(tmpdir, 'init_model')
-                with open(init_mf, 'w') as f:
-                    f.write(' ')
-                opt = get_opt(init_mf, mf)
-                popt, tl = get_popt_and_tl(opt)
-                agent = tl.agent
-                # init model file should be set appropriately
-                init_model_file, is_finetune = agent._get_init_model(popt, None)
-                self.assertEqual(init_model_file, init_mf)
-                self.assertTrue(is_finetune)
-                valid, test = tl.train()
-                # now, train the model for another epoch
-                opt = get_opt('{}.checkpoint'.format(mf), mf)
-                opt['load_from_checkpoint'] = True
-                popt, tl = get_popt_and_tl(opt)
-                agent = tl.agent
-                init_model_file, is_finetune = agent._get_init_model(popt, None)
-                self.assertEqual(init_model_file, '{}.checkpoint'.format(mf))
-                self.assertFalse(is_finetune)
+        with tempdir() as tmpdir:
+            # First train model with init_model path set
+            mf = os.path.join(tmpdir, 'model')
+            init_mf = os.path.join(tmpdir, 'init_model')
+            with open(init_mf, 'w') as f:
+                f.write(' ')
+            opt = get_opt(init_mf, mf)
+            popt, tl = get_popt_and_tl(opt)
+            agent = tl.agent
+            # init model file should be set appropriately
+            init_model_file, is_finetune = agent._get_init_model(popt, None)
+            self.assertEqual(init_model_file, init_mf)
+            self.assertTrue(is_finetune)
+            valid, test = tl.train()
+            # now, train the model for another epoch
+            opt = get_opt('{}.checkpoint'.format(mf), mf)
+            opt['load_from_checkpoint'] = True
+            popt, tl = get_popt_and_tl(opt)
+            agent = tl.agent
+            init_model_file, is_finetune = agent._get_init_model(popt, None)
+            self.assertEqual(init_model_file, '{}.checkpoint'.format(mf))
+            self.assertFalse(is_finetune)

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -13,7 +13,6 @@ import unittest
 from parlai.core.agents import create_agent_from_shared
 from parlai.utils.testing import tempdir
 from parlai.utils.misc import Message
-import parlai.utils.testing as testing_utils
 
 from collections import deque
 

--- a/tests/test_tra.py
+++ b/tests/test_tra.py
@@ -46,13 +46,11 @@ class _AbstractTRATest(unittest.TestCase):
     def test_train_inline(self):
         args = self._get_args()
         args['candidates'] = 'inline'
-        stdout, valid, test = testing_utils.train_model(args)
+        valid, test = testing_utils.train_model(args)
         threshold = self._get_threshold()
 
         self.assertGreaterEqual(
-            valid['hits@1'],
-            threshold,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@1'], threshold, "valid hits@1 = {}".format(valid['hits@1']),
         )
 
     # test train batch cands
@@ -60,13 +58,11 @@ class _AbstractTRATest(unittest.TestCase):
     def test_train_batch(self):
         args = self._get_args()
         args['candidates'] = 'batch'
-        stdout, valid, test = testing_utils.train_model(args)
+        valid, test = testing_utils.train_model(args)
         threshold = self._get_threshold()
 
         self.assertGreaterEqual(
-            valid['hits@1'],
-            threshold,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@1'], threshold, "valid hits@1 = {}".format(valid['hits@1']),
         )
 
     # test train fixed
@@ -75,13 +71,11 @@ class _AbstractTRATest(unittest.TestCase):
         args = self._get_args()
         args['candidates'] = 'fixed'
         args['encode_candidate_vecs'] = False
-        stdout, valid, test = testing_utils.train_model(args)
+        valid, test = testing_utils.train_model(args)
         threshold = self._get_threshold()
 
         self.assertGreaterEqual(
-            valid['hits@1'],
-            threshold,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@1'], threshold, "valid hits@1 = {}".format(valid['hits@1']),
         )
 
     # test train batch all cands
@@ -89,13 +83,11 @@ class _AbstractTRATest(unittest.TestCase):
     def test_train_batch_all(self):
         args = self._get_args()
         args['candidates'] = 'batch-all-cands'
-        stdout, valid, test = testing_utils.train_model(args)
+        valid, test = testing_utils.train_model(args)
         threshold = self._get_threshold()
 
         self.assertGreaterEqual(
-            valid['hits@1'],
-            threshold,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@1'], threshold, "valid hits@1 = {}".format(valid['hits@1']),
         )
 
     # test eval inline ecands
@@ -103,13 +95,11 @@ class _AbstractTRATest(unittest.TestCase):
     def test_eval_inline(self):
         args = self._get_args()
         args['eval_candidates'] = 'inline'
-        stdout, valid, test = testing_utils.train_model(args)
+        valid, test = testing_utils.train_model(args)
         threshold = self._get_threshold()
 
         self.assertGreaterEqual(
-            valid['hits@1'],
-            threshold,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@1'], threshold, "valid hits@1 = {}".format(valid['hits@1']),
         )
 
     # test eval batch ecands
@@ -117,13 +107,11 @@ class _AbstractTRATest(unittest.TestCase):
     def test_eval_batch(self):
         args = self._get_args()
         args['eval_candidates'] = 'batch'
-        stdout, valid, test = testing_utils.train_model(args)
+        valid, test = testing_utils.train_model(args)
         threshold = self._get_threshold()
 
         self.assertGreaterEqual(
-            valid['hits@1'],
-            threshold,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@1'], threshold, "valid hits@1 = {}".format(valid['hits@1']),
         )
 
     # test eval fixed ecands
@@ -133,15 +121,13 @@ class _AbstractTRATest(unittest.TestCase):
         args['eval_candidates'] = 'fixed'
         args['encode_candidate_vecs'] = True
         args['ignore_bad_candidates'] = True
-        stdout, valid, test = testing_utils.train_model(args)
+        valid, test = testing_utils.train_model(args)
 
         # none of the train candidates appear in evaluation, so should have
         # zero accuracy: this tests whether the fixed candidates were built
         # properly (i.e., only using candidates from the train set)
         self.assertEqual(
-            valid['hits@1'],
-            0,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@1'], 0, "valid hits@1 = {}".format(valid['hits@1']),
         )
 
         # now try again with a fixed candidate file that includes all possible
@@ -158,11 +144,9 @@ class _AbstractTRATest(unittest.TestCase):
             args['encode_candidate_vecs'] = False  # don't encode before training
             args['ignore_bad_candidates'] = False
             args['num_epochs'] = 4
-            stdout, valid, test = testing_utils.train_model(args)
+            valid, test = testing_utils.train_model(args)
             self.assertGreaterEqual(
-                valid['hits@100'],
-                0.1,
-                "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+                valid['hits@100'], 0.1, "valid hits@1 = {}".format(valid['hits@1']),
             )
 
     # test eval vocab ecands
@@ -171,14 +155,12 @@ class _AbstractTRATest(unittest.TestCase):
         args = self._get_args()
         args['eval_candidates'] = 'vocab'
         args['encode_candidate_vecs'] = True
-        stdout, valid, test = testing_utils.train_model(args)
+        valid, test = testing_utils.train_model(args)
 
         # accuracy should be zero, none of the vocab candidates should be the
         # correct label
         self.assertEqual(
-            valid['hits@100'],
-            0,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@100'], 0, "valid hits@1 = {}".format(valid['hits@1']),
         )
 
 
@@ -253,11 +235,9 @@ class TestPolyRanker(_AbstractTRATest):
             args['dict_file'] = os.path.join(tmpdir, 'model.dict')
             args['num_epochs'] = 4
             # Train model where it has access to the candidate in labels
-            stdout, valid, test = testing_utils.train_model(args)
+            valid, test = testing_utils.train_model(args)
             self.assertGreaterEqual(
-                valid['hits@100'],
-                0.0,
-                "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+                valid['hits@100'], 0.0, "valid hits@1 = {}".format(valid['hits@1']),
             )
 
             # Evaluate model where label is not in fixed candidates
@@ -268,11 +248,9 @@ class TestPolyRanker(_AbstractTRATest):
                 testing_utils.eval_model(args, skip_valid=True)
 
             args['add_label_to_fixed_cands'] = True
-            stdout, valid, test = testing_utils.eval_model(args, skip_valid=True)
+            valid, test = testing_utils.eval_model(args, skip_valid=True)
             self.assertGreaterEqual(
-                test['hits@100'],
-                0.0,
-                "test hits@1 = {}\nLOG:\n{}".format(test['hits@1'], stdout),
+                test['hits@100'], 0.0, "test hits@1 = {}".format(test['hits@1']),
             )
 
 

--- a/tests/test_tra.py
+++ b/tests/test_tra.py
@@ -49,9 +49,7 @@ class _AbstractTRATest(unittest.TestCase):
         valid, test = testing_utils.train_model(args)
         threshold = self._get_threshold()
 
-        self.assertGreaterEqual(
-            valid['hits@1'], threshold, "valid hits@1 = {}".format(valid['hits@1']),
-        )
+        self.assertGreaterEqual(valid['hits@1'], threshold)
 
     # test train batch cands
     @testing_utils.retry(ntries=3)
@@ -61,9 +59,7 @@ class _AbstractTRATest(unittest.TestCase):
         valid, test = testing_utils.train_model(args)
         threshold = self._get_threshold()
 
-        self.assertGreaterEqual(
-            valid['hits@1'], threshold, "valid hits@1 = {}".format(valid['hits@1']),
-        )
+        self.assertGreaterEqual(valid['hits@1'], threshold)
 
     # test train fixed
     @testing_utils.retry(ntries=3)
@@ -74,9 +70,7 @@ class _AbstractTRATest(unittest.TestCase):
         valid, test = testing_utils.train_model(args)
         threshold = self._get_threshold()
 
-        self.assertGreaterEqual(
-            valid['hits@1'], threshold, "valid hits@1 = {}".format(valid['hits@1']),
-        )
+        self.assertGreaterEqual(valid['hits@1'], threshold)
 
     # test train batch all cands
     @testing_utils.retry(ntries=3)
@@ -86,9 +80,7 @@ class _AbstractTRATest(unittest.TestCase):
         valid, test = testing_utils.train_model(args)
         threshold = self._get_threshold()
 
-        self.assertGreaterEqual(
-            valid['hits@1'], threshold, "valid hits@1 = {}".format(valid['hits@1']),
-        )
+        self.assertGreaterEqual(valid['hits@1'], threshold)
 
     # test eval inline ecands
     @testing_utils.retry(ntries=3)
@@ -98,9 +90,7 @@ class _AbstractTRATest(unittest.TestCase):
         valid, test = testing_utils.train_model(args)
         threshold = self._get_threshold()
 
-        self.assertGreaterEqual(
-            valid['hits@1'], threshold, "valid hits@1 = {}".format(valid['hits@1']),
-        )
+        self.assertGreaterEqual(valid['hits@1'], threshold)
 
     # test eval batch ecands
     @testing_utils.retry(ntries=3)
@@ -110,9 +100,7 @@ class _AbstractTRATest(unittest.TestCase):
         valid, test = testing_utils.train_model(args)
         threshold = self._get_threshold()
 
-        self.assertGreaterEqual(
-            valid['hits@1'], threshold, "valid hits@1 = {}".format(valid['hits@1']),
-        )
+        self.assertGreaterEqual(valid['hits@1'], threshold)
 
     # test eval fixed ecands
     @testing_utils.retry(ntries=3)
@@ -126,9 +114,7 @@ class _AbstractTRATest(unittest.TestCase):
         # none of the train candidates appear in evaluation, so should have
         # zero accuracy: this tests whether the fixed candidates were built
         # properly (i.e., only using candidates from the train set)
-        self.assertEqual(
-            valid['hits@1'], 0, "valid hits@1 = {}".format(valid['hits@1']),
-        )
+        self.assertEqual(valid['hits@1'], 0)
 
         # now try again with a fixed candidate file that includes all possible
         # candidates
@@ -145,9 +131,7 @@ class _AbstractTRATest(unittest.TestCase):
             args['ignore_bad_candidates'] = False
             args['num_epochs'] = 4
             valid, test = testing_utils.train_model(args)
-            self.assertGreaterEqual(
-                valid['hits@100'], 0.1, "valid hits@1 = {}".format(valid['hits@1']),
-            )
+            self.assertGreaterEqual(valid['hits@100'], 0.1)
 
     # test eval vocab ecands
     @testing_utils.retry(ntries=3)
@@ -159,9 +143,7 @@ class _AbstractTRATest(unittest.TestCase):
 
         # accuracy should be zero, none of the vocab candidates should be the
         # correct label
-        self.assertEqual(
-            valid['hits@100'], 0, "valid hits@1 = {}".format(valid['hits@1']),
-        )
+        self.assertEqual(valid['hits@100'], 0)
 
 
 class TestTransformerRanker(_AbstractTRATest):
@@ -236,9 +218,7 @@ class TestPolyRanker(_AbstractTRATest):
             args['num_epochs'] = 4
             # Train model where it has access to the candidate in labels
             valid, test = testing_utils.train_model(args)
-            self.assertGreaterEqual(
-                valid['hits@100'], 0.0, "valid hits@1 = {}".format(valid['hits@1']),
-            )
+            self.assertGreaterEqual(valid['hits@100'], 0.0)
 
             # Evaluate model where label is not in fixed candidates
             args['fixed_candidates_path'] = tmp_train_val_cands_file
@@ -249,9 +229,7 @@ class TestPolyRanker(_AbstractTRATest):
 
             args['add_label_to_fixed_cands'] = True
             valid, test = testing_utils.eval_model(args, skip_valid=True)
-            self.assertGreaterEqual(
-                test['hits@100'], 0.0, "test hits@1 = {}".format(test['hits@1']),
-            )
+            self.assertGreaterEqual(test['hits@100'], 0.0)
 
 
 if __name__ == '__main__':

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -14,7 +14,7 @@ import parlai.utils.testing as testing_utils
 
 class TestTrainModel(unittest.TestCase):
     def test_fast_final_eval(self):
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             {
                 'task': 'integration_tests',
                 'validation_max_exs': 10,
@@ -27,7 +27,7 @@ class TestTrainModel(unittest.TestCase):
         self.assertEqual(test['exs'], 10, 'Test exs is wrong')
 
     def test_multitasking_metrics(self):
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             {
                 'task': 'integration_tests:candidate,'
                 'integration_tests:multiturnCandidate',
@@ -48,7 +48,7 @@ class TestTrainModel(unittest.TestCase):
             'Task accuracy is averaged incorrectly',
         )
 
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             {
                 'task': 'integration_tests:candidate,'
                 'integration_tests:multiturnCandidate',

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -42,12 +42,8 @@ class TestTransformerRanker(unittest.TestCase):
             )
         )
 
-        self.assertGreaterEqual(
-            valid['hits@1'], 0.90, "valid hits@1 = {}".format(valid['hits@1']),
-        )
-        self.assertGreaterEqual(
-            test['hits@1'], 0.90, "test hits@1 = {}".format(test['hits@1']),
-        )
+        self.assertGreaterEqual(valid['hits@1'], 0.90)
+        self.assertGreaterEqual(test['hits@1'], 0.90)
 
     def test_resuming(self):
         """
@@ -147,20 +143,12 @@ class TestTransformerRanker(unittest.TestCase):
             )
         )
 
-        self.assertGreaterEqual(
-            valid['hits@1'], 0.99, 'valid hits@1 = {}'.format(valid['hits@1']),
-        )
-        self.assertGreaterEqual(
-            valid['accuracy'], 0.99, 'valid accuracy = {}'.format(valid['accuracy']),
-        )
-        self.assertGreaterEqual(valid['f1'], 0.99, 'valid f1 = {}'.format(valid['f1']))
-        self.assertGreaterEqual(
-            test['hits@1'], 0.99, 'test hits@1 = {}'.format(test['hits@1']),
-        )
-        self.assertGreaterEqual(
-            test['accuracy'], 0.99, 'test accuracy = {}'.format(test['accuracy']),
-        )
-        self.assertGreaterEqual(test['f1'], 0.99, 'test f1 = {}'.format(test['f1']))
+        self.assertGreaterEqual(valid['hits@1'], 0.99)
+        self.assertGreaterEqual(valid['accuracy'], 0.99)
+        self.assertGreaterEqual(valid['f1'], 0.99)
+        self.assertGreaterEqual(test['hits@1'], 0.99)
+        self.assertGreaterEqual(test['accuracy'], 0.99)
+        self.assertGreaterEqual(test['f1'], 0.99)
 
     @testing_utils.retry(ntries=3)
     def test_xlm(self):
@@ -188,12 +176,8 @@ class TestTransformerRanker(unittest.TestCase):
             )
         )
 
-        self.assertGreaterEqual(
-            valid['hits@1'], 0.90, "valid hits@1 = {}".format(valid['hits@1']),
-        )
-        self.assertGreaterEqual(
-            test['hits@1'], 0.90, "test hits@1 = {}".format(test['hits@1']),
-        )
+        self.assertGreaterEqual(valid['hits@1'], 0.90)
+        self.assertGreaterEqual(test['hits@1'], 0.90)
 
     @testing_utils.retry(ntries=3)
     def test_alt_reduction(self):
@@ -222,12 +206,8 @@ class TestTransformerRanker(unittest.TestCase):
             )
         )
 
-        self.assertGreaterEqual(
-            valid['hits@1'], 0.90, "valid hits@1 = {}".format(valid['hits@1']),
-        )
-        self.assertGreaterEqual(
-            test['hits@1'], 0.90, "test hits@1 = {}".format(test['hits@1']),
-        )
+        self.assertGreaterEqual(valid['hits@1'], 0.90)
+        self.assertGreaterEqual(test['hits@1'], 0.90)
 
 
 class TestTransformerGenerator(unittest.TestCase):
@@ -257,14 +237,10 @@ class TestTransformerGenerator(unittest.TestCase):
             )
         )
 
-        self.assertLessEqual(valid['ppl'], 1.30, "valid ppl = {}".format(valid['ppl']))
-        self.assertGreaterEqual(
-            valid['bleu-4'], 0.90, "valid blue = {}".format(valid['bleu-4']),
-        )
-        self.assertLessEqual(test['ppl'], 1.30, "test ppl = {}".format(test['ppl']))
-        self.assertGreaterEqual(
-            test['bleu-4'], 0.90, "test bleu = {}".format(test['bleu-4']),
-        )
+        self.assertLessEqual(valid['ppl'], 1.30)
+        self.assertGreaterEqual(valid['bleu-4'], 0.90)
+        self.assertLessEqual(test['ppl'], 1.30)
+        self.assertGreaterEqual(test['bleu-4'], 0.90)
 
     @testing_utils.retry(ntries=3)
     def test_beamsearch(self):
@@ -288,14 +264,10 @@ class TestTransformerGenerator(unittest.TestCase):
             )
         )
 
-        self.assertLessEqual(valid['ppl'], 1.20, "valid ppl = {}".format(valid['ppl']))
-        self.assertGreaterEqual(
-            valid['bleu-4'], 0.95, "valid blue = {}".format(valid['bleu-4']),
-        )
-        self.assertLessEqual(test['ppl'], 1.20, "test ppl = {}".format(test['ppl']))
-        self.assertGreaterEqual(
-            test['bleu-4'], 0.95, "test bleu = {}".format(test['bleu-4']),
-        )
+        self.assertLessEqual(valid['ppl'], 1.20)
+        self.assertGreaterEqual(valid['bleu-4'], 0.95)
+        self.assertLessEqual(test['ppl'], 1.20)
+        self.assertGreaterEqual(test['bleu-4'], 0.95)
 
     @testing_utils.retry(ntries=3)
     def test_beamsearch_blocking(self):
@@ -347,16 +319,12 @@ class TestTransformerGenerator(unittest.TestCase):
                     skip_generation=False,
                 )
             )
-        self.assertLessEqual(valid['ppl'], 1.30, "valid ppl = {}".format(valid['ppl']))
-        self.assertGreaterEqual(valid['f1'], 0.80, "valid f1 = {}".format(valid['f1']))
-        self.assertGreaterEqual(
-            valid['bleu-4'], 0.5, "valid bleu = {}".format(valid['bleu-4']),
-        )
-        self.assertLessEqual(test['ppl'], 1.30, "test ppl = {}".format(test['ppl']))
-        self.assertGreaterEqual(test['f1'], 0.80, "test f1 = {}".format(test['bleu-4']))
-        self.assertGreaterEqual(
-            test['bleu-4'], 0.5, "test bleu = {}".format(test['bleu-4']),
-        )
+        self.assertLessEqual(valid['ppl'], 1.30)
+        self.assertGreaterEqual(valid['f1'], 0.80)
+        self.assertGreaterEqual(valid['bleu-4'], 0.5)
+        self.assertLessEqual(test['ppl'], 1.30)
+        self.assertGreaterEqual(test['f1'], 0.80)
+        self.assertGreaterEqual(test['bleu-4'], 0.5)
 
         # Beam Block 1
         self.assertLessEqual(
@@ -522,22 +490,14 @@ class TestTransformerGenerator(unittest.TestCase):
             )
         )
 
-        self.assertGreaterEqual(
-            valid['hits@1'], 0.95, 'valid hits@1 = {}'.format(valid['hits@1']),
-        )
-        self.assertLessEqual(valid['ppl'], 1.01, 'valid ppl = {}'.format(valid['ppl']))
-        self.assertGreaterEqual(
-            valid['accuracy'], 0.99, 'valid accuracy = {}'.format(valid['accuracy']),
-        )
-        self.assertGreaterEqual(valid['f1'], 0.99, 'valid f1 = {}'.format(valid['f1']))
-        self.assertGreaterEqual(
-            test['hits@1'], 0.95, 'test hits@1 = {}'.format(test['hits@1']),
-        )
-        self.assertLessEqual(test['ppl'], 1.01, 'test ppl = {}'.format(test['ppl']))
-        self.assertGreaterEqual(
-            test['accuracy'], 0.99, 'test accuracy = {}'.format(test['accuracy']),
-        )
-        self.assertGreaterEqual(test['f1'], 0.99, 'test f1 = {}'.format(test['f1']))
+        self.assertGreaterEqual(valid['hits@1'], 0.95)
+        self.assertLessEqual(valid['ppl'], 1.01)
+        self.assertGreaterEqual(valid['accuracy'], 0.99)
+        self.assertGreaterEqual(valid['f1'], 0.99)
+        self.assertGreaterEqual(test['hits@1'], 0.95)
+        self.assertLessEqual(test['ppl'], 1.01)
+        self.assertGreaterEqual(test['accuracy'], 0.99)
+        self.assertGreaterEqual(test['f1'], 0.99)
 
     def test_badinput(self):
         """
@@ -583,14 +543,10 @@ class TestTransformerGenerator(unittest.TestCase):
             )
         )
 
-        self.assertLessEqual(valid['ppl'], 1.30, "valid ppl = {}".format(valid['ppl']))
-        self.assertGreaterEqual(
-            valid['bleu-4'], 0.90, "valid blue = {}".format(valid['bleu-4']),
-        )
-        self.assertLessEqual(test['ppl'], 1.30, "test ppl = {}".format(test['ppl']))
-        self.assertGreaterEqual(
-            test['bleu-4'], 0.90, "test bleu = {}".format(test['bleu-4']),
-        )
+        self.assertLessEqual(valid['ppl'], 1.30)
+        self.assertGreaterEqual(valid['bleu-4'], 0.90)
+        self.assertLessEqual(test['ppl'], 1.30)
+        self.assertGreaterEqual(test['bleu-4'], 0.90)
 
 
 class TestLearningRateScheduler(unittest.TestCase):

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -23,7 +23,7 @@ class TestTransformerRanker(unittest.TestCase):
         """
         Test a simple repeat-after-me model.
         """
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='integration_tests:candidate',
                 model='transformer/ranker',
@@ -43,14 +43,10 @@ class TestTransformerRanker(unittest.TestCase):
         )
 
         self.assertGreaterEqual(
-            valid['hits@1'],
-            0.90,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@1'], 0.90, "valid hits@1 = {}".format(valid['hits@1']),
         )
         self.assertGreaterEqual(
-            test['hits@1'],
-            0.90,
-            "test hits@1 = {}\nLOG:\n{}".format(test['hits@1'], stdout),
+            test['hits@1'], 0.90, "test hits@1 = {}".format(test['hits@1']),
         )
 
     def test_resuming(self):
@@ -60,7 +56,7 @@ class TestTransformerRanker(unittest.TestCase):
         with testing_utils.tempdir() as tmpdir:
             model_file = os.path.join(tmpdir, 'model')
 
-            stdout1, valid1, test1 = testing_utils.train_model(
+            valid1, test1 = testing_utils.train_model(
                 dict(
                     model_file=model_file,
                     task='integration_tests:candidate',
@@ -78,7 +74,7 @@ class TestTransformerRanker(unittest.TestCase):
                 )
             )
 
-            stdout2, valid2, test2 = testing_utils.train_model(
+            valid2, test2 = testing_utils.train_model(
                 dict(
                     model_file=model_file,
                     task='integration_tests:candidate',
@@ -105,7 +101,7 @@ class TestTransformerRanker(unittest.TestCase):
         """
         with testing_utils.tempdir() as tmpdir:
             model_file = os.path.join(tmpdir, 'model')
-            stdout1, valid1, test1 = testing_utils.train_model(
+            valid1, test1 = testing_utils.train_model(
                 dict(
                     model_file=model_file,
                     task='integration_tests:candidate',
@@ -123,7 +119,7 @@ class TestTransformerRanker(unittest.TestCase):
                 )
             )
 
-            stdout2, valid2, test2 = testing_utils.train_model(
+            valid2, test2 = testing_utils.train_model(
                 dict(
                     model_file=model_file,
                     task='integration_tests:candidate',
@@ -141,7 +137,7 @@ class TestTransformerRanker(unittest.TestCase):
         """
         Tests that the transformer ranker model files continue to work over time.
         """
-        stdout, valid, test = testing_utils.eval_model(
+        valid, test = testing_utils.eval_model(
             dict(
                 task='integration_tests:multiturn_candidate',
                 model='transformer/ranker',
@@ -152,38 +148,26 @@ class TestTransformerRanker(unittest.TestCase):
         )
 
         self.assertGreaterEqual(
-            valid['hits@1'],
-            0.99,
-            'valid hits@1 = {}\nLOG:\n{}'.format(valid['hits@1'], stdout),
+            valid['hits@1'], 0.99, 'valid hits@1 = {}'.format(valid['hits@1']),
         )
         self.assertGreaterEqual(
-            valid['accuracy'],
-            0.99,
-            'valid accuracy = {}\nLOG:\n{}'.format(valid['accuracy'], stdout),
+            valid['accuracy'], 0.99, 'valid accuracy = {}'.format(valid['accuracy']),
+        )
+        self.assertGreaterEqual(valid['f1'], 0.99, 'valid f1 = {}'.format(valid['f1']))
+        self.assertGreaterEqual(
+            test['hits@1'], 0.99, 'test hits@1 = {}'.format(test['hits@1']),
         )
         self.assertGreaterEqual(
-            valid['f1'], 0.99, 'valid f1 = {}\nLOG:\n{}'.format(valid['f1'], stdout)
+            test['accuracy'], 0.99, 'test accuracy = {}'.format(test['accuracy']),
         )
-        self.assertGreaterEqual(
-            test['hits@1'],
-            0.99,
-            'test hits@1 = {}\nLOG:\n{}'.format(test['hits@1'], stdout),
-        )
-        self.assertGreaterEqual(
-            test['accuracy'],
-            0.99,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
-        )
-        self.assertGreaterEqual(
-            test['f1'], 0.99, 'test f1 = {}\nLOG:\n{}'.format(test['f1'], stdout)
-        )
+        self.assertGreaterEqual(test['f1'], 0.99, 'test f1 = {}'.format(test['f1']))
 
     @testing_utils.retry(ntries=3)
     def test_xlm(self):
         """
         Test --variant xlm.
         """
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='integration_tests:candidate',
                 model='transformer/ranker',
@@ -205,14 +189,10 @@ class TestTransformerRanker(unittest.TestCase):
         )
 
         self.assertGreaterEqual(
-            valid['hits@1'],
-            0.90,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@1'], 0.90, "valid hits@1 = {}".format(valid['hits@1']),
         )
         self.assertGreaterEqual(
-            test['hits@1'],
-            0.90,
-            "test hits@1 = {}\nLOG:\n{}".format(test['hits@1'], stdout),
+            test['hits@1'], 0.90, "test hits@1 = {}".format(test['hits@1']),
         )
 
     @testing_utils.retry(ntries=3)
@@ -220,7 +200,7 @@ class TestTransformerRanker(unittest.TestCase):
         """
         Test a transformer ranker reduction method other than `mean`.
         """
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='integration_tests:candidate',
                 model='transformer/ranker',
@@ -243,14 +223,10 @@ class TestTransformerRanker(unittest.TestCase):
         )
 
         self.assertGreaterEqual(
-            valid['hits@1'],
-            0.90,
-            "valid hits@1 = {}\nLOG:\n{}".format(valid['hits@1'], stdout),
+            valid['hits@1'], 0.90, "valid hits@1 = {}".format(valid['hits@1']),
         )
         self.assertGreaterEqual(
-            test['hits@1'],
-            0.90,
-            "test hits@1 = {}\nLOG:\n{}".format(test['hits@1'], stdout),
+            test['hits@1'], 0.90, "test hits@1 = {}".format(test['hits@1']),
         )
 
 
@@ -264,7 +240,7 @@ class TestTransformerGenerator(unittest.TestCase):
         """
         Test greedy search.
         """
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='integration_tests:nocandidate',
                 model='transformer/generator',
@@ -281,21 +257,13 @@ class TestTransformerGenerator(unittest.TestCase):
             )
         )
 
-        self.assertLessEqual(
-            valid['ppl'], 1.30, "valid ppl = {}\nLOG:\n{}".format(valid['ppl'], stdout)
-        )
+        self.assertLessEqual(valid['ppl'], 1.30, "valid ppl = {}".format(valid['ppl']))
         self.assertGreaterEqual(
-            valid['bleu-4'],
-            0.90,
-            "valid blue = {}\nLOG:\n{}".format(valid['bleu-4'], stdout),
+            valid['bleu-4'], 0.90, "valid blue = {}".format(valid['bleu-4']),
         )
-        self.assertLessEqual(
-            test['ppl'], 1.30, "test ppl = {}\nLOG:\n{}".format(test['ppl'], stdout)
-        )
+        self.assertLessEqual(test['ppl'], 1.30, "test ppl = {}".format(test['ppl']))
         self.assertGreaterEqual(
-            test['bleu-4'],
-            0.90,
-            "test bleu = {}\nLOG:\n{}".format(test['bleu-4'], stdout),
+            test['bleu-4'], 0.90, "test bleu = {}".format(test['bleu-4']),
         )
 
     @testing_utils.retry(ntries=3)
@@ -303,7 +271,7 @@ class TestTransformerGenerator(unittest.TestCase):
         """
         Test beamsearch.
         """
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='integration_tests:nocandidate',
                 model='transformer/generator',
@@ -320,21 +288,13 @@ class TestTransformerGenerator(unittest.TestCase):
             )
         )
 
-        self.assertLessEqual(
-            valid['ppl'], 1.20, "valid ppl = {}\nLOG:\n{}".format(valid['ppl'], stdout)
-        )
+        self.assertLessEqual(valid['ppl'], 1.20, "valid ppl = {}".format(valid['ppl']))
         self.assertGreaterEqual(
-            valid['bleu-4'],
-            0.95,
-            "valid blue = {}\nLOG:\n{}".format(valid['bleu-4'], stdout),
+            valid['bleu-4'], 0.95, "valid blue = {}".format(valid['bleu-4']),
         )
-        self.assertLessEqual(
-            test['ppl'], 1.20, "test ppl = {}\nLOG:\n{}".format(test['ppl'], stdout)
-        )
+        self.assertLessEqual(test['ppl'], 1.20, "test ppl = {}".format(test['ppl']))
         self.assertGreaterEqual(
-            test['bleu-4'],
-            0.95,
-            "test bleu = {}\nLOG:\n{}".format(test['bleu-4'], stdout),
+            test['bleu-4'], 0.95, "test bleu = {}".format(test['bleu-4']),
         )
 
     @testing_utils.retry(ntries=3)
@@ -345,7 +305,7 @@ class TestTransformerGenerator(unittest.TestCase):
         with testing_utils.tempdir() as tmpdir:
             mf = os.path.join(tmpdir, 'model')
             df = os.path.join(tmpdir, 'model.dict')
-            stdout, valid, test = testing_utils.train_model(
+            valid, test = testing_utils.train_model(
                 dict(
                     task='integration_tests:repeat_words',
                     model='transformer/generator',
@@ -363,7 +323,7 @@ class TestTransformerGenerator(unittest.TestCase):
                     beam_size=2,
                 )
             )
-            stdout_bb, valid_beam_block, test_beam_block = testing_utils.eval_model(
+            valid_beam_block, test_beam_block = testing_utils.eval_model(
                 dict(
                     task='integration_tests:repeat_words',
                     model_file=mf,
@@ -375,7 +335,7 @@ class TestTransformerGenerator(unittest.TestCase):
                     skip_generation=False,
                 )
             )
-            stdout_bb2, valid_beam_block2, test_beam_block2 = testing_utils.eval_model(
+            valid_beam_block2, test_beam_block2 = testing_utils.eval_model(
                 dict(
                     task='integration_tests:repeat_words',
                     model_file=mf,
@@ -387,87 +347,59 @@ class TestTransformerGenerator(unittest.TestCase):
                     skip_generation=False,
                 )
             )
-        self.assertLessEqual(
-            valid['ppl'], 1.30, "valid ppl = {}\nLOG:\n{}".format(valid['ppl'], stdout)
-        )
+        self.assertLessEqual(valid['ppl'], 1.30, "valid ppl = {}".format(valid['ppl']))
+        self.assertGreaterEqual(valid['f1'], 0.80, "valid f1 = {}".format(valid['f1']))
         self.assertGreaterEqual(
-            valid['f1'], 0.80, "valid f1 = {}\nLOG:\n{}".format(valid['f1'], stdout)
+            valid['bleu-4'], 0.5, "valid bleu = {}".format(valid['bleu-4']),
         )
+        self.assertLessEqual(test['ppl'], 1.30, "test ppl = {}".format(test['ppl']))
+        self.assertGreaterEqual(test['f1'], 0.80, "test f1 = {}".format(test['bleu-4']))
         self.assertGreaterEqual(
-            valid['bleu-4'],
-            0.5,
-            "valid bleu = {}\nLOG:\n{}".format(valid['bleu-4'], stdout),
-        )
-        self.assertLessEqual(
-            test['ppl'], 1.30, "test ppl = {}\nLOG:\n{}".format(test['ppl'], stdout)
-        )
-        self.assertGreaterEqual(
-            test['f1'], 0.80, "test f1 = {}\nLOG:\n{}".format(test['bleu-4'], stdout)
-        )
-        self.assertGreaterEqual(
-            test['bleu-4'],
-            0.5,
-            "test bleu = {}\nLOG:\n{}".format(test['bleu-4'], stdout),
+            test['bleu-4'], 0.5, "test bleu = {}".format(test['bleu-4']),
         )
 
         # Beam Block 1
         self.assertLessEqual(
             valid_beam_block['f1'],
             0.4,
-            "valid beam block f1 = {}\nLOG:\n{}".format(
-                valid_beam_block['f1'], stdout_bb
-            ),
+            "valid beam block f1 = {}".format(valid_beam_block['f1']),
         )
         self.assertLessEqual(
             valid_beam_block['bleu-4'],
             1e-9,
-            "valid beam block bleu = {}\nLOG:\n{}".format(
-                valid_beam_block['bleu-4'], stdout_bb
-            ),
+            "valid beam block bleu = {}".format(valid_beam_block['bleu-4']),
         )
         self.assertLessEqual(
             test_beam_block['f1'],
             0.4,
-            "test beam block f1 = {}\nLOG:\n{}".format(
-                test_beam_block['f1'], stdout_bb
-            ),
+            "test beam block f1 = {}".format(test_beam_block['f1']),
         )
         self.assertLessEqual(
             test_beam_block['bleu-4'],
             1e-9,
-            "test beam block bleu = {}\nLOG:\n{}".format(
-                test_beam_block['bleu-4'], stdout_bb
-            ),
+            "test beam block bleu = {}".format(test_beam_block['bleu-4']),
         )
 
         # Beam Block 2
         self.assertLessEqual(
             valid_beam_block2['f1'],
             0.6,
-            "valid beam block f1 = {}\nLOG:\n{}".format(
-                valid_beam_block2['f1'], stdout_bb2
-            ),
+            "valid beam block f1 = {}".format(valid_beam_block2['f1']),
         )
         self.assertLessEqual(
             valid_beam_block2['bleu-4'],
             1e-6,
-            "valid beam block bleu = {}\nLOG:\n{}".format(
-                valid_beam_block2['bleu-4'], stdout_bb2
-            ),
+            "valid beam block bleu = {}".format(valid_beam_block2['bleu-4']),
         )
         self.assertLessEqual(
             test_beam_block2['f1'],
             0.6,
-            "test beam block f1 = {}\nLOG:\n{}".format(
-                test_beam_block2['f1'], stdout_bb2
-            ),
+            "test beam block f1 = {}".format(test_beam_block2['f1']),
         )
         self.assertLessEqual(
             test_beam_block2['bleu-4'],
             1e-6,
-            "test beam block bleu = {}\nLOG:\n{}".format(
-                test_beam_block2['bleu-4'], stdout_bb2
-            ),
+            "test beam block bleu = {}".format(test_beam_block2['bleu-4']),
         )
 
     @testing_utils.retry(ntries=3)
@@ -486,7 +418,7 @@ class TestTransformerGenerator(unittest.TestCase):
             args = dict(
                 task='integration_tests', model_file=mf, dict_file=df, metrics='all'
             )
-            _, noblock_valid, _ = testing_utils.train_model(
+            noblock_valid, _ = testing_utils.train_model(
                 dict(
                     model='transformer/generator',
                     optimizer='adamax',
@@ -505,14 +437,14 @@ class TestTransformerGenerator(unittest.TestCase):
             self.assertGreaterEqual(noblock_valid['f1'], 0.95)
 
             # first confirm all is good without blocking
-            _, valid, test = testing_utils.eval_model(
+            valid, test = testing_utils.eval_model(
                 dict(beam_context_block_ngram=-1, **args)
             )
             self.assertGreaterEqual(valid['f1'], 0.95)
             self.assertGreaterEqual(valid['bleu-4'], 0.95)
 
             # there's a special case for block == 1
-            _, valid, test = testing_utils.eval_model(
+            valid, test = testing_utils.eval_model(
                 dict(beam_context_block_ngram=1, **args)
             )
             # bleu and f1 should be totally wrecked.
@@ -520,7 +452,7 @@ class TestTransformerGenerator(unittest.TestCase):
             self.assertLess(valid['bleu-4'], 0.01)
 
             # a couple general cases
-            _, valid, test = testing_utils.eval_model(
+            valid, test = testing_utils.eval_model(
                 dict(beam_context_block_ngram=2, **args)
             )
             # should take a big hit here
@@ -532,7 +464,7 @@ class TestTransformerGenerator(unittest.TestCase):
             self.assertLessEqual(valid['bleu-2'], 0.01)
 
             # larger blocking, we can do better now
-            _, valid, test = testing_utils.eval_model(
+            valid, test = testing_utils.eval_model(
                 dict(beam_context_block_ngram=3, **args)
             )
             # not as hard a hit from the larger hit
@@ -579,7 +511,7 @@ class TestTransformerGenerator(unittest.TestCase):
         """
         Tests that the generator model files work over time.
         """
-        stdout, valid, test = testing_utils.eval_model(
+        valid, test = testing_utils.eval_model(
             dict(
                 task='integration_tests:multiturn_candidate',
                 model='transformer/generator',
@@ -591,43 +523,27 @@ class TestTransformerGenerator(unittest.TestCase):
         )
 
         self.assertGreaterEqual(
-            valid['hits@1'],
-            0.95,
-            'valid hits@1 = {}\nLOG:\n{}'.format(valid['hits@1'], stdout),
+            valid['hits@1'], 0.95, 'valid hits@1 = {}'.format(valid['hits@1']),
         )
-        self.assertLessEqual(
-            valid['ppl'], 1.01, 'valid ppl = {}\nLOG:\n{}'.format(valid['ppl'], stdout)
-        )
+        self.assertLessEqual(valid['ppl'], 1.01, 'valid ppl = {}'.format(valid['ppl']))
         self.assertGreaterEqual(
-            valid['accuracy'],
-            0.99,
-            'valid accuracy = {}\nLOG:\n{}'.format(valid['accuracy'], stdout),
+            valid['accuracy'], 0.99, 'valid accuracy = {}'.format(valid['accuracy']),
         )
+        self.assertGreaterEqual(valid['f1'], 0.99, 'valid f1 = {}'.format(valid['f1']))
         self.assertGreaterEqual(
-            valid['f1'], 0.99, 'valid f1 = {}\nLOG:\n{}'.format(valid['f1'], stdout)
+            test['hits@1'], 0.95, 'test hits@1 = {}'.format(test['hits@1']),
         )
+        self.assertLessEqual(test['ppl'], 1.01, 'test ppl = {}'.format(test['ppl']))
         self.assertGreaterEqual(
-            test['hits@1'],
-            0.95,
-            'test hits@1 = {}\nLOG:\n{}'.format(test['hits@1'], stdout),
+            test['accuracy'], 0.99, 'test accuracy = {}'.format(test['accuracy']),
         )
-        self.assertLessEqual(
-            test['ppl'], 1.01, 'test ppl = {}\nLOG:\n{}'.format(test['ppl'], stdout)
-        )
-        self.assertGreaterEqual(
-            test['accuracy'],
-            0.99,
-            'test accuracy = {}\nLOG:\n{}'.format(test['accuracy'], stdout),
-        )
-        self.assertGreaterEqual(
-            test['f1'], 0.99, 'test f1 = {}\nLOG:\n{}'.format(test['f1'], stdout)
-        )
+        self.assertGreaterEqual(test['f1'], 0.99, 'test f1 = {}'.format(test['f1']))
 
     def test_badinput(self):
         """
         Ensures model doesn't crash on malformed inputs.
         """
-        stdout, _, _ = testing_utils.train_model(
+        testing_utils.train_model(
             dict(
                 task='integration_tests:bad_example',
                 model='transformer/generator',
@@ -640,15 +556,13 @@ class TestTransformerGenerator(unittest.TestCase):
                 hiddensize=16,
             )
         )
-        self.assertIn('valid:{', stdout)
-        self.assertIn('test:{', stdout)
 
     @testing_utils.retry(ntries=3)
     def test_xlm(self):
         """
         Test --variant xlm.
         """
-        stdout, valid, test = testing_utils.train_model(
+        valid, test = testing_utils.train_model(
             dict(
                 task='integration_tests:nocandidate',
                 model='transformer/generator',
@@ -669,21 +583,13 @@ class TestTransformerGenerator(unittest.TestCase):
             )
         )
 
-        self.assertLessEqual(
-            valid['ppl'], 1.30, "valid ppl = {}\nLOG:\n{}".format(valid['ppl'], stdout)
-        )
+        self.assertLessEqual(valid['ppl'], 1.30, "valid ppl = {}".format(valid['ppl']))
         self.assertGreaterEqual(
-            valid['bleu-4'],
-            0.90,
-            "valid blue = {}\nLOG:\n{}".format(valid['bleu-4'], stdout),
+            valid['bleu-4'], 0.90, "valid blue = {}".format(valid['bleu-4']),
         )
-        self.assertLessEqual(
-            test['ppl'], 1.30, "test ppl = {}\nLOG:\n{}".format(test['ppl'], stdout)
-        )
+        self.assertLessEqual(test['ppl'], 1.30, "test ppl = {}".format(test['ppl']))
         self.assertGreaterEqual(
-            test['bleu-4'],
-            0.90,
-            "test bleu = {}\nLOG:\n{}".format(test['bleu-4'], stdout),
+            test['bleu-4'], 0.90, "test bleu = {}".format(test['bleu-4']),
         )
 
 
@@ -699,27 +605,25 @@ class TestLearningRateScheduler(unittest.TestCase):
         mdl = args['model']
         with testing_utils.tempdir() as tmpdir:
             model_file = os.path.join(tmpdir, 'model')
-            stdout1, valid1, test1 = testing_utils.train_model(
+            valid1, test1 = testing_utils.train_model(
                 dict(model_file=model_file, lr_scheduler='invsqrt', **args)
             )
-            stdout2, valid2, test2 = testing_utils.train_model(
+            valid2, test2 = testing_utils.train_model(
                 dict(model_file=model_file, lr_scheduler='invsqrt', **args)
             )
             # make sure the number of updates is being tracked correctly
             self.assertGreater(
                 valid2['total_train_updates'],
                 valid1['total_train_updates'],
-                '({}) Number of updates is not increasing'.format(mdl),
+                'Number of updates is not increasing',
             )
             # make sure the learning rate is decreasing
             self.assertLess(
-                valid2['lr'],
-                valid1['lr'],
-                '({}) Learning rate is not decreasing'.format(mdl),
+                valid2['lr'], valid1['lr'], 'Learning rate is not decreasing',
             )
             # but make sure we're not loading the scheduler if we're fine
             # tuning
-            stdout3, valid3, test3 = testing_utils.train_model(
+            valid3, test3 = testing_utils.train_model(
                 dict(
                     init_model=os.path.join(tmpdir, 'model'),
                     model_file=os.path.join(tmpdir, 'newmodel'),
@@ -730,16 +634,15 @@ class TestLearningRateScheduler(unittest.TestCase):
             self.assertEqual(
                 valid3['total_train_updates'],
                 valid1['total_train_updates'],
-                '({}) Finetuning LR scheduler reset failed '
-                '(total_train_updates).'.format(mdl),
+                'Finetuning LR scheduler reset failed (total_train_updates).',
             )
             self.assertEqual(
                 valid3['lr'],
                 valid1['lr'],
-                '({}) Finetuning LR scheduler reset failed ' '(lr).'.format(mdl),
+                'Finetuning LR scheduler reset failed ' '(lr).',
             )
             # and make sure we're not loading the scheduler if it changes
-            stdout4, valid4, test4 = testing_utils.train_model(
+            valid4, test4 = testing_utils.train_model(
                 dict(
                     init_model=os.path.join(tmpdir, 'model'),
                     model_file=os.path.join(tmpdir, 'newmodel2'),
@@ -750,13 +653,10 @@ class TestLearningRateScheduler(unittest.TestCase):
             self.assertEqual(
                 valid4['total_train_updates'],
                 valid1['total_train_updates'],
-                '({}) LR scheduler change reset failed (total_train_updates).'
-                '\n{}'.format(mdl, stdout4),
+                'LR scheduler change reset failed (total_train_updates).',
             )
             self.assertEqual(
-                valid4['lr'],
-                1e-3,
-                '({}) LR is not correct in final resume.\n{}'.format(mdl, stdout4),
+                valid4['lr'], 1e-3, '({}) LR is not correct in final resume.'
             )
 
     def test_resuming_generator(self):
@@ -817,10 +717,10 @@ class TestLearningRateScheduler(unittest.TestCase):
 
         args['num_epochs'] = 9 / 500
         args['validation_every_n_epochs'] = 9 / 500
-        stdout1, valid1, test1 = testing_utils.train_model(args)
+        valid1, test1 = testing_utils.train_model(args)
         args['num_epochs'] = 16 / 500
         args['validation_every_n_epochs'] = 16 / 500
-        stdout2, valid2, test2 = testing_utils.train_model(args)
+        valid2, test2 = testing_utils.train_model(args)
 
         self.assertAlmostEqual(
             valid1['lr'],

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -526,7 +526,6 @@ class TestLearningRateScheduler(unittest.TestCase):
         """
         Test learning rate resumes correctly.
         """
-        mdl = args['model']
         with testing_utils.tempdir() as tmpdir:
             model_file = os.path.join(tmpdir, 'model')
             valid1, test1 = testing_utils.train_model(

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -327,48 +327,16 @@ class TestTransformerGenerator(unittest.TestCase):
         self.assertGreaterEqual(test['bleu-4'], 0.5)
 
         # Beam Block 1
-        self.assertLessEqual(
-            valid_beam_block['f1'],
-            0.4,
-            "valid beam block f1 = {}".format(valid_beam_block['f1']),
-        )
-        self.assertLessEqual(
-            valid_beam_block['bleu-4'],
-            1e-9,
-            "valid beam block bleu = {}".format(valid_beam_block['bleu-4']),
-        )
-        self.assertLessEqual(
-            test_beam_block['f1'],
-            0.4,
-            "test beam block f1 = {}".format(test_beam_block['f1']),
-        )
-        self.assertLessEqual(
-            test_beam_block['bleu-4'],
-            1e-9,
-            "test beam block bleu = {}".format(test_beam_block['bleu-4']),
-        )
+        self.assertLessEqual(valid_beam_block['f1'], 0.4)
+        self.assertLessEqual(valid_beam_block['bleu-4'], 1e-9)
+        self.assertLessEqual(test_beam_block['f1'], 0.4)
+        self.assertLessEqual(test_beam_block['bleu-4'], 1e-9)
 
         # Beam Block 2
-        self.assertLessEqual(
-            valid_beam_block2['f1'],
-            0.6,
-            "valid beam block f1 = {}".format(valid_beam_block2['f1']),
-        )
-        self.assertLessEqual(
-            valid_beam_block2['bleu-4'],
-            1e-6,
-            "valid beam block bleu = {}".format(valid_beam_block2['bleu-4']),
-        )
-        self.assertLessEqual(
-            test_beam_block2['f1'],
-            0.6,
-            "test beam block f1 = {}".format(test_beam_block2['f1']),
-        )
-        self.assertLessEqual(
-            test_beam_block2['bleu-4'],
-            1e-6,
-            "test beam block bleu = {}".format(test_beam_block2['bleu-4']),
-        )
+        self.assertLessEqual(valid_beam_block2['f1'], 0.6)
+        self.assertLessEqual(valid_beam_block2['bleu-4'], 1e-6)
+        self.assertLessEqual(test_beam_block2['f1'], 0.6)
+        self.assertLessEqual(test_beam_block2['bleu-4'], 1e-6)
 
     @testing_utils.retry(ntries=3)
     def test_beamsearch_contextblocking(self):


### PR DESCRIPTION
**Patch description**
The switch to pytests gives us output capturing and debug friendly for free. On a failed test, stdout is automatically presented to the user. The user can also always force it on with the `-s` flag: `python -m pytest -s`.


**Testing**
CI should pass.