### PR TITLE
Transformer attention softmax in fp32.

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -1159,7 +1159,7 @@ class MultiHeadAttention(nn.Module):
         assert attn_mask.shape == dot_prod.shape
         dot_prod.masked_fill_(attn_mask, neginf(dot_prod.dtype))
 
-        attn_weights = F.softmax(dot_prod, dim=-1).type_as(query)
+        attn_weights = F.softmax(dot_prod, dim=-1, dtype=torch.float).type_as(query)
         attn_weights = self.attn_dropout(attn_weights)  # --attention-dropout
 
         attentioned = attn_weights.bmm(v)


### PR DESCRIPTION
**Patch description**
Following Emily's fp32 softmax for the vocab, also do the attention softmax in fp32 in transformers. Adds a good bit more stability when working with larger model sizes.

**Testing steps**
Ran a few sweeps. CI. Minor speed regression, but increase in stability makes it worthwhile. We can actually reasonably fine tune in fp16 now, so we actually get a speedup in that scenario.