### PR TITLE
[pickle] Gracefully handle torch objects saved with old opt.

### DIFF
--- a/parlai/agents/starspace/starspace.py
+++ b/parlai/agents/starspace/starspace.py
@@ -596,7 +596,11 @@ class StarspaceAgent(Agent):
         Return opt and model states.
         """
         print('Loading existing model params from ' + path)
-        data = torch.load(path, map_location=lambda cpu, _: cpu)
+        import parlai.utils.pickle
+
+        data = torch.load(
+            path, map_location=lambda cpu, _: cpu, pickle_module=parlai.utils.pickle
+        )
         self.model.load_state_dict(data['model'])
         self.reset()
         self.optimizer.load_state_dict(data['optimizer'])

--- a/parlai/utils/pickle.py
+++ b/parlai/utils/pickle.py
@@ -38,6 +38,10 @@ class Unpickler(pickle._Unpickler):  # type: ignore
                 # user doesn't have apex installed. We'll deal with this later.
                 return FakeAPEXClass
             else:
+                if module == 'parlai.core.utils' and name == 'Opt':
+                    from parlai.core.opt import Opt
+
+                    return Opt
                 raise
 
 


### PR DESCRIPTION
**Patch description**
If the user saved their opt with their torch model, and that model file is sufficiently old enough, it might refer to the older location of Opt. This handles a migration.

**Testing steps**
Manual testing with starspace LIGHT models.