### PR TITLE
Segments and softmaxes.

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -992,7 +992,6 @@ class BasicAttention(nn.Module):
 
     def __init__(self, dim=1, attn='cosine', residual=False, get_weights=True):
         super().__init__()
-        self.softmax = nn.Softmax(dim=dim)
         if attn == 'cosine':
             self.cosine = nn.CosineSimilarity(dim=dim)
         self.attn = attn
@@ -1026,8 +1025,8 @@ class BasicAttention(nn.Module):
         if mask_ys is not None:
             attn_mask = (mask_ys == 0).view(bsz, 1, y_len)
             attn_mask = attn_mask.repeat(1, x_len, 1)
-            l1.masked_fill_(attn_mask, -float('inf'))
-        l2 = self.softmax(l1)
+            l1.masked_fill(attn_mask, neginf(attn_mask.dtype))
+        l2 = F.softmax(l1, dim=self.dim, dtype=torch.float).type_as(l1)
         if values is None:
             values = ys
         lhs_emb = torch.bmm(l2, values)

--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -1025,7 +1025,7 @@ class BasicAttention(nn.Module):
         if mask_ys is not None:
             attn_mask = (mask_ys == 0).view(bsz, 1, y_len)
             attn_mask = attn_mask.repeat(1, x_len, 1)
-            l1.masked_fill(attn_mask, neginf(attn_mask.dtype))
+            l1.masked_fill(attn_mask, neginf(l1.dtype))
         l2 = F.softmax(l1, dim=self.dim, dtype=torch.float).type_as(l1)
         if values is None:
             values = ys

--- a/parlai/agents/transformer/polyencoder.py
+++ b/parlai/agents/transformer/polyencoder.py
@@ -301,7 +301,7 @@ class PolyEncoderModule(torch.nn.Module):
             embeddings_scale=opt['embeddings_scale'],
             reduction_type=reduction_type,
             n_positions=n_positions,
-            n_segments=2,
+            n_segments=opt.get('n_segments', 2),
             activation=opt['activation'],
             variant=opt['variant'],
             output_scaling=opt['output_scaling'],

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -221,7 +221,10 @@ class TorchRankerAgent(TorchAgent):
 
         By default torch.nn.CrossEntropyLoss.
         """
-        return torch.nn.CrossEntropyLoss(reduction='none')
+        if self.fp16:
+            return FP16SafeCrossEntropy(reduction='none')
+        else:
+            return torch.nn.CrossEntropyLoss(reduction='none')
 
     def set_interactive_mode(self, mode, shared=False):
         super().set_interactive_mode(mode, shared)

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -25,6 +25,7 @@ from parlai.utils.distributed import is_distributed
 from parlai.core.torch_agent import TorchAgent, Output
 from parlai.utils.misc import warn_once
 from parlai.utils.torch import padded_3d
+from parlai.utils.fp16 import FP16SafeCrossEntropy
 from parlai.core.metrics import AverageMetric
 
 

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -30,16 +30,16 @@ class FP16SafeCrossEntropy(torch.nn.Module):
     This avoids overflow in the softmax by doing the operation in FP32.
     """
 
-    def __init__(self, ignore_index, reduction='none'):
+    def __init__(self, ignore_index=None, reduction='none'):
         super().__init__()
-        self.NULL_IDX = ignore_index
+        self.ignore_index = ignore_index
         self.reduction = reduction
 
     def forward(self, scores, targets):
         return F.nll_loss(
             F.log_softmax(scores, 1, dtype=torch.float32),
             targets,
-            ignore_index=self.NULL_IDX,
+            ignore_index=self.ignore_index,
             reduction=self.reduction,
         )
 

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -30,7 +30,9 @@ class FP16SafeCrossEntropy(torch.nn.Module):
     This avoids overflow in the softmax by doing the operation in FP32.
     """
 
-    def __init__(self, ignore_index=None, reduction='none'):
+    def __init__(self, ignore_index=-100, reduction='none'):
+        # default ignore_index=-100 mimics pytorch's default in
+        # torch.nn.functional.nll_loss
         super().__init__()
         self.ignore_index = ignore_index
         self.reduction = reduction


### PR DESCRIPTION
**Patch description**
- Support `--n-segments` in polyencoder
- Use fp16 safe cross entropy loss for the ranking objective.

**Testing steps**
Internal sweeps.