### PR TITLE
Asymmetrical transformers

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -99,7 +99,7 @@ def _build_decoder(
     return TransformerDecoder(
         n_heads=opt['n_heads'],
         n_layers=(
-            opt['n_encoder_layers'] if opt['n_encoder_layers'] > 0 else opt['n_layers']
+            opt['n_decoder_layers'] if opt['n_decoder_layers'] > 0 else opt['n_layers']
         ),
         embedding_size=opt['embedding_size'],
         ffn_size=opt['ffn_size'],

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -72,9 +72,7 @@ def _build_encoder(
     return TransformerEncoder(
         n_heads=opt['n_heads'],
         n_layers=(
-            opt['n_encoder_layers']
-            if opt['n_encoder_layers'] > 0
-            else opt['n_layers']
+            opt['n_encoder_layers'] if opt['n_encoder_layers'] > 0 else opt['n_layers']
         ),
         embedding_size=opt['embedding_size'],
         ffn_size=opt['ffn_size'],
@@ -101,9 +99,7 @@ def _build_decoder(
     return TransformerDecoder(
         n_heads=opt['n_heads'],
         n_layers=(
-            opt['n_encoder_layers']
-            if opt['n_encoder_layers'] > 0
-            else opt['n_layers']
+            opt['n_encoder_layers'] if opt['n_encoder_layers'] > 0 else opt['n_layers']
         ),
         embedding_size=opt['embedding_size'],
         ffn_size=opt['ffn_size'],

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -69,9 +69,19 @@ def _build_encoder(
     n_positions=1024,
     n_segments=0,
 ):
+    if opt['num_encoder_layers'] > 0:
+        warn_once(
+            'Building a Asymmetrical Transformer with encoder size of {}.'.format(
+                opt['num_encoder_layers']
+            )
+        )
     return TransformerEncoder(
         n_heads=opt['n_heads'],
-        n_layers=opt['n_layers'],
+        n_layers=(
+            opt['num_encoder_layers']
+            if opt['num_encoder_layers'] > 0
+            else opt['n_layers']
+        ),
         embedding_size=opt['embedding_size'],
         ffn_size=opt['ffn_size'],
         vocabulary_size=len(dictionary),
@@ -94,9 +104,19 @@ def _build_encoder(
 def _build_decoder(
     opt, dictionary, embedding=None, padding_idx=None, n_positions=1024, n_segments=0
 ):
+    if opt['num_decoder_layers'] > 0:
+        warn_once(
+            'Building a Asymmetrical Transformer with decoder size of {}.'.format(
+                opt['num_decoder_layers']
+            )
+        )
     return TransformerDecoder(
         n_heads=opt['n_heads'],
-        n_layers=opt['n_layers'],
+        n_layers=(
+            opt['num_encoder_layers']
+            if opt['num_encoder_layers'] > 0
+            else opt['n_layers']
+        ),
         embedding_size=opt['embedding_size'],
         ffn_size=opt['ffn_size'],
         vocabulary_size=len(dictionary),

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -69,17 +69,11 @@ def _build_encoder(
     n_positions=1024,
     n_segments=0,
 ):
-    if opt['num_encoder_layers'] > 0:
-        warn_once(
-            'Building a Asymmetrical Transformer with encoder size of {}.'.format(
-                opt['num_encoder_layers']
-            )
-        )
     return TransformerEncoder(
         n_heads=opt['n_heads'],
         n_layers=(
-            opt['num_encoder_layers']
-            if opt['num_encoder_layers'] > 0
+            opt['n_encoder_layers']
+            if opt['n_encoder_layers'] > 0
             else opt['n_layers']
         ),
         embedding_size=opt['embedding_size'],
@@ -104,17 +98,11 @@ def _build_encoder(
 def _build_decoder(
     opt, dictionary, embedding=None, padding_idx=None, n_positions=1024, n_segments=0
 ):
-    if opt['num_decoder_layers'] > 0:
-        warn_once(
-            'Building a Asymmetrical Transformer with decoder size of {}.'.format(
-                opt['num_decoder_layers']
-            )
-        )
     return TransformerDecoder(
         n_heads=opt['n_heads'],
         n_layers=(
-            opt['num_encoder_layers']
-            if opt['num_encoder_layers'] > 0
+            opt['n_encoder_layers']
+            if opt['n_encoder_layers'] > 0
             else opt['n_layers']
         ),
         embedding_size=opt['embedding_size'],

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -102,6 +102,18 @@ def add_common_cmdline_args(argparser):
         help='Share word embeddings table for candidate and context'
         'in the memory network',
     )
+    argparser.add_argument(
+        '--num-encoder-layers',
+        type=int,
+        default=-1,
+        help='This will overide the n-layers for asymmetrical transformers',
+    )
+    argparser.add_argument(
+        '--num-decoder-layers',
+        type=int,
+        default=-1,
+        help='This will overide the n-layers for asymmetrical transformers',
+    )
 
 
 class Transformer(Agent):

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -103,13 +103,13 @@ def add_common_cmdline_args(argparser):
         'in the memory network',
     )
     argparser.add_argument(
-        '--num-encoder-layers',
+        '--n-encoder-layers',
         type=int,
         default=-1,
         help='This will overide the n-layers for asymmetrical transformers',
     )
     argparser.add_argument(
-        '--num-decoder-layers',
+        '--n-decoder-layers',
         type=int,
         default=-1,
         help='This will overide the n-layers for asymmetrical transformers',

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -103,12 +103,14 @@ def add_common_cmdline_args(argparser):
         'in the memory network',
     )
     argparser.add_argument(
+        '-nel',
         '--n-encoder-layers',
         type=int,
         default=-1,
         help='This will overide the n-layers for asymmetrical transformers',
     )
     argparser.add_argument(
+        '-ndl',
         '--n-decoder-layers',
         type=int,
         default=-1,

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -11,6 +11,8 @@ Test many variants of transformers.
 import os
 import unittest
 import parlai.utils.testing as testing_utils
+from parlai.core.agents import create_agent
+from parlai.core.opt import Opt
 
 
 class TestTransformerRanker(unittest.TestCase):
@@ -516,6 +518,49 @@ class TestTransformerGenerator(unittest.TestCase):
         self.assertLessEqual(test['ppl'], 1.30)
         self.assertGreaterEqual(test['bleu-4'], 0.90)
 
+    def test_asymmetry(self):
+        opt = Opt({
+                'model': 'transformer/generator',
+                'n_layers': 1,
+           })
+        agent = create_agent(opt)
+        self.assertEqual(agent.model.encoder.n_layers, 1)
+        self.assertEqual(agent.model.decoder.n_layers, 1)
+
+        opt = Opt({
+                'model':'transformer/generator',
+                'n_layers': 1,
+                'n_encoder_layers': 2,
+           })
+        agent = create_agent(opt)
+        self.assertEqual(agent.model.encoder.n_layers, 2)
+        self.assertEqual(agent.model.decoder.n_layers, 1)
+
+        opt = Opt({
+                'model':'transformer/generator',
+                'n_layers': 1,
+                'n_encoder_layers': 2,
+                'n_decoder_layers': 4,
+           })
+        agent = create_agent(opt)
+        self.assertEqual(agent.model.encoder.n_layers, 2)
+        self.assertEqual(agent.model.decoder.n_layers, 4)
+
+        opt = Opt({
+                'model':'transformer/generator',
+                'n_layers': 1,
+                'n_decoder_layers': 4,
+           })
+        agent = create_agent(opt)
+        self.assertEqual(agent.model.encoder.n_layers, 1)
+        self.assertEqual(agent.model.decoder.n_layers, 4)
+
+        opt = Opt({
+                'model':'transformer/generator',
+           })
+        agent = create_agent(opt)
+        self.assertEqual(agent.model.encoder.n_layers, 2)
+        self.assertEqual(agent.model.decoder.n_layers, 2)
 
 class TestLearningRateScheduler(unittest.TestCase):
     """

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -519,48 +519,42 @@ class TestTransformerGenerator(unittest.TestCase):
         self.assertGreaterEqual(test['bleu-4'], 0.90)
 
     def test_asymmetry(self):
-        opt = Opt({
+        opt = Opt({'model': 'transformer/generator', 'n_layers': 1})
+        agent = create_agent(opt)
+        self.assertEqual(agent.model.encoder.n_layers, 1)
+        self.assertEqual(agent.model.decoder.n_layers, 1)
+
+        opt = Opt(
+            {'model': 'transformer/generator', 'n_layers': 1, 'n_encoder_layers': 2}
+        )
+        agent = create_agent(opt)
+        self.assertEqual(agent.model.encoder.n_layers, 2)
+        self.assertEqual(agent.model.decoder.n_layers, 1)
+
+        opt = Opt(
+            {
                 'model': 'transformer/generator',
                 'n_layers': 1,
-           })
-        agent = create_agent(opt)
-        self.assertEqual(agent.model.encoder.n_layers, 1)
-        self.assertEqual(agent.model.decoder.n_layers, 1)
-
-        opt = Opt({
-                'model':'transformer/generator',
-                'n_layers': 1,
-                'n_encoder_layers': 2,
-           })
-        agent = create_agent(opt)
-        self.assertEqual(agent.model.encoder.n_layers, 2)
-        self.assertEqual(agent.model.decoder.n_layers, 1)
-
-        opt = Opt({
-                'model':'transformer/generator',
-                'n_layers': 1,
                 'n_encoder_layers': 2,
                 'n_decoder_layers': 4,
-           })
+            }
+        )
         agent = create_agent(opt)
         self.assertEqual(agent.model.encoder.n_layers, 2)
         self.assertEqual(agent.model.decoder.n_layers, 4)
 
-        opt = Opt({
-                'model':'transformer/generator',
-                'n_layers': 1,
-                'n_decoder_layers': 4,
-           })
+        opt = Opt(
+            {'model': 'transformer/generator', 'n_layers': 1, 'n_decoder_layers': 4}
+        )
         agent = create_agent(opt)
         self.assertEqual(agent.model.encoder.n_layers, 1)
         self.assertEqual(agent.model.decoder.n_layers, 4)
 
-        opt = Opt({
-                'model':'transformer/generator',
-           })
+        opt = Opt({'model': 'transformer/generator'})
         agent = create_agent(opt)
         self.assertEqual(agent.model.encoder.n_layers, 2)
         self.assertEqual(agent.model.decoder.n_layers, 2)
+
 
 class TestLearningRateScheduler(unittest.TestCase):
     """
@@ -587,7 +581,7 @@ class TestLearningRateScheduler(unittest.TestCase):
             )
             # make sure the learning rate is decreasing
             self.assertLess(
-                valid2['lr'], valid1['lr'], 'Learning rate is not decreasing',
+                valid2['lr'], valid1['lr'], 'Learning rate is not decreasing'
             )
             # but make sure we're not loading the scheduler if we're fine
             # tuning


### PR DESCRIPTION
**Patch description**
This PR allows asymmetrical transformers. The transformers who have different number of layers in encoder and decoder.
We add two options, num-encoder-layer, num-decoder-layer, they will override the n-layers option if they are given. 

**Testing steps**
For testing the original transformers for backward compatible. 
```
python examples/train_model.py -t twitter -mf /tmp/tr_twitter -m transformer/ranker -bs 10 -vtim 3600 -cands batch -ecands batch --data-parallel True
```
```
 python examples/train_model.py -t twitter -mf /tmp/tr_twitter -m transformer/generator -bs 10 -vtim 3600   --num-encoder-layers 1 --num-decoder-layers 4
```
**Logs**
```
[ num words =  366522 ]
/private/home/daju/ParlAI/parlai/agents/transformer/modules.py:73: UserWarning: Building a Asymmetrical Transformer with encoder size of 1.
  warn_once('Building a Asymmetrical Transformer with encoder size of {}.'.format(opt['num_encoder_layers']))
/private/home/daju/ParlAI/parlai/agents/transformer/modules.py:104: UserWarning: Building a Asymmetrical Transformer with decoder size of 4.
  warn_once('Building a Asymmetrical Transformer with decoder size of {}.'.format(opt['num_decoder_layers']))
```


