### PR TITLE
Flush old versions of the ED data

### DIFF
--- a/parlai/tasks/empathetic_dialogues/build.py
+++ b/parlai/tasks/empathetic_dialogues/build.py
@@ -21,7 +21,7 @@ RESOURCES = [
 
 def build(opt):
     dpath = os.path.join(opt['datapath'], 'empatheticdialogues')
-    version = 'None'
+    version = '1.0'
 
     if not build_data.built(dpath, version_string=version):
         print('[building data: ' + dpath + ']')


### PR DESCRIPTION
Some people have old versions of the EmpatheticDialogues dataset, which doesn't contain inline candidates. This string change forces everyone to redownload the latest version of the data.

Testing: files redownloaded when running `python examples/display_data.py -t empathetic_dialogues`