### PR TITLE
[WoW] Wizard Teacher Fix

### DIFF
--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -309,7 +309,7 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
                 labels = ['{} {}'.format(title, sentence)]
 
         # finally, get label_candidates
-        label_cands = [TOKEN_NOCHOSEN + ' ' + TOKEN_NOCHOSEN]
+        label_cands = ['{} {}'.format(TOKEN_NOCHOSEN, TOKEN_NOCHOSEN)]
         knowledge_str = ''
         for title, passage in knowledge_dict.items():
             for p in passage:

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -303,7 +303,10 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
             labels = [wizard_entry['text']]
         else:
             title, sentence = _get_chosen_title_and_sent(wizard_entry, knowledge_dict)
-            labels = ['{} {}'.format(title, sentence)]
+            if self.knowledge_separator and title != TOKEN_NOCHOSEN:
+                labels = ['{} {} {}'.format(title, TOKEN_KNOWLEDGE, sentence)]
+            else:
+                labels = ['{} {}'.format(title, sentence)]
 
         # finally, get label_candidates
         label_cands = [TOKEN_NOCHOSEN + ' ' + TOKEN_NOCHOSEN]


### PR DESCRIPTION
**Patch description**
Per #2417 we should be checking for `self.knowledge_separator` and adding if necessary to the `label`.

**Testing steps**
Ran `verify_data` before and after change.

**Logs**
Before:


```
$ python parlai/scripts/verify_data.py -t wizard_of_wikipedia:WizardDialogKnowledge --label-type chosen_sent --include-knowledge-separator true
.
.
.
28s elapsed: {"missing_text": 0, "missing_labels": 0, "missing_label_candidates": 0, "empty_string_label_candidates": 0, "label_candidates_with_missing_label": 69389, "did_not_return_message": 0, "exs": 74092, "%done": "100.00%", "time_left": "0s"}
```

After:

```
$ python parlai/scripts/verify_data.py -t wizard_of_wikipedia:WizardDialogKnowledge --label-type chosen_sent --include-knowledge-separator true
.
.
.
44s elapsed: {"missing_text": 0, "missing_labels": 0, "missing_label_candidates": 0, "empty_string_label_candidates": 0, "label_candidates_with_missing_label": 1, "did_not_return_message": 0, "exs": 74092, "%done": "100.00%", "time_left": "0s"}
```
