### PR TITLE
Acute-Eval helper code

### DIFF
--- a/parlai/mturk/tasks/acute_eval/run.py
+++ b/parlai/mturk/tasks/acute_eval/run.py
@@ -102,6 +102,12 @@ def add_args(from_argv=False):
     argparser.add_argument(
         '--seed', type=int, default=42, help='seed for random and np.random'
     )
+    argparser.add_argument(
+        '--softblock-list-path',
+        type=str,
+        default=None,
+        help='Path to list of workers to softblock, separated by line breaks',
+    )
     argparser.set_defaults(allowed_conversation=1)
     if from_argv:
         return argparser.parse_args()
@@ -410,15 +416,14 @@ def main(opt):
                 )
             return save_data
 
-        if not opt['is_sandbox']:
-
-            # Soft-block all chosen workers
-            violating_workers_path = '/private/home/ems/GitHub/facebookresearch/ParlAI/parlai_internal/mturk/tasks/pairwise_dialogue_eval/scripts/workers.txt'
-            violating_workers = []
-            with open(violating_workers_path, 'r') as f:
+        # Soft-block all chosen workers
+        if not opt['is_sandbox'] and opt['softblock_list_path'] is not None:
+            softblock_list = set()
+            with open(opt['softblock_list_path'], 'r') as f:
                 for line in f:
-                    violating_workers.append(line.strip())
-            for w in set(FULL_BLOCKLIST + violating_workers):
+                    softblock_list.add(line.strip())
+            print(f'Will softblock {len(softblock_list):d} workers.')
+            for w in softblock_list:
                 try:
                     print('Soft Blocking {}\n'.format(w))
                     mturk_manager.soft_block_worker(w)

--- a/parlai/mturk/tasks/acute_eval/run.py
+++ b/parlai/mturk/tasks/acute_eval/run.py
@@ -15,9 +15,6 @@ from parlai.core.params import ParlaiParser
 from parlai.mturk.core.mturk_manager import StaticMTurkManager
 from parlai.mturk.core.worlds import StaticMTurkTaskWorld
 from parlai.utils.misc import warn_once
