### PR TITLE
[FP16] Memory efficient optimizer

### DIFF
--- a/parlai/agents/bert_ranker/helpers.py
+++ b/parlai/agents/bert_ranker/helpers.py
@@ -9,7 +9,8 @@ BERT helpers.
 """
 
 from parlai.core.torch_ranker_agent import TorchRankerAgent
-from parlai.utils.torch import neginf, fp16_optimizer_wrapper
+from parlai.utils.fp16 import fp16_optimizer_wrapper
+from parlai.utils.torch import neginf
 
 try:
     from pytorch_pretrained_bert.modeling import BertLayer, BertConfig

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -38,7 +38,7 @@ from parlai.core.message import Message
 from parlai.utils.fp16 import (
     fp16_apex_available,
     fp16_optimizer_wrapper,
-    ParlAIFP16MemoryEfficientOptimizer
+    ParlAIFP16MemoryEfficientOptimizer,
 )
 from parlai.utils.misc import AttrDict, warn_once, round_sigfigs
 from parlai.utils.torch import argsort, padded_tensor

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -854,7 +854,6 @@ class TorchAgent(ABC, Agent):
                 'switch to --optimizer adam.'
             )
 
-        # TODO: if self.fp16 and self.fp16_impl == 'mem_efficient'... check that class is ok
         optim_class = self.optim_opts()[opt['optimizer']]
         self.optimizer = optim_class(params, **kwargs)
         if self.fp16:
@@ -862,6 +861,15 @@ class TorchAgent(ABC, Agent):
                 self.optimizer = fp16_optimizer_wrapper(self.optimizer)
             else:
                 # Using memory efficient optimizer
+                opt_name = opt['optimizer']
+                compatible_list = MemoryEfficientFP16Optimizer.compatible_optimizers()
+                is_compat = opt_name in compatible_list
+                if not is_compat:
+                    raise RuntimeError(
+                        f'The optimizer you selected {opt_name} is not compatible '
+                        'with Memory Efficient FP16. Please select from among this '
+                        f'list:\n{compatible_list}'
+                    )
                 self.optimizer = MemoryEfficientFP16Optimizer(self.optimizer)
         # TODO: we might want to hard reset optimizers here in the
         # case of fine tuning. Some rudimentary experiments seemed to

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -35,13 +35,9 @@ from parlai.utils.thread import SharedTable
 from parlai.core.dict import DictionaryAgent
 from parlai.nn.lr_scheduler import ParlAILRScheduler
 from parlai.core.message import Message
+from parlai.utils.fp16 import fp16_available, fp16_optimizer_wrapper
 from parlai.utils.misc import AttrDict, warn_once, round_sigfigs
-from parlai.utils.torch import (
-    argsort,
-    fp16_optimizer_wrapper,
-    padded_tensor,
-    fp16_available,
-)
+from parlai.utils.torch import argsort
 
 
 class Batch(AttrDict):

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -888,9 +888,11 @@ class TorchAgent(ABC, Agent):
                 optim_states['loss_scaler'] = self.optimizer.state_dict()['loss_scaler']
             elif optimstate_fp16 and not self.fp16:
                 # old optimizer was fp16 but now we're doing fp32,
-                # drop the fp16 wrapper from the state_dict and just load
+                # if apex, drop the fp16 wrapper from the state_dict and just load
                 # the fp16 weights into the fp32 tensors
-                optim_states = optim_states['optimizer_state_dict']
+                if 'optimizer_state_dict' in optim_states:
+                    # trained with apex
+                    optim_states = optim_states['optimizer_state_dict']
             elif not optimstate_fp16 and self.fp16:
                 # old optimizer was fp32, but now we're doing fp16.
                 # this is a bit clunky, but alternatives are worse

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -38,7 +38,7 @@ from parlai.core.message import Message
 from parlai.utils.fp16 import (
     fp16_apex_available,
     fp16_optimizer_wrapper,
-    ParlAIFP16MemoryEfficientOptimizer,
+    MemoryEfficientFP16Optimizer,
 )
 from parlai.utils.misc import AttrDict, warn_once, round_sigfigs
 from parlai.utils.torch import argsort, padded_tensor
@@ -833,7 +833,7 @@ class TorchAgent(ABC, Agent):
                 self.optimizer = fp16_optimizer_wrapper(self.optimizer)
             else:
                 # Using memory efficient optimizer
-                self.optimizer = ParlAIFP16MemoryEfficientOptimizer(self.optimizer)
+                self.optimizer = MemoryEfficientFP16Optimizer(self.optimizer)
         # TODO: we might want to hard reset optimizers here in the
         # case of fine tuning. Some rudimentary experiments seemed to
         # indicate that keeping adam weights around was desirable, so this

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -485,8 +485,9 @@ class TorchAgent(ABC, Agent):
             '--adafactor-eps',
             default='1e-30,1e-3',
             type='floats',
-            help='Epsilon values for adafactor optimizer: regularization'
-            'constants for square gradienta nd parameter scale respectively',
+            help='Epsilon values for adafactor optimizer: regularization '
+            'constants for square gradient and parameter scale respectively',
+            recommended='1e-30,1e-3',
         )
         optim_group.add_argument(
             '-mom',

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -29,8 +29,9 @@ import torch.nn.functional as F
 from parlai.core.opt import Opt
 from parlai.utils.distributed import is_distributed, sync_parameters
 from parlai.core.torch_agent import TorchAgent, Batch, Output
+from parlai.utils.fp16 import FP16SafeCrossEntropy
 from parlai.utils.misc import round_sigfigs, warn_once
-from parlai.utils.torch import neginf, FP16SafeCrossEntropy
+from parlai.utils.torch import neginf
 
 
 try:

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -137,7 +137,7 @@ def fp16_apex_available() -> bool:
 
 
 ###################################################
-## ParlAI Wrappers
+## Memory Efficient Wrappers
 ###################################################
 
 
@@ -252,6 +252,7 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         # TODO: we should probably set a bunch of these args with opt?
         self.min_loss_scale = min_loss_scale
         self.scaler = DynamicLossScaler(init_scale=loss_initial_scale)
+        # TODO: add warning here about which optimizers this works with
 
     @property
     def params(self):
@@ -310,7 +311,7 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
                     ).format(self.min_loss_scale)
                 )
             warn_once(f'[ Overflow: setting loss scale to {self.scaler.loss_scale} ]')
-            # TODO: dso we want to zero grad here?
+            # TODO: do we actually want to zero grad here? or in the train loop?
             self.zero_grad()
             return -1
 

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -254,6 +254,14 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         self.scaler = DynamicLossScaler(init_scale=loss_initial_scale)
         # TODO: add warning here about which optimizers this works with
 
+    @staticmethod
+    def compatible_optimizers():
+        return [
+            'sgd',
+            'adam',
+            'adafactor',
+        ]
+
     @property
     def params(self):
         """
