### PR TITLE
[Torch Classifier] print scores bug fix

### DIFF
--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -287,7 +287,7 @@ class TorchClassifierAgent(TorchAgent):
 
         if batch.labels is None or self.opt['ignore_labels']:
             # interactive mode
-            if self.opt.get('interactive_mode', False):
+            if self.opt.get('print_scores', False):
                 preds = self._format_interactive_output(probs, prediction_id)
         else:
             labels = self._get_labels(batch)


### PR DESCRIPTION
**Patch description**
Torch Classifier bug introduced by #2419. Scores should only be returned in interactive mode if `print_scores` = True. Otherwise we simply want the label to be printed.