### PR TITLE
Fix broken test

### DIFF
--- a/example_parlai_internal/agents/parrot/parrot.py
+++ b/example_parlai_internal/agents/parrot/parrot.py
@@ -14,3 +14,7 @@ class ParrotAgent(TorchAgent):
     def eval_step(self, batch):
         # for each row in batch, convert tensor to back to text strings
         return Output([self.dict.vec2txt(row) for row in batch.text_vec])
+
+    def build_model(self):
+        # force it not to be abstract
+        return None


### PR DESCRIPTION
**Patch description**
In #2346, I marked TorchAgent as an abstract model, defined by build_model. This broke our quickstart example, which didn't implement build_model. This fixes the test.

**Testing steps**
Long CI.