-from parlai_internal.mturk.tasks.blended_skill_talk.human_and_bot_convos.constants import (
-    FULL_BLOCKLIST,
-)
 
 
 DEFAULT_TASK_CONFIG = {

--- a/parlai/mturk/tasks/acute_eval/run.py
+++ b/parlai/mturk/tasks/acute_eval/run.py
@@ -9,11 +9,15 @@ import numpy as np
 import os
 from queue import Queue
 import random
+import time
 
 from parlai.core.params import ParlaiParser
 from parlai.mturk.core.mturk_manager import StaticMTurkManager
 from parlai.mturk.core.worlds import StaticMTurkTaskWorld
 from parlai.utils.misc import warn_once
+from parlai_internal.mturk.tasks.blended_skill_talk.human_and_bot_convos.constants import (
+    FULL_BLOCKLIST,
+)
 
 
 DEFAULT_TASK_CONFIG = {
@@ -405,6 +409,23 @@ def main(opt):
                     save_data,
                 )
             return save_data
+
+        if not opt['is_sandbox']:
+
+            # Soft-block all chosen workers
+            violating_workers_path = '/private/home/ems/GitHub/facebookresearch/ParlAI/parlai_internal/mturk/tasks/pairwise_dialogue_eval/scripts/workers.txt'
+            violating_workers = []
+            with open(violating_workers_path, 'r') as f:
+                for line in f:
+                    violating_workers.append(line.strip())
+            import pdb; pdb.set_trace()
+            for w in set(FULL_BLOCKLIST + violating_workers):
+                try:
+                    print('Soft Blocking {}\n'.format(w))
+                    mturk_manager.soft_block_worker(w)
+                except Exception as e:
+                    print(f'Did not soft block worker {w}: {e}')
+                time.sleep(0.1)
 
         print("This run id: {}".format(task_group_id))
 

--- a/parlai/mturk/tasks/acute_eval/run.py
+++ b/parlai/mturk/tasks/acute_eval/run.py
@@ -418,7 +418,6 @@ def main(opt):
             with open(violating_workers_path, 'r') as f:
                 for line in f:
                     violating_workers.append(line.strip())
-            import pdb; pdb.set_trace()
             for w in set(FULL_BLOCKLIST + violating_workers):
                 try:
                     print('Soft Blocking {}\n'.format(w))

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Utility functions and classes for handling text strings.
+"""
+
+
+def format_model_reply(text: str) -> str:
+    """Standardize the capitalization and punctuation spacing of the input text."""
+
+    switch_list = [(' .', '.'), (' ,', ','), (' ?', '?'), (' !', '!'), (" ' ", "'")]
+
+    # add spaces so that words and punctuation can be seaprated
+    new_text = text.lower()
+
+    # normalize in case of human:
+    for new, old in switch_list:
+        new_text = new_text.replace(old, new).replace('  ', ' ')
+
+    # split on punctuation to find sentence boundaries
+    # capitalize stuff
+    tokens = new_text.split(' ')
+    for i in range(len(tokens)):
+        if i == 0:
+            tokens[i] = uppercase(tokens[i])
+        elif tokens[i] in ('i', "i'm", "i've", "i'll", "i'd"):
+            tokens[i] = uppercase(tokens[i])
+        elif tokens[i] in '?.!' and i < len(tokens) - 1:
+            tokens[i + 1] = uppercase(tokens[i + 1])
+    new_text = ' '.join(tokens)
+    new_text = ' ' + new_text + ' '
+
+    for tup in switch_list:
+        new_text = new_text.replace(tup[0], tup[1])
+
+    # get rid of surrounding whitespace
+    new_text = new_text.strip()
+    new_text = new_text.replace('  ', ' ')
+
+    return new_text
+
+
+def uppercase(string: str) -> str:
+    """Make the first character of the string uppercase, if the string is non-empty."""
+    if len(string) == 0:
+        return string
+    else:
+        return string[0].upper() + string[1:]

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -8,7 +8,7 @@ Utility functions and classes for handling text strings.
 """
 
 
-def format_model_reply(text: str) -> str:
+def standardize_string(text: str) -> str:
     """Standardize the capitalization and punctuation spacing of the input text."""
 
     switch_list = [(' .', '.'), (' ,', ','), (' ?', '?'), (' !', '!'), (" ' ", "'")]

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -8,7 +8,7 @@ Utility functions and classes for handling text strings.
 """
 
 
-def standardize_string(text: str) -> str:
+def normalize_reply(text: str) -> str:
     """
     Standardize the capitalization and punctuation spacing of the input text.
     """

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -9,7 +9,9 @@ Utility functions and classes for handling text strings.
 
 
 def standardize_string(text: str) -> str:
-    """Standardize the capitalization and punctuation spacing of the input text."""
+    """
+    Standardize the capitalization and punctuation spacing of the input text.
+    """
 
     switch_list = [(' .', '.'), (' ,', ','), (' ?', '?'), (' !', '!'), (" ' ", "'")]
 
@@ -44,7 +46,9 @@ def standardize_string(text: str) -> str:
 
 
 def uppercase(string: str) -> str:
-    """Make the first character of the string uppercase, if the string is non-empty."""
+    """
+    Make the first character of the string uppercase, if the string is non-empty.
+    """
     if len(string) == 0:
         return string
     else:

--- a/projects/controllable_dialogue/mturk/worlds.py
+++ b/projects/controllable_dialogue/mturk/worlds.py
@@ -8,6 +8,7 @@ from parlai.mturk.core.legacy_2018.agents import TIMEOUT_MESSAGE
 from parlai.core.worlds import validate, MultiAgentDialogWorld
 from parlai.mturk.core.legacy_2018.worlds import MTurkOnboardWorld
 from parlai.core.message import Message
+from parlai.utils.strings import format_model_reply
 
 from joblib import Parallel, delayed
 import numpy as np
@@ -164,13 +165,6 @@ def _strip_tensors(act):
 
 def _random_delay():
     time.sleep(max(0, 4 + np.random.randn() * 0.5))
-
-
-def uppercase(string):
-    if len(string) == 0:
-        return string
-    else:
-        return string[0].upper() + string[1:]
 
 
 class PersonasGenerator(object):
@@ -341,37 +335,6 @@ class ControllableDialogEval(MultiAgentDialogWorld):
             act = agent.act(timeout=self.max_resp_time)
         return act
 
-    def format_model_reply(self, text):
-        switch_list = [(' .', '.'), (' ,', ','), (' ?', '?'), (' !', '!'), (" ' ", "'")]
-        # add the spaces so that
-        new_text = text.lower()
-
-        # normalize in case of human:
-        for new, old in switch_list:
-            new_text = new_text.replace(old, new).replace('  ', ' ')
-
-        # split on punctuation to find sentence boundaries
-        # capitalize stuff
-        tokens = new_text.split(' ')
-        for i in range(len(tokens)):
-            if i == 0:
-                tokens[i] = uppercase(tokens[i])
-            elif tokens[i] in ('i', "i'm", "i've", "i'll", "i'd"):
-                tokens[i] = uppercase(tokens[i])
-            elif tokens[i] in '?.!' and i < len(tokens) - 1:
-                tokens[i + 1] = uppercase(tokens[i + 1])
-        new_text = ' '.join(tokens)
-        new_text = ' ' + new_text + ' '
-
-        for tup in switch_list:
-            new_text = new_text.replace(tup[0], tup[1])
-
-        # get rid of surrounding whitespace
-        new_text = new_text.strip()
-        new_text = new_text.replace('  ', ' ')
-
-        return new_text
-
     def format_personachat_text(self, text):
         new_text = text.lower()
 
@@ -439,7 +402,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
                 self.model_agent.observe(persona_act)
                 self.bot_seen_persona = True
                 model_act = copy.deepcopy(self.model_agent.act())
-                model_act.force_set('text', self.format_model_reply(model_act['text']))
+                model_act.force_set('text', format_model_reply(model_act['text']))
                 model_act.force_set('id', 'PERSON_2')
                 self.dialog.append((1, model_act.get('text')))
                 _random_delay()
@@ -456,7 +419,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
                 else:
                     self.dialog.append((1, act.get('text')))
                     act = copy.deepcopy(act)
-                    act.force_set('text', self.format_model_reply(act['text']))
+                    act.force_set('text', format_model_reply(act['text']))
                     self.eval_agent.observe(act)
 
         # Eval agent turn
@@ -500,7 +463,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
             self.model_agent.observe(act)
         else:
             act = copy.deepcopy(act)
-            act.force_set('text', self.format_model_reply(act['text']))
+            act.force_set('text', format_model_reply(act['text']))
             self.other_agent.observe(act)
 
         # Model_agent turn
@@ -508,7 +471,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
             if self.model_agent is not None:
                 _random_delay()
                 act = _strip_tensors(copy.deepcopy(self.model_agent.act()))
-                act.force_set('text', self.format_model_reply(act['text']))
+                act.force_set('text', format_model_reply(act['text']))
                 act.force_set('id', 'PERSON_2')
                 # NOTE: your model may or may not need to observe itself here
                 # If it does, call model_observes_itself or some other specialized
@@ -525,7 +488,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
 
             self.dialog.append((1, act.get('text')))
             act = copy.deepcopy(act)
-            act.force_set('text', self.format_model_reply(act['text']))
+            act.force_set('text', format_model_reply(act['text']))
             self.eval_agent.observe(act)
 
     def _evaluate_characteristic(self, question, choices, addto):

--- a/projects/controllable_dialogue/mturk/worlds.py
+++ b/projects/controllable_dialogue/mturk/worlds.py
@@ -8,7 +8,7 @@ from parlai.mturk.core.legacy_2018.agents import TIMEOUT_MESSAGE
 from parlai.core.worlds import validate, MultiAgentDialogWorld
 from parlai.mturk.core.legacy_2018.worlds import MTurkOnboardWorld
 from parlai.core.message import Message
-from parlai.utils.strings import standardize_string
+from parlai.utils.strings import normalize_reply
 
 from joblib import Parallel, delayed
 import numpy as np
@@ -402,7 +402,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
                 self.model_agent.observe(persona_act)
                 self.bot_seen_persona = True
                 model_act = copy.deepcopy(self.model_agent.act())
-                model_act.force_set('text', standardize_string(model_act['text']))
+                model_act.force_set('text', normalize_reply(model_act['text']))
                 model_act.force_set('id', 'PERSON_2')
                 self.dialog.append((1, model_act.get('text')))
                 _random_delay()
@@ -419,7 +419,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
                 else:
                     self.dialog.append((1, act.get('text')))
                     act = copy.deepcopy(act)
-                    act.force_set('text', standardize_string(act['text']))
+                    act.force_set('text', normalize_reply(act['text']))
                     self.eval_agent.observe(act)
 
         # Eval agent turn
@@ -463,7 +463,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
             self.model_agent.observe(act)
         else:
             act = copy.deepcopy(act)
-            act.force_set('text', standardize_string(act['text']))
+            act.force_set('text', normalize_reply(act['text']))
             self.other_agent.observe(act)
 
         # Model_agent turn
@@ -471,7 +471,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
             if self.model_agent is not None:
                 _random_delay()
                 act = _strip_tensors(copy.deepcopy(self.model_agent.act()))
-                act.force_set('text', standardize_string(act['text']))
+                act.force_set('text', normalize_reply(act['text']))
                 act.force_set('id', 'PERSON_2')
                 # NOTE: your model may or may not need to observe itself here
                 # If it does, call model_observes_itself or some other specialized
@@ -488,7 +488,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
 
             self.dialog.append((1, act.get('text')))
             act = copy.deepcopy(act)
-            act.force_set('text', standardize_string(act['text']))
+            act.force_set('text', normalize_reply(act['text']))
             self.eval_agent.observe(act)
 
     def _evaluate_characteristic(self, question, choices, addto):

--- a/projects/controllable_dialogue/mturk/worlds.py
+++ b/projects/controllable_dialogue/mturk/worlds.py
@@ -8,7 +8,7 @@ from parlai.mturk.core.legacy_2018.agents import TIMEOUT_MESSAGE
 from parlai.core.worlds import validate, MultiAgentDialogWorld
 from parlai.mturk.core.legacy_2018.worlds import MTurkOnboardWorld
 from parlai.core.message import Message
-from parlai.utils.strings import format_model_reply
+from parlai.utils.strings import standardize_string
 
 from joblib import Parallel, delayed
 import numpy as np
@@ -402,7 +402,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
                 self.model_agent.observe(persona_act)
                 self.bot_seen_persona = True
                 model_act = copy.deepcopy(self.model_agent.act())
-                model_act.force_set('text', format_model_reply(model_act['text']))
+                model_act.force_set('text', standardize_string(model_act['text']))
                 model_act.force_set('id', 'PERSON_2')
                 self.dialog.append((1, model_act.get('text')))
                 _random_delay()
@@ -419,7 +419,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
                 else:
                     self.dialog.append((1, act.get('text')))
                     act = copy.deepcopy(act)
-                    act.force_set('text', format_model_reply(act['text']))
+                    act.force_set('text', standardize_string(act['text']))
                     self.eval_agent.observe(act)
 
         # Eval agent turn
@@ -463,7 +463,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
             self.model_agent.observe(act)
         else:
             act = copy.deepcopy(act)
-            act.force_set('text', format_model_reply(act['text']))
+            act.force_set('text', standardize_string(act['text']))
             self.other_agent.observe(act)
 
         # Model_agent turn
@@ -471,7 +471,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
             if self.model_agent is not None:
                 _random_delay()
                 act = _strip_tensors(copy.deepcopy(self.model_agent.act()))
-                act.force_set('text', format_model_reply(act['text']))
+                act.force_set('text', standardize_string(act['text']))
                 act.force_set('id', 'PERSON_2')
                 # NOTE: your model may or may not need to observe itself here
                 # If it does, call model_observes_itself or some other specialized
@@ -488,7 +488,7 @@ class ControllableDialogEval(MultiAgentDialogWorld):
 
             self.dialog.append((1, act.get('text')))
             act = copy.deepcopy(act)
-            act.force_set('text', format_model_reply(act['text']))
+            act.force_set('text', standardize_string(act['text']))
             self.eval_agent.observe(act)
 
     def _evaluate_characteristic(self, question, choices, addto):


### PR DESCRIPTION
**Patch description**
- Allow passing in a file of workers to softban in Acute-Eval
- Move the controllable dialogue `.format_model_reply()` method into a new `parlai.utils.strings` module so that it can be used more broadly (for instance, to standardize the utterances of Acute-Eval dialogues)

**Testing steps**
Currently running command, which softblocks ~1100 workers:
```
python parlai/mturk/tasks/acute_eval/run.py \
--pairings-filepath /checkpoint/ems/parlai_scaling/scripts/s2020_01_31__acute_eval_meena/convo_sets/compiled_2020_02_03.jsonl \
-nc 250 \
--max-hits-per-worker 2 \
-r 0.5 \
--live \
--softblock-list-path /checkpoint/ems/parlai_scaling/scripts/s2020_01_31__acute_eval_meena/softblock_list.txt
```