### PR TITLE
Auto-approve HITs after 5 days

### DIFF
--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -153,7 +153,7 @@ class MTurkManager:
 
         self.required_hits = math.ceil(base_required_hits * self.hit_mult)
         self.minimum_messages = opt.get('min_messages', 0)
-        self.auto_approve_delay = opt.get('auto_approve_delay', 4 * 7 * 24 * 3600)
+        self.auto_approve_delay = opt.get('auto_approve_delay', 5 * 24 * 3600)
         self.has_time_limit = opt.get('max_time', 0) > 0
         self.socket_manager = None
         self.worker_manager = WorkerManager(self, opt)

--- a/parlai/mturk/core/test/test_mturk_manager.py
+++ b/parlai/mturk/core/test/test_mturk_manager.py
@@ -177,7 +177,7 @@ class InitTestMTurkManager(unittest.TestCase):
 
         self.assertEqual(manager.minimum_messages, opt.get('min_messages', 0))
         self.assertEqual(
-            manager.auto_approve_delay, opt.get('auto_approve_delay', 4 * 7 * 24 * 3600)
+            manager.auto_approve_delay, opt.get('auto_approve_delay', 5 * 24 * 3600)
         )
         self.assertEqual(manager.has_time_limit, opt.get('max_time', 0) > 0)
         self.assertIsInstance(manager.worker_manager, WorkerManager)


### PR DESCRIPTION
Currently, we auto-approve HITs after 4 weeks, which causes Turkers to be frustrated at our slowness. This changes auto-approval to 5 days, which should still give us plenty of time to review work and take care of idiosyncrasies in Turkers' work if need be.