### PR TITLE
Retry on HTTPS errors.

### DIFF
--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -204,7 +204,10 @@ def download(url, path, fname, redownload=False):
                                 pbar.total = total_size
                             pbar.update(len(chunk))
                     break
-            except requests.exceptions.ConnectionError:
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.ReadTimeout,
+            ):
                 retry -= 1
                 pbar.clear()
                 if retry >= 0:


### PR DESCRIPTION
**Patch description**
Some of our downloads in CI fail with regularity, usually because some sort of weird HTTPS concerns (see [here](https://app.circleci.com/jobs/github/facebookresearch/ParlAI/32426/parallel-runs/5?filterBy=FAILED)). This patch makes it so that ReadTimeout errors are also treated llke ConnectionErrors, and retries automatically happen.

**Testing steps**
CI.