### PR TITLE
Improve adafactor optimizer

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -495,6 +495,13 @@ class TorchAgent(ABC, Agent):
             recommended='1e-30,1e-3',
         )
         optim_group.add_argument(
+            '--adafactor-scale-parameter',
+            default=True,
+            type='bool',
+            help='Rescale the lr by model parameters, used in adafactor.',
+            recommended='True',
+        )
+        optim_group.add_argument(
             '-mom',
             '--momentum',
             default=0,
@@ -839,6 +846,7 @@ class TorchAgent(ABC, Agent):
             # adafactor params
             kwargs['beta1'] = opt.get('betas', (0.9, 0.999))[0]
             kwargs['eps'] = opt['adafactor_eps']
+            kwargs['scale_parameter'] = opt['adafactor_scale_parameter']
             kwargs['warmup_init'] = opt.get('warmup_updates', -1) > 0
 
         if opt['optimizer'] in [

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -846,7 +846,7 @@ class TorchAgent(ABC, Agent):
             # adafactor params
             kwargs['beta1'] = opt.get('betas', (0.9, 0.999))[0]
             kwargs['eps'] = opt['adafactor_eps']
-            kwargs['scale_parameter'] = opt['adafactor_scale_parameter']
+            kwargs['scale_parameter'] = opt.get('adafactor_scale_parameter', True)
             kwargs['warmup_init'] = opt.get('warmup_updates', -1) > 0
 
         if opt['optimizer'] in [

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -523,9 +523,6 @@ class Adafactor(torch.optim.Optimizer):
     :param scale_parameter (bool):
         if true, learning rate is scaled by root mean square of parameter
         (default: True)
-    :param relative_step (bool):
-        if true, time-dependent learning rate is computed instead of external
-        learning rate (default: True)
     :param warmup_init (bool):
         time-dependent learning rate computation depends on whether warm-up
         initialization is being used (default: False)
@@ -541,7 +538,6 @@ class Adafactor(torch.optim.Optimizer):
         beta1=None,
         weight_decay=0.0,
         scale_parameter=True,
-        relative_step=True,
         warmup_init=False,
     ):
         defaults = dict(
@@ -552,20 +548,15 @@ class Adafactor(torch.optim.Optimizer):
             beta1=beta1,
             weight_decay=weight_decay,
             scale_parameter=scale_parameter,
-            relative_step=relative_step,
             warmup_init=warmup_init,
         )
         super(Adafactor, self).__init__(params, defaults)
 
     def _get_lr(self, param_group, param_state):
         rel_step_sz = param_group['lr']
-        if param_group['relative_step']:
-            min_step = (
-                1e-6 * param_state['step'] if param_group['warmup_init'] else 1e-2
-            )
-            rel_step_sz = min(min_step, 1.0 / math.sqrt(param_state['step']))
         param_scale = 1.0
         if param_group['scale_parameter']:
+            warn_once('Lr is rescaled by Adafactor optimizer.')
             param_scale = max(param_group['eps'][1], param_state['RMS'])
         return param_scale * rel_step_sz
 


### PR DESCRIPTION
**Patch description**
The current implementation of ada factor is a bit confusing of the lr rate scheduler design. 
In my own case, it took me sometime to realize why my lr was not the same as I set and why it gets even larger than the lr given.

Changes I have done:
1.  Remove the relative step part, since that is the same as `inverse square root lr schduler`
2. Add options and warnings when we scale the lr by the model parameters. 

**Testing steps**
Tested with new fiarseq fine-tuning runs. 
