### PR TITLE
[FP16] FP16-safe cross entropy loss

### DIFF
--- a/parlai/agents/hugging_face/gpt2.py
+++ b/parlai/agents/hugging_face/gpt2.py
@@ -7,7 +7,7 @@
 from parlai.core.torch_generator_agent import TorchGeneratorAgent, TorchGeneratorModel
 from parlai.agents.hugging_face.dict import Gpt2DictionaryAgent
 from parlai.utils.misc import warn_once
-from parlai.utils.torch import IdentityLayer, concat_without_padding
+from parlai.utils.torch import IdentityLayer, concat_without_padding, padded_tensor
 
 try:
     from transformers import GPT2Model
@@ -262,3 +262,14 @@ class Gpt2Agent(TorchGeneratorAgent):
 
     def _encoder_input(self, batch):
         return (batch.text_vec,)
+
+    def _pad_tensor(self, items):
+        """
+        Override to always set fp16friendly to False.
+        """
+        return padded_tensor(
+            items,
+            pad_idx=self.NULL_IDX,
+            use_cuda=self.use_cuda,
+            fp16friendly=False,
+        )

--- a/parlai/agents/hugging_face/gpt2.py
+++ b/parlai/agents/hugging_face/gpt2.py
@@ -268,8 +268,5 @@ class Gpt2Agent(TorchGeneratorAgent):
         Override to always set fp16friendly to False.
         """
         return padded_tensor(
-            items,
-            pad_idx=self.NULL_IDX,
-            use_cuda=self.use_cuda,
-            fp16friendly=False,
+            items, pad_idx=self.NULL_IDX, use_cuda=self.use_cuda, fp16friendly=False,
         )

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1256,8 +1256,7 @@ class TorchAgent(ABC, Agent):
         return obs
 
     def _pad_tensor(
-        self,
-        items: List[Union[List[int], torch.LongTensor]]
+        self, items: List[Union[List[int], torch.LongTensor]]
     ) -> Tuple[torch.LongTensor, List[int]]:
         """
         Create a right padded matrix from an uneven list of lists.

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -30,7 +30,7 @@ from parlai.core.opt import Opt
 from parlai.utils.distributed import is_distributed, sync_parameters
 from parlai.core.torch_agent import TorchAgent, Batch, Output
 from parlai.utils.misc import round_sigfigs, warn_once
-from parlai.utils.torch import padded_tensor, neginf
+from parlai.utils.torch import neginf, FP16SafeCrossEntropy
 
 
 try:
@@ -418,7 +418,11 @@ class TorchGeneratorAgent(TorchAgent, ABC):
 
         If overridden, this model should produce a sum that can be used for a per-token loss.
         """
-        return torch.nn.CrossEntropyLoss(ignore_index=self.NULL_IDX, reduction='none')
+        if not self.fp16:
+            return torch.nn.CrossEntropyLoss(ignore_index=self.NULL_IDX, reduction='none')
+        else:
+            # FP16 safe cross entropy (softmax done in FP32)
+            return FP16SafeCrossEntropy(ignore_index=self.NULL_IDX, reduction='none')
 
     def _v2t(self, vec):
         """
@@ -792,9 +796,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
             for i in range(bsz):
                 num_cands = len(batch.candidate_vecs[i])
                 enc = self.model.reorder_encoder_states(encoder_states, [i] * num_cands)
