### PR TITLE
Revert "Agent metrics mw (#2433)"

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -38,7 +38,6 @@ from parlai.core.message import Message
 from parlai.core.metrics import TeacherMetrics, aggregate_named_reports
 from parlai.core.opt import Opt
 from parlai.utils.misc import AttrDict, no_lock, str_to_msg, warn_once
-from parlai.utils.distributed import get_rank, num_workers, is_distributed
 
 from functools import lru_cache
 from abc import ABC, abstractmethod
@@ -645,7 +644,6 @@ class DialogData(object):
         # self.data is a list of episodes
         # each episode is a tuple of entries
         # each entry is a tuple of values for the action/observation table
-
         if shared:
             self.image_loader = shared.get('image_loader', None)
             self.data = shared.get('data', [])
@@ -655,13 +653,6 @@ class DialogData(object):
             self.data = []
             self._load(data_loader, opt['datafile'])
             self.cands = None if cands is None else set(sys.intern(c) for c in cands)
-
-        self.rank = get_rank()
-        self.num_workers = num_workers()
-        self.is_distributed_and_is_eval = is_distributed() and any(
-            x in opt['datatype'] for x in ('valid', 'test', 'train:evalmode')
-        )
-
         self.addedCands = []
         self.copied_cands = False
 
@@ -684,7 +675,6 @@ class DialogData(object):
             an iterable which returns tuples in the format described in the
             class docstring.
         """
-
         episode = []
         last_cands = None
         for entry, new in data_loader:
@@ -785,24 +775,11 @@ class DialogData(object):
             which example to return from the episode. Many datasets have only
             single-entry episodes, so this defaults to zero.
         """
-        next_episode_idx_for_rank = episode_idx + 1
-        if self.is_distributed_and_is_eval:
-            raw_episode_idx = episode_idx
-            episode_idx = raw_episode_idx * self.num_workers + self.rank
-            next_episode_idx_for_rank = episode_idx + self.num_workers
-
-            if episode_idx >= len(self.data):
-                # This can occur in spite of the check below if epoch ends
-                # mid-batch b/c BatchWorld calls act() on all the worlds without
-                # checking if epochDone
-                return {'episode_done': True}, True
-
         # first look up data
         episode = self.data[episode_idx]
         entry = episode[entry_idx]
         episode_done = entry_idx == len(episode) - 1
-
-        end_of_data = episode_done and next_episode_idx_for_rank >= len(self.data)
+        end_of_data = episode_done and episode_idx == len(self.data) - 1
 
         # now pack it in a action-observation dictionary
         table = self.build_table(entry)
@@ -892,7 +869,6 @@ class StreamDialogData(DialogData):
         # super() call initiates stream in self.data by calling _load()
         super().__init__(opt, data_loader, cands, shared, **kwargs)
         self.cycle = kwargs['cycle'] if 'cycle' in kwargs else True
-
         if shared:
             # auxiliary instances hold pointer to main datastream in self.data
             self.reset_data = shared['reset']
@@ -917,12 +893,6 @@ class StreamDialogData(DialogData):
         self.cur_episode = self._FIRST_PASS
         self.num_eps = None
         self.num_exs = None
-
-        self.rank = get_rank()
-        self.num_workers = num_workers()
-        self.is_distributed_and_is_eval = self.num_workers > 1 and any(
-            x in opt['datatype'] for x in ('valid', 'test', 'train:evalmode')
-        )
 
     def share(self):
         """
@@ -950,16 +920,9 @@ class StreamDialogData(DialogData):
         Generate data using the iterator over tuples constructed by data_loader.
         """
         self.is_reset = False
-        idx = 0
         while True:
             for episode in self._read_episode(data_loader(datafile)):
