### PR TITLE
New transformer variant + fairseq compatibility 

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -679,7 +679,7 @@ class TransformerDecoder(nn.Module):
 
         self.embeddings = embedding
 
-        if self.variant == 'xlm':
+        if self.variant == 'xlm' or self.variant == 'prelayernorm':
             self.norm_embeddings = LayerNorm(self.dim, eps=LAYER_NORM_EPS)
         elif self.variant == 'aiayn':
             pass

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -979,6 +979,9 @@ class TransformerGeneratorModel(TorchGeneratorModel):
         """
         # project back to vocabulary
         output = F.linear(tensor, self.embeddings.weight)
+        # compatibility with fairseq: fairseq sometimes reuses BOS tokens and
+        # we need to force their probability of generation to be 0.
+        output[:, :, self.start_idx] = neginf(output.dtype)
         return output
 
 

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -603,13 +603,13 @@ class TransformerEncoderLayer(nn.Module):
             tensor = _normalize(tensor, self.norm1)
         attended_tensor, _ = self.attention(tensor, mask=mask)
         tensor = residual + self.dropout(attended_tensor)
-        if self.variant != 'prelayernorm':
+        if self.variant == 'aiayn' or self.variant == 'xlm':
             tensor = _normalize(tensor, self.norm1)
         residual = tensor
         if self.variant == 'prelayernorm':
             tensor = _normalize(tensor, self.norm2)
         tensor = residual + self.dropout(self.ffn(tensor))
-        if self.variant != 'prelayernorm':
+        if self.variant == 'aiayn' or self.variant == 'xlm':
             tensor = _normalize(tensor, self.norm2)
         tensor *= mask.unsqueeze(-1).type_as(tensor)
         return tensor
@@ -835,7 +835,7 @@ class TransformerDecoderLayer(nn.Module):
         )
         x = self.dropout(x)  # --dropout
         x = x + residual
-        if self.variant != 'prelayernorm':
+        if self.variant == 'aiayn' or self.variant == 'xlm':
             x = _normalize(x, self.norm1)
 
         residual = x
@@ -852,7 +852,7 @@ class TransformerDecoderLayer(nn.Module):
         )
         x = self.dropout(x)  # --dropout
         x = residual + x
-        if self.variant != 'prelayernorm':
+        if self.variant == 'aiayn' or self.variant == 'xlm':
             x = _normalize(x, self.norm2)
 
         # finally the ffn
@@ -862,7 +862,7 @@ class TransformerDecoderLayer(nn.Module):
         x = self.ffn(x)
         x = self.dropout(x)  # --dropout
         x = residual + x
-        if self.variant != 'prelayernorm':
+        if self.variant == 'aiayn' or self.variant == 'xlm':
             x = _normalize(x, self.norm3)
 
         new_incr_state = {

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -76,9 +76,10 @@ def add_common_cmdline_args(argparser):
     )
     argparser.add_argument(
         '--variant',
-        choices={'aiayn', 'xlm'},
+        choices={'aiayn', 'xlm', 'layernormbefore'},
         default='aiayn',
-        help='Chooses locations of layer norms, etc.',
+        help='Chooses locations of layer norms, etc. layernormbefore'
+        'is used to match some fairseq models',
         recommended='xlm',
     )
     argparser.add_argument(

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -76,9 +76,9 @@ def add_common_cmdline_args(argparser):
     )
     argparser.add_argument(
         '--variant',
-        choices={'aiayn', 'xlm', 'layernormbefore'},
+        choices={'aiayn', 'xlm', 'prelayernorm'},
         default='aiayn',
-        help='Chooses locations of layer norms, etc. layernormbefore'
+        help='Chooses locations of layer norms, etc. prelayernorm'
         'is used to match some fairseq models',
         recommended='xlm',
     )

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -78,7 +78,7 @@ def add_common_cmdline_args(argparser):
         '--variant',
         choices={'aiayn', 'xlm', 'prelayernorm'},
         default='aiayn',
-        help='Chooses locations of layer norms, etc. prelayernorm'
+        help='Chooses locations of layer norms, etc. prelayernorm '
         'is used to match some fairseq models',
         recommended='xlm',
     )

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -189,7 +189,7 @@ class History(object):
         self.delimiter_tok = self.parse(self.delimiter)
         self.size = size
         self.split_on_newln = opt.get('split_lines', False)
-        self._global_end_token = opt['history_add_global_end_token']
+        self._global_end_token = opt.get('history_add_global_end_token', None)
         if self._global_end_token is not None:
             self._global_end_token = self.dict[self.dict.end_token]
 
@@ -616,6 +616,7 @@ class TorchAgent(ABC, Agent):
             '--history-add-global-end-token',
             type='nonestr',
             default=None,
+            hidden=True,
             choices=[None, 'end'],
             help='Add special token to the end of history encoding.',
         )

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -189,13 +189,9 @@ class History(object):
         self.delimiter_tok = self.parse(self.delimiter)
         self.size = size
         self.split_on_newln = opt.get('split_lines', False)
-        self.global_end_token = opt['history_add_global_end_token']
-        if self.global_end_token is not None:
-            self.global_end_token = (
-                self.dict[self.dict.start_token]
-                if self.global_end_token == 'start'
-                else self.dict[self.dict.end_token]
-            )
+        self._global_end_token = opt['history_add_global_end_token']
+        if self._global_end_token is not None:
+            self._global_end_token = self.dict[self.dict.end_token]
 
         # set up history objects
         if vec_type != 'deque' and vec_type != 'list':
@@ -298,8 +294,8 @@ class History(object):
                 history.extend(vec)
                 history.extend(self.delimiter_tok)
             history.extend(self.history_vecs[-1])
-            if self.global_end_token is not None:
-                history.extend([self.global_end_token])
+            if self._global_end_token is not None:
+                history.extend([self._global_end_token])
         else:
             # vec type is a list
             history = []
@@ -307,8 +303,8 @@ class History(object):
                 history += vec
                 history += self.delimiter_tok
             history += self.history_vecs[-1]
-            if self.global_end_token is not None:
-                history += [self.global_end_token]
+            if self._global_end_token is not None:
+                history += [self._global_end_token]
         return history
 
     def get_history_vec_list(self):
@@ -620,8 +616,8 @@ class TorchAgent(ABC, Agent):
             '--history-add-global-end-token',
             type='nonestr',
             default=None,
-            choices=[None, 'start', 'end'],
-            help='Add a special token at the end of the history block,',
+            choices=[None, 'end'],
+            help='Add special token to the end of history encoding.',
         )
         # GPU arguments
         # these gpu options are all mutually exclusive, and should error if the

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -189,6 +189,13 @@ class History(object):
         self.delimiter_tok = self.parse(self.delimiter)
         self.size = size
         self.split_on_newln = opt.get('split_lines', False)
+        self.global_end_token = opt['history_add_global_end_token']
+        if self.global_end_token is not None:
+            self.global_end_token = (
+                self.dict[self.dict.start_token]
+                if self.global_end_token == 'start'
+                else self.dict[self.dict.end_token]
+            )
 
         # set up history objects
         if vec_type != 'deque' and vec_type != 'list':
@@ -291,6 +298,8 @@ class History(object):
                 history.extend(vec)
                 history.extend(self.delimiter_tok)
             history.extend(self.history_vecs[-1])
+            if self.global_end_token is not None:
+                history.extend([self.global_end_token])
         else:
             # vec type is a list
             history = []
@@ -298,7 +307,8 @@ class History(object):
                 history += vec
                 history += self.delimiter_tok
             history += self.history_vecs[-1]
-
+            if self.global_end_token is not None:
+                history += [self.global_end_token]
         return history
 
     def get_history_vec_list(self):
@@ -605,6 +615,13 @@ class TorchAgent(ABC, Agent):
             type=str,
             default='\n',
             help='Join history lines with this token, defaults to newline',
+        )
+        agent.add_argument(
+            '--history-add-global-end-token',
+            type='nonestr',
+            default=None,
+            choices=[None, 'start', 'end'],
+            help='Add a special token at the end of the history block,',
         )
         # GPU arguments
         # these gpu options are all mutually exclusive, and should error if the

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -741,6 +741,20 @@ class TestTorchAgent(unittest.TestCase):
         text = agent.history.get_history_str()
         self.assertEqual(text, 'I am Groot. Groot! I am Groot.')
 
+        # test global_end_token, this will append a selected token to the end
+        # of history block
+        agent = get_agent(history_add_global_end_token='start')
+        agent.history.reset()
+        agent.history.update_history(obs)
+        vec = agent.history.get_history_vec()
+        self.assertEqual(vec, deque([1, 2, 3, MockDict.BEG_IDX]))
+
+        agent = get_agent(history_add_global_end_token='end')
+        agent.history.reset()
+        agent.history.update_history(obs)
+        vec = agent.history.get_history_vec()
+        self.assertEqual(vec, deque([1, 2, 3, MockDict.END_IDX]))
+
     def test_observe(self):
         """
         Make sure agent stores and returns observation.

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -743,12 +743,6 @@ class TestTorchAgent(unittest.TestCase):
 
         # test global_end_token, this will append a selected token to the end
         # of history block
