### PR TITLE
[WIP] Fix WoW oddities

### DIFF
--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -413,14 +413,14 @@ class BasicdialogTeacher(WizardOfWikipediaTeacher):
 
 class BasicWizardDialogTeacher(BasicdialogTeacher):
     def __init__(self, opt, shared=None):
+        opt['speaker_label'] = "wizard"
         super().__init__(opt, shared)
-        self.speaker_label = "wizard"
 
 
 class BasicApprenticeDialogTeacher(BasicdialogTeacher):
     def __init__(self, opt, shared=None):
+        opt['speaker_label'] = 'apprentice'
         super().__init__(opt, shared)
-        self.speaker_label = 'apprentice'
 
 
 class BasicBothDialogTeacher(MultiTaskTeacher):

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -414,14 +414,12 @@ class BasicWizardDialogTeacher(BasicdialogTeacher):
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
         self.speaker_label = "wizard"
-        self.add_topic = True
 
 
 class BasicApprenticeDialogTeacher(BasicdialogTeacher):
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
         self.speaker_label = 'apprentice'
-        self.add_topic = True
 
 
 class BasicBothDialogTeacher(MultiTaskTeacher):

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -348,7 +348,7 @@ class BasicdialogTeacher(WizardOfWikipediaTeacher):
         super().__init__(opt, shared)
         self.speaker_label = opt.get('speaker_label', 'both')
         self.add_topic = opt.get('add_topic', False)
-        self.num_exs = sum(len(d['dialog']) // 2 for d in self.data)
+        self.num_exs = sum(self.len_episode(i) for i in range(len(self.data)))
 
     @staticmethod
     def add_cmdline_args(argparser):

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -392,6 +392,7 @@ class BasicdialogTeacher(WizardOfWikipediaTeacher):
         text = dialog_entry_1['text']
         labels = [dialog_entry_2['text']]
 
+        assert isinstance(self.add_topic, bool)
         if self.add_topic and entry_idx == 0:
             text = d.get('chosen_topic', '') + '\n' + text
 


### PR DESCRIPTION
1. Remove discrepancy in the number of examples in some of the WoW teachers
1. Don't add WoW topic by default for `BasicWizardDialogTeacher`, `BasicApprenticeDialogTeacher`, and `BasicBothDialogTeacher`, because it's not added by default to the other WoW teachers and it'd be good to be able to use these teachers without having WoW topic added. (This screwed me up for a bit when I was testing negative-history-candidate training.)