### PR TITLE
Byte level bpe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ installdeps: &installdeps
       pip install -q -r requirements.txt
       python setup.py develop
       python -c "import nltk; nltk.download('punkt')"
+      pip3 install --progress-bar off tokenizers
 
 installtorchgpu14: &installtorchgpu14
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,8 @@ installtorchgpu14: &installtorchgpu14
       pip3 install --progress-bar off 'torchtext==0.5.0'
       pip3 install --progress-bar off 'torchvision==0.5.0'
       pip3 install --progress-bar off transformers
-      pip3 install --progress-bar off tokenizers
+      pip3 install --progress-bar off snips-nlu
+      pip3 install --progress-bar off --upgrade tokenizers
       python -c 'import torch; print("Torch version:", torch.__version__)'
       python -m torch.utils.collect_env
 
@@ -92,7 +93,8 @@ installtorchgpu13: &installtorchgpu13
       pip3 install --progress-bar off 'subword-nmt==0.3.7'
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off transformers
-      pip3 install --progress-bar off tokenizers
+      pip3 install --progress-bar off snips-nlu
+      pip3 install --progress-bar off --upgrade tokenizers
       python -c 'import torch; print("Torch version:", torch.__version__)'
       python -m torch.utils.collect_env
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,11 +143,11 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v3-dt-{{ checksum "requirements.txt" }}
+          key: deps-v4-dt-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - save_cache:
-          key: deps-v3-dt-{{ checksum "requirements.txt" }}
+          key: deps-v4-dt-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -167,12 +167,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v3-osx-{{ checksum "requirements.txt" }}
+          key: deps-v4-osx-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchcpuosx
       - save_cache:
-          key: deps-v3-osx-{{ checksum "requirements.txt" }}
+          key: deps-v4-osx-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -194,12 +194,12 @@ jobs:
           command: circleci tests split --split-by=timings --timings-type=classname
       - <<: *fixgit
       - restore_cache:
-          key: deps-v3-ut36-{{ checksum "requirements.txt" }}
+          key: deps-v4-ut36-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchcpu
       - save_cache:
-          key: deps-v3-ut36-{{ checksum "requirements.txt" }}
+          key: deps-v4-ut36-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -218,12 +218,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v3-ut37-{{ checksum "requirements.txt" }}
+          key: deps-v4-ut37-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchcpu
       - save_cache:
-          key: deps-v3-ut37-{{ checksum "requirements.txt" }}
+          key: deps-v4-ut37-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -242,19 +242,19 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: nvidia-downloads-v3
+          key: nvidia-downloads-v4
       - <<: *setupcuda
       - save_cache:
-          key: nvidia-downloads-v3
+          key: nvidia-downloads-v4
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v3-gpu13-{{ checksum "requirements.txt" }}
+          key: deps-v4-gpu13-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu13
       - save_cache:
-          key: deps-v3-gpu13-{{ checksum "requirements.txt" }}
+          key: deps-v4-gpu13-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -273,19 +273,19 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: nvidia-downloads-v3
+          key: nvidia-downloads-v4
       - <<: *setupcuda
       - save_cache:
-          key: nvidia-downloads-v3
+          key: nvidia-downloads-v4
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v3-gpu14-{{ checksum "requirements.txt" }}
+          key: deps-v4-gpu14-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-v3-gpu14-{{ checksum "requirements.txt" }}
+          key: deps-v4-gpu14-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -304,19 +304,19 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: nvidia-downloads-v3
+          key: nvidia-downloads-v4
       - <<: *setupcuda
       - save_cache:
-          key: nvidia-downloads-v3
+          key: nvidia-downloads-v4
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v3-nightly-{{ checksum "requirements.txt" }}
+          key: deps-v4-nightly-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-v3-nightly-{{ checksum "requirements.txt" }}
+          key: deps-v4-nightly-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -338,11 +338,11 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v3-mturk-{{ checksum "requirements.txt" }}
+          key: deps-v4-mturk-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - save_cache:
-          key: deps-v3-mturk-{{ checksum "requirements.txt" }}
+          key: deps-v4-mturk-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -360,7 +360,7 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v3-bw-{{ checksum "requirements.txt" }}
+          key: deps-v4-bw-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
@@ -371,7 +371,7 @@ jobs:
             pip install s3cmd
             sudo apt-get install linkchecker
       - save_cache:
-          key: deps-v3-bw-{{ checksum "requirements.txt" }}
+          key: deps-v4-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -391,12 +391,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v3-dw-{{ checksum "requirements.txt" }}
+          key: deps-v4-dw-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-v3-dw-{{ checksum "requirements.txt" }}
+          key: deps-v4-dw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ installtorchgpu14: &installtorchgpu14
       pip3 install --progress-bar off 'torchtext==0.5.0'
       pip3 install --progress-bar off 'torchvision==0.5.0'
       pip3 install --progress-bar off transformers
+      pip3 install --progress-bar off tokenizers
       python -c 'import torch; print("Torch version:", torch.__version__)'
       python -m torch.utils.collect_env
 
@@ -91,6 +92,7 @@ installtorchgpu13: &installtorchgpu13
       pip3 install --progress-bar off 'subword-nmt==0.3.7'
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off transformers
+      pip3 install --progress-bar off tokenizers
       python -c 'import torch; print("Torch version:", torch.__version__)'
       python -m torch.utils.collect_env
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ installdeps: &installdeps
       pip install -q -r requirements.txt
       python setup.py develop
       python -c "import nltk; nltk.download('punkt')"
