### PR TITLE
Fixing subs bug in websocket-based chat_service

### DIFF
--- a/parlai/chat_service/services/websocket/sockets.py
+++ b/parlai/chat_service/services/websocket/sockets.py
@@ -20,7 +20,7 @@ T = TypeVar('T', bound='MessageSocketHandler')
 
 class MessageSocketHandler(WebSocketHandler):
     def __init__(self: T, *args, **kwargs):
-        self.subs: Dict[int, T] = {}
+        self.subs: Dict[int, T] = kwargs.pop('subs')
 
         def _default_callback(message, socketID):
             logging.warn(f"No callback defined for new WebSocket messages.")

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -43,7 +43,7 @@ class WebsocketManager(ChatServiceManager):
         super().__init__(opt)
         self.opt = opt
         self.port = opt.get('port')
-        self.subs = []
+        self.subs = {}
 
         self.app = None
         self.debug = opt.get('is_debug', False)
@@ -227,7 +227,7 @@ class WebsocketManager(ChatServiceManager):
                 (
                     r"/websocket",
                     MessageSocketHandler,
-                    {'message_callback': message_callback},
+                    {'subs': self.subs, 'message_callback': message_callback},
                 )
             ],
             debug=self.debug,
@@ -254,10 +254,10 @@ class WebsocketManager(ChatServiceManager):
         )
 
         asyncio.set_event_loop(asyncio.new_event_loop())
-        if socket_id not in MessageSocketHandler.subs:
+        if socket_id not in self.subs:
             self.agent_id_to_overworld_future[socket_id].cancel()
             return
-        return MessageSocketHandler.subs[socket_id].write_message(message)
+        return self.subs[socket_id].write_message(message)
 
     def observe_payload(self, socket_id, payload, quick_replies=None):
         """
@@ -278,10 +278,10 @@ class WebsocketManager(ChatServiceManager):
         payload = json.dumps(message)
 
         asyncio.set_event_loop(asyncio.new_event_loop())
-        if socket_id not in MessageSocketHandler.subs:
+        if socket_id not in self.subs:
             self.agent_id_to_overworld_future[socket_id].cancel()
             return
-        return MessageSocketHandler.subs[socket_id].write_message(message)
+        return self.subs[socket_id].write_message(message)
 
     def restructure_message(self):
         """


### PR DESCRIPTION
**Patch description**
Was testing out some of the `chat_service` code, and found a small bug in the websocket subscription management for it. This fix ensures that all websockets share the same list of subscriptions, which allows the manager to be able to find the relevant subscription by socket id.

**Testing steps**
Automated testing, manual logs below

**Logs**

