### PR TITLE
Tests for special tokens in bytelevel bpe

### DIFF
--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -132,10 +132,20 @@ class TestDictionary(unittest.TestCase):
             agent.txt2vec(u'Hello, ParlAI! \U0001f600'),
             [agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT],
         )
-        # Test special token
-        self.assertEqual(
-            agent.txt2vec(agent.start_token), [agent.tok2ind[agent.start_token]]
-        )
+        # Test special token ids are mapped correctly
+        # 4 special tokens are added in ParlAI dict in the begining and at the end for Hugging Face
+        # null token would be 0 in ParlAI dict and original_vocab in Hugging Face
+        special_tokens = [
+            agent.null_token,
+            agent.start_token,
+            agent.end_token,
+            agent.unk_token,
+        ]
+        for each_token in special_tokens:
+            self.assertEqual(
+                agent.byte_level_bpe.tokenizer.token_to_id(each_token),
+                agent.tok2ind[each_token] - 4 + vocab_size,
+            )
 
     def test_byte_level_bpe_tokenize_prefix_space(self):
         """


### PR DESCRIPTION
**Patch description**
In byte-level-bpe tokenizer, we add 4 special tokens to the Hugging Face tokenizer and to the ParlAI dict as well.
This test ensures that all these 4 tokens are added in the correct sequence in both cases, so the mapping between them is consistent. 

**Testing steps**
```
py tests/test_dict.py
```