-                # We only shard the data set at evaluation time, as training is
-                # done using sampling-with-replacement.
-                if not self.is_distributed_and_is_eval or (
-                    idx % self.num_workers == self.rank
-                ):
-                    yield episode
-                idx += 1
+                yield episode
             while not self.cycle:
                 yield self._END_OF_EPOCH
 

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -202,6 +202,10 @@ def load_eval_worlds(agent, opt, datatype):
     :param string datatype:
         The new datatype.
     """
+    if not is_primary_worker():
+        # don't load worlds in workers
+        # TODO(MW): this block will need to be removed
+        return None
 
     if 'stream' in opt['datatype']:
         datatype += ':stream'
@@ -229,6 +233,69 @@ def load_eval_worlds(agent, opt, datatype):
         worlds.append(valid_world)
 
     return worlds
+
+
+def _run_single_eval(opt, valid_world, max_exs):
+    # run evaluation on a single world
+    valid_world.reset()
+
+    cnt = 0
+    max_cnt = max_exs if max_exs > 0 else float('inf')
+    while not valid_world.epoch_done() and cnt < max_cnt:
+        valid_world.parley()
+        if cnt == 0 and opt['display_examples']:
+            print(valid_world.display() + '\n~~')
+            print(valid_world.report())
+        cnt = valid_world.report().get('exs') or 0
+
+    valid_report = valid_world.report()
+    valid_world.reset()  # make sure world doesn't remember valid data
+
+    return valid_report
+
+
+def run_eval(valid_worlds, opt, datatype, max_exs=-1, write_log=False):
+    """
+    Eval on validation/test data.
+
+    :param valid_world:
+        list of the pre-created validation worlds.
+    :param opt:
+        the options that specific the task, eval_task, etc
+    :param datatype:
+        the datatype to use, such as "valid" or "test"
+    :param bool write_log:
+        specifies to write metrics to file if the model_file is set
+    :param int max_exs:
+        limits the number of examples if max_exs > 0
+    """
+    if valid_worlds is None:
+        # This isn't the primary worker, so we can just skip evaluation
+        return sync_object(None)
+
+    print('[ running eval: ' + datatype + ' ]')
+    timer = Timer()
+    reports = []
+    for v_world in valid_worlds:
+        task_report = _run_single_eval(opt, v_world, max_exs / len(valid_worlds))
+        reports.append(task_report)
+
+    tasks = [world.getID() for world in valid_worlds]
+    named_reports = dict(zip(tasks, reports))
+    report = aggregate_named_reports(named_reports)
+
+    metrics = f'{datatype}:{nice_report(report)}'
+    print(f'[ eval completed in {timer.time():.2f}s ]')
+    print(metrics)
+
+    # write to file
+    if write_log and opt.get('model_file'):
+        # Write out metrics
+        f = open(opt['model_file'] + '.' + datatype, 'a+')
+        f.write(f'{metrics}\n')
+        f.close()
+
+    return sync_object(report)
 
 
 class TrainLoop:
@@ -407,7 +474,9 @@ class TrainLoop:
             self.valid_worlds = load_eval_worlds(self.agent, opt, 'valid')
 
         # run evaluation on valid set
-        valid_report = self._run_eval(
+        # TODO(MW): replace sync_object with self._sync_metrics. You'll need some
+        # logic to handle 'validation_max_exs' properly
+        valid_report = run_eval(
             self.valid_worlds, opt, 'valid', opt['validation_max_exs']
         )
         v = valid_report.copy()
@@ -481,67 +550,6 @@ class TrainLoop:
             print('[ ran out of patience! stopping training. ]')
             return True
         return False
-
-    def _run_single_eval(self, opt, valid_world, max_exs):
-
-        # run evaluation on a single world
-        valid_world.reset()
-
-        cnt = 0
-        max_cnt = max_exs if max_exs > 0 else float('inf')
-        while not valid_world.epoch_done() and cnt < max_cnt:
-            valid_world.parley()
-            if cnt == 0 and opt['display_examples']:
-                print(valid_world.display() + '\n~~')
-                print(valid_world.report())
-            cnt = valid_world.report().get('exs') or 0
-
-        valid_report = valid_world.report()
-        valid_world.reset()  # make sure world doesn't remember valid data
-
-        return valid_report
-
-    def _run_eval(self, valid_worlds, opt, datatype, max_exs=-1, write_log=False):
-        """
-        Eval on validation/test data.
-
-        :param valid_world:
-            list of the pre-created validation worlds.
-        :param opt:
-            the options that specific the task, eval_task, etc
-        :param datatype:
-            the datatype to use, such as "valid" or "test"
-        :param bool write_log:
-            specifies to write metrics to file if the model_file is set
-        :param int max_exs:
-            limits the number of examples if max_exs > 0
-        """
-
-        print('[ running eval: ' + datatype + ' ]')
-        timer = Timer()
-        reports = []
-
-        max_exs_per_worker = max_exs / (len(valid_worlds) * num_workers())
-        for v_world in valid_worlds:
-            task_report = self._run_single_eval(opt, v_world, max_exs_per_worker)
-            reports.append(task_report)
-
-        tasks = [world.getID() for world in valid_worlds]
-        named_reports = dict(zip(tasks, reports))
-        report = aggregate_named_reports(named_reports)
-
-        metrics = f'{datatype}:{nice_report(report)}'
-        print(f'[ eval completed in {timer.time():.2f}s ]')
-        print(metrics)
-
-        # write to file
-        if write_log and opt.get('model_file'):
-            # Write out metrics
-            f = open(opt['model_file'] + '.' + datatype, 'a+')
-            f.write(f'{metrics}\n')
-            f.close()
-
-        return self._sync_metrics(report)
 
     def _sync_metrics(self, metrics):
         """