```
******TERMINAL 1:******
python parlai/chat_service/services/terminal_chat/run.py --config-path parlai/chat_service/tasks/overworld_demo/config.yml --port 1234
[ optional arguments: ] 
[  datapath: /Users/jju/ParlAI/data ]
[ Chat Services: ] 
[  config_path: parlai/chat_service/tasks/overworld_demo/config.yml ]
[  is_debug: False ]
[  password: None ]
[ Terminal Chat: ] 
[  port: 1234 ]
[ Current ParlAI commit: c06c40603f45918f58cb09122fa8c74dd4047057 ]
[ Current internal commit: 4558a046a633fa1b54869231e45d7dc042dcc938 ]
[I 200122 17:14:16 web:2246] 101 GET /websocket (::1) 1.16ms
[I 200122 17:14:16 sockets:39] Opened new socket from ip: ::1
[I 200122 17:14:16 sockets:40] Current subscribers: {'b9391de0-b6eb-498b-96b2-8d778b05d4ff': <parlai.chat_service.services.websocket.sockets.MessageSocketHandler object at 0x7fae81871908>}
[I 200122 17:14:24 sockets:59] websocket message from client: {"id": "756c24ba-d92a-4dc6-8157-85b10c88710a", "text": "test"}
[I 200122 17:14:28 sockets:59] websocket message from client: {"id": "756c24ba-d92a-4dc6-8157-85b10c88710a", "text": "ParlAI"}
[I 200122 17:14:28 agents:40] Sending new message: {'id': 'Overworld', 'text': 'Welcome to the overworld for the ParlAI messenger demo. Choose one of the demos from the listed quick replies. ', 'quick_replies': dict_keys(['echo', 'onboard data', 'chat'])}
[I 200122 17:14:43 sockets:59] websocket message from client: {"id": "756c24ba-d92a-4dc6-8157-85b10c88710a", "text": "echo"}
[I 200122 17:14:43 agents:55] Received new message: {'text': 'echo', 'payload': None, 'sender': {'id': 'b9391de0-b6eb-498b-96b2-8d778b05d4ff'}, 'recipient': {'id': 0}}
[I 200122 17:14:43 agents:40] Sending new message: {'id': 'Overworld', 'text': 'Transferring to echo'}
[I 200122 17:14:43 agents:40] Sending new message: {'id': 'Onboarding', 'text': 'Welcome to the onboarding world for our echo bot. The next message you send will be echoed. Use [DONE] to finish the chat.'}
[E 200122 17:14:43 base_events:1266] Task was destroyed but it is pending!
    task: <Task pending coro=<WebSocketProtocol13.write_message.<locals>.wrapper() running at /Users/jju/miniconda3/lib/python3.6/site-packages/tornado/websocket.py:1102>>
/Users/jju/miniconda3/lib/python3.6/asyncio/base_events.py:493: RuntimeWarning: coroutine 'WebSocketProtocol13.write_message.<locals>.wrapper' was never awaited
  self._ready.clear()
[E 200122 17:14:43 base_events:1266] Task was destroyed but it is pending!
    task: <Task pending coro=<WebSocketProtocol13.write_message.<locals>.wrapper() running at /Users/jju/miniconda3/lib/python3.6/site-packages/tornado/websocket.py:1102>>
2020-01-22 17:14:43: Adding agent b9391de0-b6eb-498b-96b2-8d778b05d4ff to pool...
onboarding/overworld complete
starting pool
2020-01-22 17:14:44: Removing agent b9391de0-b6eb-498b-96b2-8d778b05d4ff from pool...
Starting task t_1...
[I 200122 17:14:50 sockets:59] websocket message from client: {"id": "756c24ba-d92a-4dc6-8157-85b10c88710a", "text": "Test Message!"}
[I 200122 17:14:50 agents:55] Received new message: {'text': 'Test Message!', 'payload': None, 'sender': {'id': 'b9391de0-b6eb-498b-96b2-8d778b05d4ff'}, 'recipient': {'id': 0}}
[I 200122 17:14:50 agents:40] Sending new message: {'episode_done': False, 'text': 'Test Message!', 'payload': None, 'id': 'World'}
[I 200122 17:14:58 sockets:59] websocket message from client: {"id": "756c24ba-d92a-4dc6-8157-85b10c88710a", "text": "[DONE]"}
[I 200122 17:14:58 agents:55] Received new message: {'text': '[DONE]', 'payload': None, 'sender': {'id': 'b9391de0-b6eb-498b-96b2-8d778b05d4ff'}, 'recipient': {'id': 0}}
World echo had no error
exiting overworld

******TERMINAL 2:******
python parlai/chat_service/services/terminal_chat/client.py --port 1234
[ Terminal Chat: ] 
[  port: 1234 ]
[ Current ParlAI commit: c06c40603f45918f58cb09122fa8c74dd4047057 ]
[ Current internal commit: 4558a046a633fa1b54869231e45d7dc042dcc938 ]
Connecting to port:  1234
 Me: test

Bot: Sorry, this conversation bot is password-protected. If you have the password, please send it now. 

 Me: ParlAI

Bot: Welcome to the overworld for the ParlAI messenger demo. Choose one of the demos from the listed quick replies.  

 Me: echo

Bot: Transferring to echo 

Bot: Welcome to the onboarding world for our echo bot. The next message you send will be echoed. Use [DONE] to finish the chat. 

 Me: Test Message!

Bot: Test Message! 

 Me: [DONE]       

Bot: See you later! 
```

**Other information**
There are definitely some other errors to clean up here (as seen in logs, I'm pretty sure returning to the overworld is broken or not implemented) but this is a first step.
