### PR TITLE
Ignore copyright on empty files.

### DIFF
--- a/parlai/utils/flake8.py
+++ b/parlai/utils/flake8.py
@@ -92,5 +92,5 @@ class ParlAIChecker:
         for i, msg in enumerate(COPYRIGHT, 1):
             if any(wl in self.filename for wl in WHITELIST_FNS) and i < 3:
                 continue
-            if msg not in source:
+            if source and msg not in source:
                 yield (i, 0, f'PAI20{i} Missing copyright `{msg}`', '')


### PR DESCRIPTION
**Patch description**
Copyright isn't required on empty files, but flake8 was complaining about it.

**Testing steps**
Before
```
$ flake8 | grep PAI | wc -l
66
flake8  74.63s user 4.80s system 577% cpu 13.759 total
grep PAI  0.00s user 0.00s system 0% cpu 13.758 total
wc -l  0.00s user 0.00s system 0% cpu 13.758 total
```
After
```
$ flake8 | grep PAI
flake8  74.61s user 4.38s system 558% cpu 14.141 total
grep PAI  0.00s user 0.00s system 0% cpu 14.140 total
```