@@ -711,9 +719,9 @@ class TrainLoop:
 
         valid_worlds = load_eval_worlds(self.agent, opt, 'valid')
         max_exs = opt['validation_max_exs'] if opt.get('short_final_eval') else -1
-        v_report = self._run_eval(valid_worlds, opt, 'valid', max_exs, write_log=True)
+        v_report = run_eval(valid_worlds, opt, 'valid', max_exs, write_log=True)
         test_worlds = load_eval_worlds(self.agent, opt, 'test')
-        t_report = self._run_eval(test_worlds, opt, 'test', max_exs, write_log=True)
+        t_report = run_eval(test_worlds, opt, 'test', max_exs, write_log=True)
         if valid_worlds:
             for valid_world in valid_worlds:
                 valid_world.shutdown()

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-import copy
 import unittest
 import torch.distributed as dist
 import parlai.utils.testing as testing_utils
@@ -27,30 +26,6 @@ def _forced_parse(parser, opt):
 
 @testing_utils.skipUnlessGPU
 class TestDistributed(unittest.TestCase):
-    _base_config = dict(
-        task='integration_tests:nocandidate',
-        model='transformer/generator',
-        optimizer='adamax',
-        learningrate=7e-3,
-        batchsize=7,
-        validation_every_n_epochs=5,
-        num_epochs=20,
-        n_layers=1,
-        n_heads=1,
-        ffn_size=32,
-        embedding_size=32,
-        beam_size=1,
-        verbose=True,
-    )
-
-    def setUp(self):
-        print(f'[Setting up test {self._testMethodName}]')
-
-    def tearDown(self):
-        # we need to de-initialize the distributed world, otherwise other
-        # tests will they're we're distributed when we're really not.
-        dist.destroy_process_group()
-
     def _distributed_train_model(self, opt):
         with testing_utils.tempdir() as tmpdir:
             if 'model_file' not in opt:
@@ -69,68 +44,33 @@ class TestDistributed(unittest.TestCase):
 
         return (valid, test)
 
+    def tearDown(self):
+        # we need to de-initialize the distributed world, otherwise other
+        # tests will they're we're distributed when we're really not.
+        dist.destroy_process_group()
+
     def test_generator_distributed(self):
