### PR TITLE
More Chat Service Parity

### DIFF
--- a/parlai/chat_service/core/chat_service_manager.py
+++ b/parlai/chat_service/core/chat_service_manager.py
@@ -129,6 +129,8 @@ class ChatServiceManager(ABC):
         def typing_on(self, receiver_id, persona_id=None):
             pass
 
+    EXIT_STR = 'EXIT'
+
     def __init__(self, opt):
         """
         Create a ChatServiceManager using the given setup options.
@@ -309,6 +311,56 @@ class ChatServiceManager(ABC):
                 # send a message observed event to everyone else in the chat
                 self.sender.send_read(partner.id)
 
+    def _remove_agent(self, agent_id):
+        """
+        Remove an agent from the system (after they disconnect or 
+        leave in some other way)
+        """
+        self.observe_message(agent_id, 'See you later!')
+        for world_type in self.agent_pool:
+            agent_state = self.get_agent_state(agent_id)
+            if agent_state in self.agent_pool[world_type]:
+                self.agent_pool[world_type].remove(agent_state)
+                self.remove_agent_from_pool(agent_state, world_type=world_type)
+        del self.messenger_agent_states[agent_id]
+        del self.agent_id_to_overworld_future[agent_id]
+
+    def _launch_overworld(self, agent_id):
+        """
+        Launch an overworld for the given agent id, replacing the existing 
+        overworld if it exists already
+        """
+        agent_state = self.get_agent_state(agent_id)
+        task_id = 'overworld-{}-{}'.format(agent_id, time.time())
+        if agent_state is None:
+            # new agent
+            agent = self._create_agent(task_id, agent_id)
+            agent_state = AgentState(agent_id, agent)
+            self.messenger_agent_states[agent_id] = agent_state
+        else:
+            agent = agent_state.overworld_agent
+            # kill existing overworld
+            self.agent_id_to_overworld_future[agent_id].cancel()
+
+        # launch overworld
+        future = self.world_runner.launch_overworld(
+            task_id, self.overworld, self.onboard_map, agent
+        )
+
+        def _done_callback(fut):
+            e = fut.exception()
+            if e is not None:
+                shared_utils.print_and_log(
+                    logging.ERROR,
+                    'World {} had error {}'.format(task_id, repr(e)),
+                    should_print=True,
+                )
+                if self.debug:
+                    raise e
+
+        future.add_done_callback(_done_callback)
+        self.agent_id_to_overworld_future[agent_id] = future
+
     def _on_first_message(self, message):
         """
         Handle first message from player.
@@ -332,40 +384,7 @@ class ChatServiceManager(ABC):
                 )
                 return
 
-        task_id = 'overworld-{}-{}'.format(agent_id, time.time())
-        agent = self._create_agent(task_id, agent_id)
-        agent_state = AgentState(agent_id, agent)
-        if self.opt['password'] is not None:
-            agent_state.stored_data['first_message'] = message
-        self.messenger_agent_states[agent_id] = agent_state
-
-        # launch overworld
-        future = self.world_runner.launch_overworld(
-            task_id, self.overworld, self.onboard_map, agent
-        )
-
-        def _done_callback(fut):
-            e = fut.exception()
-            if e is not None:
-                shared_utils.print_and_log(
-                    logging.ERROR,
-                    'World {} had error {}'.format(task_id, repr(e)),
-                    should_print=True,
-                )
-                if self.debug:
-                    raise e
-            else:
-                self.observe_message(agent_id, 'See you later!')
-                for world_type in self.agent_pool:
-                    agent_state = self.get_agent_state(agent_id)
-                    if agent_state in self.agent_pool[world_type]:
-                        self.agent_pool[world_type].remove(agent_state)
-                        self.remove_agent_from_pool(agent_state, world_type=world_type)
-                del self.messenger_agent_states[agent_id]
-                del self.agent_id_to_overworld_future[agent_id]
-
-        future.add_done_callback(_done_callback)
-        self.agent_id_to_overworld_future[agent_id] = future
+        self._launch_overworld(agent_id)
 
     def _on_new_message(self, message):
         """
@@ -419,7 +438,7 @@ class ChatServiceManager(ABC):
         Add the agent to pool.
 
         :param agent:
-            MessengerAgent object
+            AgentState object
         :param world_type:
             Name of world whose pool should now contain agent
         """
