### PR TITLE
Fix ByteLevelBPE special token ordering

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -883,10 +883,10 @@ class DictionaryAgent(Agent):
         if self.tokenizer != 'bytelevelbpe':
             return
         special_tokens = [
-            self.unk_token,
+            self.null_token,
             self.start_token,
             self.end_token,
-            self.null_token,
+            self.unk_token,
         ]
         self.byte_level_bpe.tokenizer.add_special_tokens(special_tokens)
         for i in range(self.byte_level_bpe.tokenizer.get_vocab_size() - 4):


### PR DESCRIPTION
**Patch description**
This fix the ordering of the special tokens when they are added to hugging face tokenizers.
The right order should be ( as ParlAI dict default):
```
null,
bos,
eos,
unk
```
**Testing steps**
```
py tests/test_dict.py
```

**Logs**
```
[ Using CUDA ]
Total parameters: 19076
Trainable parameters:  19076
[ Loading existing model params from /private/home/daju/ParlAI/data/models/unittest/seq2seq/model ]
....
----------------------------------------------------------------------
Ran 9 tests in 26.788s

OK
```


