### PR TITLE
Bump circleci cache. Include pip in cache.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ codecov: &codecov
   run:
     name: Coverage report
     command: |
-      codecov --flags $CIRCLE_JOB
+      python -m codecov --flags $CIRCLE_JOB
 
 installdeps: &installdeps
   run:
@@ -148,7 +148,7 @@ jobs:
       - <<: *installtorchcpu
       - run:
           name: Data tests
-          command: coverage run -m pytest --junitxml=test-results/junit.xml -m data
+          command: python -m coverage run -m pytest --junitxml=test-results/junit.xml -m data
       - <<: *codecov
       - store_test_results:
           path: test-results
@@ -171,7 +171,7 @@ jobs:
             - "~/venv/lib"
       - run:
           name: Unit tests (OSX)
-          command: coverage run -m pytest --junitxml=test-results/junit.xml -m unit
+          command: python -m coverage run -m pytest --junitxml=test-results/junit.xml -m unit
       - <<: *codecov
       - store_test_results:
           path: test-results
@@ -197,7 +197,7 @@ jobs:
             - "~/venv/lib"
       - run:
           name: Unit tests (py36)
-          command: coverage run -m pytest --junitxml=test-results/junit.xml -m unit
+          command: python -m coverage run -m pytest --junitxml=test-results/junit.xml -m unit
       - <<: *codecov
       - store_test_results:
           path: test-results
@@ -220,7 +220,7 @@ jobs:
             - "~/venv/lib"
       - run:
           name: Unit tests (py37)
-          command: coverage run -m pytest --junitxml=test-results/junit.xml -m unit
+          command: python -m coverage run -m pytest --junitxml=test-results/junit.xml -m unit
       - <<: *codecov
       - store_test_results:
           path: test-results
@@ -250,7 +250,7 @@ jobs:
             - "~/venv/lib"
       - run:
           name: Unit tests (GPU; pytorch 1.3)
-          command: coverage run -m pytest --junitxml=test-results/junit.xml -m unit
+          command: python -m coverage run -m pytest --junitxml=test-results/junit.xml -m unit
       - <<: *codecov
       - store_test_results:
           path: test-results
@@ -280,7 +280,7 @@ jobs:
             - "~/venv/lib"
       - run:
           name: Unit tests (GPU; pytorch 1.4)
-          command: coverage run -m pytest --junitxml=test-results/junit.xml -m unit
+          command: python -m coverage run -m pytest --junitxml=test-results/junit.xml -m unit
       - <<: *codecov
       - store_test_results:
           path: test-results
@@ -311,7 +311,7 @@ jobs:
       - run:
           name: Nightly GPU tests
           no_output_timeout: 60m
-          command: coverage run -m pytest --junitxml=test-results/junit.xml -m nightly_gpu
+          command: python -m coverage run -m pytest --junitxml=test-results/junit.xml -m nightly_gpu
       - run:
           name: Quickstart unit tests (GPU; pytorch 1.4)
           command: sh tests/test_quickstart.sh
@@ -335,7 +335,7 @@ jobs:
             - "~/venv/lib"
       - run:
           name: All mturk tests