-      pip3 install --progress-bar off tokenizers
 
 installtorchgpu14: &installtorchgpu14
   run:
@@ -79,8 +78,6 @@ installtorchgpu14: &installtorchgpu14
       pip3 install --progress-bar off 'torchtext==0.5.0'
       pip3 install --progress-bar off 'torchvision==0.5.0'
       pip3 install --progress-bar off transformers
-      pip3 install --progress-bar off snips-nlu
-      pip3 install --progress-bar off --upgrade tokenizers
       python -c 'import torch; print("Torch version:", torch.__version__)'
       python -m torch.utils.collect_env
 
@@ -93,8 +90,6 @@ installtorchgpu13: &installtorchgpu13
       pip3 install --progress-bar off 'subword-nmt==0.3.7'
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off transformers
-      pip3 install --progress-bar off snips-nlu
-      pip3 install --progress-bar off --upgrade tokenizers
       python -c 'import torch; print("Torch version:", torch.__version__)'
       python -m torch.utils.collect_env
 

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -351,12 +351,11 @@ class DictionaryAgent(Agent):
             opt_for_byte_level_bpe = copy.copy(opt)
             if loaded:
                 dict_basename = os.path.splitext(opt['dict_file'])[0]
-                if os.path.isfile(
-                    '{}-merges.txt'.format(dict_basename)
-                ) and os.path.isfile('{}-vocab.json'.format(dict_basename)):
+                if os.path.isfile('{}-merges.txt'.format(dict_basename)):
                     opt_for_byte_level_bpe['bpe_vocab'] = '{}-vocab.json'.format(
                         dict_basename
                     )
+                if os.path.isfile('{}-vocab.json'.format(dict_basename)):
                     opt_for_byte_level_bpe['bpe_merge'] = '{}-merges.txt'.format(
                         dict_basename
                     )
@@ -728,6 +727,7 @@ class DictionaryAgent(Agent):
             json.dump(self.opt, handle, indent=4)
         # save the byte level bpe model file as well
         if self.tokenizer == 'bytelevelbpe':
+            # This saves filename-vocab.json and finlename-merges.txt as hugging face tokenizer do
             self.byte_level_bpe.tokenizer.save(
                 os.path.dirname(filename), os.path.splitext(filename)[0]
             )

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -871,6 +871,7 @@ class DictionaryAgent(Agent):
         for i in range(self.byte_level_bpe.tokenizer.get_vocab_size()):
             token = self.byte_level_bpe.tokenizer.id_to_token(i)
             self.add_token(token)
+            # We don't have access to the hugging face word frequency table, just set it to 1 instead
             self.freq[token] = 1
 
 

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -696,7 +696,6 @@ class DictionaryAgent(Agent):
             # never remove or sort tokens from gpt2
             pass
         elif self.tokenizer == 'bytelevelbpe':
-            # never remove or sort tokens from bytelevel bpe
             pass
         elif sort:
             self.sort(trim=True)
@@ -714,6 +713,9 @@ class DictionaryAgent(Agent):
         # save opt file
         with open(filename + '.opt', 'w', encoding='utf-8') as handle:
             json.dump(self.opt, handle, indent=4)
+        # save the byte level bpe model file as well
+        if self.tokenizer == 'bytelevelbpe':
+            self.byte_level_bpe.tokenizer(os.path.dirname(filename), filename)
 
     def sort(self, trim=True):
         """

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -349,7 +349,7 @@ class DictionaryAgent(Agent):
                     ' (no --dict-minfreq or --dict-maxtokens).'
                 )
             self.byte_level_bpe = HuggingFaceBpeHelper(opt)
-            self.sync_bytelevelbpe_dict()
+            self._sync_bytelevelbpe_dict()
 
         if not shared:
             if self.null_token:
@@ -696,6 +696,7 @@ class DictionaryAgent(Agent):
             # never remove or sort tokens from gpt2
             pass
         elif self.tokenizer == 'bytelevelbpe':
+            # never remove or sort tokens from bytelevelbpe, it should be the same as the hugging face tokenizer
             pass
         elif sort:
             self.sort(trim=True)
@@ -715,7 +716,7 @@ class DictionaryAgent(Agent):
             json.dump(self.opt, handle, indent=4)
         # save the byte level bpe model file as well
         if self.tokenizer == 'bytelevelbpe':
-            self.byte_level_bpe.tokenizer(os.path.dirname(filename), filename)
+            self.byte_level_bpe.tokenizer.save(os.path.dirname(filename), filename)
 
     def sort(self, trim=True):
         """
@@ -850,9 +851,11 @@ class DictionaryAgent(Agent):
         """
         return str(self.freq)
 
-    def sync_bytelevelbpe_dict(self):
+    def _sync_bytelevelbpe_dict(self):
         """
