### PR TITLE
set tensorboard to true in train script by default

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -189,6 +189,7 @@ def setup_args(parser=None) -> ParlaiParser:
         'the rouge metrics will be computed as rouge-1, rouge-2 and rouge-l',
     )
     TensorboardLogger.add_cmdline_args(parser)
+    parser.set_defaults(tensorboard_log=True)
     parser = setup_dict_args(parser)
     return parser
 


### PR DESCRIPTION
**Patch description**
This sets tensorboard logging option to True in training script.

**Testing steps**
```
 python  examples/train_model.py -m examples/tra  -t integration_tests  -mf /tmp/test -bs 5 -eps 2
```
**Logs**
```
[ Saving tensorboard logs to: /tmp/test.tensorboard ]
/private/home/daju/ParlAI/parlai/core/torch_ranker_agent.py:650: UserWarning: [ Executing train mode with provided inline set of candidates ]
  ''.format(mode)
/private/home/daju/ParlAI/parlai/core/torch_ranker_agent.py:413: UserWarning: Some training metrics are omitted for speed. Set the flag `--train-predict` to calculate train metrics.
  "Some training metrics are omitted for speed. Set the flag "
[ time:1.0s total_exs:1510 epochs:3.02 time_left:0s ] {'exs': 5, 'lr': 1, 'total_train_updates': 302, 'gnorm': 2.197e-05, 'clip': 0, 'gpu_mem_percent': 0.00698, 'examples': 5, 'loss': 1.386, 'mean_loss': 0.2773}
[ num_epochs completed:2.0 time elapsed:1.8269503116607666s ]
```


