### PR TITLE
Pass in non-string flags in task name

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2166,7 +2166,24 @@ def _add_task_flags_to_agent_opt(agent, opt: Opt, flags):
     for f in fl:
         if '=' in f:
             one_flag = f.split('=')
-            opt[one_flag[0].replace('-', '_')] = one_flag[1].replace(';', ':')
+            key = one_flag[0].replace('-', '_')
+            raw_value = one_flag[1].replace(';', ':')
+
+            # Convert to bool/int/float if necessary
+            if raw_value.lower() == 'true':
+                value = True
+            elif raw_value.lower() == 'false':
+                value = False
+            else:
+                try:
+                    value = int(raw_value)
+                except ValueError:
+                    try:
+                        value = float(raw_value)
+                    except ValueError:
+                        value = raw_value
+
+            opt[key] = value
         else:
             task.append(f)
     opt['task'] = ':'.join(task)


### PR DESCRIPTION
**Patch description**
Pass in non-string flag values in task names using the ":" notation

**Testing steps**
```
>>> from parlai.core.teachers import _add_task_flags_to_agent_opt
>>> from parlai.core.opt import Opt
>>> opt = Opt({})
>>> flags='TestTeacher:flag1=string:flag2=true:flag3=false:flag4=4:flag5=5.0:flag6=foo'
>>> _add_task_flags_to_agent_opt(agent=None, opt=opt, flags=flags)
>>> opt
```
gives `{'flag1': 'string', 'flag2': True, 'flag3': False, 'flag4': 4, 'flag5': 5.0, 'flag6': 'foo', 'task': 'TestTeacher'}` as expected
