### PR TITLE
Byte Level BPE fixes and usability improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,8 @@ standard_cpu36: &standard_cpu36
 
 osx_cpu37: &osx_cpu37
   macos:
-    xcode: "10.1.0"
+      # https://circleci.com/docs/2.0/testing-ios/
+    xcode: "11.3.1"
   environment:
     PYTHON: 3.7.1
     HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ installdeps: &installdeps
       pip3 install --progress-bar off coverage
       pip3 install --progress-bar off codecov
       mkdir -p ~/ParlAI/test-results
-      pip install -q -r requirements.txt
+      pip install -v -r requirements.txt
       python setup.py develop
       python -c "import nltk; nltk.download('punkt')"
 

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -348,18 +348,13 @@ class DictionaryAgent(Agent):
                     'You should not filter vocabulary with using --dict-tokenizer bytelevelbpe'
                     ' (no --dict-minfreq or --dict-maxtokens).'
                 )
-            opt_for_byte_level_bpe = copy.copy(opt)
             if loaded:
-                dict_basename = os.path.splitext(opt['dict_file'])[0]
-                if os.path.isfile('{}-merges.txt'.format(dict_basename)):
-                    opt_for_byte_level_bpe['bpe_vocab'] = '{}-vocab.json'.format(
-                        dict_basename
-                    )
-                if os.path.isfile('{}-vocab.json'.format(dict_basename)):
-                    opt_for_byte_level_bpe['bpe_merge'] = '{}-merges.txt'.format(
-                        dict_basename
-                    )
-            self.byte_level_bpe = HuggingFaceBpeHelper(opt_for_byte_level_bpe)
+                dfname = opt['dict_file']
+                if os.path.isfile(f'{dfname}-merges.txt'):
+                    opt['bpe_vocab'] = f'{dfname}-vocab.json'
+                if os.path.isfile(f'{dfname}-vocab.json'):
+                    opt['bpe_merge'] = f'{dfname}-merges.txt'
+            self.byte_level_bpe = HuggingFaceBpeHelper(opt)
             self._sync_bytelevelbpe_dict()
 
         if not shared:
@@ -707,7 +702,8 @@ class DictionaryAgent(Agent):
             # never remove or sort tokens from gpt2
             pass
         elif self.tokenizer == 'bytelevelbpe':
-            # never remove or sort tokens from bytelevelbpe, it should be the same as the hugging face tokenizer
+            # never remove or sort tokens from bytelevelbpe, it should be the
+            # same as the hugging face tokenizer
             pass
         elif sort:
             self.sort(trim=True)
@@ -727,9 +723,10 @@ class DictionaryAgent(Agent):
             json.dump(self.opt, handle, indent=4)
         # save the byte level bpe model file as well
         if self.tokenizer == 'bytelevelbpe':
-            # This saves filename-vocab.json and finlename-merges.txt as hugging face tokenizer do
+            # This saves filename-vocab.json and finlename-merges.txt as
+            # hugging face tokenizer do
             self.byte_level_bpe.tokenizer.save(
-                os.path.dirname(filename), os.path.splitext(filename)[0]
+                os.path.dirname(filename), os.path.basename(filename),
             )
 
     def sort(self, trim=True):
@@ -892,7 +889,8 @@ class DictionaryAgent(Agent):
         for i in range(self.byte_level_bpe.tokenizer.get_vocab_size() - 4):
             token = self.byte_level_bpe.tokenizer.id_to_token(i)
             self.add_token(token)
-            # We don't have access to the hugging face word frequency table, just set it to 1 instead
+            # We don't have access to the hugging face word frequency table,
+            # just set it to 1 instead
             self.freq[token] = 1
 
 

--- a/parlai/core/hugging_face_bpe_helper.py
+++ b/parlai/core/hugging_face_bpe_helper.py
@@ -4,6 +4,8 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+
+import os
 from parlai.core.opt import Opt
 from typing import List
 
@@ -22,6 +24,7 @@ class HuggingFaceBpeHelper(object):
             '--bpe-add-prefix-space',
             type='bool',
             hidden=True,
