### PR TITLE
Dynamic batching doesn't work with batchsize < 8

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1175,7 +1175,7 @@ class DynamicBatchWorld(World):
             this_width = self._ceil(sum(self._scores[index]))
             new_width = max(width, this_width)
             # compute the cost of the new batch
-            new_bsz = self._ceil(len(batch) + 1)
+            new_bsz = len(batch) + 1
             new_words = new_width * new_bsz
             if new_words <= self.max_words and new_bsz <= self.max_batch_size:
                 # cool, this one fits, let's add it
@@ -1193,8 +1193,9 @@ class DynamicBatchWorld(World):
             batch.pop(-1)
 
         # double check our assumed invariant
-        assert self._ceil(width) * self._ceil(len(batch)) <= self.max_words
-        assert self._ceil(len(batch)) <= self.max_batch_size
+        assert self._ceil(width) * len(batch) <= self.max_words
+        assert len(batch) > 0
+        assert len(batch) <= self.max_batch_size
 
         # great, this batch is good to go! let's run it!
         acts = self.world.get_model_agent().batch_act([self._obs[i] for i in batch])

--- a/tests/test_dynamicbatching.py
+++ b/tests/test_dynamicbatching.py
@@ -83,6 +83,14 @@ class TestDynamicBatching(unittest.TestCase):
             datatype='train:stream',
         )
 
+    def test_weird_batchsize(self):
+        # intentionally a difficult number
+        self._test_correct_processed(NUM_TEST, batchsize=7)
+
+    def test_batchsize4(self):
+        # intentionally an edgecase in the world
+        self._test_correct_processed(NUM_TEST, batchsize=4)
+
 
 class TestBatchSort(unittest.TestCase):
     def _test_correct_processed(self, num_goal: int, **kwargs: Dict[str, Any]):
@@ -130,6 +138,14 @@ class TestBatchSort(unittest.TestCase):
             task='integration_tests:variable_length,integration_tests:multiturn',
             datatype='train:stream',
         )
+
+    def test_weird_batchsize(self):
+        # intentionally a difficult number
+        self._test_correct_processed(NUM_TEST, batchsize=7)
+
+    def test_batchsize4(self):
+        # intentionally an edgecase in the world
+        self._test_correct_processed(NUM_TEST, batchsize=4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Patch description**
If the user set a batchsize < 8, then the max batchsize would be rounded up to over the batchsize, resulting in a new batchsize. Solution is to not round up the batchsize.

**Testing steps**
Two new tests, and a new assert that the batchsize > 0.