-        agent = get_agent(history_add_global_end_token='start')
-        agent.history.reset()
-        agent.history.update_history(obs)
-        vec = agent.history.get_history_vec()
-        self.assertEqual(vec, deque([1, 2, 3, MockDict.BEG_IDX]))
-
         agent = get_agent(history_add_global_end_token='end')
         agent.history.reset()
         agent.history.update_history(obs)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -184,7 +184,7 @@ class TestTransformerRanker(unittest.TestCase):
     @testing_utils.retry(ntries=3)
     def test_layernormbefore(self):
         """
-        Test --variant xlm.
+        Test --variant layernormbefore.
         """
         valid, test = testing_utils.train_model(
             dict(

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -548,6 +548,7 @@ class TestTransformerGenerator(unittest.TestCase):
         self.assertLessEqual(test['ppl'], 1.30)
         self.assertGreaterEqual(test['bleu-4'], 0.90)
 
+    @testing_utils.retry(ntries=3)
     def test_prelayernorm(self):
         """
         Test --variant prelayernorm.
@@ -568,8 +569,6 @@ class TestTransformerGenerator(unittest.TestCase):
                 beam_size=1,
                 variant='prelayernorm',
                 activation='gelu',
-                n_segments=8,  # doesn't do anything but still good to test
-                adam_eps=1e-6,  # just to test another flag simultaneously
             )
         )
 

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -184,7 +184,7 @@ class TestTransformerRanker(unittest.TestCase):
     @testing_utils.retry(ntries=3)
     def test_prelayernorm(self):
         """
-        Test --variant prelayernorm with history_add_global_end_token option
+        Test --variant prelayernorm with history_add_global_end_token option.
         """
         valid, test = testing_utils.train_model(
             dict(
@@ -537,6 +537,36 @@ class TestTransformerGenerator(unittest.TestCase):
                 inference='greedy',
                 beam_size=1,
                 variant='xlm',
+                activation='gelu',
+                n_segments=8,  # doesn't do anything but still good to test
+                adam_eps=1e-6,  # just to test another flag simultaneously
+            )
+        )
+
+        self.assertLessEqual(valid['ppl'], 1.30)
+        self.assertGreaterEqual(valid['bleu-4'], 0.90)
+        self.assertLessEqual(test['ppl'], 1.30)
+        self.assertGreaterEqual(test['bleu-4'], 0.90)
+
+    def test_prelayernorm(self):
+        """
+        Test --variant prelayernorm.
+        """
+        valid, test = testing_utils.train_model(
+            dict(
+                task='integration_tests:nocandidate',
+                model='transformer/generator',
+                optimizer='adamax',
+                learningrate=7e-3,
+                batchsize=32,
+                num_epochs=20,
+                n_layers=1,
+                n_heads=1,
+                ffn_size=32,
+                embedding_size=32,
+                inference='greedy',
+                beam_size=1,
+                variant='prelayernorm',
                 activation='gelu',
                 n_segments=8,  # doesn't do anything but still good to test
                 adam_eps=1e-6,  # just to test another flag simultaneously

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -182,9 +182,9 @@ class TestTransformerRanker(unittest.TestCase):
         self.assertGreaterEqual(test['hits@1'], 0.90)
 
     @testing_utils.retry(ntries=3)
-    def test_layernormbefore(self):
+    def test_prelayernorm(self):
         """
-        Test --variant layernormbefore.
+        Test --variant prelayernorm.
         """
         valid, test = testing_utils.train_model(
             dict(
@@ -202,7 +202,7 @@ class TestTransformerRanker(unittest.TestCase):
                 candidates='batch',
                 eval_candidates='inline',
                 gradient_clip=0.5,
-                variant='layernormbefore',
+                variant='prelayernorm',
                 activation='gelu',
             )
         )

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -182,6 +182,35 @@ class TestTransformerRanker(unittest.TestCase):
         self.assertGreaterEqual(test['hits@1'], 0.90)
 
     @testing_utils.retry(ntries=3)
+    def test_layernormbefore(self):
+        """
+        Test --variant xlm.
+        """
+        valid, test = testing_utils.train_model(
+            dict(
+                task='integration_tests:candidate',
+                model='transformer/ranker',
+                optimizer='adamax',
+                learningrate=7e-3,
+                batchsize=16,
+                validation_every_n_epochs=5,
+                validation_patience=2,
+                n_layers=1,
+                n_heads=4,
+                ffn_size=64,
+                embedding_size=32,
+                candidates='batch',
+                eval_candidates='inline',
+                gradient_clip=0.5,
+                variant='layernormbefore',
+                activation='gelu',
+            )
+        )
+
+        self.assertGreaterEqual(valid['hits@1'], 0.90)
+        self.assertGreaterEqual(test['hits@1'], 0.90)
+
+    @testing_utils.retry(ntries=3)
     def test_alt_reduction(self):
         """
         Test a transformer ranker reduction method other than `mean`.

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -184,7 +184,7 @@ class TestTransformerRanker(unittest.TestCase):
     @testing_utils.retry(ntries=3)
     def test_prelayernorm(self):
         """
-        Test --variant prelayernorm.
+        Test --variant prelayernorm with history_add_global_end_token option
         """
         valid, test = testing_utils.train_model(
             dict(
@@ -204,6 +204,7 @@ class TestTransformerRanker(unittest.TestCase):
                 gradient_clip=0.5,
                 variant='prelayernorm',
                 activation='gelu',
+                history_add_global_end_token='end',
             )
         )
 


### PR DESCRIPTION
**Patch description**
This adds a new transformer variant called 'layernormbefore', which reflects some models used in fairseq.
The tests are added accordingly.

**Testing steps**
```
 pytest tests/test_transformers.py -k test_prelayernorm
 pytest tests/test_torch_agent.py -k test_history
```
**Logs**
```
test:{'exs': 100, 'accuracy': 1.0, 'f1': 1.0, 'bleu-4': 1.0, 'hits@1': 1.0, 'hits@5': 1.0, 'hits@10': 1.0, 'hits@100': 1.0, 'loss': 0.007489, 'rank': 1.0, 'mrr': 1.0, 'tokens_per_batch': 57.14, 'lr': 0.007, 'gpu_mem_percent': 7.941e-05, 'total_train_updates': 314}
.
----------------------------------------------------------------------
Ran 1 test in 12.719s

OK

 tests/test_torch_agent.py::TestTorchAgent::test_history pass
```