-        valid, test = self._distributed_train_model(self._base_config)
+        valid, test = self._distributed_train_model(
+            dict(
+                task='integration_tests:nocandidate',
+                model='transformer/generator',
+                optimizer='adamax',
+                learningrate=7e-3,
+                batchsize=32,
+                validation_every_n_epochs=5,
+                num_epochs=20,
+                n_layers=1,
+                n_heads=1,
+                ffn_size=32,
+                embedding_size=32,
+                beam_size=1,
+            )
+        )
 
         self.assertLessEqual(valid['ppl'], 1.20)
         self.assertGreaterEqual(valid['bleu-4'], 0.95)
         self.assertLessEqual(test['ppl'], 1.20)
         self.assertGreaterEqual(test['bleu-4'], 0.95)
-
-        # Tests that DialogData.get() is doing the right thing
-        # Ensure no duplication of examples among workers
-        # It would be 200 if each worker did all the examples
-        self.assertEqual(valid['exs'].value(), 100)
-        self.assertEqual(test['exs'].value(), 100)
-
-    def test_distributed_eval_max_exs(self):
-        config = copy.deepcopy(self._base_config)
-        config['validation_max_exs'] = 90
-        config['short_final_eval'] = True
-        valid, test = self._distributed_train_model(config)
-
-        # Tests that DialogData.get() is doing the right thing
-        # Ensure no duplication of examples among workers
-        # It would be 200 if each worker did all the examples
-        # Note: we decided that it was OK for the total count to be slightly off
-        # when using validation_max_exs and distributed.
-        # It's > 90 b/c there are two workers, told to do 45 each, & BatchWorld
-        # parley() does batchsize examples each time, so each worker will do 49
-        # example. In the future, if we fix VME, this assert should be changed
-        # to exactly 90.
-        self.assertEqual(valid['exs'].value(), 98)
-        self.assertEqual(test['exs'].value(), 98)
-
-    def test_distributed_eval_stream_mode(self):
-        config = copy.deepcopy(self._base_config)
-        config['datatype'] = 'train:stream'
-        valid, test = self._distributed_train_model(config)
-
-        # Tests that StreamDialogData.get() is doing the right thing
-        # Ensure no duplication of examples among workers
-        # It would be 200 if each worker did all the examples
-        self.assertEqual(valid['exs'].value(), 100)
-        self.assertEqual(test['exs'].value(), 100)
-
-    def test_distributed_eval_stream_mode_max_exs(self):
-        config = copy.deepcopy(self._base_config)
-        config['datatype'] = 'train:stream'
-        config['validation_max_exs'] = 90
-        config['short_final_eval'] = True
-
-        valid, test = self._distributed_train_model(config)
-
-        # Tests that StreamDialogData.get() is doing the right thing
-        # Ensure no duplication of examples among workers
-        # It would be 200 if each worker did all the examples
-        # As in the test above:
-        # It does 98 instead of 90 b/c there are two workers, told to do 45
-        # each, and BatchWorld parley() does batchsize examples each time, so
-        # each worker will do 49 examples.
-        # In the future, if we fix VME, this assert should be changed to
-        # exactly 90.
-        self.assertEqual(valid['exs'].value(), 98)
-        self.assertEqual(test['exs'].value(), 98)
 
 
 if __name__ == '__main__':

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -637,7 +637,9 @@ class TestLearningRateScheduler(unittest.TestCase):
                 'Finetuning LR scheduler reset failed (total_train_updates).',
             )
             self.assertEqual(
-                valid3['lr'], valid1['lr'], 'Finetuning LR scheduler reset failed (lr).'
+                valid3['lr'],
+                valid1['lr'],
+                'Finetuning LR scheduler reset failed (lr).',
             )
             # and make sure we're not loading the scheduler if it changes
             valid4, test4 = testing_utils.train_model(


### PR DESCRIPTION
This reverts commit aa30be4c7a228650e0e2548b9a68bf85cee9ef48.

**Patch description**
Commit aa30be4c7a228650e0e2548b9a68bf85cee9ef48 brings unexpected behavior that leads to metrics only reported on part to the eval set during distributed training.
In convai2, it only tests on 965 exps instead of 7801.

