### PR TITLE
[Not for merge][Feedback Welcome]All-in-one image modifications for ParlAI

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -518,6 +518,13 @@ class Metrics(object):
                     m['f1'] = round_sigfigs(
                         self.metrics['f1'] / max(1, self.metrics['f1_cnt']), 4
                     )
+                if 'rouge' in self.metrics_list:
+                    for each_rouge in ROUGE_METRICS:
+                        m[each_rouge] = round_sigfigs(
+                            self.metrics[each_rouge]
+                            / max(1, self.metrics['{}_cnt'.format(each_rouge)]),
+                            4,
+                        )
             if self.flags['has_text_cands']:
                 for k in self.eval_pr:
                     m['hits@' + str(k)] = round_sigfigs(

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -431,7 +431,6 @@ class Metrics(object):
         correct = 0
         prediction = observation.get('text', None)
         if prediction is not None:
-            # import ipdb; ipdb.set_trace()
             if _exact_match(prediction, labels):
                 correct = 1
             with self._lock():
@@ -519,13 +518,6 @@ class Metrics(object):
                     m['f1'] = round_sigfigs(
                         self.metrics['f1'] / max(1, self.metrics['f1_cnt']), 4
                     )
-                if 'rouge' in self.metrics_list:
-                    for each_rouge in ROUGE_METRICS:
-                        m[each_rouge] = round_sigfigs(
-                            self.metrics[each_rouge]
-                            / max(1, self.metrics['{}_cnt'.format(each_rouge)]),
-                            4,
-                        )
             if self.flags['has_text_cands']:
                 for k in self.eval_pr:
                     m['hits@' + str(k)] = round_sigfigs(

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -431,6 +431,7 @@ class Metrics(object):
         correct = 0
         prediction = observation.get('text', None)
         if prediction is not None:
+            # import ipdb; ipdb.set_trace()
             if _exact_match(prediction, labels):
                 correct = 1
             with self._lock():

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -251,7 +251,7 @@ class TorchClassifierAgent(TorchAgent):
         labels = self._get_labels(batch)
         scores = self.score(batch)
         loss = self.criterion(scores, labels)
-        loss = loss * scores.size(1)
+        # loss = loss * scores.size(1)
         loss.backward()
         self.update_params()
 

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -174,7 +174,7 @@ class TorchClassifierAgent(TorchAgent):
             if 'optimizer' in shared:
                 self.optimizer = shared['optimizer']
         else:
-            optim_params = [p for p in self.model.parameters() if p.requires_grad]
+            optim_params = [p for p in self.model.parameters() if p.modus_grad]
             self.init_optim(optim_params)
             self.build_lr_scheduler()
 
@@ -251,7 +251,7 @@ class TorchClassifierAgent(TorchAgent):
         labels = self._get_labels(batch)
         scores = self.score(batch)
         loss = self.criterion(scores, labels)
-        # loss = loss * scores.size(1)
+        loss = loss * scores.size(1)
         loss.backward()
         self.update_params()
 

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -180,7 +180,7 @@ class TorchClassifierAgent(TorchAgent):
 
     def build_criterion(self):
         weight_tensor = torch.FloatTensor(self.class_weights)
-        return torch.nn.CrossEntropyLoss(weight_tensor)
+        return torch.nn.CrossEntropyLoss()
 
     def share(self):
         """
@@ -249,9 +249,9 @@ class TorchClassifierAgent(TorchAgent):
 
         # calculate loss
         labels = self._get_labels(batch)
-        scores = self.score(batch).float()
-        # import ipdb; ipdb.set_trace()
+        scores = self.score(batch)
         loss = self.criterion(scores, labels)
+        loss = loss * scores.size(1)
         loss.backward()
         self.update_params()
 

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -666,9 +666,9 @@ class TorchRankerAgent(TorchAgent):
                 use_cuda=self.use_cuda,
                 fp16friendly=self.fp16,
             )
-            if (
-                label_vecs is not None
-                and batch.id != 'internal:vqa_v2:PersonalityTeacher'
+            if label_vecs is not None and (
+                batch.id != 'internal:vqa_v2:PersonalityTeacherClassifier'
+                and batch.id != 'internal:vqa_v2:PersonalityTeacherRanking'
             ):
                 label_inds = label_vecs.new_empty((batchsize))
                 bad_batch = False
@@ -707,9 +707,9 @@ class TorchRankerAgent(TorchAgent):
             cands = self.fixed_candidates
             cand_vecs = self.fixed_candidate_vecs
 
-            if (
-                label_vecs is not None
-                and batch.id != 'internal:vqa_v2:PersonalityTeacher'
+            if label_vecs is not None and (
+                batch.id != 'internal:vqa_v2:PersonalityTeacherClassifier'
+                and batch.id != 'internal:vqa_v2:PersonalityTeacherRanking'
             ):
                 label_inds = label_vecs.new_empty((batchsize))
                 bad_batch = False

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -666,9 +666,9 @@ class TorchRankerAgent(TorchAgent):
                 use_cuda=self.use_cuda,
                 fp16friendly=self.fp16,
             )
-            if label_vecs is not None and (
-                batch.id != 'internal:vqa_v2:PersonalityTeacherClassifier'
-                and batch.id != 'internal:vqa_v2:PersonalityTeacherRanking'
+            if (
+                label_vecs is not None
+                and batch.id != 'internal:vqa_v2:PersonalityTeacher'
             ):
                 label_inds = label_vecs.new_empty((batchsize))
                 bad_batch = False
@@ -707,9 +707,9 @@ class TorchRankerAgent(TorchAgent):
             cands = self.fixed_candidates
             cand_vecs = self.fixed_candidate_vecs
 
-            if label_vecs is not None and (
-                batch.id != 'internal:vqa_v2:PersonalityTeacherClassifier'
-                and batch.id != 'internal:vqa_v2:PersonalityTeacherRanking'
+            if (
+                label_vecs is not None
+                and batch.id != 'internal:vqa_v2:PersonalityTeacher'
             ):
                 label_inds = label_vecs.new_empty((batchsize))
                 bad_batch = False

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -666,9 +666,8 @@ class TorchRankerAgent(TorchAgent):
                 use_cuda=self.use_cuda,
                 fp16friendly=self.fp16,
             )
-            if (
-                label_vecs is not None
-                and batch.id != 'internal:vqa_v2:PersonalityTeacher'
+            if label_vecs is not None and not batch.id.startswith(
+                'internal:vqa_v2:PersonalityTeacher'
             ):
                 label_inds = label_vecs.new_empty((batchsize))
                 bad_batch = False
@@ -707,9 +706,8 @@ class TorchRankerAgent(TorchAgent):
             cands = self.fixed_candidates
             cand_vecs = self.fixed_candidate_vecs
 
-            if (
-                label_vecs is not None
-                and batch.id != 'internal:vqa_v2:PersonalityTeacher'
+            if label_vecs is not None and not batch.id.startswith(
+                'internal:vqa_v2:PersonalityTeacher'
             ):
                 label_inds = label_vecs.new_empty((batchsize))
                 bad_batch = False

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -432,7 +432,6 @@ class TorchRankerAgent(TorchAgent):
         cands, cand_vecs, label_inds = self._build_candidates(
             batch, source=self.eval_candidates, mode='eval'
         )
-        # import ipdb; ipdb.set_trace()
 
         cand_encs = None
         if self.encode_candidate_vecs and self.eval_candidates in ['fixed', 'vocab']:
@@ -579,7 +578,6 @@ class TorchRankerAgent(TorchAgent):
                 exception of self.NULL_IDX.
         """
         label_vecs = batch.label_vec  # [bsz] list of lists of LongTensors
-        # import ipdb; ipdb.set_trace()
         label_inds = None
         batchsize = (
             batch.text_vec.size(0)
@@ -659,7 +657,6 @@ class TorchRankerAgent(TorchAgent):
                 )
 
             cands = batch.candidates
-            # import ipdb; ipdb.set_trace()
             cand_vecs = padded_3d(
                 batch.candidate_vecs,
                 self.NULL_IDX,
@@ -719,7 +716,6 @@ class TorchRankerAgent(TorchAgent):
                     label_vec_pad[0 : label_vec.size(0)] = label_vec
                     label_inds[batch_idx] = self._find_match(cand_vecs, label_vec_pad)
                     if label_inds[batch_idx] == -1:
-                        # import ipdb; ipdb.set_trace()
                         bad_batch = True
                 if bad_batch:
                     if self.ignore_bad_candidates and not self.is_training:
@@ -742,7 +738,6 @@ class TorchRankerAgent(TorchAgent):
             # the set of vocab candidates
         else:
             raise Exception("Unrecognized source: %s" % source)
-        # import ipdb; ipdb.set_trace()
         return (cands, cand_vecs, label_inds)
 
     @staticmethod

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -747,6 +747,34 @@ def _override_opts_in_shared(table, overrides):
     return table
 
 
+class BatchMultiwWorld(MultiWorld):
+    def __init__(self, opt, worlds):
+        World.__init__(self, opt)
+        self.worlds = worlds
+        self.world_idx = 0
+        self.new_world = True
+        self.parleys = -1
+        self.random = opt.get('datatype', None) == 'train'
+        # Make multi-task task probabilities.
+        self.cum_task_weights = [1] * len(self.worlds)
+        self.task_choices = range(len(self.worlds))
+        weights = self.opt.get('multitask_weights', [1])
+        sum = 0
+        for i in self.task_choices:
+            if len(weights) > i:
+                weight = weights[i]
+            else:
+                weight = 1
+            self.cum_task_weights[i] = weight + sum
+            sum += weight
+
+    def parley_init(self):
+        """
+        Flipping world id
+        """
+        self.world_idx = (self.world_idx + 1) % len(self.worlds)
+
+
 class BatchWorld(World):
     """
     BatchWorld contains many copies of the same world.
@@ -1349,20 +1377,37 @@ def create_task(opt: Opt, user_agents, default_world=None):
     print('[creating task(s): ' + opt['task'] + ']')
 
     # check if single or multithreaded, and single-example or batched examples
+    worlds = []
     if ',' not in opt['task']:
         # Single task
         world = create_task_world(opt, user_agents, default_world=default_world)
     else:
         # Multitask teacher/agent
         # TODO: remove and replace with multiteachers only?
-        world = MultiWorld(opt, user_agents, default_world=default_world)
-
-    if opt.get('numthreads', 1) > 1:
-        # use hogwild world if more than one thread requested
-        # hogwild world will create sub batch worlds as well if bsz > 1
-        world = HogwildWorld(opt, world)
-    elif opt.get('batchsize', 1) > 1:
-        # otherwise check if should use batchworld
-        world = BatchWorld(opt, world)
+        # world = MultiWorld(opt, user_agents, default_world=default_world)
+        for index, k in enumerate(opt['task'].split(',')):
+            k = k.strip()
+            if k:
+                opt_singletask = copy.deepcopy(opt)
+                opt_singletask['task'] = k
+                # Agents are already specified.
+                worlds.append(
+                    BatchWorld(
+                        opt_singletask,
+                        create_task_world(
+                            opt_singletask, user_agents, default_world=default_world
+                        ),
+                    )
+                )
+    if len(worlds) != 0:
+        world = BatchMultiwWorld(opt, worlds)
+    else:
+        if opt.get('numthreads', 1) > 1:
+            # use hogwild world if more than one thread requested
+            # hogwild world will create sub batch worlds as well if bsz > 1
+            world = HogwildWorld(opt, world)
+        elif opt.get('batchsize', 1) > 1:
+            # otherwise check if should use batchworld
+            world = BatchWorld(opt, world)
 
     return world

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -656,7 +656,7 @@ class MultiWorld(World):
         if self.new_world:
             self.new_world = False
             self.parleys = 0
-            if self.random:
+            if False:
                 # select random world
                 self.world_idx = random.choices(
                     self.task_choices, cum_weights=self.cum_task_weights
@@ -838,6 +838,33 @@ class BatchWorld(World):
                 acts[agent_idx] = agents[agent_idx].act()
                 batch_actions.append(acts[agent_idx])
         return batch_actions
+
+    def parley_init(self):
+        """
+        Update the current subworld.
+
+        If we are in the middle of an episode, keep the same world and finish this
+        episode. If we have finished this episode, pick a new world (either in a
+        random or round-robin fashion).
+        """
+        self.parleys = self.parleys + 1
+        if self.world_idx >= 0 and self.worlds[self.world_idx].episode_done():
+            self.new_world = True
+        if self.new_world:
+            self.new_world = False
+            self.parleys = 0
+            if self.random:
+                # select random world
+                self.world_idx = random.choices(
+                    self.task_choices, cum_weights=self.cum_task_weights
+                )[0]
+            else:
+                # do at most one full loop looking for unfinished world
+                for _ in range(len(self.worlds)):
+                    self.world_idx = (self.world_idx + 1) % len(self.worlds)
+                    if not self.worlds[self.world_idx].epoch_done():
+                        # if this world has examples ready, break
+                        break
 
     def parley(self):
         """

--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -809,6 +809,9 @@ def set_namedtuple_defaults(namedtuple, default=None):
 
 _seen_warnings: Set[str] = set()
 
+    if fp16friendly and (t % 4 != 0):
+        # pad to be a multiple of 4 to ensure we use the tensor cores
+        t += 4 - (t % 4)
 
 def warn_once(msg: str, warningtype=None) -> None:
     """

--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -13,6 +13,7 @@ import random
 import time
 from typing import Union, Optional, Set, Any, Dict, List
 import warnings
+from parlai.core.opt import Opt
 
 from parlai.core.message import Message
 
@@ -809,9 +810,6 @@ def set_namedtuple_defaults(namedtuple, default=None):
 
 _seen_warnings: Set[str] = set()
 
-    if fp16friendly and (t % 4 != 0):
-        # pad to be a multiple of 4 to ensure we use the tensor cores
-        t += 4 - (t % 4)
 
 def warn_once(msg: str, warningtype=None) -> None:
     """


### PR DESCRIPTION
**Patch description**
This PR is for collecting feedbacks on how I can get these All-in-One Image-Grounded Conversational Agents https://arxiv.org/abs/1912.12394 paper code merge back to ParlAI. A joint work with @klshuster @ylannb @jaseweston 
This includes several modifications:
1. parlai/core/torch_classifier_agent.py: [A nice plus]
I added codes to load a list of classes file from disk and use them as classification classes on top of the original binary classifier setting.
2. parlai/core/torch_ranker_agent.py [Necessary]
My changes let torch ranker agent take a binary matrix of size [btz * target_classes], this allows it handle multi-label classification. (In the VQA dataset setting, more than one label is considered as correct), so we don't penalize the rest of the correct labels.  
3.  parlai/core/worlds.py[Necessary]
My changes create a new world which flips the multi and batch settings as we had in master. 
4. parlai/utils/misc.py[For compatibility]
For a bug I observed when I tried to load the old model file back. Some previous versions of @klshuster's work packed the opt file with the model file together, and it failed without this line of code. 