-          command: coverage run -m pytest --junitxml=test-results/junit.xml -m mturk parlai/mturk/core/test/*.py
+          command: python -m coverage run -m pytest --junitxml=test-results/junit.xml -m mturk parlai/mturk/core/test/*.py
       - <<: *codecov
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,6 @@ setup: &setup
       echo ". ~/venv/bin/activate" >> $BASH_ENV
       . ~/venv/bin/activate
       python --version
-      pip3 install --progress-bar off --upgrade pip setuptools
-      pip3 install --progress-bar off coverage
-      pip3 install --progress-bar off codecov
-      mkdir -p ~/ParlAI/test-results
 
 
 codecov: &codecov
@@ -64,6 +60,10 @@ installdeps: &installdeps
   run:
     name: Installs basic dependencies
     command: |
+      pip3 install --progress-bar off --upgrade pip setuptools
+      pip3 install --progress-bar off coverage
+      pip3 install --progress-bar off codecov
+      mkdir -p ~/ParlAI/test-results
       pip install -q -r requirements.txt
       python setup.py develop
       python -c "import nltk; nltk.download('punkt')"
@@ -139,10 +139,10 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-dt-v7{{ checksum "requirements.txt" }}
+          key: deps-dt-v8{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-dt-v7{{ checksum "requirements.txt" }}
+          key: deps-dt-v8{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *installtorchcpu
@@ -162,11 +162,11 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-osx-v7{{ checksum "requirements.txt" }}
+          key: deps-osx-v8{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - <<: *installtorchcpuosx
       - save_cache:
-          key: deps-osx-v7{{ checksum "requirements.txt" }}
+          key: deps-osx-v8{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -188,11 +188,11 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-ut36-v7{{ checksum "requirements.txt" }}
+          key: deps-ut36-v8{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - <<: *installtorchcpu
       - save_cache:
-          key: deps-ut36-v7{{ checksum "requirements.txt" }}
+          key: deps-ut36-v8{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -211,11 +211,11 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-ut37-v7{{ checksum "requirements.txt" }}
+          key: deps-ut37-v8{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - <<: *installtorchcpu
       - save_cache:
-          key: deps-ut37-v7{{ checksum "requirements.txt" }}
+          key: deps-ut37-v8{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -241,11 +241,11 @@ jobs:
             - "~/nvidia-downloads/"
       - <<: *setup
       - restore_cache:
-          key: deps-gpu13-v7{{ checksum "requirements.txt" }}
+          key: deps-gpu13-v8{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - <<: *installtorchgpu13
       - save_cache:
-          key: deps-gpu13-v7{{ checksum "requirements.txt" }}
+          key: deps-gpu13-v8{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -271,11 +271,11 @@ jobs:
             - "~/nvidia-downloads/"
       - <<: *setup
       - restore_cache:
-          key: deps-gpu14-v7{{ checksum "requirements.txt" }}
+          key: deps-gpu14-v8{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-gpu14-v7{{ checksum "requirements.txt" }}
+          key: deps-gpu14-v8{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -301,11 +301,11 @@ jobs:
             - "~/nvidia-downloads/"
       - <<: *setup
       - restore_cache:
-          key: deps-nightly-v7{{ checksum "requirements.txt" }}
+          key: deps-nightly-v8{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-nightly-v7{{ checksum "requirements.txt" }}
+          key: deps-nightly-v8{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -327,10 +327,10 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-mturk-v7{{ checksum "requirements.txt" }}
+          key: deps-mturk-v8{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - save_cache:
-          key: deps-mturk-v7{{ checksum "requirements.txt" }}
+          key: deps-mturk-v8{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -348,7 +348,7 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-bw-v9{{ checksum "requirements.txt" }}
+          key: deps-bw-v10{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - <<: *installtorchgpu14
       - run:
@@ -358,7 +358,7 @@ jobs:
             pip install s3cmd
             sudo apt-get install linkchecker
       - save_cache:
-          key: deps-bw-v9{{ checksum "requirements.txt" }}
+          key: deps-bw-v10{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *buildwebsite
@@ -378,11 +378,11 @@ jobs:
       - <<: *fixgit
       - <<: *setup
       - restore_cache:
-          key: deps-dw-v8{{ checksum "requirements.txt" }}
+          key: deps-dw-v9{{ checksum "requirements.txt" }}
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-dw-v8{{ checksum "requirements.txt" }}
+          key: deps-dw-v9{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *buildwebsite

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,12 +137,12 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
-      - <<: *setup
       - restore_cache:
-          key: deps-dt-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-dt-{{ checksum "requirements.txt" }}
+      - <<: *setup
       - <<: *installdeps
       - save_cache:
-          key: deps-dt-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-dt-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *installtorchcpu
@@ -160,13 +160,13 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
-      - <<: *setup
       - restore_cache:
-          key: deps-osx-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-osx-{{ checksum "requirements.txt" }}
+      - <<: *setup
       - <<: *installdeps
       - <<: *installtorchcpuosx
       - save_cache:
-          key: deps-osx-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-osx-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -186,13 +186,13 @@ jobs:
           name: output test split
           command: circleci tests split --split-by=timings --timings-type=classname
       - <<: *fixgit
-      - <<: *setup
       - restore_cache:
-          key: deps-ut36-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-ut36-{{ checksum "requirements.txt" }}
+      - <<: *setup
       - <<: *installdeps
       - <<: *installtorchcpu
       - save_cache:
-          key: deps-ut36-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-ut36-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -209,13 +209,13 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
-      - <<: *setup
       - restore_cache:
-          key: deps-ut37-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-ut37-{{ checksum "requirements.txt" }}
+      - <<: *setup
       - <<: *installdeps
       - <<: *installtorchcpu
       - save_cache:
-          key: deps-ut37-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-ut37-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -239,13 +239,13 @@ jobs:
           key: nvidia-downloads-v3
           paths:
             - "~/nvidia-downloads/"
-      - <<: *setup
       - restore_cache:
-          key: deps-gpu13-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-gpu13-{{ checksum "requirements.txt" }}
+      - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu13
       - save_cache:
-          key: deps-gpu13-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-gpu13-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -269,13 +269,13 @@ jobs:
           key: nvidia-downloads-v3
           paths:
             - "~/nvidia-downloads/"
-      - <<: *setup
       - restore_cache:
-          key: deps-gpu14-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-gpu14-{{ checksum "requirements.txt" }}
+      - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-gpu14-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-gpu14-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -299,13 +299,13 @@ jobs:
           key: nvidia-downloads-v3
           paths:
             - "~/nvidia-downloads/"
-      - <<: *setup
       - restore_cache:
-          key: deps-nightly-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-nightly-{{ checksum "requirements.txt" }}
+      - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-nightly-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-nightly-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -325,12 +325,12 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
-      - <<: *setup
       - restore_cache:
-          key: deps-mturk-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-mturk-{{ checksum "requirements.txt" }}
+      - <<: *setup
       - <<: *installdeps
       - save_cache:
-          key: deps-mturk-v8{{ checksum "requirements.txt" }}
+          key: deps-v1-mturk-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - run:
@@ -346,9 +346,9 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
-      - <<: *setup
       - restore_cache:
-          key: deps-bw-v10{{ checksum "requirements.txt" }}
+          key: deps-v1-bw-{{ checksum "requirements.txt" }}
+      - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
       - run:
@@ -358,7 +358,7 @@ jobs:
             pip install s3cmd
             sudo apt-get install linkchecker
       - save_cache:
-          key: deps-bw-v10{{ checksum "requirements.txt" }}
+          key: deps-v1-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *buildwebsite
@@ -376,13 +376,13 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
-      - <<: *setup
       - restore_cache:
-          key: deps-dw-v9{{ checksum "requirements.txt" }}
+          key: deps-v1-dw-{{ checksum "requirements.txt" }}
+      - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-dw-v9{{ checksum "requirements.txt" }}
+          key: deps-v1-dw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/lib"
       - <<: *buildwebsite


### PR DESCRIPTION
**Patch description**
CI keeps breaking because the authors of `pip` have released 3 versions in as many days. The issue is that the version of pip installed stops matching the version in the cache.

Solution:
- bump the cache
- Include pip IN the cache.

**Testing steps**
CI should go back to passing.