### PR TITLE
Fairseqcompat

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -955,6 +955,9 @@ class TransformerGeneratorModel(TorchGeneratorModel):
         """
         # project back to vocabulary
         output = F.linear(tensor, self.embeddings.weight)
+        # compatibility with fairseq: fairseq sometimes reuses BOS tokens and
+        # we need to force their probability of generation to be 0.
+        output[:, :, self.start_idx] = neginf(output.dtype)
         return output
 
 


### PR DESCRIPTION
**Patch description**
Since fairseq uses the same token for BOS and EOS in the model, we handle this case by copying the EOS embedding to BOS so we don't have to change TGA. However, in order to prevent probability mass equally shared between the two, we need to hardcode BOS to have zero output probability.

**Testing steps**
Playing with a model internally.
