### PR TITLE
[Bug Fix]Fix nightly gpu test

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -69,11 +69,10 @@ def _build_encoder(
     n_positions=1024,
     n_segments=0,
 ):
+    n_layers = opt['n_encoder_layers'] if opt.get('n_encoder_layers', -1) > 0 else opt['n_layers']
     return TransformerEncoder(
         n_heads=opt['n_heads'],
-        n_layers=(
-            opt['n_encoder_layers'] if opt['n_encoder_layers'] > 0 else opt['n_layers']
-        ),
+        n_layers=n_layers,
         embedding_size=opt['embedding_size'],
         ffn_size=opt['ffn_size'],
         vocabulary_size=len(dictionary),
@@ -96,11 +95,10 @@ def _build_encoder(
 def _build_decoder(
     opt, dictionary, embedding=None, padding_idx=None, n_positions=1024, n_segments=0
 ):
+    n_layers = opt['n_decoder_layers'] if opt.get('n_decoder_layers', -1) > 0 else opt['n_layers']
     return TransformerDecoder(
         n_heads=opt['n_heads'],
-        n_layers=(
-            opt['n_decoder_layers'] if opt['n_decoder_layers'] > 0 else opt['n_layers']
-        ),
+        n_layers=n_layers,
         embedding_size=opt['embedding_size'],
         ffn_size=opt['ffn_size'],
         vocabulary_size=len(dictionary),

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -69,7 +69,11 @@ def _build_encoder(
     n_positions=1024,
     n_segments=0,
 ):
-    n_layers = opt['n_encoder_layers'] if opt.get('n_encoder_layers', -1) > 0 else opt['n_layers']
+    n_layers = (
+        opt['n_encoder_layers']
+        if opt.get('n_encoder_layers', -1) > 0
+        else opt['n_layers']
+    )
     return TransformerEncoder(
         n_heads=opt['n_heads'],
         n_layers=n_layers,
@@ -95,7 +99,11 @@ def _build_encoder(
 def _build_decoder(
     opt, dictionary, embedding=None, padding_idx=None, n_positions=1024, n_segments=0
 ):
-    n_layers = opt['n_decoder_layers'] if opt.get('n_decoder_layers', -1) > 0 else opt['n_layers']
+    n_layers = (
+        opt['n_decoder_layers']
+        if opt.get('n_decoder_layers', -1) > 0
+        else opt['n_layers']
+    )
     return TransformerDecoder(
         n_heads=opt['n_heads'],
         n_layers=n_layers,


### PR DESCRIPTION
**Patch description**
The previous asymmetric transformer code introduced a nightly gpu test failure. It was caused by ```add_common_cmdline_args``` function was only called in some transformer based agent, while the wizard of wikipedia agent was only using transformer but it was not a Transformer agent. So the options for encoder / decoder layer were not added.
**Testing steps**
```py tests/nightly/gpu/test_wizard.py TestKnowledgeRetriever```

**Logs**
```
Ran 1 test in 36.845s

OK
```