@@ -577,13 +596,9 @@ class ChatServiceManager(ABC):
                     self.sender.typing_on(agent_state.service_id)
                     agent_state.stored_data['seen_wait_message'] = True
 
-    def start_task(self):
+    def _get_done_callback_for_agents(self, task_id, world_type, agents):
         """
-        Begin handling task.
-
-        Periodically check to see when enough agents are in the agent pool to start an
-        instance of the task. Continue doing this until the desired number of
-        conversations is had.
+        Create a done callback for finishing a task world with particular agents
         """
 
         def _done_callback(fut):
@@ -614,7 +629,28 @@ class ChatServiceManager(ABC):
             for agent in agents:
                 self.after_agent_removed(agent.id)
                 agent_state = self.get_agent_state(agent.id)
-                agent_state.set_active_agent(agent_state.get_overworld_agent())
+                next_task = agent.data.get("next_task")
+                shared_utils.print_and_log(
+                    logging.INFO, "Next task: {}".format(next_task)
+                )
+                if next_task is None:
+                    self._launch_overworld(agent.id)
+                    agent_state.set_active_agent(agent_state.get_overworld_agent())
+                elif next_task == self.EXIT_STR:
+                    self._remove_agent(agent.id)
+                else:
+                    self.add_agent_to_pool(agent_state, next_task)
+
+        return _done_callback
+
+    def start_task(self):
+        """
+        Begin handling task.
+
+        Periodically check to see when enough agents are in the agent pool to start an
+        instance of the task. Continue doing this until the desired number of
+        conversations is had.
+        """
 
         self.running = True
         while self.running:
@@ -672,11 +708,16 @@ class ChatServiceManager(ABC):
                             partner_list = agents.copy()
                             partner_list.remove(a)
                             a.message_partners = partner_list
+
+                        done_callback = self._get_done_callback_for_agents(
+                            task_id, world_type, agents
+                        )
+
                         # launch task world.
                         future = self.world_runner.launch_task_world(
                             task_id, self.taskworld_map[world_type], agents
                         )
-                        future.add_done_callback(_done_callback)
+                        future.add_done_callback(done_callback)
                         self.active_worlds[task_id] = future
 
             time.sleep(shared_utils.THREAD_MEDIUM_SLEEP)

--- a/parlai/chat_service/core/chat_service_manager.py
+++ b/parlai/chat_service/core/chat_service_manager.py
@@ -313,8 +313,8 @@ class ChatServiceManager(ABC):
 
     def _remove_agent(self, agent_id):
         """
-        Remove an agent from the system (after they disconnect or 
-        leave in some other way)
+        Remove an agent from the system (after they disconnect or leave in some other
+        way)
         """
         self.observe_message(agent_id, 'See you later!')
         for world_type in self.agent_pool:
@@ -327,8 +327,8 @@ class ChatServiceManager(ABC):
 
     def _launch_overworld(self, agent_id):
         """
-        Launch an overworld for the given agent id, replacing the existing 
-        overworld if it exists already
+        Launch an overworld for the given agent id, replacing the existing overworld if
+        it exists already.
         """
         agent_state = self.get_agent_state(agent_id)
         task_id = 'overworld-{}-{}'.format(agent_id, time.time())
@@ -598,7 +598,7 @@ class ChatServiceManager(ABC):
 
     def _get_done_callback_for_agents(self, task_id, world_type, agents):
         """
-        Create a done callback for finishing a task world with particular agents
+        Create done callback for finishing task world with particular agents.
         """
 
         def _done_callback(fut):

--- a/parlai/chat_service/core/manager_utils.py
+++ b/parlai/chat_service/core/manager_utils.py
@@ -334,6 +334,10 @@ class ChatServiceWorldRunner:
                     time.sleep(0.5)
                     continue
 
+                if world_type == self.manager.EXIT_STR:
+                    self.manager._remove_agent(overworld_agent.id)
+                    return world_type
+
                 # perform onboarding
                 onboard_type = onboard_map.get(world_type)
                 if onboard_type:
@@ -345,7 +349,6 @@ class ChatServiceWorldRunner:
                     agent_state.onboard_data = onboard_data
                 self.manager.add_agent_to_pool(agent_state, world_type)
                 utils.print_and_log(logging.INFO, 'onboarding/overworld complete')
-                time.sleep(5)
 
             return world_type
 

