### PR TITLE
Disable convai2 seq2seq test

### DIFF
--- a/tests/nightly/gpu/test_convai2.py
+++ b/tests/nightly/gpu/test_convai2.py
@@ -17,7 +17,7 @@ You can see the full validation set leaderboard here:
 """
 
 
-@testing_utils.skipUnlessGPU
+@testing_utils.skip("Disabled due to LSTM CUDNN bug. (#2436)")
 class TestConvai2Seq2Seq(unittest.TestCase):
     """
     Checks that the Convai2 seq2seq model produces correct results.

--- a/tests/nightly/gpu/test_convai2.py
+++ b/tests/nightly/gpu/test_convai2.py
@@ -17,7 +17,7 @@ You can see the full validation set leaderboard here:
 """
 
 
-@testing_utils.skip("Disabled due to LSTM CUDNN bug. (#2436)")
+@unittest.skip("Disabled due to LSTM CUDNN bug. (#2436)")
 class TestConvai2Seq2Seq(unittest.TestCase):
     """
     Checks that the Convai2 seq2seq model produces correct results.


### PR DESCRIPTION
**Patch description**
Convai2 seq2seq model has been broken for a while, due to some weird CUDNN bug I haven't been able to figure out. It seemed like I mitigated it for a bit, but then it came right back. It doesn't even happen every time, only on some hosts.

#2420 will delete all of this, but landing that is low priority for me. In the mean time, just skip the test.

**Testing steps**
CI should finally pass with no issue.