### PR TITLE
[WIP]Free memory before loading model back when overfitting

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -28,6 +28,7 @@ import json
 import numpy as np
 import os
 import signal
+import torch
 
 from parlai.core.metrics import Metric
 from parlai.core.agents import create_agent, create_agent_from_shared
@@ -715,6 +716,8 @@ class TrainLoop:
             self.save_model()
         elif opt.get('model_file'):
             # reload best validation model
+            del self.agent
+            torch.cuda.empty_cache()
             self.agent = create_agent(opt)
 
         valid_worlds = load_eval_worlds(self.agent, opt, 'valid')


### PR DESCRIPTION
**Patch description**
The previous code caused CUDA OOM issues with large models, but those models were able to fit in CUDA mem when train script launched. 
It seems that python doesn't do garbage collection in time, so we would have 2 copies of the model at same time when we do self.agent = create_agent() when load best model back. 


**Testing steps**
Pending on testing jobs runs. Will update later. 