--- a/parlai/chat_service/core/manager_utils.py
+++ b/parlai/chat_service/core/manager_utils.py
@@ -347,11 +347,6 @@ class ChatServiceWorldRunner:
                 utils.print_and_log(logging.INFO, 'onboarding/overworld complete')
                 time.sleep(5)
 
-                # sleep until agent returns from task world
-                while agent_state.get_active_agent() != overworld_agent:
-                    time.sleep(2)
-                overworld.return_overworld()
-            utils.print_and_log(logging.INFO, 'exiting overworld')
             return world_type
 
         fut = self.executor.submit(_world_function)

--- a/parlai/chat_service/services/messenger/worlds.py
+++ b/parlai/chat_service/services/messenger/worlds.py
@@ -19,9 +19,6 @@ class SimpleMessengerOverworld(World):
         self.agent = agent
         self.opt = opt
 
-    def return_overworld(self):
-        pass
-
     @staticmethod
     def generate_world(opt, agents):
         return SimpleMessengerOverworld(opt, agents[0])

--- a/parlai/chat_service/services/terminal_chat/client.py
+++ b/parlai/chat_service/services/terminal_chat/client.py
@@ -36,7 +36,12 @@ def on_message(ws, message):
     :param message: json with 'text' field to be printed
     """
     incoming_message = json.loads(message)
-    print("\033[0m\nBot: " + incoming_message['text'], "\033[44m\n")
+    print("\033[0m\n")
+    print("Bot: " + incoming_message['text'])
+    quick_replies = incoming_message.get('quick_replies')
+    if quick_replies is not None and len(quick_replies) > 0:
+        print(f"\nOptions: [{'|'.join(quick_replies)}]")
+    print("\033[44m\n")
 
 
 def on_error(ws, error):

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -87,35 +87,6 @@ class WebsocketManager(ChatServiceManager):
         An iteration of the manager's main loop to launch worlds.
         """
 
-        def _done_callback(fut):
-            """
-            Log and raise exception of task world, if there is one.
-
-            Additionally, set active agent to overworld agent.
-            """
-            e = fut.exception()
-            if e is not None:
-                shared_utils.print_and_log(
-                    logging.ERROR,
-                    'World {} had error {}'.format(world_type, repr(e)),
-                    should_print=True,
-                )
-                traceback.print_exc(file=sys.stdout)
-                for agent in agents:
-                    self.observe_message(
-                        agent.id, 'Sorry, this world closed. Returning to overworld.'
-                    )
-            else:
-                shared_utils.print_and_log(
-                    logging.INFO,
-                    'World {} had no error'.format(world_type),
-                    should_print=True,
-                )
-            self.active_worlds[task_id] = None
-            for agent in agents:
-                agent_state = self.get_agent_state(agent.id)
-                agent_state.set_active_agent(agent_state.get_overworld_agent())
-
         with self.agent_pool_change_condition:
             valid_pools = self._get_unique_pool()
             for world_type, agent_pool in valid_pools.items():
@@ -168,11 +139,16 @@ class WebsocketManager(ChatServiceManager):
                         partner_list = agents.copy()
                         partner_list.remove(a)
                         a.message_partners = partner_list
+
+                    done_callback = self._get_done_callback_for_agents(
+                        task_id, world_type, agents
+                    )
+
                     # launch task world.
                     future = self.world_runner.launch_task_world(
                         task_id, self.taskworld_map[world_type], agents
                     )
-                    future.add_done_callback(_done_callback)
+                    future.add_done_callback(done_callback)
                     self.active_worlds[task_id] = future
 
     def start_task(self):

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -11,8 +11,6 @@ ParlAI via websockets.
 import json
 import asyncio
 import logging
-import traceback
-import sys
 from parlai.core.agents import create_agent
 from parlai.chat_service.core.chat_service_manager import ChatServiceManager
 

--- a/parlai/chat_service/tasks/chatbot/worlds.py
+++ b/parlai/chat_service/tasks/chatbot/worlds.py
@@ -96,9 +96,6 @@ class MessengerOverworld(World):
         self.first_time = True
         self.episodeDone = False
 
-    def return_overworld(self):
-        self.first_time = True
-
     @staticmethod
     def generate_world(opt, agents):
         return MessengerOverworld(opt, agents[0])

