### PR TITLE
[TGA] Flexible context for n-gram blocking

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -873,6 +873,14 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         else:
             raise ValueError(f"Can't use inference method {method}")
 
+    def _get_context(self, batch, batch_idx):
+        """
+        Set the beam context for n-gram context blocking.
+
+        Intentionally overridable for more complex model histories.
+        """
+        return batch.text_vec[batch_idx]
+
     def _generate(self, batch, beam_size, max_ts):
         """
         Generate an output with beam search.
@@ -911,8 +919,10 @@ class TorchGeneratorAgent(TorchAgent, ABC):
             else len(batch.image)
         )
         if batch.text_vec is not None:
+            batchsize = batch.text_vec.size(0)
             beams = [
-                self._treesearch_factory(dev).set_context(ctx) for ctx in batch.text_vec
+                self._treesearch_factory(dev).set_context(self._get_context(batch, batch_idx))
+                for batch_idx in range(batchsize)
             ]
         else:
             beams = [self._treesearch_factory(dev) for _ in range(bsz)]

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -921,7 +921,9 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         if batch.text_vec is not None:
             batchsize = batch.text_vec.size(0)
             beams = [
-                self._treesearch_factory(dev).set_context(self._get_context(batch, batch_idx))
+                self._treesearch_factory(dev).set_context(
+                    self._get_context(batch, batch_idx)
+                )
                 for batch_idx in range(batchsize)
             ]
         else:


### PR DESCRIPTION
**Patch description**
Added a `_get_context` function so that more complex models can override the context that is used for n-gram blocking.