### PR TITLE
Upgrade to Pytorch 1.4.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ installtorchcpu: &installtorchcpu
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off torch==1.4.0+cpu torchtext==0.5.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      pip3 install --progress-bar off torch==1.4.0+cpu torchtext==0.5.0 torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
       python -c 'import torch; print("Torch version:", torch.__version__)'
 
 setupcuda: &setupcuda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,45 +68,41 @@ installdeps: &installdeps
       python setup.py develop
       python -c "import nltk; nltk.download('punkt')"
 
-installtorchgpu11: &installtorchgpu11
+installtorchgpu14: &installtorchgpu14
   run:
     name: Install torch GPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch<1.2.0'
-      pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
+      pip3 install --progress-bar off 'torch==1.4.0'
+      pip3 install --progress-bar off 'subword-nmt==0.3.7'
       pip3 install --progress-bar off pytorch-pretrained-bert
-      pip3 install --progress-bar off torchtext
-      pip3 install --progress-bar off torchvision
+      pip3 install --progress-bar off 'torchtext==0.5.0'
+      pip3 install --progress-bar off 'torchvision==0.5.0'
+      python -c 'import torch; print("Torch version:", torch.__version__)'
 
 
-installtorchgpu12: &installtorchgpu12
+installtorchgpu13: &installtorchgpu13
   run:
     name: Install torch GPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch>=1.2.0'
-      pip3 install --progress-bar off 'git+https://github.com/rsennrich/subword-nmt.git#egg=subword-nmt' # bpe support
+      pip3 install --progress-bar off 'torch==1.3.1'
+      pip3 install --progress-bar off 'subword-nmt==0.3.7'
       pip3 install --progress-bar off pytorch-pretrained-bert
-      pip3 install --progress-bar off torchtext
-      pip3 install --progress-bar off torchvision
+      python -c 'import torch; print("Torch version:", torch.__version__)'
 
 
 installtorchcpuosx: &installtorchcpuosx
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.3.1-cp37-none-macosx_10_7_x86_64.whl
+      pip3 install --progress-bar off torch
+      python -c 'import torch; print("Torch version:", torch.__version__)'
 
-installtorchcpu36: &installtorchcpu36
+installtorchcpu: &installtorchcpu
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp36-cp36m-linux_x86_64.whl
-
-installtorchcpu37: &installtorchcpu37
-  run:
-    name: Install torch CPU and dependencies
-    command: |
-      pip3 install --progress-bar off https://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp37-cp37m-linux_x86_64.whl
+      pip3 install --progress-bar off torch==1.4.0+cpu torchtext==0.5.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      python -c 'import torch; print("Torch version:", torch.__version__)'
 
 setupcuda: &setupcuda
   run:
@@ -149,7 +145,7 @@ jobs:
           key: deps-dt-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
-      - <<: *installtorchcpu37
+      - <<: *installtorchcpu
       - run:
           name: Data tests
           command: coverage run -m pytest --junitxml=test-results/junit.xml -m data
@@ -166,13 +162,13 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-osx-v4{{ checksum "requirements.txt" }}
+          key: deps-osx-v5{{ checksum "requirements.txt" }}
       - <<: *installdeps
+      - <<: *installtorchcpuosx
       - save_cache:
