### PR TITLE
Upgrade classmethod super() behavior.

### DIFF
--- a/docs/source/tutorial_torch_generator_agent.md
+++ b/docs/source/tutorial_torch_generator_agent.md
@@ -40,7 +40,7 @@ class Seq2seqAgent(tga.TorchGeneratorAgent):
 
     @classmethod
     def add_cmdline_args(cls, argparser):
-        super(Seq2seqAgent, cls).add_cmdline_args(argparser)
+        super().add_cmdline_args(argparser)
         group = argparser.add_argument_group('Example TGA Agent')
         group.add_argument(
             '-hid', '--hidden-size', type=int, default=1024, help='Hidden size.'

--- a/parlai/agents/bert_classifier/bert_classifier.py
+++ b/parlai/agents/bert_classifier/bert_classifier.py
@@ -131,7 +131,7 @@ class BertClassifierAgent(TorchClassifierAgent):
         """
         Upgrade opts from older model files.
         """
-        super(BertClassifierAgent, cls).upgrade_opt(opt_on_disk)
+        super().upgrade_opt(opt_on_disk)
 
         # 2019-06-25: previous versions of the model did not add a CLS token
         # to the beginning of text_vec.

--- a/parlai/agents/examples/seq2seq.py
+++ b/parlai/agents/examples/seq2seq.py
@@ -194,7 +194,7 @@ class Seq2seqAgent(tga.TorchGeneratorAgent):
         Add CLI arguments.
         """
         # Make sure to add all of TorchGeneratorAgent's arguments
-        super(Seq2seqAgent, cls).add_cmdline_args(argparser)
+        super().add_cmdline_args(argparser)
 
         # Add custom arguments only for this model.
         group = argparser.add_argument_group('Example TGA Agent')

--- a/parlai/agents/image_seq2seq/image_seq2seq.py
+++ b/parlai/agents/image_seq2seq/image_seq2seq.py
@@ -45,7 +45,7 @@ class ImageSeq2seqAgent(TransformerGeneratorAgent):
         """
         Override to add one arg.
         """
-        super(ImageSeq2seqAgent, cls).add_cmdline_args(argparser)
+        super().add_cmdline_args(argparser)
         group = argparser.add_argument_group('Image Encoder Args')
         group.add_argument(
             '--image-features-dim', type=int, default=2048, help='dim for image feats'

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -136,7 +136,7 @@ class Seq2seqAgent(TorchGeneratorAgent):
             help='Probability of replacing tokens with UNK in training.',
         )
 
-        super(Seq2seqAgent, cls).add_cmdline_args(argparser)
+        super().add_cmdline_args(argparser)
         return agent
 
     @staticmethod

--- a/parlai/agents/transformer/biencoder.py
+++ b/parlai/agents/transformer/biencoder.py
@@ -29,7 +29,7 @@ class AddLabelFixedCandsTRA(TorchRankerAgent):
         """
         Override to include new arg.
         """
-        super(TorchRankerAgent, cls).add_cmdline_args(argparser)
+        super().add_cmdline_args(argparser)
         agent = argparser.add_argument_group('AddLabelFixedCandsTRA')
         agent.add_argument(
             '--add-label-to-fixed-cands',
@@ -132,10 +132,4 @@ class IRFriendlyBiencoderAgent(AddLabelFixedCandsTRA, BiencoderAgent):
     Bi-encoder agent that allows for adding label to fixed cands.
     """
 
-    @classmethod
-    def add_cmdline_args(cls, argparser):
-        """
-        Add cmd line args.
-        """
-        super(AddLabelFixedCandsTRA, cls).add_cmdline_args(argparser)
-        super(BiencoderAgent, cls).add_cmdline_args(argparser)
+    pass

--- a/parlai/agents/transformer/polyencoder.py
+++ b/parlai/agents/transformer/polyencoder.py
@@ -495,10 +495,4 @@ class IRFriendlyPolyencoderAgent(AddLabelFixedCandsTRA, PolyencoderAgent):
     Poly-encoder agent that allows for adding label to fixed cands.
     """
 
-    @classmethod
-    def add_cmdline_args(cls, argparser):
-        """
-        Add cmd line args.
-        """
-        super(AddLabelFixedCandsTRA, cls).add_cmdline_args(argparser)
-        super(PolyencoderAgent, cls).add_cmdline_args(argparser)
+    pass

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -131,7 +131,7 @@ class TransformerRankerAgent(TorchRankerAgent):
         """
         Add command-line arguments specifically for this agent.
         """
-        super(TransformerRankerAgent, cls).add_cmdline_args(argparser)
+        super().add_cmdline_args(argparser)
         agent = argparser.add_argument_group('Transformer Arguments')
         add_common_cmdline_args(agent)
         # memory and knowledge arguments
@@ -307,7 +307,7 @@ class TransformerGeneratorAgent(TorchGeneratorAgent):
         add_common_cmdline_args(agent)
         cls.dictionary_class().add_cmdline_args(argparser)
 
-        super(TransformerGeneratorAgent, cls).add_cmdline_args(argparser)
+        super().add_cmdline_args(argparser)
         return agent
 
     def build_model(self, states=None):

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -254,7 +254,7 @@ class TorchGeneratorAgent(TorchAgent):
     @classmethod
     def upgrade_opt(cls, opt_from_disk: Opt):
         # call the parent upgrades
-        opt_from_disk = super(TorchGeneratorAgent, cls).upgrade_opt(opt_from_disk)
+        opt_from_disk = super().upgrade_opt(opt_from_disk)
 
         # 2019-08-18: Adding support for generation other than beam search
         # Previously, selecting --beam-size > 1 enabled beam search and == 1 was
@@ -329,7 +329,7 @@ class TorchGeneratorAgent(TorchAgent):
             help='if true, compute tokenized bleu scores',
         )
 
-        super(TorchGeneratorAgent, cls).add_cmdline_args(argparser)
+        super().add_cmdline_args(argparser)
         return agent
 
     def __init__(self, opt: Opt, shared=None):

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -44,7 +44,7 @@ class TorchRankerAgent(TorchAgent):
         """
         Add CLI args.
         """
-        super(TorchRankerAgent, cls).add_cmdline_args(argparser)
+        super().add_cmdline_args(argparser)
         agent = argparser.add_argument_group('TorchRankerAgent')
         agent.add_argument(
             '-cands',

--- a/projects/self_feeding/self_feeding_agent.py
+++ b/projects/self_feeding/self_feeding_agent.py
@@ -285,7 +285,7 @@ class SelfFeedingAgent(TransformerRankerAgent):
         """
         Upgrade opts from older model files.
         """
-        super(SelfFeedingAgent, cls).upgrade_opt(opt_on_disk)
+        super().upgrade_opt(opt_on_disk)
 
         # 2019-06-25: previous versions of the model did not add a CLS token
         # to the beginning of text_vec.

--- a/projects/wizard_of_wikipedia/generator/agents.py
+++ b/projects/wizard_of_wikipedia/generator/agents.py
@@ -46,7 +46,7 @@ class _GenericWizardAgent(TransformerGeneratorAgent):
     @classmethod
     def add_cmdline_args(cls, argparser):
         argparser.set_defaults(**DEFAULT_OPTS)
-        super(_GenericWizardAgent, cls).add_cmdline_args(argparser)
+        super().add_cmdline_args(argparser)
 
     def batchify(self, obs_batch):
         batch = super().batchify(obs_batch)
@@ -285,7 +285,7 @@ class EndToEndAgent(_GenericWizardAgent):
 
     @classmethod
     def add_cmdline_args(cls, argparser):
-        super(EndToEndAgent, cls).add_cmdline_args(argparser)
+        super().add_cmdline_args(argparser)
         group = argparser.add_argument_group("EndToEnd Agent")
         group.add_argument(
             '--knowledge-alpha',

--- a/projects/wizard_of_wikipedia/wizard_transformer_ranker/wizard_transformer_ranker.py
+++ b/projects/wizard_of_wikipedia/wizard_transformer_ranker/wizard_transformer_ranker.py
@@ -23,7 +23,7 @@ class WizardTransformerRankerAgent(TransformerRankerAgent):
         """
         Add command-line arguments specifically for this agent.
         """
-        super(WizardTransformerRankerAgent, cls).add_cmdline_args(argparser)
+        super().add_cmdline_args(argparser)
         agent = argparser.add_argument_group('Wizard Transformer Ranker Arguments')
         agent.add_argument(
             '--use-knowledge',

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -25,7 +25,7 @@ class _ExampleUpgradeOptAgent(agents.Agent):
 
     @classmethod
     def upgrade_opt(cls, opt):
-        opt = super(_ExampleUpgradeOptAgent, cls).upgrade_opt(opt)
+        opt = super().upgrade_opt(opt)
         assert 'is_upgraded' not in opt
         opt['is_upgraded'] = True
         return opt

--- a/tests/test_ta_inheritence.py
+++ b/tests/test_ta_inheritence.py
@@ -29,7 +29,7 @@ class SubClassA(TorchGeneratorAgent):
     @classmethod
     def add_cmdline_args(cls, parser):
         parser.add_argument('--withclassinheritence', default='a')
-        super(SubClassA, cls).add_cmdline_args(parser)
+        super().add_cmdline_args(parser)
 
 
 class SubClassB(SubClassA):

--- a/tests/test_tra.py
+++ b/tests/test_tra.py
@@ -23,7 +23,7 @@ class _AbstractTRATest(unittest.TestCase):
     def setUpClass(cls):
         if cls is _AbstractTRATest:
             raise unittest.SkipTest('Skip abstract parent class')
-        super(_AbstractTRATest, cls).setUpClass()
+        super().setUpClass()
 
     def _get_args(self):
         # Add arguments for the Torch Ranker Agent to test


### PR DESCRIPTION
**Patch description**
Turns out, you don't have to use the awkward super syntax with classmethods, you can use the standard stuff. This upgrades our repo to use the nicer syntax.

Closes #2115 

**Testing steps**
```
devfair0237 parlai nicesuper $ python examples/train_model.py  -m transformer/polyencoder  --init-model zoo:pretrained_transformers/model_poly/model --fp16 true -opt fused_adam -t convai2 --ignore-bad-candidates true -mf /tmp/x --help > after
devfair0237 parlai nicesuper $ git co master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
devfair0237 parlai master $ python examples/train_model.py  -m transformer/polyencoder  --init-model zoo:pretrained_transformers/model_poly/model --fp16 true -opt fused_adam -t convai2 --ignore-bad-candidates true -mf /tmp/x --help > before
devfair0237 parlai master $ diff -u after before
--- after       2020-01-22 08:20:08.645185000 -0800
+++ before      2020-01-22 08:20:14.876890000 -0800
@@ -19,7 +19,7 @@
                       [--repeat-blocking-heuristic REPEAT_BLOCKING_HEURISTIC] [-fcp FIXED_CANDIDATES_PATH]
                       [--fixed-candidate-vecs FIXED_CANDIDATE_VECS] [--encode-candidate-vecs ENCODE_CANDIDATE_VECS]
                       [--init-model INIT_MODEL] [--train-predict TRAIN_PREDICT] [--cap-num-predictions CAP_NUM_PREDICTIONS]
-                      [--ignore-bad-candidates IGNORE_BAD_CANDIDATES] [--rank-top-k RANK_TOP_K] [--inference {max,topk}]
+                      [--ignore-bad-candidates IGNORE_BAD_CANDIDATES] [--rank-top-k RANK_TOP_K] [--inference {topk,max}]
                       [--topk TOPK] [-esz EMBEDDING_SIZE] [-nl N_LAYERS] [-hid FFN_SIZE] [--dropout DROPOUT]
                       [--attention-dropout ATTENTION_DROPOUT] [--relu-dropout RELU_DROPOUT] [--n-heads N_HEADS]
                       [--learn-positional-embeddings LEARN_POSITIONAL_EMBEDDINGS] [--embeddings-scale EMBEDDINGS_SCALE]
@@ -205,7 +205,7 @@
         (default: False)
   --rank-top-k RANK_TOP_K
         Ranking returns the top k results of k > 0, otherwise sorts every single candidate according to the ranking. (default: -1)
-  --inference {max,topk}
+  --inference {topk,max}
         Final response output algorithm (default: max)
   --topk TOPK
         K used in Top K sampling inference, when selected (default: 5)
```