### PR TITLE
Don't use @import in docs css.

### DIFF
--- a/docs/source/_static/css/parlai_theme.css
+++ b/docs/source/_static/css/parlai_theme.css
@@ -4,8 +4,6 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 
-@import url("theme.css");
-
 body {
     font-family: "Lato","proxima-nova","Helvetica Neue",Arial,sans-serif;
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,7 +121,7 @@ html_theme_options = {'collapse_navigation': False}
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-html_style = 'css/parlai_theme.css'
+html_css_files = ['css/parlai_theme.css']
 
 
 # -- Options for HTMLHelp output ------------------------------------------


### PR DESCRIPTION
**Patch description**
Some weirdness in our website was causing CSS not to be imported to work correctly. This is a work around.

Hopefully when we land it looks good.