-        This will sync the dict agent and the hugging face bytelevel bpe dict.
+        Sync the dictionary agent with Hugging Face tokenizer's BPE dict.
+
+        Called only once on initialization.
         """
         if self.tokenizer != 'bytelevelbpe':
             return

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -810,10 +810,16 @@ class DictionaryAgent(Agent):
         if self.tokenizer == 'gpt2' and not self.opt.get('bpe_debug', False):
             return self.gpt2_bpe.decode(self[int(idx)] for idx in vector)
         if self.tokenizer == 'bytelevelbpe' and not self.opt.get('bpe_debug', False):
+            # We add special tokens in the beginning of ParlAI dict but in the
+            # end of Hugging Face dict,there is an offset of 4 between them.
             vector = [
                 idx + len(self.tok2ind) - 4 if idx < 4 else idx - 4 for idx in vector
             ]
-            return self.byte_level_bpe.tokenizer.decode(vector)
+            text = self.byte_level_bpe.tokenizer.decode(vector)
+            if self.byte_level_bpe.add_prefix_space:
+                assert text.startswith(' ')
+                text = text.lstrip(' ')
+            return text
         # if we want to debug into this gpt2 bpe, you will get next line
         text = delimiter.join(self[int(idx)] for idx in vector)
         # if we used a BPE tokenizer we need to rejoin the encodings

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -810,6 +810,9 @@ class DictionaryAgent(Agent):
         if self.tokenizer == 'gpt2' and not self.opt.get('bpe_debug', False):
             return self.gpt2_bpe.decode(self[int(idx)] for idx in vector)
         if self.tokenizer == 'bytelevelbpe' and not self.opt.get('bpe_debug', False):
+            vector = [
+                idx + len(self.tok2ind) - 4 if idx < 4 else idx - 4 for idx in vector
+            ]
             return self.byte_level_bpe.tokenizer.decode(vector)
         # if we want to debug into this gpt2 bpe, you will get next line
         text = delimiter.join(self[int(idx)] for idx in vector)
@@ -874,15 +877,13 @@ class DictionaryAgent(Agent):
         if self.tokenizer != 'bytelevelbpe':
             return
         special_tokens = [
+            self.unk_token,
             self.start_token,
             self.end_token,
-            self.unk_token,
             self.null_token,
         ]
         self.byte_level_bpe.tokenizer.add_special_tokens(special_tokens)
-        self.ind2tok = {}
-        self.tok2ind = {}
-        for i in range(self.byte_level_bpe.tokenizer.get_vocab_size()):
+        for i in range(self.byte_level_bpe.tokenizer.get_vocab_size() - 4):
             token = self.byte_level_bpe.tokenizer.id_to_token(i)
             self.add_token(token)
             # We don't have access to the hugging face word frequency table, just set it to 1 instead

--- a/parlai/core/hugging_face_bpe_helper.py
+++ b/parlai/core/hugging_face_bpe_helper.py
@@ -11,7 +11,7 @@ from typing import List
 class HuggingFaceBpeHelper(object):
     @staticmethod
     def add_cmdline_args(argparser):
-        parser = argparser.add_argument_group('HuggingFaceBpeHelper Arguments')
+        parser = argparser.add_argument_group('ByteLevelBPE Arguments')
         parser.add_argument(
             '--bpe-vocab', type=str, help='path to pre-trained tokenizer vocab'
         )
@@ -25,15 +25,15 @@ class HuggingFaceBpeHelper(object):
             from tokenizers import ByteLevelBPETokenizer
         except ImportError:
             raise ImportError(
-                'Please install huggingface tokenizer with: pip install tokenizers'
+                'Please install HuggingFace tokenizer with: pip install tokenizers'
             )
 
-        if opt.get('bpe_vocab', None) is None:
+        if 'bpe_vocab' in opt:
             raise ValueError('--bpe-vocab is required for loading pretrained tokenizer')
-        if opt.get('bpe_merge', None) is None:
+        if 'bpe_merge' in opt:
             raise ValueError('--bpe-merge is required for loading pretrained tokenizer')
-        self.vocab_path = opt.get('bpe_vocab')
-        self.merge_path = opt.get('bpe_merge')
+        self.vocab_path = opt['bpe_vocab']
+        self.merge_path = opt['bpe_merge']
         self.tokenizer = ByteLevelBPETokenizer(self.vocab_path, self.merge_path)
 
     def encode(self, text: str) -> List[str]:

--- a/parlai/core/hugging_face_bpe_helper.py
+++ b/parlai/core/hugging_face_bpe_helper.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from parlai.core.opt import Opt
+from typing import List
+
+
+class HuggingFaceBpeHelper(object):
+    @staticmethod
+    def add_cmdline_args(argparser):
+        parser = argparser.add_argument_group('HuggingFaceBpeHelper Arguments')
+        parser.add_argument(
+            '--bpe-vocab', type=str, help='path to pre-trained tokenizer vocab'
+        )
+        parser.add_argument(
+            '--bpe-merge', type=str, help='path to pre-trained tokenizer merge'
+        )
+        parser.add_argument(
+            '--bpe-train-from',
+            type=str,
+            help='path to the text files for training the byte level bpe tokenizer',
+        )
+        return parser
+
+    def __init__(self, opt: Opt, shared=None):
+        try:
+            from tokenizers import ByteLevelBPETokenizer
+        except ImportError:
+            raise ImportError(
+                'Please install huggingface tokenizer with: pip install tokenizers'
+            )
+
+        if opt.get('bpe_train_from', None) is None:
+            # load trained instead
+            if opt.get('bpe_vocab', None) is None:
+                raise ValueError(
+                    '--bpe-vocab is required for loading pretrained tokenizer'
+                )
+            if opt.get('bpe_merge', None) is None:
+                raise ValueError(
+                    '--bpe-merge is required for loading pretrained tokenizer'
+                )
+            self.vocab_path = opt.get('bpe_vocab')
+            self.merge_path = opt.get('bpe_merge')
+            self.tokenizer = ByteLevelBPETokenizer(self.vocab_path, self.merge_path)
+        else:
+            self.train_corpus = opt.get('bpe_train_from')
+            self.tokenizer = ByteLevelBPETokenizer()
+            self.tokenizer.train(self.train_corpus)
+
+    def encode(self, text: str) -> List[str]:
+        return self.tokenizer.encode(text).tokens
+
+    def decode(self, x: List[str]) -> str:
+        return self.tokenizer.decode(self.tokenizer.token_to_id(c) for c in x)

--- a/parlai/core/hugging_face_bpe_helper.py
+++ b/parlai/core/hugging_face_bpe_helper.py
@@ -18,11 +18,6 @@ class HuggingFaceBpeHelper(object):
         parser.add_argument(
             '--bpe-merge', type=str, help='path to pre-trained tokenizer merge'
         )
-        parser.add_argument(
-            '--bpe-train-from',
-            type=str,
-            help='path to the text files for training the byte level bpe tokenizer',
-        )
         return parser
 
     def __init__(self, opt: Opt, shared=None):
@@ -33,23 +28,13 @@ class HuggingFaceBpeHelper(object):
                 'Please install huggingface tokenizer with: pip install tokenizers'
             )
 
-        if opt.get('bpe_train_from', None) is None:
-            # load trained instead
-            if opt.get('bpe_vocab', None) is None:
-                raise ValueError(
-                    '--bpe-vocab is required for loading pretrained tokenizer'
-                )
-            if opt.get('bpe_merge', None) is None:
-                raise ValueError(
-                    '--bpe-merge is required for loading pretrained tokenizer'
-                )
-            self.vocab_path = opt.get('bpe_vocab')
-            self.merge_path = opt.get('bpe_merge')
-            self.tokenizer = ByteLevelBPETokenizer(self.vocab_path, self.merge_path)
-        else:
-            self.train_corpus = opt.get('bpe_train_from')
-            self.tokenizer = ByteLevelBPETokenizer()
-            self.tokenizer.train(self.train_corpus)
+        if opt.get('bpe_vocab', None) is None:
+            raise ValueError('--bpe-vocab is required for loading pretrained tokenizer')
+        if opt.get('bpe_merge', None) is None:
+            raise ValueError('--bpe-merge is required for loading pretrained tokenizer')
+        self.vocab_path = opt.get('bpe_vocab')
+        self.merge_path = opt.get('bpe_merge')
+        self.tokenizer = ByteLevelBPETokenizer(self.vocab_path, self.merge_path)
 
     def encode(self, text: str) -> List[str]:
         return self.tokenizer.encode(text).tokens

--- a/parlai/core/hugging_face_bpe_helper.py
+++ b/parlai/core/hugging_face_bpe_helper.py
@@ -18,6 +18,12 @@ class HuggingFaceBpeHelper(object):
         parser.add_argument(
             '--bpe-merge', type=str, help='path to pre-trained tokenizer merge'
         )
+        parser.add_argument(
+            '--bpe-add-prefix-space',
+            type='bool',
+            hidden=True,
+            help='add prefix space before encoding',
+        )
         return parser
 
     def __init__(self, opt: Opt, shared=None):
@@ -32,9 +38,13 @@ class HuggingFaceBpeHelper(object):
             raise ValueError('--bpe-vocab is required for loading pretrained tokenizer')
         if 'bpe_merge' not in opt:
             raise ValueError('--bpe-merge is required for loading pretrained tokenizer')
+
         self.vocab_path = opt['bpe_vocab']
         self.merge_path = opt['bpe_merge']
-        self.tokenizer = ByteLevelBPETokenizer(self.vocab_path, self.merge_path)
+        self.add_prefix_space = opt.get('bpe_add_prefix_space', True)
+        self.tokenizer = ByteLevelBPETokenizer(
+            self.vocab_path, self.merge_path, self.add_prefix_space
+        )
 
     def encode(self, text: str) -> List[str]:
         return self.tokenizer.encode(text).tokens

--- a/parlai/core/hugging_face_bpe_helper.py
+++ b/parlai/core/hugging_face_bpe_helper.py
@@ -28,9 +28,9 @@ class HuggingFaceBpeHelper(object):
                 'Please install HuggingFace tokenizer with: pip install tokenizers'
             )
 
-        if 'bpe_vocab' in opt:
+        if 'bpe_vocab' not in opt:
             raise ValueError('--bpe-vocab is required for loading pretrained tokenizer')
-        if 'bpe_merge' in opt:
+        if 'bpe_merge' not in opt:
             raise ValueError('--bpe-merge is required for loading pretrained tokenizer')
         self.vocab_path = opt['bpe_vocab']
         self.merge_path = opt['bpe_merge']

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -949,7 +949,7 @@ class ParlaiParser(argparse.ArgumentParser):
             self._load_opts(self.opt)
 
         # map filenames that start with 'zoo:' to point to the model zoo dir
-        options_to_change = {'model_file', 'dict_file', 'bpe-vocab', 'bpe-merge'}
+        options_to_change = {'model_file', 'dict_file', 'bpe_vocab', 'bpe_merge'}
         for each_key in options_to_change:
             if self.opt.get(each_key) is not None:
                 self.opt[each_key] = modelzoo_path(

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -949,24 +949,17 @@ class ParlaiParser(argparse.ArgumentParser):
             self._load_opts(self.opt)
 
         # map filenames that start with 'zoo:' to point to the model zoo dir
-        if self.opt.get('model_file') is not None:
-            self.opt['model_file'] = modelzoo_path(
-                self.opt.get('datapath'), self.opt['model_file']
-            )
-        if self.opt['override'].get('model_file') is not None:
-            # also check override
-            self.opt['override']['model_file'] = modelzoo_path(
-                self.opt.get('datapath'), self.opt['override']['model_file']
-            )
-        if self.opt.get('dict_file') is not None:
-            self.opt['dict_file'] = modelzoo_path(
-                self.opt.get('datapath'), self.opt['dict_file']
-            )
-        if self.opt['override'].get('dict_file') is not None:
-            # also check override
-            self.opt['override']['dict_file'] = modelzoo_path(
-                self.opt.get('datapath'), self.opt['override']['dict_file']
-            )
+        options_to_change = {'model_file', 'dict_file', 'bpe-vocab', 'bpe-merge'}
+        for each_key in options_to_change:
+            if self.opt.get(each_key) is not None:
+                self.opt[each_key] = modelzoo_path(
+                    self.opt.get('datapath'), self.opt[each_key]
+                )
+            if self.opt['override'].get(each_key) is not None:
+                # also check override
+                self.opt['override'][each_key] = modelzoo_path(
+                    self.opt.get('datapath'), self.opt['override'][each_key]
+                )
 
         # add start time of an experiment
         self.opt['starttime'] = datetime.datetime.today().strftime('%b%d_%H-%M')

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -829,9 +829,7 @@ class ParlaiParser(argparse.ArgumentParser):
 
         # add world args, if we know a priori which world is being used
         if task is not None:
-            self.add_world_args(
-                task, parsed.get('interactive_task', False),
-            )
+            self.add_world_args(task, parsed.get('interactive_task', False))
 
         # reset parser-level defaults over any model-level defaults
         try:

--- a/parlai/zoo/unittest/build.py
+++ b/parlai/zoo/unittest/build.py
@@ -21,4 +21,4 @@ def download(datapath):
         'apex_v1.tar.gz',
         'test_bytelevel_bpe_v1.tar.gz',
     ]
-    download_models(opt, model_filenames, 'unittest', version='v4.0')
+    download_models(opt, model_filenames, 'unittest', version='v5.0')

--- a/parlai/zoo/unittest/build.py
+++ b/parlai/zoo/unittest/build.py
@@ -19,5 +19,6 @@ def download(datapath):
         'transformer_generator2.tar.gz',
         'memnn.tar.gz',
         'apex_v1.tar.gz',
+        'test_bytelevel_bpe_v1.tar.gz',
     ]
     download_models(opt, model_filenames, 'unittest', version='v4.0')

--- a/parlai/zoo/unittest/build.py
+++ b/parlai/zoo/unittest/build.py
@@ -19,6 +19,6 @@ def download(datapath):
         'transformer_generator2.tar.gz',
         'memnn.tar.gz',
         'apex_v1.tar.gz',
-        'test_bytelevel_bpe_v1.tar.gz',
+        'test_bytelevel_bpe_v2.tar.gz',
     ]
     download_models(opt, model_filenames, 'unittest', version='v5.0')

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ sh==1.12.14
 Sphinx==2.2.0
 sphinx_rtd_theme==0.4.3
 sphinx-autodoc-typehints==1.10.3
+tokenizers==0.4.2
 tqdm==4.36.1
 Unidecode==1.1.1
 websocket-client==0.56.0

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -85,10 +85,10 @@ class TestDictionary(unittest.TestCase):
         )
 
     def test_byte_level_bpe_tokenize(self):
-        # test loading
-        import parlai.scripts.train_model as tms
-
-        parser = tms.setup_args()
+        """
+        Tests a bytelevel bpe tokenizer inside ParlAI.
+        """
+        parser = ParlaiParser()
         parser.set_params(
             dict_tokenizer='bytelevelbpe',
             bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -60,6 +60,124 @@ class TestDictionary(unittest.TestCase):
             u'Hello, ParlAI! \U0001f600',
         )
 
+    def test_byte_level_bpe_tokenize(self):
+        opt = Opt(
+            {
+                'dict_tokenizer': 'bytelevelbpe',
+                'datapath': './data',
+                'bpe_train_from': './data/ConvAI2/train_both_original_no_cands.txt',
+            }
+        )
+        agent = DictionaryAgent(opt)
+        self.assertEqual(
+            # grinning face emoji
+            agent.bytelevelbpe_tokenize(u'Hello, ParlAI! \U0001f600'),
+            [
+                'H',
+                'ello',
+                ',',
+                'Ġ',
+                'P',
+                'ar',
+                'l',
+                'A',
+                'I',
+                '!',
+                'Ġ',
+                'ð',
+                'Ł',
+                'ĺ',
+                'Ģ',
+            ],
+        )
+        self.assertEqual(
+            agent.vec2txt(
+                [
+                    agent.tok2ind[w]
+                    for w in [
+                        'H',
+                        'ello',
+                        ',',
+                        'Ġ',
+                        'P',
+                        'ar',
+                        'l',
+                        'A',
+                        'I',
+                        '!',
+                        'Ġ',
+                        'ð',
+                        'Ł',
+                        'ĺ',
+                        'Ģ',
+                    ]
+                ]
+            ),
+            # grinning face emoji
+            u'Hello, ParlAI! \U0001f600',
+        )
+        agent.byte_level_bpe.tokenizer.save('./data', 'test-byte-level-bpe')
+
+        # test loading
+        opt = Opt(
+            {
+                'dict_tokenizer': 'bytelevelbpe',
+                'datapath': './data',
+                'bpe_vocab': './data/test-byte-level-bpe-vocab.json',
+                'bpe_merge': './data/test-byte-level-bpe-merges.txt',
+            }
+        )
+        agent = DictionaryAgent(opt)
+        self.assertEqual(
+            # grinning face emoji
+            agent.bytelevelbpe_tokenize(u'Hello, ParlAI! \U0001f600'),
+            [
+                'H',
+                'ello',
+                ',',
+                'Ġ',
+                'P',
+                'ar',
+                'l',
+                'A',
+                'I',
+                '!',
+                'Ġ',
+                'ð',
+                'Ł',
+                'ĺ',
+                'Ģ',
+            ],
+        )
+        self.assertEqual(
+            agent.vec2txt(
+                [
+                    agent.tok2ind[w]
+                    for w in [
+                        'H',
+                        'ello',
+                        ',',
+                        'Ġ',
+                        'P',
+                        'ar',
+                        'l',
+                        'A',
+                        'I',
+                        '!',
+                        'Ġ',
+                        'ð',
+                        'Ł',
+                        'ĺ',
+                        'Ģ',
+                    ]
+                ]
+            ),
+            # grinning face emoji
+            u'Hello, ParlAI! \U0001f600',
+        )
+        os.remove('./data/test-byte-level-bpe-vocab.json')
+        os.remove('./data/test-byte-level-bpe-merges.txt')
+
     def test_space_tokenize(self):
         """
         Space tokenize assumes raw tokenization as input.

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -20,10 +20,10 @@ import shutil
 import unittest
 
 DEFAULT_BYTELEVEL_BPE_VOCAB = (
-    'zoo:unittests/test_bytelevel_bpe_v2/test-byte-level-bpe-v2-vocab.json'
+    'zoo:unittest/test_bytelevel_bpe_v2/test-byte-level-bpe-v2-vocab.json'
 )
 DEFAULT_BYTELEVEL_BPE_MERGE = (
-    'zoo:unittests/test_bytelevel_bpe_v2/test-byte-level-bpe-v2-merges.txt'
+    'zoo:unittest/test_bytelevel_bpe_v2/test-byte-level-bpe-v2-merges.txt'
 )
 BYTELEVEL_BPE_RESULT = [
     'H',

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -18,10 +18,30 @@ import parlai.utils.testing as testing_utils
 import os
 import shutil
 import unittest
-from parlai.core.build_data import download
 
-DEFAULT_BYTELEVEL_BPE_VOCAB = 'https://dl.fbaipublicfiles.com/parlai/test_bytelevel_bpe_v1/test-byte-level-bpe-v1-vocab.json'
-DEFAULT_BYTELEVEL_BPE_MERGE = 'https://dl.fbaipublicfiles.com/parlai/test_bytelevel_bpe_v1/test-byte-level-bpe-v1-merges.txt'
+DEFAULT_BYTELEVEL_BPE_VOCAB = (
+    'zoo:unittests/test_bytelevel_bpe_v1/test-byte-level-bpe-v1-vocab.json'
+)
+DEFAULT_BYTELEVEL_BPE_MERGE = (
+    'zoo:unittests/test_bytelevel_bpe_v1/test-byte-level-bpe-v1-merges.txt'
+)
+BYTELEVEL_BPE_RESULT = [
+    'H',
+    'ello',
+    ',',
+    'Ġ',
+    'P',
+    'ar',
+    'l',
+    'A',
+    'I',
+    '!',
+    'Ġ',
+    'ð',
+    'Ł',
+    'ĺ',
+    'Ģ',
+]
 
 
 class TestDictionary(unittest.TestCase):
@@ -66,61 +86,22 @@ class TestDictionary(unittest.TestCase):
 
     def test_byte_level_bpe_tokenize(self):
         # test loading
-        download(DEFAULT_BYTELEVEL_BPE_VOCAB, './', 'test-byte-level-bpe-vocab.json')
-        download(DEFAULT_BYTELEVEL_BPE_MERGE, './', 'test-byte-level-bpe-merges.txt')
         opt = Opt(
             {
                 'dict_tokenizer': 'bytelevelbpe',
                 'datapath': './',
-                'bpe_vocab': './test-byte-level-bpe-vocab.json',
-                'bpe_merge': './test-byte-level-bpe-merges.txt',
+                'bpe_vocab': DEFAULT_BYTELEVEL_BPE_VOCAB,
+                'bpe_merge': DEFAULT_BYTELEVEL_BPE_MERGE,
             }
         )
         agent = DictionaryAgent(opt)
         self.assertEqual(
             # grinning face emoji
             agent.bytelevelbpe_tokenize(u'Hello, ParlAI! \U0001f600'),
-            [
-                'H',
-                'ello',
-                ',',
-                'Ġ',
-                'P',
-                'ar',
-                'l',
-                'A',
-                'I',
-                '!',
-                'Ġ',
-                'ð',
-                'Ł',
-                'ĺ',
-                'Ģ',
-            ],
+            BYTELEVEL_BPE_RESULT,
         )
         self.assertEqual(
-            agent.vec2txt(
-                [
-                    agent.tok2ind[w]
-                    for w in [
-                        'H',
-                        'ello',
-                        ',',
-                        'Ġ',
-                        'P',
-                        'ar',
-                        'l',
-                        'A',
-                        'I',
-                        '!',
-                        'Ġ',
-                        'ð',
-                        'Ł',
-                        'ĺ',
-                        'Ģ',
-                    ]
-                ]
-            ),
+            agent.vec2txt([agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT]),
             # grinning face emoji
             u'Hello, ParlAI! \U0001f600',
         )

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -86,14 +86,15 @@ class TestDictionary(unittest.TestCase):
 
     def test_byte_level_bpe_tokenize(self):
         # test loading
-        opt = Opt(
-            {
-                'dict_tokenizer': 'bytelevelbpe',
-                'datapath': './data',
-                'bpe_vocab': DEFAULT_BYTELEVEL_BPE_VOCAB,
-                'bpe_merge': DEFAULT_BYTELEVEL_BPE_MERGE,
-            }
+        import parlai.scripts.train_model as tms
+
+        parser = tms.setup_args()
+        parser.set_params(
+            dict_tokenizer='bytelevelbpe',
+            bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,
+            bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
         )
+        opt = parser.parse_args([], print_args=False)
         agent = DictionaryAgent(opt)
         self.assertEqual(
             # grinning face emoji

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -18,6 +18,10 @@ import parlai.utils.testing as testing_utils
 import os
 import shutil
 import unittest
+from parlai.core.build_data import download
+
+DEFAULT_BYTELEVEL_BPE_VOCAB = 'https://dl.fbaipublicfiles.com/parlai/test_bytelevel_bpe_v1/test-byte-level-bpe-v1-vocab.json'
+DEFAULT_BYTELEVEL_BPE_MERGE = 'https://dl.fbaipublicfiles.com/parlai/test_bytelevel_bpe_v1/test-byte-level-bpe-v1-merges.txt'
 
 
 class TestDictionary(unittest.TestCase):
@@ -61,64 +65,13 @@ class TestDictionary(unittest.TestCase):
         )
 
     def test_byte_level_bpe_tokenize(self):
-        opt = Opt(
-            {
-                'dict_tokenizer': 'bytelevelbpe',
-                'datapath': './data',
-                'bpe_train_from': './data/ConvAI2/train_both_original_no_cands.txt',
-            }
-        )
-        agent = DictionaryAgent(opt)
-        self.assertEqual(
-            # grinning face emoji
-            agent.bytelevelbpe_tokenize(u'Hello, ParlAI! \U0001f600'),
-            [
-                'H',
-                'ello',
-                ',',
-                'Ġ',
-                'P',
-                'ar',
-                'l',
-                'A',
-                'I',
-                '!',
-                'Ġ',
-                'ð',
-                'Ł',
-                'ĺ',
-                'Ģ',
-            ],
-        )
-        self.assertEqual(
-            agent.vec2txt(
-                [
-                    agent.tok2ind[w]
-                    for w in [
-                        'H',
-                        'ello',
-                        ',',
-                        'Ġ',
-                        'P',
-                        'ar',
-                        'l',
-                        'A',
-                        'I',
-                        '!',
-                        'Ġ',
-                        'ð',
-                        'Ł',
-                        'ĺ',
-                        'Ģ',
-                    ]
-                ]
-            ),
-            # grinning face emoji
-            u'Hello, ParlAI! \U0001f600',
-        )
-        agent.byte_level_bpe.tokenizer.save('./data', 'test-byte-level-bpe')
-
         # test loading
+        download(
+            DEFAULT_BYTELEVEL_BPE_VOCAB, './data', 'test-byte-level-bpe-vocab.json'
+        )
+        download(
+            DEFAULT_BYTELEVEL_BPE_MERGE, './data', 'test-byte-level-bpe-merges.txt'
+        )
         opt = Opt(
             {
                 'dict_tokenizer': 'bytelevelbpe',

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -66,18 +66,14 @@ class TestDictionary(unittest.TestCase):
 
     def test_byte_level_bpe_tokenize(self):
         # test loading
-        download(
-            DEFAULT_BYTELEVEL_BPE_VOCAB, './data', 'test-byte-level-bpe-vocab.json'
-        )
-        download(
-            DEFAULT_BYTELEVEL_BPE_MERGE, './data', 'test-byte-level-bpe-merges.txt'
-        )
+        download(DEFAULT_BYTELEVEL_BPE_VOCAB, './', 'test-byte-level-bpe-vocab.json')
+        download(DEFAULT_BYTELEVEL_BPE_MERGE, './', 'test-byte-level-bpe-merges.txt')
         opt = Opt(
             {
                 'dict_tokenizer': 'bytelevelbpe',
-                'datapath': './data',
-                'bpe_vocab': './data/test-byte-level-bpe-vocab.json',
-                'bpe_merge': './data/test-byte-level-bpe-merges.txt',
+                'datapath': './',
+                'bpe_vocab': './test-byte-level-bpe-vocab.json',
+                'bpe_merge': './test-byte-level-bpe-merges.txt',
             }
         )
         agent = DictionaryAgent(opt)
@@ -128,8 +124,8 @@ class TestDictionary(unittest.TestCase):
             # grinning face emoji
             u'Hello, ParlAI! \U0001f600',
         )
-        os.remove('./data/test-byte-level-bpe-vocab.json')
-        os.remove('./data/test-byte-level-bpe-merges.txt')
+        os.remove('./test-byte-level-bpe-vocab.json')
+        os.remove('./test-byte-level-bpe-merges.txt')
 
     def test_space_tokenize(self):
         """

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -89,7 +89,7 @@ class TestDictionary(unittest.TestCase):
         opt = Opt(
             {
                 'dict_tokenizer': 'bytelevelbpe',
-                'datapath': './',
+                'datapath': './data',
                 'bpe_vocab': DEFAULT_BYTELEVEL_BPE_VOCAB,
                 'bpe_merge': DEFAULT_BYTELEVEL_BPE_MERGE,
             }

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -20,10 +20,10 @@ import shutil
 import unittest
 
 DEFAULT_BYTELEVEL_BPE_VOCAB = (
-    'zoo:unittests/test_bytelevel_bpe_v1/test-byte-level-bpe-v1-vocab.json'
+    'zoo:unittests/test_bytelevel_bpe_v2/test-byte-level-bpe-v2-vocab.json'
 )
 DEFAULT_BYTELEVEL_BPE_MERGE = (
-    'zoo:unittests/test_bytelevel_bpe_v1/test-byte-level-bpe-v1-merges.txt'
+    'zoo:unittests/test_bytelevel_bpe_v2/test-byte-level-bpe-v2-merges.txt'
 )
 BYTELEVEL_BPE_RESULT = [
     'H',
@@ -105,8 +105,6 @@ class TestDictionary(unittest.TestCase):
             # grinning face emoji
             u'Hello, ParlAI! \U0001f600',
         )
-        os.remove('./test-byte-level-bpe-vocab.json')
-        os.remove('./test-byte-level-bpe-merges.txt')
 
     def test_space_tokenize(self):
         """

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -93,6 +93,7 @@ class TestDictionary(unittest.TestCase):
             dict_tokenizer='bytelevelbpe',
             bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,
             bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
+            bpe_add_prefix_space=False,
         )
         opt = parser.parse_args([], print_args=False)
         agent = DictionaryAgent(opt)
@@ -134,6 +135,33 @@ class TestDictionary(unittest.TestCase):
         # Test special token
         self.assertEqual(
             agent.txt2vec(agent.start_token), [agent.tok2ind[agent.start_token]]
+        )
+
+    def test_byte_level_bpe_tokenize_prefix_space(self):
+        """
+        Tests a bytelevel bpe tokenizer inside ParlAI.
+        """
+        parser = ParlaiParser()
+        parser.set_params(
+            dict_tokenizer='bytelevelbpe',
+            bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,
+            bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
+        )
+        opt = parser.parse_args([], print_args=False)
+        agent = DictionaryAgent(opt)
+        self.assertEqual(
+            # grinning face emoji
+            agent.bytelevelbpe_tokenize(u'Hello, ParlAI! \U0001f600'),
+            ['Ġ'] + BYTELEVEL_BPE_RESULT,
+        )
+        self.assertEqual(
+            agent.vec2txt([agent.tok2ind[w] for w in ['Ġ'] + BYTELEVEL_BPE_RESULT]),
+            # grinning face emoji
+            u'Hello, ParlAI! \U0001f600',
+        )
+        self.assertEqual(
+            agent.txt2vec(u'Hello, ParlAI! \U0001f600'),
+            [agent.tok2ind[w] for w in ['Ġ'] + BYTELEVEL_BPE_RESULT],
         )
 
     def test_space_tokenize(self):

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -131,6 +131,10 @@ class TestDictionary(unittest.TestCase):
             agent.txt2vec(u'Hello, ParlAI! \U0001f600'),
             [agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT],
         )
+        # Test special token
+        self.assertEqual(
+            agent.txt2vec(agent.start_token), [agent.tok2ind[agent.start_token]]
+        )
 
     def test_space_tokenize(self):
         """

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -106,6 +106,31 @@ class TestDictionary(unittest.TestCase):
             # grinning face emoji
             u'Hello, ParlAI! \U0001f600',
         )
+        self.assertEqual(
+            agent.txt2vec(u'Hello, ParlAI! \U0001f600'),
+            [agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT],
+        )
+        vocab_size = agent.byte_level_bpe.tokenizer.get_vocab_size()
+        with testing_utils.tempdir() as tmpdir:
+            path = os.path.join(tmpdir, 'dict-checkpoint')
+            agent.save(filename=path)
+            agent.load(filename=path)
+        # Test loading / saving
+        self.assertEqual(vocab_size, agent.byte_level_bpe.tokenizer.get_vocab_size())
+        self.assertEqual(
+            # grinning face emoji
+            agent.bytelevelbpe_tokenize(u'Hello, ParlAI! \U0001f600'),
+            BYTELEVEL_BPE_RESULT,
+        )
+        self.assertEqual(
+            agent.vec2txt([agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT]),
+            # grinning face emoji
+            u'Hello, ParlAI! \U0001f600',
+        )
+        self.assertEqual(
+            agent.txt2vec(u'Hello, ParlAI! \U0001f600'),
+            [agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT],
+        )
 
     def test_space_tokenize(self):
         """


### PR DESCRIPTION
**Patch description**
This PR adds a byte level bpe tokenizer into ParlAI, the original implementation is from hugging face.
We add this to provide more support to work closely with fairseq.
You can 
1. Load a pre-trained byte level bpe tokenizer 
2. train it from scratch by giving a test corpus. 


**Testing steps**
Test is added.
For saving:
```
python examples/train_model.py -t integration_tests  -mf /tmp/babi_new  -bs 1 -nt 4 -eps 5 -m memnn --no-cuda --dict-tokenizer bytelevelbpe --bpe-vocab ./data/test-byte-level-bpe-v1-vocab.json --bpe-merge ./data/test-byte-level-bpe-v1-merges.txt --validation-every-n-secs 5
```
For loading:
```
python examples/train_model.py -t integration_tests  -mf /tmp/babi_new  -bs 1 -nt 4 -eps 5 -m memnn --no-cuda --dict-tokenizer bytelevelbpe
```