+            default=True,
             help='add prefix space before encoding',
         )
         return parser
@@ -41,6 +44,22 @@ class HuggingFaceBpeHelper(object):
 
         self.vocab_path = opt['bpe_vocab']
         self.merge_path = opt['bpe_merge']
+
+        if not self.vocab_path or not self.merge_path:
+            raise IOError(
+                '--bpe-vocab and --bpe-merge are mandatory with '
+                '--dict-tokenizer bytelevelbpe'
+            )
+
+        if not os.path.isfile(self.vocab_path):
+            raise IOError(
+                f'File {self.vocab_path} does not exist. --bpe-vocab must be pretrained.'
+            )
+        if not os.path.isfile(self.merge_path):
+            raise IOError(
+                f'File {self.merge_path} does not exist. --bpe-merge must be pretrained.'
+            )
+
         self.add_prefix_space = opt.get('bpe_add_prefix_space', True)
         self.tokenizer = ByteLevelBPETokenizer(
             self.vocab_path, self.merge_path, self.add_prefix_space

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -84,96 +84,6 @@ class TestDictionary(unittest.TestCase):
             u'Hello, ParlAI! \U0001f600',
         )
 
-    def test_byte_level_bpe_tokenize(self):
-        """
-        Tests a bytelevel bpe tokenizer inside ParlAI.
-        """
-        parser = ParlaiParser()
-        parser.set_params(
-            dict_tokenizer='bytelevelbpe',
-            bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,
-            bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
-            bpe_add_prefix_space=False,
-        )
-        opt = parser.parse_args([], print_args=False)
-        agent = DictionaryAgent(opt)
-        self.assertEqual(
-            # grinning face emoji
-            agent.bytelevelbpe_tokenize(u'Hello, ParlAI! \U0001f600'),
-            BYTELEVEL_BPE_RESULT,
-        )
-        self.assertEqual(
-            agent.vec2txt([agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT]),
-            # grinning face emoji
-            u'Hello, ParlAI! \U0001f600',
-        )
-        self.assertEqual(
-            agent.txt2vec(u'Hello, ParlAI! \U0001f600'),
-            [agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT],
-        )
-        vocab_size = agent.byte_level_bpe.tokenizer.get_vocab_size()
-        with testing_utils.tempdir() as tmpdir:
-            path = os.path.join(tmpdir, 'dict-checkpoint')
-            agent.save(filename=path)
-            agent.load(filename=path)
-        # Test loading / saving
-        self.assertEqual(vocab_size, agent.byte_level_bpe.tokenizer.get_vocab_size())
-        self.assertEqual(
-            # grinning face emoji
-            agent.bytelevelbpe_tokenize(u'Hello, ParlAI! \U0001f600'),
-            BYTELEVEL_BPE_RESULT,
-        )
-        self.assertEqual(
-            agent.vec2txt([agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT]),
-            # grinning face emoji
-            u'Hello, ParlAI! \U0001f600',
-        )
-        self.assertEqual(
-            agent.txt2vec(u'Hello, ParlAI! \U0001f600'),
-            [agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT],
-        )
-        # Test special token ids are mapped correctly
-        # 4 special tokens are added in ParlAI dict in the begining and at the end for Hugging Face
-        # null token would be 0 in ParlAI dict and original_vocab in Hugging Face
-        special_tokens = [
-            agent.null_token,
-            agent.start_token,
-            agent.end_token,
-            agent.unk_token,
-        ]
-        for each_token in special_tokens:
-            self.assertEqual(
-                agent.byte_level_bpe.tokenizer.token_to_id(each_token),
-                agent.tok2ind[each_token] - 4 + vocab_size,
-            )
-
-    def test_byte_level_bpe_tokenize_prefix_space(self):
-        """
-        Tests a bytelevel bpe tokenizer inside ParlAI.
-        """
-        parser = ParlaiParser()
-        parser.set_params(
-            dict_tokenizer='bytelevelbpe',
-            bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,
-            bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
-        )
-        opt = parser.parse_args([], print_args=False)
-        agent = DictionaryAgent(opt)
-        self.assertEqual(
-            # grinning face emoji
-            agent.bytelevelbpe_tokenize(u'Hello, ParlAI! \U0001f600'),
-            ['Ġ'] + BYTELEVEL_BPE_RESULT,
-        )
-        self.assertEqual(
-            agent.vec2txt([agent.tok2ind[w] for w in ['Ġ'] + BYTELEVEL_BPE_RESULT]),
-            # grinning face emoji
-            u'Hello, ParlAI! \U0001f600',
-        )
-        self.assertEqual(
-            agent.txt2vec(u'Hello, ParlAI! \U0001f600'),
-            [agent.tok2ind[w] for w in ['Ġ'] + BYTELEVEL_BPE_RESULT],
-        )
-
     def test_space_tokenize(self):
         """
         Space tokenize assumes raw tokenization as input.
@@ -275,6 +185,192 @@ class TestDictionary(unittest.TestCase):
         popt = parser.parse_args([], print_args=False)
         with self.assertRaises(RuntimeError):
             tms.TrainLoop(popt)
+
+
+class TestByteLevelBPE(unittest.TestCase):
+    """
+    Test ByteLevelBPE is well-behaved.
+    """
+
+    def test_tokenize_prefix_space(self):
+        """
+        Tests a bytelevel bpe tokenizer inside ParlAI.
+        """
+        parser = ParlaiParser()
+        parser.set_params(
+            dict_tokenizer='bytelevelbpe',
+            bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,
+            bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
+        )
+        opt = parser.parse_args([], print_args=False)
+        agent = DictionaryAgent(opt)
+        self.assertEqual(
+            # grinning face emoji
+            agent.bytelevelbpe_tokenize(u'Hello, ParlAI! \U0001f600'),
+            ['Ġ'] + BYTELEVEL_BPE_RESULT,
+        )
+        self.assertEqual(
+            agent.vec2txt([agent.tok2ind[w] for w in ['Ġ'] + BYTELEVEL_BPE_RESULT]),
+            # grinning face emoji
+            u'Hello, ParlAI! \U0001f600',
+        )
+        self.assertEqual(
+            agent.txt2vec(u'Hello, ParlAI! \U0001f600'),
+            [agent.tok2ind[w] for w in ['Ġ'] + BYTELEVEL_BPE_RESULT],
+        )
+
+    def test_byte_level_bpe_tokenize(self):
+        """
+        Tests a bytelevel bpe tokenizer inside ParlAI.
+        """
+        parser = ParlaiParser()
+        parser.set_params(
+            dict_tokenizer='bytelevelbpe',
+            bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,
+            bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
+            bpe_add_prefix_space=False,
+        )
+        opt = parser.parse_args([], print_args=False)
+        agent = DictionaryAgent(opt)
+        self.assertEqual(
+            # grinning face emoji
+            agent.bytelevelbpe_tokenize(u'Hello, ParlAI! \U0001f600'),
+            BYTELEVEL_BPE_RESULT,
+        )
+        self.assertEqual(
+            agent.vec2txt([agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT]),
+            # grinning face emoji
+            u'Hello, ParlAI! \U0001f600',
+        )
+        self.assertEqual(
+            agent.txt2vec(u'Hello, ParlAI! \U0001f600'),
+            [agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT],
+        )
+        vocab_size = agent.byte_level_bpe.tokenizer.get_vocab_size()
+        with testing_utils.tempdir() as tmpdir:
+            path = os.path.join(tmpdir, 'dict-checkpoint')
+            agent.save(filename=path)
+            agent.load(filename=path)
+        # Test loading / saving
+        self.assertEqual(vocab_size, agent.byte_level_bpe.tokenizer.get_vocab_size())
+        self.assertEqual(
+            # grinning face emoji
+            agent.bytelevelbpe_tokenize(u'Hello, ParlAI! \U0001f600'),
+            BYTELEVEL_BPE_RESULT,
+        )
+        self.assertEqual(
+            agent.vec2txt([agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT]),
+            # grinning face emoji
+            u'Hello, ParlAI! \U0001f600',
+        )
+        self.assertEqual(
+            agent.txt2vec(u'Hello, ParlAI! \U0001f600'),
+            [agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT],
+        )
+        # Test special token ids are mapped correctly:
+        # 4 special tokens are added in ParlAI dict in the begining and at the
+        # end for Hugging Face null token would be 0 in ParlAI dict and
+        # original_vocab in Hugging Face
+        assert agent.txt2vec("__null__") == [0]
+        assert agent.txt2vec("__start__") == [1]
+        assert agent.txt2vec("__end__") == [2]
+        assert agent.txt2vec("__unk__") == [3]
+
+    def test_nofile(self):
+        pp = ParlaiParser()
+        DictionaryAgent.add_cmdline_args(pp)
+        with self.assertRaises(IOError):
+            # did not specify bpe merge or vocab
+            DictionaryAgent(pp.parse_args(['--dict-tokenizer', 'bytelevelbpe']))
+
+        with self.assertRaises(IOError):
+            # specified one
+            DictionaryAgent(
+                pp.parse_args(
+                    [
+                        '--dict-tokenizer',
+                        'bytelevelbpe',
+                        '--bpe-merge',
+                        DEFAULT_BYTELEVEL_BPE_MERGE,
+                    ]
+                )
+            )
+
+        with self.assertRaises(IOError):
+            # specified the other
+            DictionaryAgent(
+                pp.parse_args(
+                    [
+                        '--dict-tokenizer',
+                        'bytelevelbpe',
+                        '--bpe-vocab',
+                        DEFAULT_BYTELEVEL_BPE_VOCAB,
+                    ]
+                )
+            )
+
+        with self.assertRaises(IOError):
+            # intentionally missing file
+            DictionaryAgent(
+                pp.parse_args(
+                    [
+                        '--dict-tokenizer',
+                        'bytelevelbpe',
+                        '--bpe-merge',
+                        'foobar',  # intentionally wrong
+                        '--bpe-vocab',
+                        DEFAULT_BYTELEVEL_BPE_VOCAB,
+                    ]
+                )
+            )
+
+        with self.assertRaises(IOError):
+            # intentionally missing file
+            DictionaryAgent(
+                pp.parse_args(
+                    [
+                        '--dict-tokenizer',
+                        'bytelevelbpe',
+                        '--bpe-merge',
+                        DEFAULT_BYTELEVEL_BPE_MERGE,
+                        '--bpe-vocab',
+                        'foobar',  # intentionally wrong
+                    ]
+                )
+            )
+
+    def test_save_reload(self):
+        """
+        Save and reload an existing BL-BPE dictionary.
+        """
+        pp = ParlaiParser()
+        DictionaryAgent.add_cmdline_args(pp)
+        da = DictionaryAgent(
+            pp.parse_args(
+                [
+                    '--dict-tokenizer',
+                    'bytelevelbpe',
+                    '--bpe-merge',
+                    DEFAULT_BYTELEVEL_BPE_MERGE,
+                    '--bpe-vocab',
+                    DEFAULT_BYTELEVEL_BPE_VOCAB,
+                ]
+            )
+        )
+        # poor behavior if we failed to load
+        assert da.txt2vec("hello") != []
+
+        with testing_utils.tempdir() as tmpdir:
+            newdf = os.path.join(tmpdir, "dict")
+            da.save(newdf)
+
+            # now load it
+            da2 = DictionaryAgent(
+                pp.parse_args(
+                    ['--dict-tokenizer', 'bytelevelbpe', '--dict-file', newdf]
+                )
+            )
+            assert da2.txt2vec("hello") == da.txt2vec("hello")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Patch description**
- [x] Fix an issue where hf tokenizers wasn't installing correctly on OS X, causing OS X tests to fail.
- [x] Fix an issue where BPE merge/vocab files were being saved incorrectly with the model
- [x] Add loud errors when the user fails to specify `--bpe-merge` or `--bpe-vocab`. 
- [x] Refine tests that special tokens are correctly parsed to be less likely to fail to notice future changes.

**Testing steps**
New tests in CI. Usage with an internal model.