@@ -397,6 +405,11 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         self._grads_are_scaled = False
 
 
+###################################################
+## Optimizers for Memory Efficient FP16
+###################################################
+
+
 class MemoryEfficientFP16Adam(torch.optim.Adam):
     """
     Override from Pytorch implementation to ensure aggregations done in FP32.
@@ -460,6 +473,200 @@ class MemoryEfficientFP16Adam(torch.optim.Adam):
                 step_size = group['lr'] * math.sqrt(bias_correction2) / bias_correction1
 
                 p_data_fp32.addcdiv_(-step_size, exp_avg, denom)
+
+                p.data.copy_(p_data_fp32)
+
+        return loss
+
+
+class Adafactor(torch.optim.Optimizer):
+    """
+    Implements Adafactor algorithm.
+
+    This implementation is based on:
+    `Adafactor: Adaptive Learning Rates with Sublinear Memory Cost`
+    (see https://arxiv.org/abs/1804.04235)
+
+    Taken from the fairseq implementation, which can be found here:
+    <https://github.com/pytorch/fairseq/blob/master/fairseq/optim/adafactor.py>.
+
+    :param params (iterable):
+        iterable of parameters to optimize or dicts defining parameter groups
+    :param lr (float, optional):
+        external learning rate (default: None)
+    :param eps (tuple[float, float]):
+        regularization constans for square gradient and parameter scale
+        respectively (default: (1e-30, 1e-3))
+    :param clip_threshold (float):
+        threshold of root mean square of final gradient update
+        (default: 1.0)
+    :param decay_rate (float):
+        coefficient used to compute running averages of square gradient
+        (default: -0.8)
+    :param beta1 (float):
+        coefficient used for computing running averages of gradient
+        (default: None)
+    :param weight_decay (float, optional):
+        weight decay (L2 penalty) (default: 0)
+    :param scale_parameter (bool):
+        if true, learning rate is scaled by root mean square of parameter
+        (default: True)
+    :param relative_step (bool):
+        if true, time-dependent learning rate is computed instead of external
+        learning rate (default: True)
+    :param warmup_init (bool):
+        time-dependent learning rate computation depends on whether warm-up
+        initialization is being used (default: False)
+    """
+
+    def __init__(
+        self,
+        params,
+        lr=None,
+        eps=(1e-30, 1e-3),
+        clip_threshold=1.0,
+        decay_rate=-0.8,
+        beta1=None,
+        weight_decay=0.0,
+        scale_parameter=True,
+        relative_step=True,
+        warmup_init=False,
+    ):
+        defaults = dict(
+            lr=lr,
+            eps=eps,
+            clip_threshold=clip_threshold,
+            decay_rate=decay_rate,
+            beta1=beta1,
+            weight_decay=weight_decay,
+            scale_parameter=scale_parameter,
+            relative_step=relative_step,
+            warmup_init=warmup_init,
+        )
+        super(Adafactor, self).__init__(params, defaults)
+
+    def _get_lr(self, param_group, param_state):
+        rel_step_sz = param_group['lr']
+        if param_group['relative_step']:
+            min_step = (
+                1e-6 * param_state['step'] if param_group['warmup_init'] else 1e-2
+            )
+            rel_step_sz = min(min_step, 1.0 / math.sqrt(param_state['step']))
+        param_scale = 1.0
+        if param_group['scale_parameter']:
+            param_scale = max(param_group['eps'][1], param_state['RMS'])
+        return param_scale * rel_step_sz
+
+    def _get_options(self, param_group, param_shape):
+        """
+        TODO: this is a weird name
+        """
+        factored = len(param_shape) >= 2
+        use_first_moment = param_group['beta1'] is not None
+        return factored, use_first_moment
+
+    def _rms(self, tensor):
+        """
+        Root mean square of a tensor.
+        """
+        return tensor.norm(2) / (tensor.numel() ** 0.5)
+
+    def _approx_sq_grad(self, exp_avg_sq_row, exp_avg_sq_col, output):
+        r_factor = (
+            (exp_avg_sq_row / exp_avg_sq_row.mean(dim=-1).unsqueeze(-1))
+            .rsqrt_()
+            .unsqueeze(-1)
+        )
+        c_factor = exp_avg_sq_col.unsqueeze(-2).rsqrt()
+        torch.mul(r_factor, c_factor, out=output)
+
+    def step(self, closure=None):
+        """
+        Performs a single optimization step.
+
+        Arguments:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+                grad = p.grad.data.float()  # NOTE: cast to FP32
+                if grad.is_sparse:
+                    raise RuntimeError('Adafactor does not support sparse gradients.')
+
+                state = self.state[p]
+                grad_shape = grad.shape
+
+                factored, use_first_moment = self._get_options(group, grad_shape)
+                # State Initialization
+                if len(state) == 0:
+                    state['step'] = 0
+
+                    if use_first_moment:
+                        # Exponential moving average of gradient values
+                        state['exp_avg'] = torch.zeros_like(grad)
+                    if factored:
+                        state['exp_avg_sq_row'] = torch.zeros(grad_shape[:-1]).type_as(
+                            grad
+                        )
+                        state['exp_avg_sq_col'] = torch.zeros(
+                            grad_shape[:-2] + grad_shape[-1:]
+                        ).type_as(grad)
+                    else:
+                        state['exp_avg_sq'] = torch.zeros_like(grad)
+
+                    state['RMS'] = 0
+                else:
+                    if use_first_moment:
+                        state['exp_avg'] = state['exp_avg'].type_as(grad)
+                    if factored:
+                        state['exp_avg_sq_row'] = state['exp_avg_sq_row'].type_as(grad)
+                        state['exp_avg_sq_col'] = state['exp_avg_sq_col'].type_as(grad)
+                    else:
+                        state['exp_avg_sq'] = state['exp_avg_sq'].type_as(grad)
+
+                p_data_fp32 = p.data.float()  # NOTE: cast to FP32
+
+                state['step'] += 1
+                state['RMS'] = self._rms(p_data_fp32)
+                group['lr'] = self._get_lr(group, state)
+
+                beta2t = 1.0 - math.pow(state['step'], group['decay_rate'])
+                update = (grad ** 2) + group['eps'][0]
+                if factored:
+                    exp_avg_sq_row = state['exp_avg_sq_row']
+                    exp_avg_sq_col = state['exp_avg_sq_col']
+
+                    exp_avg_sq_row.mul_(beta2t).add_(1.0 - beta2t, update.mean(dim=-1))
+                    exp_avg_sq_col.mul_(beta2t).add_(1.0 - beta2t, update.mean(dim=-2))
+
+                    # Approximation of exponential moving average of square of gradient
+                    self._approx_sq_grad(exp_avg_sq_row, exp_avg_sq_col, update)
+                    update.mul_(grad)
+                else:
+                    exp_avg_sq = state['exp_avg_sq']
+
+                    exp_avg_sq.mul_(beta2t).add_(1.0 - beta2t, update)
+                    torch.rsqrt(exp_avg_sq, out=update).mul_(grad)
+
+                update.div_(max(1.0, self._rms(update) / group['clip_threshold']))
+                update.mul_(group['lr'])
+
+                if use_first_moment:
+                    exp_avg = state['exp_avg']
+                    exp_avg.mul_(group['beta1']).add_(1 - group['beta1'], update)
+                    update = exp_avg
+
+                if group['weight_decay'] != 0:
+                    p_data_fp32.add_(-group['weight_decay'] * group['lr'], p_data_fp32)
+
+                p_data_fp32.add_(-update)
 
                 p.data.copy_(p_data_fp32)
 

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -123,7 +123,6 @@ def fp16_optimizer_wrapper(
 
 
 def fp16_apex_available() -> bool:
-    # TODO: deprecate this function parlai_fp16_optimizer is available
     try:
         import apex.fp16_utils  # noqa: F401
 

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -136,8 +136,7 @@ class DynamicLossScaler(object):
     """
     Shamelessly stolen from Fairseq.
 
-    Dynamically adjusts the loss scaling factor.
-    Useful for mixed-precision training.
+    Dynamically adjusts the loss scaling factor. Useful for mixed-precision training.
     """
 
     def __init__(
@@ -252,7 +251,9 @@ class ParlAIFP16MemoryEfficientOptimizer(torch.optim.Optimizer):
 
     @property
     def params(self):
-        """Return an iterable of the parameters held by the optimizer."""
+        """
+        Return an iterable of the parameters held by the optimizer.
+        """
         for param_group in self.optimizer.param_groups:
             for p in param_group['params']:
                 yield p

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -9,6 +9,7 @@ Utility methods for mixed precision training.
 from parlai.utils.misc import warn_once
 
 from itertools import chain
+import math
 
 try:
     import torch
@@ -394,3 +395,72 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         """
         self.optimizer.zero_grad()
         self._grads_are_scaled = False
+
+
+class MemoryEfficientFP16Adam(torch.optim.Adam):
+    """
+    Override from Pytorch implementation to ensure aggregations done in FP32.
+    """
+
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+                grad = p.grad.data.float()  # NOTE: cast to FP32 here
+                if grad.is_sparse:
+                    raise RuntimeError(
+                        'Adam does not support sparse gradients, '
+                        'please consider SparseAdam instead'
+                    )
+                amsgrad = group['amsgrad']
+
+                p_data_fp32 = p.data.float()  # NOTE: cast to FP32 here
+
+                state = self.state[p]
+
+                # State initialization
+                if len(state) == 0:
+                    state['step'] = 0
+                    # Exponential moving average of gradient values
+                    state['exp_avg'] = torch.zeros_like(p_data_fp32)
+                    # Exponential moving average of squared gradient values
+                    state['exp_avg_sq'] = torch.zeros_like(p_data_fp32)
+                    if amsgrad:
+                        # Maintains max of all exp. moving avg. of sq. grad. values
+                        state['max_exp_avg_sq'] = torch.zeros_like(p_data_fp32)
+
+                exp_avg, exp_avg_sq = state['exp_avg'], state['exp_avg_sq']
+                if amsgrad:
+                    max_exp_avg_sq = state['max_exp_avg_sq']
+                beta1, beta2 = group['betas']
+
+                state['step'] += 1
+
+                if group['weight_decay'] != 0:
+                    grad.add_(group['weight_decay'], p_data_fp32)
+
+                # Decay the first and second moment running average coefficient
+                exp_avg.mul_(beta1).add_(1 - beta1, grad)
+                exp_avg_sq.mul_(beta2).addcmul_(1 - beta2, grad, grad)
+                if amsgrad:
+                    # Maintains the maximum of all 2nd moment running avg. till now
+                    torch.max(max_exp_avg_sq, exp_avg_sq, out=max_exp_avg_sq)
+                    # Use the max. for normalizing running avg. of gradient
+                    denom = max_exp_avg_sq.sqrt().add_(group['eps'])
+                else:
+                    denom = exp_avg_sq.sqrt().add_(group['eps'])
+
+                bias_correction1 = 1 - beta1 ** state['step']
+                bias_correction2 = 1 - beta2 ** state['step']
+                step_size = group['lr'] * math.sqrt(bias_correction2) / bias_correction1
+
+                p_data_fp32.addcdiv_(-step_size, exp_avg, denom)
+
+                p.data.copy_(p_data_fp32)
+
+        return loss

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Utility methods for mixed precision training.
+"""
+from parlai.utils.misc import warn_once
+
+try:
+    import torch
+except ImportError:
+    raise ImportError('Parlai requires pytorch. Go to http://pytorch.org to install.')
+
+
+###################################################
+## APEX Wrapper
+###################################################
+
+
+def fp16_optimizer_wrapper(
+    optimizer: torch.optim.Optimizer,  # type: ignore
+    verbose: bool = False,
+    dynamic_loss_scale: bool = True,
+    loss_initial_scale: float = 2.0 ** 17,
+):
+    """
+    Wrap the an optimizer with FP16 loss scaling protection.
+
+    Requires apex to be installed. Will throw an ImportError if it is not.
+
+    :param optimizer:
+        Any torch optimizer
+    :param bool verbose:
+        Enables verbose output in the FP16 optimizer. Turning this on can help
+        debug when FP16 is underperforming.
+    :param bool dynamic_loss_scaling:
+        FP16 requires loss scaling to avoid underflows. It is recommended this
+        stays on, but advanced users may want it off.
+    :param float loss_initial_scale:
+        Initial loss scaling. Default chosen empirically, but models with very low
+        or high loss values may need this adjusted. Stick with powers of 2.
+
+    :returns:
+        An APEX FP16 optimizer. Please note this has different requirements on
+        how backward() and step() are called.
+    """
+    try:
+        import apex.fp16_utils
+    except ImportError:
+        raise ImportError(
+            'No fp16 support without apex. Please install it from '
+            'https://github.com/NVIDIA/apex'
+        )
+    return apex.fp16_utils.FP16_Optimizer(
+        optimizer,
+        dynamic_loss_scale=dynamic_loss_scale,
+        verbose=verbose,
+        # TODO: We may later want to remove this flag. Right now it
+        # empirically improves the first few backward passes, but future APEX
+        # improvements may make this unnecessary.
+        dynamic_loss_args={'init_scale': loss_initial_scale},
+    )
+
+
+def fp16_available() -> bool:
+    # TODO: deprecate this function parlai_fp16_optimizer is available
+    try:
+        import apex.fp16_utils  # noqa: F401
+
+        return True
+    except ImportError:
+        warn_once(
+            'You set --fp16 true, but fp16 is unavailable. To use fp16, please '
+            'install APEX from https://github.com/NVIDIA/apex.'
+        )
+        return False
+
+
+###################################################
+## ParlAI Wrappers
+###################################################
+
+
+class DynamicLossScaler(object):
+    """
+    Directly stolen from fairseq (thanks Myle)!
+
+    TODO: Add a description here
+    """
+    def __init__(
+        self,
+        init_scale: float = 2.0 ** 15,
+        scale_factor: float = 2.0,
+        scale_window: int = 2000,
+        tolerance: float = 0.05,
+        threshold: float = None,
+    ):
+        """
+        :param init_scale:
+            Initial loss scale.
+        :param scale_factor:
+            Factor by which to increase or decrease loss scale.
+        :param scale_window:
+            If we do not experience overflow in scale_window iterations,
+            loss scale will increase by scale_factor.
+        :param tolerance:
+            Pct of iterations that have overflowed after which we must
+            decrease the loss scale
+        :param threshold:
+            If not None, loss scale will decrease below this threshold
+        """
+        self.loss_scale = init_scale
+        self.scale_factor = scale_factor
+        self.scale_window = scale_window
+        self.tolerance = tolerance
+        self.threshold = threshold
+
+        self._iter = 0
+        self._last_overflow_iter = -1
+        self._last_rescale_iter = -1
+        self._overflows_since_rescale = 0
+
+    def update_scale(self, overflow: bool):
+        """
+        Update the loss scale.
+
+        If overflow exceeds our tolerance, we decrease the loss scale.
+        If the number of iterations since the last overflow exceeds the
+        scale window, we increase the loss scale.
+        """
+        iter_since_rescale = self._iter - self._last_rescale_iter
+
+        if overflow:
+            # calculate how often we overflowed already
+            self._last_overflow_iter = self._iter
+            self._overflows_since_rescale += 1
+            pct_overflow = self._overflows_since_rescale / float(iter_since_rescale)
+            if pct_overflow >= self.tolerance:
+                # decrease loss scale by the scale factor
+                self._decrease_loss_scale()
+                # reset iters
+                self._last_rescale_iter = self._iter
+                self._overflows_since_rescale = 0
+        elif (self._iter - self._last_overflow_iter) % self.scale_window == 0:
+            # increase the loss scale by scale factor
+            self.loss_scale *= self.scale_factor
+            self._last_rescale_iter = self._iter
+
+        self._iter += 1
+
+    def _decrease_loss_scale(self):
+        """
+        Decrease the loss scale by self.scale_factor.
+
+        NOTE: the loss_scale will not go below self.threshold.
+        """
+        self.loss_scale /= self.scale_factor
+        if self.threshold is not None:
+            self.loss_scale = max(self.loss_scale, self.threshold)
+
+    @staticmethod
+    def has_overflow(grad_norm):
+        """
+        Detect inf and NaN in grad_norm.
+        """
+        if grad_norm == float('inf') or grad_norm != grad_norm:
+            return True
+        return False
+
+
+class ParlAIFP16Optimizer(torch.optim.Optimizer):
+    """
+    Wrap an optimizer to perform mixed precision training.
+
+    Based on the fairseq implementation. This wraps an optimizer to perform
+    FP16 training.
+
+    :param optimizer:
+        Any torch optimizer
+    :param float loss_initial_scale:
+        Initial loss scaling. Default chosen empirically, but models with very low
+        or high loss values may need this adjusted. Stick with powers of 2.
+    """
+
+    def __init__(
+        init_optimizer: torch.optim.Optimizer,  # type: ignore
+        loss_initial_scale: float = 2.0 ** 17,
+    ):
+        self.wrapped_optimizer = init_optimizer  # wrapped optimizer is FP32 optimizer
+        self.scaler = DynamicLossScaler(init_scale=loss_initial_scale)
+        # TODO: finish
+
+    def __getstate__(self):
+        return self.wrapped_optimizer.__getstate__()
+
+    def __setstate__(self, state):
+        self.wrapped_optimizer.__setstate__(state)
+
+    def __repr__(self):
+        self.wrapped_optimizer.__repr__()
+
+    def state_dict(self):
+        """Return the optimizer's state dict."""
+        state_dict = self.fp32_optimizer.state_dict()
+        state_dict['loss_scale'] = self.scaler.loss_scale
+        return state_dict
+
+    def zero_grad(self):
+        """Clears the gradients of all optimized parameters."""
+        for p in self.fp16_params:
+            p.grad = None
+        if self.has_flat_params:
+            self.fp32_params.grad.zero_()
+        else:
+            for p32 in self.fp32_params:
+                p32.grad.zero_()
+        self._needs_sync = False
+
+    def step(self, closure):
+        """
+        Performs a single optimization step.
+        """
+        self._sync_fp16_grads_to_fp32()
+        self.fp32_optimizer.step(closure)
+
+        # copy FP32 params back into FP16 model
+        if self.has_flat_params:
+            offset = 0
+            for p in self.fp16_params:
+                if not p.requires_grad:
+                    continue
+                numel = p.data.numel()
+                p.data.copy_(self.fp32_params.data[offset:offset+numel].view_as(p.data))
+                offset += numel
+        else:
+            for p, p32 in zip(self.fp16_params, self.fp32_params):
+                if not p.requires_grad:
+                    continue
+                p.data.copy_(p32.data)
+
+    def load_state_dict(self, state_dict, optimizer_overrides=None):
+        """Load an optimizer state dict.
+
+        In general we should prefer the configuration of the existing optimizer
+        instance (e.g., learning rate) over that found in the state_dict. This
+        allows us to resume training from a checkpoint using a new set of
+        optimizer args.
+        """
+        if 'loss_scale' in state_dict:
+            self.scaler.loss_scale = state_dict['loss_scale']
+        self.fp32_optimizer.load_state_dict(state_dict, optimizer_overrides)
+
+    def add_param_group(self, param_group):
+        self.wrapped_optimizer.add_param_group(param_group)
+
+
+class ParlAIFP16MemoryEfficientOptimizer(ParlAIFP16Optimizer):
+    """
+    Wrap an optimizer to perform memory-efficient mixed precision training.
+
+    Based on the fairseq implementation. This wraps an optimizer to perform
+    FP16 training.
+
+    :param optimizer:
+        Any torch optimizer
+    :param float loss_initial_scale:
+        Initial loss scaling. Default chosen empirically, but models with very low
+        or high loss values may need this adjusted. Stick with powers of 2.
+    """
+
+    def __init__(
+        init_optimizer: torch.optim.Optimizer,  # type: ignore
+        loss_initial_scale: float = 2.0 ** 17,
+    ):
+        self.wrapped_optimizer = init_optimizer
+        # TODO: finish
+
+    def zero_grad(self):
+        """Clears the gradients of all optimized parameters."""
+        self.wrapped_optimizer.zero_grad()
+        self._grads_are_scaled = False
+
+    def step(self, closure=None):
+        """Performs a single optimization step."""
+        self._unscale_grads()
+        self.wrapped_optimizer.step(closure)
+
+    def state_dict(self):
+        """Return the optimizer's state dict."""
+        state_dict = self.wrapped_optimizer.state_dict()
+        state_dict['loss_scale'] = self.scaler.loss_scale
+        return state_dict
+
+    def load_state_dict(self, state_dict):
+        """
+        Load an optimizer state dict.
+
+        Override from PyTorch implementation to avoid casting to FP32.
+        """
+        if 'loss_scale' in state_dict:
+            self.scaler.loss_scale = state_dict['loss_scale']
+
+        self.wrapped_optimizer.load_state_dict(state_dict)
+
+        # Hack: PyTorch automatically casts the optimizer state to match the
+        # type of the current parameters. But with --memory-efficient-fp16 the
+        # params are FP16 while the optimizer state is FP32 and we don't want
+        # to cast. A workaround is to manually copy back the original state
+        # after the optimizer has been loaded.
+        groups = self.optimizer.param_groups
+        saved_groups = state_dict['param_groups']
+        id_map = {
+            old_id: p
+            for old_id, p in zip(
+                chain(*(g['params'] for g in saved_groups)),
+                chain(*(g['params'] for g in groups))
+            )
+        }
+        for k, v in state_dict['state'].items():
+            if k in id_map:
+                param = id_map[k]
+                self.optimizer.state[param] = v

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -231,6 +231,9 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
     of `MemoryEfficientFP16Optimizer`, which can be found here:
     <https://github.com/pytorch/fairseq/blob/master/fairseq/optim/fp16_optimizer.py#L382>
 
+    This allows you to train bigger models on a single GPU, but can be unstable.
+    Opt for the APEX implementation if you do not have concerns about memory.
+
     :param params:
         Model parameters
     :param optimizer:
@@ -256,6 +259,9 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
 
     @staticmethod
     def compatible_optimizers():
+        """
+        List of compatible optimizers.
+        """
         return [
             'adam',
             'mem_eff_adam',

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -252,10 +252,9 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         min_loss_scale: float = 1e-4,
     ):
         self.optimizer = init_optimizer
-        # TODO: we should probably set a bunch of these args with opt?
+        # TODO: set some of these args with opt
         self.min_loss_scale = min_loss_scale
         self.scaler = DynamicLossScaler(init_scale=loss_initial_scale)
-        # TODO: add warning here about which optimizers this works with
 
     @staticmethod
     def compatible_optimizers():
@@ -325,7 +324,6 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
                     ).format(self.min_loss_scale)
                 )
             warn_once(f'[ Overflow: setting loss scale to {self.scaler.loss_scale} ]')
-            # TODO: do we actually want to zero grad here? or in the train loop?
             self.zero_grad()
             return -1
 
@@ -565,7 +563,7 @@ class Adafactor(torch.optim.Optimizer):
 
     def _get_options(self, param_group, param_shape):
         """
-        TODO: this is a weird name
+        Return factored and whether to use first moment (beta1).
         """
         factored = len(param_shape) >= 2
         use_first_moment = param_group['beta1'] is not None

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -257,8 +257,8 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
     @staticmethod
     def compatible_optimizers():
         return [
-            'sgd',
             'adam',
+            'mem_eff_adam',
             'adafactor',
         ]
 

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -130,7 +130,8 @@ def fp16_apex_available() -> bool:
         return True
     except ImportError:
         warn_once(
-            'You set --fp16 true, but fp16 is unavailable. To use fp16, please '
+            'You set --fp16 true with --fp16-impl apex, but fp16 '
+            'with apex is unavailable. To use apex fp16, please '
             'install APEX from https://github.com/NVIDIA/apex.'
         )
         return False

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -354,7 +354,7 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         Return the optimizer's state dict.
         """
         state_dict = self.optimizer.state_dict()
-        state_dict['loss_scale'] = self.scaler.loss_scale
+        state_dict['loss_scaler'] = self.scaler
         return state_dict
 
     def load_state_dict(self, state_dict):
@@ -363,8 +363,9 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
 
         Override from PyTorch implementation to avoid casting to FP32.
         """
-        if 'loss_scale' in state_dict:
-            self.scaler.loss_scale = state_dict['loss_scale']
+        if 'loss_scaler' in state_dict:
+            # init from the state dict
+            self.scaler = state_dict['loss_scaler']
 
         self.optimizer.load_state_dict(state_dict)
 

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -15,7 +15,6 @@ except ImportError:
     raise ImportError('Parlai requires pytorch. Go to http://pytorch.org to install.')
 
 import torch.optim
-import torch.nn.functional as F
 
 """Near infinity, useful as a large penalty for scoring when inf is bad."""
 NEAR_INF = 1e20

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -8,7 +8,6 @@ Utility methods for dealing with torch code.
 """
 
 from typing import Union, Optional, Tuple, Any, List, Sized
-from parlai.utils.misc import warn_once
 
 try:
     import torch
@@ -210,64 +209,6 @@ def argsort(keys: List[Any], *lists: List[List[Any]], descending: bool = False):
         else:
             output.append([lst[i] for i in ind_sorted])
     return output
-
-
-def fp16_optimizer_wrapper(
-    optimizer: torch.optim.Optimizer,  # type: ignore
-    verbose: bool = False,
-    dynamic_loss_scale: bool = True,
-    loss_initial_scale: float = 2.0 ** 17,
-):
-    """
-    Wrap the an optimizer with FP16 loss scaling protection.
-
-    Requires apex to be installed. Will throw an ImportError if it is not.
-
-    :param optimizer:
-        Any torch optimizer
-    :param bool verbose:
-        Enables verbose output in the FP16 optimizer. Turning this on can help
-        debug when FP16 is underperforming.
-    :param bool dynamic_loss_scaling:
-        FP16 requires loss scaling to avoid underflows. It is recommended this
-        stays on, but advanced users may want it off.
-    :param float loss_initial_scale:
-        Initial loss scaling. Default chosen empirically, but models with very low
-        or high loss values may need this adjusted. Stick with powers of 2.
-
-    :returns:
-        An APEX FP16 optimizer. Please note this has different requirements on
-        how backward() and step() are called.
-    """
-    try:
-        import apex.fp16_utils
-    except ImportError:
-        raise ImportError(
-            'No fp16 support without apex. Please install it from '
-            'https://github.com/NVIDIA/apex'
-        )
-    return apex.fp16_utils.FP16_Optimizer(
-        optimizer,
-        dynamic_loss_scale=dynamic_loss_scale,
-        verbose=verbose,
-        # TODO: We may later want to remove this flag. Right now it
-        # empirically improves the first few backward passes, but future APEX
-        # improvements may make this unnecessary.
-        dynamic_loss_args={'init_scale': loss_initial_scale},
-    )
-
-
-def fp16_available() -> bool:
-    try:
-        import apex.fp16_utils  # noqa: F401
-
-        return True
-    except ImportError:
-        warn_once(
-            'You set --fp16 true, but fp16 is unavailable. To use fp16, please '
-            'install APEX from https://github.com/NVIDIA/apex.'
-        )
-        return False
 
 
 class IdentityLayer(torch.nn.Module):

--- a/tests/test_mem_efficient_fp16.py
+++ b/tests/test_mem_efficient_fp16.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import unittest
+
+import parlai.utils.testing as testing_utils
+
+
+@testing_utils.skipUnlessGPU
+class TestMemEfficientFP16(unittest.TestCase):
+    """
+    Test memory efficient FP16 implementation.
+    """
+
+    def test_adam(self):
+        valid, _ = testing_utils.train_model(
+            dict(
+                task='integration_tests:candidate',
+                model='transformer/ranker',
+                optimizer='adam',
+                fp16=True,
+                fp16_impl='mem_efficient',
+                learningrate=7e-3,
+                batchsize=32,
+                num_epochs=1,
+                n_layers=1,
+                n_heads=1,
+                ffn_size=32,
+                embedding_size=32,
+                warmup_updates=1,
+                lr_scheduler='invsqrt',
+            )
+        )
+        self.assertGreaterEqual(valid['hits@1'], 0.4)
+
+    def test_unsupported(self):
+        with self.assertRaises(RuntimeError):
+            # SGD unsupported currently
+            testing_utils.train_model(
+                dict(
+                    task='integration_tests:candidate',
+                    model='transformer/ranker',
+                    optimizer='sgd',
+                    fp16=True,
+                    fp16_impl='mem_efficient',
+                )
+            )
+
+    def test_resuming(self):
+        """
+        Test resuming without FP16.
+        """
+        with testing_utils.tempdir() as tmpdir:
+            model_file = os.path.join(tmpdir, 'model')
+
+            valid1, test1 = testing_utils.train_model(
+                dict(
+                    model_file=model_file,
+                    task='integration_tests:candidate',
+                    model='transformer/ranker',
+                    optimizer='adam',
+                    fp16=True,
+                    fp16_impl='mem_efficient',
+                    learningrate=7e-3,
+                    batchsize=32,
+                    num_epochs=1,
+                    n_layers=1,
+                    n_heads=1,
+                    ffn_size=32,
+                    embedding_size=32,
+                    warmup_updates=1,
+                    lr_scheduler='invsqrt',
+                )
+            )
+
+            valid2, test2 = testing_utils.train_model(
+                dict(
+                    model_file=model_file,
+                    task='integration_tests:candidate',
+                    model='transformer/ranker',
+                    num_epochs=1,
+                    fp16=False,
+                )
+            )
+
+            # make sure the number of updates is being tracked correctly
+            self.assertGreater(
+                valid2['total_train_updates'],
+                valid1['total_train_updates'],
+                'Number of updates is not increasing',
+            )


### PR DESCRIPTION
**Patch description**
Add a wrapper for a memory efficient FP16 optimizer. Based heavily on the fairseq implementation, which can be found here: https://github.com/pytorch/fairseq/blob/master/fairseq/optim/fp16_optimizer.py. Preliminary tests seems to show this saves about ~6.5 GB when finetuning GPT2-large.

Additionally, added a compatible Adam and Adafactor optimizer (also based on fairseq implementation). 

**Testing steps**
`python -m pytest /private/home/edinan/ParlAI/tests/test_mem_efficient_fp16.py`