--- a/parlai/chat_service/tasks/overworld_demo/worlds.py
+++ b/parlai/chat_service/tasks/overworld_demo/worlds.py
@@ -252,6 +252,7 @@ class MessengerOverworld(World):
             MessengerOnboardDataTaskWorld,
         ),
         'chat': (MessengerChatOnboardWorld, MessengerChatTaskWorld),
+        'EXIT': (None, None),
     }
 
     def __init__(self, opt, agent):

--- a/parlai/chat_service/tasks/overworld_demo/worlds.py
+++ b/parlai/chat_service/tasks/overworld_demo/worlds.py
@@ -261,9 +261,6 @@ class MessengerOverworld(World):
         self.first_time = True
         self.episodeDone = False
 
-    def return_overworld(self):
-        self.first_time = True
-
     @staticmethod
     def generate_world(opt, agents):
         return MessengerOverworld(opt, agents[0])


### PR DESCRIPTION
## Patch description
**TL:DR;** External chat services were only built to handle one single pass of a task world, and would treat subsequent messages as new instances rather than one continuous flow. This PR restores the idea of returning to a fresh overworld, and also includes the fixes that let us direct from task world to task world. This should increase the parity between OSS and our internal stuff, letting us deploy the same worlds in both places.

### Extended:
FB-Internal chat worlds were using a specific task flow surrounding launching overworlds, onboarding worlds, and tasks worlds, generally splitting into having the overworld and onboarding handled by one thread and then the task later. This behavior was mirrored here in Chat Services, except for the fact that in FB-Intern we allow the overworld/onboarding thread to exit and create a new one when the agent wants to return, but chat services would return someone to the long-running overworld thread that already existed. This was an old, somewhat inefficient model that we've deprecated internally, and so I've tried to update the external code with as minimal changes as possible to get to parity. 

This involved refactoring the `_done_callback` method for a task world (now in `_get_done_callback_for_agents`), the process for launching an overworld (now in `_launch_overworld` rather than hidden within `_on_first_message`), and the process for removing an agent for real (now in `_remove_agent`, not as a part of the task world's `_done_callback`).

I also updated the `TerminalChat` UI to show quick replies 👍 

## Testing steps
I launched the overworld demo task and tried using the onboard data task more than once in a row. I also added an EXIT option to the overworld to ensure that it would dump my information (and future messages would appear as a new user).

## Logs
### Return to overworld test
```
[ Terminal Chat: ] 
[  port: 1234 ]
[ Current ParlAI commit: 4a1f4e06166dedabf89545c6d7256b9d66395943 ]
[ Current internal commit: 4558a046a633fa1b54869231e45d7dc042dcc938 ]
Connecting to port:  1234
 Me: ParlAI

Bot: Welcome to the overworld for the ParlAI messenger demo. Choose one of the demos from the listed quick replies. 

Options: [echo|onboard data|chat]

 Me: onboard data

Bot: Transferring to onboard data


Bot: Welcome to the onboarding world the onboarding data demo.<br />Enter your name.

 Me: Jack

Bot: <br />Enter your favorite color.

 Me: Blue

Bot: During onboarding, you said your name was Jack and your favorite color was Blue


Bot: Welcome to the overworld for the ParlAI messenger demo. Choose one of the demos from the listed quick replies. 

Options: [echo|onboard data|chat]

 Me: echo

Bot: Transferring to echo


Bot: Welcome to the onboarding world for our echo bot. The next message you send will be echoed. Use [DONE] to finish the chat.

 Me: beep

Bot: beep

 Me: [DONE]
```
### Exit test
```
[ Terminal Chat: ] 
[  port: 1234 ]
Connecting to port:  1234
 Me: ParlAI

Bot: Welcome to the overworld for the ParlAI messenger demo. Choose one of the demos from the listed quick replies. 

Options: [echo|onboard data|chat|EXIT]

E Me: XIT

Bot: Transferring to EXIT


Bot: See you later!

 Me: hello

Bot: Sorry, this conversation bot is password-protected. If you have the password, please send it now.

 Me: ParlAI

Bot: Welcome to the overworld for the ParlAI messenger demo. Choose one of the demos from the listed quick replies. 

Options: [echo|onboard data|chat|EXIT]

 Me: EXIT

Bot: Transferring to EXIT


Bot: See you later!
```

# Discussion
I don't actually know how/if this interfaces with any other projects we are currently working on relying on `ChatService`, in fact I'm not sure how they could've been properly working before (insofar as getting into more than one task world). Happy to do additional testing elsewhere if needed.