-                cands, _ = padded_tensor(
-                    batch.candidate_vecs[i], self.NULL_IDX, self.use_cuda
-                )
+                cands, _ = self._pad_tensor(batch.candidate_vecs[i])
                 scores, _ = self.model.decode_forced(enc, cands)
                 cand_losses = F.cross_entropy(
                     scores.view(num_cands * cands.size(1), -1),

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -419,7 +419,9 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         If overridden, this model should produce a sum that can be used for a per-token loss.
         """
         if not self.fp16:
-            return torch.nn.CrossEntropyLoss(ignore_index=self.NULL_IDX, reduction='none')
+            return torch.nn.CrossEntropyLoss(
+                ignore_index=self.NULL_IDX, reduction='none'
+            )
         else:
             # FP16 safe cross entropy (softmax done in FP32)
             return FP16SafeCrossEntropy(ignore_index=self.NULL_IDX, reduction='none')

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -24,7 +24,7 @@ from parlai.core.opt import Opt
 from parlai.utils.distributed import is_distributed
 from parlai.core.torch_agent import TorchAgent, Output
 from parlai.utils.misc import round_sigfigs, warn_once
-from parlai.utils.torch import padded_3d, padded_tensor
+from parlai.utils.torch import padded_3d
 
 
 class TorchRankerAgent(TorchAgent):
@@ -634,12 +634,7 @@ class TorchRankerAgent(TorchAgent):
                         cands.append(cand)
                         cands_to_id[cand] = len(cands_to_id)
                         all_cands_vecs.append(batch.candidate_vecs[i][j])
-            cand_vecs, _ = padded_tensor(
-                all_cands_vecs,
-                self.NULL_IDX,
-                use_cuda=self.use_cuda,
-                fp16friendly=self.fp16,
-            )
+            cand_vecs, _ = self._pad_tensor(all_cands_vecs)
             label_inds = label_vecs.new_tensor(
                 [cands_to_id[label] for label in batch.labels]
             )

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -275,9 +275,9 @@ class FP16SafeCrossEntropy(torch.nn.Module):
     """
     FP16-safe cross entropy loss.
 
-    This avoids overflow in the softmax by doing the operation
-    in FP32.
+    This avoids overflow in the softmax by doing the operation in FP32.
     """
+
     def __init__(self, ignore_index, reduction='none'):
         super().__init__()
         self.NULL_IDX = ignore_index
@@ -304,4 +304,3 @@ class IdentityLayer(torch.nn.Module):
         Identity.
         """
         return xs
-

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -16,6 +16,7 @@ except ImportError:
     raise ImportError('Parlai requires pytorch. Go to http://pytorch.org to install.')
 
 import torch.optim
+import torch.nn.functional as F
 
 """Near infinity, useful as a large penalty for scoring when inf is bad."""
 NEAR_INF = 1e20
@@ -41,7 +42,7 @@ def padded_tensor(
     fp16friendly: bool = False,
 ) -> Tuple[torch.LongTensor, List[int]]:
     """
-    Create a right-padded matrix from an uneven list of lists.
+    Create a padded matrix from an uneven list of lists.
 
     Returns (padded, lengths), where padded is the padded matrix, and lengths
     is a list containing the lengths of each row.
@@ -270,6 +271,27 @@ def fp16_available() -> bool:
         return False
 
 
+class FP16SafeCrossEntropy(torch.nn.Module):
+    """
+    FP16-safe cross entropy loss.
+
+    This avoids overflow in the softmax by doing the operation
+    in FP32.
+    """
+    def __init__(self, ignore_index, reduction='none'):
+        super().__init__()
+        self.NULL_IDX = ignore_index
+        self.reduction = reduction
+
+    def forward(self, scores, targets):
+        return F.nll_loss(
+            F.log_softmax(scores, 1, dtype=torch.float32),
+            targets,
+            ignore_index=self.NULL_IDX,
+            reduction=self.reduction,
+        )
+
+
 class IdentityLayer(torch.nn.Module):
     """
     Identity layer module.
@@ -282,3 +304,4 @@ class IdentityLayer(torch.nn.Module):
         Identity.
         """
         return xs
+


### PR DESCRIPTION
**Patch description**
Added an FP16-safe cross entropy loss, which computes the softmax in FP32 to avoid overflow.

Additionally, I added an edit to Torch Agent that allows us to override the way we pad tensors. The immediate use for this is in the GPT-2 agent implementation, to allow us to train in FP16.


EDIT: have confirmed that there is no performance difference between regular cross entropy and "safe" cross entropy in FP16.