### PR TITLE
Correct many old links. Add a link checker to build_website.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,19 +348,25 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-bw-v8{{ checksum "requirements.txt" }}
+          key: deps-bw-v9{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - <<: *installtorchgpu14
+      - run:
+          working_directory: ~/ParlAI/
+          name: more build website dependencies
+          command: |
+            pip install s3cmd linkchecker
       - save_cache:
-          key: deps-bw-v8{{ checksum "requirements.txt" }}
+          key: deps-bw-v9{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *buildwebsite
       - run:
+          name: check for bad links
           working_directory: ~/ParlAI/
-          name: temp check
           command: |
-            pip install s3cmd
+            python -m http.server --directory website/build >/dev/null &
+            linkchecker http://localhost:8000/
 
   deploy_website:
     <<: *standard_cpu37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,8 @@ jobs:
           working_directory: ~/ParlAI/
           name: more build website dependencies
           command: |
-            pip install s3cmd linkchecker
+            pip install s3cmd
+            sudo apt-get install linkchecker
       - save_cache:
           key: deps-bw-v9{{ checksum "requirements.txt" }}
           paths:
@@ -367,6 +368,7 @@ jobs:
           command: |
             python -m http.server --directory website/build >/dev/null &
             linkchecker http://localhost:8000/
+            kill %1
 
   deploy_website:
     <<: *standard_cpu37

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ VQA (Visual Question Answering).
 Its goal is to provide researchers:
 
 - **80+ popular datasets available all in one place, with the same API**, among them [PersonaChat](https://arxiv.org/abs/1801.07243), [DailyDialog](https://arxiv.org/abs/1710.03957), [Wizard of Wikipedia](https://openreview.net/forum?id=r1l73iRqKm), [Empathetic Dialogues](https://arxiv.org/abs/1811.00207), [SQuAD](https://rajpurkar.github.io/SQuAD-explorer/), [MS MARCO](http://www.msmarco.org/), [QuAC](https://www.aclweb.org/anthology/D18-1241), [HotpotQA](https://hotpotqa.github.io/), [QACNN & QADailyMail](https://arxiv.org/abs/1506.03340), [CBT](https://arxiv.org/abs/1511.02301), [BookTest](https://arxiv.org/abs/1610.00956), [bAbI Dialogue tasks](https://arxiv.org/abs/1605.07683), [Ubuntu Dialogue](https://arxiv.org/abs/1506.08909), [OpenSubtitles](http://opus.lingfil.uu.se/OpenSubtitles.php),  [Image Chat](https://arxiv.org/abs/1811.00945), [VQA](http://visualqa.org/), [VisDial](https://arxiv.org/abs/1611.08669) and [CLEVR](http://cs.stanford.edu/people/jcjohns/clevr/). See the complete list [here](https://github.com/facebookresearch/ParlAI/blob/master/parlai/tasks/task_list.py).
-- a wide set of [**reference models**](https://www.parl.ai/docs/agents_list.html) -- from retrieval baselines to transformers.
+- a wide set of [**reference models**](https://parl.ai/docs/agents_list.html) -- from retrieval baselines to Transformers.
 - a large [zoo of **pretrained models**](https://parl.ai/docs/zoo.html) ready to use off-the-shelf
 - seamless **integration of [Amazon Mechanical Turk](https://www.mturk.com/mturk/welcome)** for data collection and human evaluation
-- **integration with [Facebook Messenger](http://www.parl.ai/docs/tutorial_messenger.html)** to connect agents with humans in a chat interface
+- **integration with [Facebook Messenger](https://parl.ai/docs/tutorial_chat_service.html)** to connect agents with humans in a chat interface
 - a large range of **helpers to create your own agents** and train on several tasks with **multitasking**
 - **multimodality**, some tasks use text and images
 
@@ -24,7 +24,7 @@ or see these [more up-to-date slides](https://drive.google.com/file/d/1JfUW4AVrj
 
 See the [news page](https://github.com/facebookresearch/ParlAI/blob/master/NEWS.md) for the latest additions & updates, and the website [http://parl.ai](http://parl.ai) for further docs.
 
-<p align="center"><img width="90%" src="docs/source/_static/img/parlai_example.png" /></p>
+<p align="center"><img width="90%" src="https://raw.githubusercontent.com/facebookresearch/ParlAI/master/docs/source/_static/img/parlai_example.png" /></p>
 
 ## Installing ParlAI
 
@@ -50,33 +50,33 @@ All needed data will be downloaded to `~/ParlAI/data`, and any non-data files if
  - [Quick Start](https://parl.ai/docs/tutorial_quick.html)
  - [Basics: world, agents, teachers, action and observations](https://parl.ai/docs/tutorial_basic.html)
  - [List of available tasks/datasets](https://parl.ai/docs/tasks.html)
- - [Creating a dataset/task](http://www.parl.ai/docs/tutorial_task.html)
- - [List of available agents](./parlai/agents)
+ - [Creating a dataset/task](http://parl.ai/docs/tutorial_task.html)
+ - [List of available agents](https://parl.ai/docs/agents_list.html)
  - [Creating a new agent](https://parl.ai/docs/tutorial_seq2seq.html#)
  - [Model zoo (pretrained models)](https://parl.ai/docs/zoo.html)
  - [Plug into MTurk](http://parl.ai/docs/tutorial_mturk.html)
- - [Plug into Facebook Messenger](http://parl.ai/docs/tutorial_messenger.html)
+ - [Plug into Facebook Messenger](https://parl.ai/docs/tutorial_chat_service.html)
 
 
 ## Examples
 
-A large set of examples can be found in [this directory](./examples). Here are a few of them.
+A large set of scripts can be found in `parlai/scripts`. Here are a few of them.
 Note: If any of these examples fail, check the [requirements section](#requirements) to see if you have missed something.
 
 Display 10 random examples from the SQuAD task
 ```bash
-python examples/display_data.py -t squad
+python -m parlai.scripts.display_data -t squad
 ```
 
 Evaluate an IR baseline model on the validation set of the Personachat task:
 ```bash
-python examples/eval_model.py -m ir_baseline -t personachat -dt valid
+python -m parlai.scripts.eval_model -m ir_baseline -t personachat -dt valid
 ```
 
 Train a single layer transformer on PersonaChat (requires pytorch and torchtext).
 Detail: embedding size 300, 4 attention heads,  2 epochs using batchsize 64, word vectors are initialized with fasttext and the other elements of the batch are used as negative during training.
 ```bash
-python examples/train_model.py -t personachat -m transformer/ranker -mf /tmp/model_tr6 --n-layers 1 --embedding-size 300 --ffn-size 600 --n-heads 4 --num-epochs 2 -veps 0.25 -bs 64 -lr 0.001 --dropout 0.1 --embedding-type fasttext_cc --candidates batch
+python parlai.scripts.train_model -t personachat -m transformer/ranker -mf /tmp/model_tr6 --n-layers 1 --embedding-size 300 --ffn-size 600 --n-heads 4 --num-epochs 2 -veps 0.25 -bs 64 -lr 0.001 --dropout 0.1 --embedding-type fasttext_cc --candidates batch
 ```
 
 
@@ -85,13 +85,13 @@ python examples/train_model.py -t personachat -m transformer/ranker -mf /tmp/mod
 
 The code is set up into several main directories:
 
-- [**core**](./parlai/core): contains the primary code for the framework
-- [**agents**](./parlai/agents): contains agents which can interact with the different tasks (e.g. machine learning models)
-- [**examples**](./parlai/examples): contains a few basic examples of different loops (building dictionary, train/eval, displaying data)
-- [**tasks**](./parlai/tasks): contains code for the different tasks available from within ParlAI
-- [**mturk**](./parlai/mturk): contains code for setting up Mechanical Turk, as well as sample MTurk tasks
-- [**messenger**](./parlai/chat_service/services/messenger): contains code for interfacing with Facebook Messenger
-- [**zoo**](./parlai/zoo): contains code to directly download and use pretrained models from our model zoo
+- [**core**](https://github.com/facebookresearch/ParlAI/tree/master/parlai/core): contains the primary code for the framework
+- [**agents**](https://github.com/facebookresearch/ParlAI/tree/master/parlai/agents): contains agents which can interact with the different tasks (e.g. machine learning models)
+- [**scripts**](https://github.com/facebookresearch/ParlAI/tree/master/parlai/scripts): contains a number of useful scripts, like training, evaluating, interactive chatting, ...
+- [**tasks**](https://github.com/facebookresearch/ParlAI/tree/master/parlai/tasks): contains code for the different tasks available from within ParlAI
+- [**mturk**](https://github.com/facebookresearch/ParlAI/tree/master/parlai/mturk): contains code for setting up Mechanical Turk, as well as sample MTurk tasks
+- [**messenger**](https://github.com/facebookresearch/ParlAI/tree/master/parlai/chat_service/services/messenger): contains code for interfacing with Facebook Messenger
+- [**zoo**](https://github.com/facebookresearch/ParlAI/tree/master/parlai/zoo): contains code to directly download and use pretrained models from our model zoo
 
 ## Support
 If you have any questions, bug reports or feature requests, please don't hesitate to post on our [Github Issues page](https://github.com/facebookresearch/ParlAI/issues).

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ python -m parlai.scripts.eval_model -m ir_baseline -t personachat -dt valid
 Train a single layer transformer on PersonaChat (requires pytorch and torchtext).
 Detail: embedding size 300, 4 attention heads,  2 epochs using batchsize 64, word vectors are initialized with fasttext and the other elements of the batch are used as negative during training.
 ```bash
-python parlai.scripts.train_model -t personachat -m transformer/ranker -mf /tmp/model_tr6 --n-layers 1 --embedding-size 300 --ffn-size 600 --n-heads 4 --num-epochs 2 -veps 0.25 -bs 64 -lr 0.001 --dropout 0.1 --embedding-type fasttext_cc --candidates batch
+python -m parlai.scripts.train_model -t personachat -m transformer/ranker -mf /tmp/model_tr6 --n-layers 1 --embedding-size 300 --ffn-size 600 --n-heads 4 --num-epochs 2 -veps 0.25 -bs 64 -lr 0.001 --dropout 0.1 --embedding-type fasttext_cc --candidates batch
 ```
 
 

--- a/parlai/core/pytorch_data_teacher.py
+++ b/parlai/core/pytorch_data_teacher.py
@@ -652,7 +652,7 @@ class PytorchDataTeacher(FixedDialogTeacher):
     A teacher that loads data using Pytorch Datasets.
 
     For details on how to use, please follow the tutorial here:
-    http://parl.ai/static/docs/tutorial_worlds.html#multiprocessed-pytorch-dataloader
+    http://parl.ai/docs/tutorial_worlds.html#multiprocessed-pytorch-dataloader
     """
 
     def __init__(self, opt, shared=None):

--- a/parlai/tasks/README.md
+++ b/parlai/tasks/README.md
@@ -6,7 +6,7 @@ The list of tasks can also be found in this file:
 https://github.com/facebookresearch/ParlAI/blob/master/parlai/tasks/task_list.py
 
 or in the documentation, here:
-http://www.parl.ai/static/docs/tasks.html
+http://www.parl.ai/docs/tasks.html
 
 
 Each task folder contains:
@@ -14,4 +14,4 @@ Each task folder contains:
 - **agents.py** file which contains default or special teacher classes used by core.create_task to instantiate these classes from command-line arguments (if desired).
 - **worlds.py** file can optionally be added for tasks that need to define new/complex environments.
 
-To add your own task, see the [tutorial](http://www.parl.ai/static/docs/tutorial_task.html).
+To add your own task, see the [tutorial](http://www.parl.ai/docs/tutorial_task.html).

--- a/parlai/zoo/README.md
+++ b/parlai/zoo/README.md
@@ -3,7 +3,7 @@ The set of reference models in ParlAI ("model zoo").
 Each directory contains a stored reference model (or set of related models). Typically this is the stored model from training one of the ParlAI agents on one or more of the ParlAI tasks.
 
 The list of models can also be found in the documentation:
-http://www.parl.ai/static/docs/zoo.html
+http://www.parl.ai/docs/zoo.html
 
 or in this file:
 https://github.com/facebookresearch/ParlAI/blob/master/parlai/zoo/model_list.py

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -531,7 +531,7 @@ model_list = [
         "task": "convai2",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
-            "Polyencoder pretrained on Reddit and fine-tuned on ConvAI2 scoring 89+ hits@1/20. See the pretrained_transformers directory for a list of other available pretrained transformers"
+            "Polyencoder pretrained on Reddit and fine-tuned on ConvAI2 scoring 89+ hits @ 1/20. See the pretrained_transformers directory for a list of other available pretrained transformers"
         ),
         "example": (
             "python examples/interactive.py -mf "
@@ -561,7 +561,7 @@ model_list = [
         "task": "convai2",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/polyencoder/",
         "description": (
-            "Bi-encoder pretrained on Reddit and fine-tuned on ConvAI2 scoring ~87 hits@1/20."
+            "Bi-encoder pretrained on Reddit and fine-tuned on ConvAI2 scoring ~87 hits @ 1/20."
         ),
         "example": (
             "python examples/interactive.py -mf "

--- a/projects/light/README.md
+++ b/projects/light/README.md
@@ -30,7 +30,7 @@ described entirely in natural language. Within that game world, we collect 11,00
 character interactions (talking and acting).
 
 You can view the data or train your own ParlAI agent on the LIGHT tasks with
-`-t light_dialog`. See the [ParlAI quickstart for help](http://www.parl.ai/static/docs/tutorial_quick.html).
+`-t light_dialog`. See the [ParlAI quickstart for help](http://parl.ai/docs/tutorial_quick.html).
 
 ## Pretrained Models
 

--- a/projects/personality_captions/README.md
+++ b/projects/personality_captions/README.md
@@ -11,7 +11,7 @@ Standard image captioning tasks such as COCO and Flickr30k are factual, neutral 
 ## Dataset
 
 The Personality-Captions dataset can be accessed via ParlAI, with `-t personality_captions`. 
-See the [ParlAI quickstart for help](http://www.parl.ai/static/docs/tutorial_quick.html).
+See the [ParlAI quickstart for help](http://www.parl.ai/docs/tutorial_quick.html).
 
 Additionally, the ParlAI MTurk tasks for data collection and human evaluation
 are [made available](https://github.com/facebookresearch/ParlAI/tree/master/parlai/mturk/tasks/personality_captions) in ParlAI.

--- a/projects/wizard_of_wikipedia/README.md
+++ b/projects/wizard_of_wikipedia/README.md
@@ -29,7 +29,7 @@ important research direction.
 
 You can train your own ParlAI agent on the Wizard of Wikipedia task with
 `-t wizard_of_wikipedia`.
-See the [ParlAI quickstart for help](http://www.parl.ai/static/docs/tutorial_quick.html).
+See the [ParlAI quickstart for help](http://www.parl.ai/docs/tutorial_quick.html).
 
 The ParlAI MTurk collection scripts are also
 [made available](https://github.com/facebookresearch/ParlAI/tree/master/parlai/mturk/tasks/wizard_of_wikipedia),

--- a/website/Makefile
+++ b/website/Makefile
@@ -3,6 +3,7 @@ all: clean
 	cd ../docs; make html
 	pwd
 	cp -a ../docs/build/html build/docs
+	cp build/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.eot build/docs/_static/fonts/RobotoSlab/roboto-slab.eot
 	cp -a static build/
 	python postprocess_docs.py
 

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -138,7 +138,7 @@ letter-spacing: 0em;">Seamless integration of Amazon Mechanical Turk for data co
 
         <div class="row">
             <div class="col-md-12" style="padding-top: 20px;">
-              <h4 style="color: #555; margin-bottom: 20px; font-size: 16px; line-height: 140%"><b>For more examples, please read our <a href="/static/docs/index.html">tutorial</a>. To learn more about ParlAI, click <a href="/about/">here</a>.</b></h4>
+              <h4 style="color: #555; margin-bottom: 20px; font-size: 16px; line-height: 140%"><b>For more examples, please read our <a href="/docs/index.html">tutorial</a>. To learn more about ParlAI, click <a href="/about/">here</a>.</b></h4>
             </div>
         </div>
     </div>


### PR DESCRIPTION
**Patch description**
We had MANY 404s on our website, mostly due to failed attempts to rewrite links from github to our website. 

**Testing steps**
Built and ran linkchecker locally. CI will test its automatic abilities.

**Logs**
```
$ linkchecker 'http://0.0.0.0:8000/' --no-status
INFO 2020-01-23 09:00:12,671 MainThread Checking intern URLs only; use --check-extern to check extern URLs.
LinkChecker 9.3              Copyright (C) 2000-2014 Bastian Kleineidam
LinkChecker comes with ABSOLUTELY NO WARRANTY!
This is free software, and you are welcome to redistribute it
under certain conditions. Look at the file `LICENSE' within this
distribution.
Get the newest version at http://wummel.github.io/linkchecker/
Write comments and bugs to https://github.com/wummel/linkchecker/issues
Support this project at http://wummel.github.io/linkchecker/donations.html

Start checking at 2020-01-23 09:00:12-007

Statistics:
Downloaded: 16.0MB.
Content types: 401 image, 73025 text, 0 video, 0 audio, 1528 application, 0 mail and 4604 other.
URL lengths: min=14, max=210, avg=67.

That's it. 79558 links in 113 URLs checked. 0 warnings found. 0 errors found.
Stopped checking at 2020-01-23 09:02:11-007 (1 minute, 58 seconds)```