-          key: deps-osx-v4{{ checksum "requirements.txt" }}
+          key: deps-osx-v5{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
-      - <<: *installtorchcpuosx
       - run:
           name: Unit tests (OSX)
           command: coverage run -m pytest --junitxml=test-results/junit.xml -m unit
@@ -192,13 +188,13 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-ut36-v4{{ checksum "requirements.txt" }}
+          key: deps-ut36-v5{{ checksum "requirements.txt" }}
       - <<: *installdeps
+      - <<: *installtorchcpu
       - save_cache:
-          key: deps-ut36-v4{{ checksum "requirements.txt" }}
+          key: deps-ut36-v5{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
-      - <<: *installtorchcpu36
       - run:
           name: Unit tests (py36)
           command: coverage run -m pytest --junitxml=test-results/junit.xml -m unit
@@ -215,13 +211,13 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-ut37-v4{{ checksum "requirements.txt" }}
+          key: deps-ut37-v5{{ checksum "requirements.txt" }}
       - <<: *installdeps
+      - <<: *installtorchcpu
       - save_cache:
-          key: deps-ut37-v4{{ checksum "requirements.txt" }}
+          key: deps-ut37-v5{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
-      - <<: *installtorchcpu37
       - run:
           name: Unit tests (py37)
           command: coverage run -m pytest --junitxml=test-results/junit.xml -m unit
@@ -229,7 +225,7 @@ jobs:
       - store_test_results:
           path: test-results
 
-  unittests_gpu11:
+  unittests_gpu13:
     <<: *gpu
     working_directory: ~/ParlAI
     parallelism: 8
@@ -245,21 +241,21 @@ jobs:
             - "~/nvidia-downloads/"
       - <<: *setup
       - restore_cache:
-          key: deps-gpu11-v5{{ checksum "requirements.txt" }}
+          key: deps-gpu13-v1{{ checksum "requirements.txt" }}
       - <<: *installdeps
+      - <<: *installtorchgpu13
       - save_cache:
-          key: deps-gpu11-v5{{ checksum "requirements.txt" }}
+          key: deps-gpu13-v1{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
-      - <<: *installtorchgpu11
       - run:
-          name: Unit tests (GPU; pytorch 1.1)
+          name: Unit tests (GPU; pytorch 1.3)
           command: coverage run -m pytest --junitxml=test-results/junit.xml -m unit
       - <<: *codecov
       - store_test_results:
           path: test-results
 
-  unittests_gpu12:
+  unittests_gpu14:
     <<: *gpu
     working_directory: ~/ParlAI
     parallelism: 8
@@ -275,15 +271,15 @@ jobs:
             - "~/nvidia-downloads/"
       - <<: *setup
       - restore_cache:
-          key: deps-gpu12-v5{{ checksum "requirements.txt" }}
+          key: deps-gpu14-v1{{ checksum "requirements.txt" }}
       - <<: *installdeps
+      - <<: *installtorchgpu14
       - save_cache:
-          key: deps-gpu12-v5{{ checksum "requirements.txt" }}
+          key: deps-gpu14-v1{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
-      - <<: *installtorchgpu12
       - run:
-          name: Unit tests (GPU; pytorch >= 1.2)
+          name: Unit tests (GPU; pytorch 1.4)
           command: coverage run -m pytest --junitxml=test-results/junit.xml -m unit
       - <<: *codecov
       - store_test_results:
@@ -307,17 +303,17 @@ jobs:
       - restore_cache:
           key: deps-nightly-v4{{ checksum "requirements.txt" }}
       - <<: *installdeps
+      - <<: *installtorchgpu14
       - save_cache:
           key: deps-nightly-v4{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
-      - <<: *installtorchgpu12
       - run:
           name: Nightly GPU tests
           no_output_timeout: 60m
           command: coverage run -m pytest --junitxml=test-results/junit.xml -m nightly_gpu
       - run:
-          name: Quickstart unit tests (GPU; pytorch 1.1)
+          name: Quickstart unit tests (GPU; pytorch 1.4)
           command: sh tests/test_quickstart.sh
       - <<: *codecov
       - store_test_results:
@@ -352,13 +348,13 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-bw-v4{{ checksum "requirements.txt" }}
+          key: deps-bw-v5{{ checksum "requirements.txt" }}
       - <<: *installdeps
+      - <<: *installtorchcpu
       - save_cache:
-          key: deps-bw-v4{{ checksum "requirements.txt" }}
+          key: deps-bw-v5{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
-      - <<: *installtorchcpu37
       - <<: *buildwebsite
       - run:
           working_directory: ~/ParlAI/
@@ -374,13 +370,13 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-dw-v4{{ checksum "requirements.txt" }}
+          key: deps-dw-v5{{ checksum "requirements.txt" }}
       - <<: *installdeps
+      - <<: *installtorchcpu
       - save_cache:
-          key: deps-dw-v4{{ checksum "requirements.txt" }}
+          key: deps-dw-v5{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
-      - <<: *installtorchcpu37
       - <<: *buildwebsite
       - run:
           working_directory: ~/ParlAI/
@@ -443,8 +439,8 @@ workflows:
   version: 2
   commit:
     jobs:
-      - unittests_gpu11
-      - unittests_gpu12
+      - unittests_gpu13
+      - unittests_gpu14
       - unittests_37
       - unittests_36
       - mturk_tests

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -92,6 +92,17 @@ def skipIfCircleCI(testfn, reason='Test disabled in CircleCI'):
     return unittest.skipIf(is_this_circleci(), reason)(testfn)
 
 
+def skipUnlessTorch14(testfn, reason='Test requires pytorch 1.4+'):
+    skip = False
+    if not TORCH_AVAILABLE:
+        skip = True
+    else:
+        version = tuple(int(x) for x in torch.__version__.split('.'))  # type: ignore
+        if version < (1, 4):
+            skip = True
+    return unittest.skipIf(skip, reason)(testfn)
+
+
 class retry(object):
     """
     Decorator for flaky tests. Test is run up to ntries times, retrying on failure.

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -97,8 +97,9 @@ def skipUnlessTorch14(testfn, reason='Test requires pytorch 1.4+'):
     if not TORCH_AVAILABLE:
         skip = True
     else:
-        version = tuple(int(x) for x in torch.__version__.split('.'))  # type: ignore
-        if version < (1, 4):
+        version = torch.__version__.replace("+cpu").split('.')  # type: ignore
+        version_ = tuple(int(x) for x in version)  # type: ignore
+        if version_ < (1, 4, 0):
             skip = True
     return unittest.skipIf(skip, reason)(testfn)
 

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -97,7 +97,7 @@ def skipUnlessTorch14(testfn, reason='Test requires pytorch 1.4+'):
     if not TORCH_AVAILABLE:
         skip = True
     else:
-        version = torch.__version__.replace("+cpu").split('.')  # type: ignore
+        version = torch.__version__.replace('+cpu', '').split('.')  # type: ignore
         version_ = tuple(int(x) for x in version)  # type: ignore
         if version_ < (1, 4, 0):
             skip = True

--- a/tests/nightly/gpu/test_transresnet.py
+++ b/tests/nightly/gpu/test_transresnet.py
@@ -42,7 +42,7 @@ class TestTransresnet(unittest.TestCase):
         """
         Test pretrained model.
         """
-        stdout, _, test = testing_utils.eval_model(MODEL_OPTIONS, skip_valid=True)
+        _, test = testing_utils.eval_model(MODEL_OPTIONS, skip_valid=True)
         self.assertEqual(test['accuracy'], 0.4)
         self.assertEqual(test['hits@5'], 0.9)
         self.assertEqual(test['hits@10'], 0.9)

--- a/tests/nightly/gpu/test_wizard.py
+++ b/tests/nightly/gpu/test_wizard.py
@@ -53,13 +53,13 @@ class TestWizardModel(unittest.TestCase):
         display_data.display_data(opt)
 
     def test_end2end(self):
-        stdout, valid, _ = testing_utils.eval_model(END2END_OPTIONS)
+        valid, _ = testing_utils.eval_model(END2END_OPTIONS)
         self.assertEqual(valid['ppl'], 61.21)
         self.assertEqual(valid['f1'], 0.1717)
         self.assertGreaterEqual(valid['know_acc'], 0.2201)
 
     def test_retrieval(self):
-        stdout, _, test = testing_utils.eval_model(RETRIEVAL_OPTIONS)
+        _, test = testing_utils.eval_model(RETRIEVAL_OPTIONS)
         self.assertGreaterEqual(test['accuracy'], 0.86)
         self.assertGreaterEqual(test['hits@5'], 0.98)
         self.assertGreaterEqual(test['hits@10'], 0.99)

--- a/tests/test_image_seq2seq.py
+++ b/tests/test_image_seq2seq.py
@@ -7,14 +7,6 @@
 import unittest
 import parlai.utils.testing as testing_utils
 
-try:
-    import torch
-
-    version = float('.'.join(torch.__version__.split('.')[:2]))  # type: ignore
-    TORCH_AVAILABLE = version >= 1.2
-except ImportError:
-    TORCH_AVAILABLE = False
-
 BASE_ARGS = {
     # Model Args
     'model': 'image_seq2seq',
@@ -61,10 +53,7 @@ EVAL_ARGS = {
 }
 
 
-@unittest.skip(
-    "need pytorch 1.4 release, https://github.com/pytorch/vision/issues/1712"
-)
-@unittest.skipUnless(TORCH_AVAILABLE, 'Must use torch 1.2 or above')
+@testing_utils.skipUnlessTorch14
 class TestImageSeq2Seq(unittest.TestCase):
     """
     Unit tests for the ImageSeq2Seq Agent.

--- a/tests/test_teachers.py
+++ b/tests/test_teachers.py
@@ -48,9 +48,7 @@ class TestAbstractImageTeacher(unittest.TestCase):
         """
         self._test_display_output('no_image_model')
 
-    # TODO: need pytorch 1.4 release, https://github.com/pytorch/vision/issues/1712
-    @unittest.skip
-    @testing_utils.skipUnlessTorch
+    @testing_utils.skipUnlessTorch14
     @testing_utils.skipUnlessGPU
     def test_display_data_resnet(self):
         """


### PR DESCRIPTION
**Patch description**
With the [release of pytorch 1.4](https://pytorch.org/blog/pytorch-1-dot-4-released-and-domain-libraries-updated/), we officially remove support for pytorch 1.2 and only support 1.3 and 1.4.

**Testing steps**
CI.