### PR TITLE
Don't die if --fp16 true but no apex.

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -30,9 +30,12 @@ from parlai.utils.torch import neginf
 
 try:
     from apex.normalization.fused_layer_norm import FusedLayerNorm as LayerNorm
+
+    APEX_LAYER_NORM = True
 except ImportError:
-    warn_once("Installing APEX can give a significant speed boost.")
     from torch.nn import LayerNorm
+
+    APEX_LAYER_NORM = False
 
 LAYER_NORM_EPS = 1e-5  # Epsilon for layer norm.
 
@@ -41,6 +44,8 @@ def _normalize(tensor, norm_layer):
     """
     Broadcast layer norm.
     """
+    if not APEX_LAYER_NORM:
+        warn_once("Installing APEX can give a significant speed boost.")
     size = tensor.size()
     return norm_layer(tensor.view(-1, size[-1])).view(size)
 

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -36,7 +36,12 @@ from parlai.core.dict import DictionaryAgent
 from parlai.nn.lr_scheduler import ParlAILRScheduler
 from parlai.core.message import Message
 from parlai.utils.misc import AttrDict, warn_once, round_sigfigs
-from parlai.utils.torch import argsort, fp16_optimizer_wrapper, padded_tensor
+from parlai.utils.torch import (
+    argsort,
+    fp16_optimizer_wrapper,
+    padded_tensor,
+    fp16_available,
+)
 
 
 class Batch(AttrDict):
@@ -606,7 +611,7 @@ class TorchAgent(ABC, Agent):
             if not shared and opt['gpu'] != -1:
                 torch.cuda.set_device(opt['gpu'])
         # indicate whether using fp16
-        self.fp16 = self.use_cuda and self.opt.get('fp16', False)
+        self.fp16 = self.use_cuda and self.opt.get('fp16', False) and fp16_available()
 
         if shared is None:
             # intitialize any important structures from scratch

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -226,7 +226,7 @@ def fp16_optimizer_wrapper(
 
 def fp16_available() -> bool:
     try:
-        import apex.fp16_utils
+        import apex.fp16_utils  # noqa: F401
 
         return True
     except ImportError:

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -8,6 +8,7 @@ Utility methods for dealing with torch code.
 """
 
 from typing import Union, Optional, Tuple, Any, List, Sized
+from parlai.utils.misc import warn_once
 
 try:
     import torch
@@ -221,3 +222,16 @@ def fp16_optimizer_wrapper(
         # improvements may make this unnecessary.
         dynamic_loss_args={'init_scale': loss_initial_scale},
     )
+
+
+def fp16_available() -> bool:
+    try:
+        import apex.fp16_utils
+
+        return True
+    except ImportError:
+        warn_once(
+            'You set --fp16 true, but fp16 is unavailable. To use fp16, please '
+            'install APEX from https://github.com/NVIDIA/apex.'
+        )
+        return False


### PR DESCRIPTION
**Patch description**
If the user specifies `--fp16 true`, we currently raise an error saying the user should install APEX. This has been annoying to some users (including internal ones, and on fbcode) who just wanted things to work without the failure.

**Testing steps**
Uninstalled apex and ran
```
$ python examples/interactive.py -m transformer/polyencoder  -mf zoo:pretrained_transformers/model_poly/model --fp16 true
[ Using CUDA ]
/private/home/roller/working/parlai/parlai/utils/torch.py:234: UserWarning: You set --fp16 true, but fp16 is unavailable. To use fp16, please install APEX from https://github.com/NVIDIA/apex.
  'You set --fp16 true, but fp16 is unavailable. To use fp16, please '
Dictionary: loading dictionary from /private/home/roller/working/parlai/data/models/pretrained_transformers/model_poly/model.dict
[ num words =  54944 ]
[Polyencoder: full interactive mode on.]
```