### PR TITLE
Log loss scalar. Adjust when logs print/flush. Change token counting.

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1835,8 +1835,7 @@ class TorchAgent(ABC, Agent):
             # we divide by the binary is_primary_worker() so that the numerator is
             # num_tokens in all workers, and the denominator is 1.
             tbp = AverageMetric(
-                (batch.label_vec != self.NULL_IDX).sum().item()
-                + (batch.text_vec != self.NULL_IDX).sum().item(),
+                (batch.label_vec != self.NULL_IDX).sum().item(),
                 float(is_primary_worker()),
             )
             self.global_metrics.add('tokens_per_batch', tbp)
@@ -1941,6 +1940,10 @@ class TorchAgent(ABC, Agent):
             self.global_metrics.add('gnorm', AverageMetric(grad_norm))
             self.global_metrics.add(
                 'clip', AverageMetric(float(grad_norm > self.opt['gradient_clip']))
+            )
+        if self.fp16:
+            self.global_metrics.add(
+                'fp16_loss_scalar', AverageMetric(self.optimizer.loss_scale)
             )
 
         self.optimizer.step()

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1234,6 +1234,9 @@ class DynamicBatchWorld(World):
         self.total_parleys += 1
         self.total_exs += len(batch)
 
+    def get_total_exs(self):
+        return self.total_exs
+
     def get_total_epochs(self):
         return self.total_exs / self.num_examples()
 

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -483,6 +483,7 @@ class TrainLoop:
         self.valid_reports.append(v)
         # logging
         if opt['tensorboard_log'] and is_primary_worker():
+            valid_report['total_exs'] = self._total_exs
             self.tb_logger.log_metrics('valid', self.parleys, valid_report)
             # flush on a validation
             self.tb_logger.flush()
@@ -642,13 +643,11 @@ class TrainLoop:
                 self.parleys += 1
 
                 # get the total training examples done, compute epochs
-                self._total_epochs = (
-                    self._preempted_epochs
-                    + num_workers() * self.world.get_total_epochs()
+                self._total_epochs = self._preempted_epochs + sum(
+                    all_gather_list(world.get_total_epochs())
                 )
-                exs_per_epoch = self.world.num_examples()
+                exs_per_epoch = world.num_examples()
                 self._total_exs = int(np.round(self._total_epochs * exs_per_epoch))
-
                 # and use the primary worker's timings for everything
                 train_time, log_time, validate_time = sync_object(
                     (
@@ -678,17 +677,23 @@ class TrainLoop:
                     >= self.val_every_n_epochs
                 ):
                     try:
+                        # log before we validate
+                        self.log()
+                        world.reset_metrics()
                         stop_training = self.validate()
                     except StopTrainException:
                         if is_distributed():
                             raise RuntimeError(
-                                "StopTrainException not "
-                                "supported for distributed mode"
+                                "StopTrainException not supported for distributed mode"
                             )
                         break
+                    # reset the log time because we logged right before validating
+                    self.log_time.reset()
                     self.last_valid_epoch = self._total_epochs
                     if stop_training:
                         break
+                    # make sure metrics are clean before we log
+                    world.reset_metrics()
                 if (
                     self.save_time.time() > self.save_every_n_secs
                     and opt.get('model_file')
@@ -699,6 +704,8 @@ class TrainLoop:
                             opt['model_file']
                         )
                     )
+                    if opt['tensorboard_log'] and is_primary_worker():
+                        self.tb_logger.flush()
                     self.save_model('.checkpoint')
                     self.save_time.reset()
 

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -402,6 +402,13 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
                 param = id_map[k]
                 self.optimizer.state[param] = v
 
+    @property
+    def loss_scale(self):
+        """
+        Convenience function which TorchAgent calls to get current scale value.
+        """
+        return self.scaler.loss_scale
+
     def zero_grad(self):
         """
         Clears the gradients of all optimized parameters.


### PR DESCRIPTION
**Patch description**
Small improvements to logging in train_model and torch agent:
- Only count label words as words-per-batch, following fairseq
- Add a tracker of the fp16 loss scalar
- Sync actual number of epochs across workers, rather than assuming it's linear
- Always log right before validation, and reset the log timer on validation so that we don't have partial metrics thanks to validation.

**Testing steps**
Several sweeps ran, CI.