### PR TITLE
Debugging the cudnn error.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
       - <<: *installtorchcpu
       - run:
           name: Data tests
-          command: coverage run pytest --junitxml=test-results/junit.xml -m data -v
+          command: coverage run -m pytest --junitxml=test-results/junit.xml -m data -v
       - <<: *codecov
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ installtorchgpu14: &installtorchgpu14
       pip3 install --progress-bar off 'torchvision==0.5.0'
       pip3 install --progress-bar off transformers
       python -c 'import torch; print("Torch version:", torch.__version__)'
+      python -m torch.utils.collect_env
 
 
 installtorchgpu13: &installtorchgpu13
@@ -90,6 +91,7 @@ installtorchgpu13: &installtorchgpu13
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off transformers
       python -c 'import torch; print("Torch version:", torch.__version__)'
+      python -m torch.utils.collect_env
 
 
 installtorchcpuosx: &installtorchcpuosx
@@ -98,6 +100,7 @@ installtorchcpuosx: &installtorchcpuosx
     command: |
       pip3 install --progress-bar off torch
       python -c 'import torch; print("Torch version:", torch.__version__)'
+      python -m torch.utils.collect_env
 
 installtorchcpu: &installtorchcpu
   run:
@@ -105,6 +108,7 @@ installtorchcpu: &installtorchcpu
     command: |
       pip3 install --progress-bar off torch==1.4.0+cpu torchtext==0.5.0 torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
       python -c 'import torch; print("Torch version:", torch.__version__)'
+      python -m torch.utils.collect_env
 
 setupcuda: &setupcuda
   run:
@@ -113,12 +117,8 @@ setupcuda: &setupcuda
     command: |
       # download and install nvidia drivers, cuda, etc
       wget --quiet --no-clobber -P ~/nvidia-downloads 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.40.run'
-      wget --quiet --no-clobber -P ~/nvidia-downloads 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-ubuntu1604.pin'
-      wget --quiet --no-clobber -P ~/nvidia-downloads 'http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda-repo-ubuntu1604-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb'
-      sudo cp ~/nvidia-downloads/cuda-ubuntu1604.pin /etc/apt/preferences.d/cuda-repository-pin-600
       time sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run --no-drm -q --ui=none
-      time sudo dpkg -i ~/nvidia-downloads/cuda-repo-ubuntu1604-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
-      echo "Done installing CUDA."
+      echo "Done installing NVIDIA drivers."
       pyenv versions
       nvidia-smi
       pyenv global 3.7.0


### PR DESCRIPTION
**Patch description**
In CI, convai2.test_seq2seq_f1 has started these weird errors:
```
THCudaCheck FAIL file=/pytorch/aten/src/THC/THCGeneral.cpp line=313 error=400 : invalid resource handle
...
../venv/lib/python3.7/site-packages/torch/nn/modules/module.py:532: in __call__
    result = self.forward(*input, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = LSTM(256, 1024, num_layers=2, batch_first=True, dropout=0.1)
input = <[RuntimeError('cuda runtime error (400) : invalid resource handle at /pytorch/aten/src/THC/THCGeneral.cpp:313') raised in repr()] Tensor object at 0x7f4f99f42480>
hx = (tensor([[[-0.0055, -0.0279,  0.0659,  ..., -0.0124, -0.0140,  0.0278],
         [-0.0276, -0.0346,  0.0912,  ..., -0....432e-01,  ...,  1.1823e-01,
          -3.0951e-01,  1.6833e-01]]], device='cuda:0',
       grad_fn=<CudnnRnnBackward>))

    def forward(self, input, hx=None):  # noqa: F811
        orig_input = input
        # xxx: isinstance check needs to be in conditional for TorchScript to compile
        if isinstance(orig_input, PackedSequence):
            input, batch_sizes, sorted_indices, unsorted_indices = input
            max_batch_size = batch_sizes[0]
            max_batch_size = int(max_batch_size)
        else:
            batch_sizes = None
            max_batch_size = input.size(0) if self.batch_first else input.size(1)
            sorted_indices = None
            unsorted_indices = None
    
        if hx is None:
            num_directions = 2 if self.bidirectional else 1
            zeros = torch.zeros(self.num_layers * num_directions,
                                max_batch_size, self.hidden_size,
                                dtype=input.dtype, device=input.device)
            hx = (zeros, zeros)
        else:
            # Each batch of the hidden state should match the input sequence that
            # the user believes he/she is passing in.
            hx = self.permute_hidden(hx, sorted_indices)
    
        self.check_forward_args(input, hx, batch_sizes)
        if batch_sizes is None:
            result = _VF.lstm(input, hx, self._flat_weights, self.bias, self.num_layers,
>                             self.dropout, self.training, self.bidirectional, self.batch_first)
E           RuntimeError: cuDNN error: CUDNN_STATUS_EXECUTION_FAILED
```

I'm trying to recreate this and figure out why.