### PR TITLE
Use a clean name for ParlAIDialogTeacher.

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -1314,7 +1314,9 @@ class ParlAIDialogTeacher(FixedDialogTeacher):
         else:
             self.episodes = shared['episodes']
             self.num_exs = sum(len(e) for e in self.episodes)
-        self.id = opt.get('parlaidialogteacher_datafile', 'teacher')
+
+        self.id = opt['task']
+
         self.reset()
 
     def share(self):


### PR DESCRIPTION
**Patch description**
Use nicer names for ParlAI format teachers, so they don't go insane in metrics.

**Testing steps**
display_data.py with `-t quac`.

**Logs**
Before:
```
[followup]: None
[yesno]: __NEITHER__
[answer_starts]: 51
[/private/home/roller/working/parlai/data/QuAC/train.txt]: Do they speak any other languages?
[labels: Malayalam is derived from old Tamil and Sanskrit in the 6th century.]
```

After:
```
[followup]: None
[yesno]: __NEITHER__
[answer_starts]: 51
[quac]: Do they speak any other languages?
[labels: Malayalam is derived from old Tamil and Sanskrit in the 6th century.]
```
