### PR TITLE
[metrics] Support macro averaging.

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -461,7 +461,7 @@ def aggregate_named_reports(
 
     # reporters is a list of teachers or worlds
     m: Dict[str, Metric] = {}
-    macro_averages = {}
+    macro_averages: Dict[str, List[Metric]] = {}
     for task_id, task_report in named_reports.items():
         for each_metric, value in task_report.items():
             if value.is_global():

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -471,7 +471,7 @@ def aggregate_named_reports(
             else:
                 task_metric = f'{task_id}/{each_metric}'
                 m[task_metric] = m.get(task_metric) + value
-                if micro_average or isinstance(value, (SumMetric, FixedMetric)):
+                if micro_average or not isinstance(value, AverageMetric):
                     # none + a => a from implementation of Metric.__add__
                     m[each_metric] = m.get(each_metric) + value
                 else:

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -457,7 +457,7 @@ def aggregate_named_reports(
         raise ValueError("Cannot aggregate empty reports.")
     if len(named_reports) == 1:
         # no real aggregation to be done
-        return next(named_reports.values())
+        return next(iter(named_reports.values()))
 
     # reporters is a list of teachers or worlds
     m: Dict[str, Metric] = {}

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -263,10 +263,10 @@ class GlobalMetric:
     """
     A global metric is one that should not be aggregated across different tasks.
 
-    Key to it is the notion that any one worker or any one task already has a
-    global view of the value, and so no combinations should be done. Note this
-    is different then a FixedMetric, in that a GlobalMetric can be still
-    averaged across multiple parleys(), but a FixedMetric is always fixed.
+    Key to it is the notion that any one worker or any one task already has a global
+    view of the value, and so no combinations should be done. Note this is different
+    then a FixedMetric, in that a GlobalMetric can be still averaged across multiple
+    parleys(), but a FixedMetric is always fixed.
     """
 
     def is_global(self) -> bool:

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -478,12 +478,17 @@ def normalize_answer(s):
 
 def aggregate_named_reports(
     named_reports: Dict[str, Dict[str, Metric]], micro_average: bool = False
-):
+) -> Dict[str, Metric]:
     """
     Aggregate metrics from multiple reports.
 
-    :param reports: Dict of tasks -> metrics.
-    :param micro_average: If true, top level metrics will be the macro average.
+    :param reports:
+        Dict of tasks -> metrics.
+    :param micro_average:
+        If true, top level metrics will be the micro average. By default, we
+        use macro average.
+    :return:
+        The aggregated report
     """
     if len(named_reports) == 0:
         raise ValueError("Cannot aggregate empty reports.")
@@ -516,7 +521,7 @@ def aggregate_named_reports(
     return m
 
 
-def aggregate_unnamed_reports(reports: List[Dict[str, Metric]]):
+def aggregate_unnamed_reports(reports: List[Dict[str, Metric]]) -> Dict[str, Metric]:
     """
     Combines metrics without regard for tracking provenence.
     """

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -1902,7 +1902,10 @@ class MultiTaskTeacher(Teacher):
         """
         Report aggregated metrics across all subtasks.
         """
-        return aggregate_named_reports({t.getID(): t.report() for t in self.tasks})
+        return aggregate_named_reports(
+            {t.getID(): t.report() for t in self.tasks},
+            micro_average=self.opt.get('aggregate_micro', False),
+        )
 
     def reset(self):
         """

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -736,7 +736,10 @@ class MultiWorld(World):
         """
         Report aggregate metrics across all subworlds.
         """
-        metrics = aggregate_named_reports({w.getID(): w.report() for w in self.worlds})
+        metrics = aggregate_named_reports(
+            {w.getID(): w.report() for w in self.worlds},
+            micro_average=self.opt.get('aggregate_micro', False),
+        )
         if 'exs' in metrics:
             self.total_exs += metrics['exs'].value()
         return metrics

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -68,7 +68,8 @@ class ParlAILRScheduler(object):
         Check if we're warming up the learning rate.
         """
         return (
-            self.warmup_scheduler is not None
+            hasattr(self, 'warmup_scheduler')
+            and self.warmup_scheduler is not None
             and self._number_training_updates <= self.warmup_updates
         )
 
@@ -91,6 +92,7 @@ class ParlAILRScheduler(object):
         if states.get('warmup_scheduler') and getattr(self, 'warmup_scheduler', None):
             self.warmup_scheduler.load_state_dict(states['warmup_scheduler'])
         self._number_training_updates = states.get('number_training_updates', 0)
+        self.step(self._number_training_updates)
 
     def get_initial_number_training_updates(self):
         return self._number_training_updates

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -62,6 +62,14 @@ def setup_args(parser=None):
         'ppl,f1,accuracy,hits@1,rouge,bleu'
         'the rouge metrics will be computed as rouge-1, rouge-2 and rouge-l',
     )
+    parser.add_argument(
+        '-micro',
+        '--aggregate-micro',
+        type='bool',
+        default=False,
+        help='Report micro-averaged metrics instead of macro averaged metrics.',
+        recommended=False,
+    )
     WorldLogger.add_cmdline_args(parser)
     TensorboardLogger.add_cmdline_args(parser)
     parser.set_defaults(datatype='valid')

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -176,7 +176,9 @@ def eval_model(opt, print_parser=None):
         task_report = _eval_single_world(opt, agent, task)
         reports.append(task_report)
 
-    report = aggregate_named_reports(dict(zip(tasks, reports)))
+    report = aggregate_named_reports(
+        dict(zip(tasks, reports)), micro_average=opt.get('aggregate_micro', False)
+    )
 
     # print announcments and report
     print_announcements(opt)

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -719,7 +719,11 @@ class TrainLoop:
         if not self.saved and is_primary_worker():
             # save agent
             self.save_model()
-        elif opt.get('model_file'):
+        # there's a rare edge case where the we never saved the model, and we try
+        # to reload it. This sync_object ensures all workers wait for the primary
+        # worker to finish flushing before loading from disk.
+        sync_object(None)
+        if opt.get('model_file'):
             # reload best validation model
             self.agent = create_agent(opt)
 

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -182,7 +182,16 @@ def setup_args(parser=None) -> ParlaiParser:
         'ppl,f1,accuracy,hits@1,rouge,bleu'
         'the rouge metrics will be computed as rouge-1, rouge-2 and rouge-l',
     )
+    train.add_argument(
+        '-micro',
+        '--aggregate-micro',
+        type='bool',
+        default=False,
+        help='Report micro-averaged metrics instead of macro averaged metrics.',
+        recommended=False,
+    )
     TensorboardLogger.add_cmdline_args(parser)
+
     parser = setup_dict_args(parser)
     return parser
 
@@ -529,7 +538,9 @@ class TrainLoop:
 
         tasks = [world.getID() for world in valid_worlds]
         named_reports = dict(zip(tasks, reports))
-        report = aggregate_named_reports(named_reports)
+        report = aggregate_named_reports(
+            named_reports, micro_average=self.opt.get('aggregate_micro', False)
+        )
         # get the results from all workers
         report = self._sync_metrics(report)
 

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -720,7 +720,7 @@ class TrainLoop:
             # save agent
             self.save_model()
         # there's a rare edge case where the we never saved the model, and we try
-        # to reload it. This sync_object ensures all workers wait for the primary
+        # # to reload it. This sync_object ensures all workers wait for the primary
         # worker to finish flushing before loading from disk.
         sync_object(None)
         if opt.get('model_file'):

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -109,13 +109,55 @@ class TestEvalModel(unittest.TestCase):
         self.assertNotIn('bleu-4', valid)
         self.assertNotIn('bleu-4', test)
 
-    def test_multitasking_metrics(self):
+    def test_multitasking_metrics_macro(self):
         valid, test = testing_utils.eval_model(
             {
                 'task': 'integration_tests:candidate,'
                 'integration_tests:multiturnCandidate',
                 'model': 'random_candidate',
                 'num_epochs': 0.5,
+                'aggregate_micro': False,
+            }
+        )
+
+        task1_acc = valid['integration_tests:candidate/accuracy']
+        task2_acc = valid['integration_tests:multiturnCandidate/accuracy']
+        total_acc = valid['accuracy']
+        # task 2 is 4 times the size of task 1
+        self.assertEqual(
+            total_acc,
+            (task1_acc.value() + task2_acc.value()) * 0.5,
+            'Task accuracy is averaged incorrectly',
+        )
+
+        valid, test = testing_utils.eval_model(
+            {
+                'task': 'integration_tests:candidate,'
+                'integration_tests:multiturnCandidate',
+                'model': 'random_candidate',
+                'num_epochs': 0.5,
+                'aggregate_micro': False,
+            }
+        )
+        task1_acc = valid['integration_tests:candidate/accuracy']
+        task2_acc = valid['integration_tests:multiturnCandidate/accuracy']
+        total_acc = valid['accuracy']
+
+        # metrics are combined correctly
+        self.assertEqual(
+            total_acc,
+            (task1_acc.value() + task2_acc.value()) * 0.5,
+            'Task accuracy is averaged incorrectly',
+        )
+
+    def test_multitasking_metrics_micro(self):
+        valid, test = testing_utils.eval_model(
+            {
+                'task': 'integration_tests:candidate,'
+                'integration_tests:multiturnCandidate',
+                'model': 'random_candidate',
+                'num_epochs': 0.5,
+                'aggregate_micro': True,
             }
         )
 
@@ -133,6 +175,7 @@ class TestEvalModel(unittest.TestCase):
                 'integration_tests:multiturnCandidate',
                 'model': 'random_candidate',
                 'num_epochs': 0.5,
+                'aggregate_micro': True,
             }
         )
         task1_acc = valid['integration_tests:candidate/accuracy']

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,7 +9,16 @@ import unittest
 import torch
 import random
 
-from parlai.core.metrics import AverageMetric, SumMetric, FixedMetric, Metrics
+from parlai.core.metrics import (
+    AverageMetric,
+    SumMetric,
+    FixedMetric,
+    Metrics,
+    GlobalAverageMetric,
+    MacroAverageMetric,
+    aggregate_unnamed_reports,
+    aggregate_named_reports,
+)
 
 
 class TestMetric(unittest.TestCase):
@@ -89,10 +98,12 @@ class TestMetric(unittest.TestCase):
             self.assertAlmostEqual(actual_output, output, places=6)
             self.assertIsInstance(actual_output, float)
 
-    def test_fixedmetric(self):
-        assert (FixedMetric(3) + FixedMetric(3)).value() == 3
-        with self.assertRaises(ValueError):
-            _ = FixedMetric(3) + FixedMetric(4)
+    def test_macroaverage_additions(self):
+        m1 = AverageMetric(1, 3)
+        m2 = AverageMetric(3, 4)
+
+        assert (m1 + m2) == AverageMetric(4, 7)
+        assert MacroAverageMetric([m1, m2]) == 0.5 * (1.0 / 3 + 3.0 / 4)
 
 
 class TestMetrics(unittest.TestCase):
@@ -171,6 +182,83 @@ class TestMetrics(unittest.TestCase):
         m2.flush()
 
         assert m.report()['key'] == 32768 + 1
+
+
+class TestAggregators(unittest.TestCase):
+    def test_unnamed_aggregation(self):
+        report1 = {
+            'avg': AverageMetric(3, 4),
+            'sum': SumMetric(3),
+            'fixed': FixedMetric(4),
+            'global_avg': GlobalAverageMetric(3, 4),
+        }
+        report2 = {
+            'avg': AverageMetric(1, 3),
+            'sum': SumMetric(4),
+            'fixed': FixedMetric(4),
+            'global_avg': GlobalAverageMetric(1, 3),
+        }
+        agg = aggregate_unnamed_reports([report1, report2])
+        assert agg['avg'] == 4.0 / 7
+        assert agg['sum'] == 7
+        assert agg['fixed'] == 4
+        assert agg['global_avg'] == 4.0 / 7
+
+    def test_macro_aggregation(self):
+        report1 = {
+            'avg': AverageMetric(3, 4),
+            'sum': SumMetric(3),
+            'fixed': FixedMetric(4),
+            'global_avg': GlobalAverageMetric(3, 4),
+        }
+        report2 = {
+            'avg': AverageMetric(1, 3),
+            'sum': SumMetric(4),
+            'fixed': FixedMetric(4),
+            'global_avg': GlobalAverageMetric(1, 3),
+        }
+        agg = aggregate_named_reports({'a': report1, 'b': report2}, micro_average=False)
+        assert agg['avg'] == 0.5 * (3.0 / 4 + 1.0 / 3)
+        assert agg['sum'] == 7
+        assert agg['fixed'] == 4
+        assert agg['global_avg'] in (report1['global_avg'], report2['global_avg'])
+        # task level metrics
+        assert agg['a/avg'] == 3.0 / 4
+        assert agg['a/sum'] == 3
+        assert agg['a/fixed'] == 4
+        assert 'a/global_avg' not in agg
+        assert agg['b/avg'] == 1.0 / 3
+        assert agg['b/sum'] == 4
+        assert agg['b/fixed'] == 4
+        assert 'b/global_avg' not in agg
+
+    def test_micro_aggregation(self):
+        report1 = {
+            'avg': AverageMetric(3, 4),
+            'sum': SumMetric(3),
+            'fixed': FixedMetric(4),
+            'global_avg': GlobalAverageMetric(3, 4),
+        }
+        report2 = {
+            'avg': AverageMetric(1, 3),
+            'sum': SumMetric(4),
+            'fixed': FixedMetric(4),
+            'global_avg': GlobalAverageMetric(1, 3),
+        }
+        agg = aggregate_named_reports({'a': report1, 'b': report2}, micro_average=True)
+        assert agg['avg'] == 4.0 / 7
+        assert agg['sum'] == 7
+        assert agg['fixed'] == 4
+        assert agg['global_avg'] in (report1['global_avg'], report2['global_avg'])
+        # task level metrics
+        assert agg['a/avg'] == 3.0 / 4
+        assert agg['a/sum'] == 3
+        assert agg['a/fixed'] == 4
+        assert 'a/global_avg' not in agg
+        assert agg['b/avg'] == 1.0 / 3
+        assert agg['b/sum'] == 4
+        assert agg['b/fixed'] == 4
+        assert 'b/global_avg' not in agg
 
 
 if __name__ == '__main__':

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -98,6 +98,11 @@ class TestMetric(unittest.TestCase):
             self.assertAlmostEqual(actual_output, output, places=6)
             self.assertIsInstance(actual_output, float)
 
+    def test_fixedmetric(self):
+        assert (FixedMetric(3) + FixedMetric(3)).value() == 3
+        with self.assertRaises(ValueError):
+            _ = FixedMetric(3) + FixedMetric(4)
+
     def test_macroaverage_additions(self):
         m1 = AverageMetric(1, 3)
         m2 = AverageMetric(3, 4)

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -26,7 +26,7 @@ class TestTrainModel(unittest.TestCase):
         self.assertEqual(valid['exs'], 10, 'Validation exs is wrong')
         self.assertEqual(test['exs'], 10, 'Test exs is wrong')
 
-    def test_multitasking_metrics(self):
+    def test_multitasking_metrics_micro(self):
         valid, test = testing_utils.train_model(
             {
                 'task': 'integration_tests:candidate,'
@@ -50,7 +50,7 @@ class TestTrainModel(unittest.TestCase):
                 'integration_tests:multiturnCandidate',
                 'model': 'random_candidate',
                 'num_epochs': 0.5,
-                'aggregate_micro': False,
+                'aggregate_micro': True,
             }
         )
         task1_acc = valid['integration_tests:candidate/accuracy']
@@ -59,6 +59,45 @@ class TestTrainModel(unittest.TestCase):
         # metrics should be averaged equally across tasks
         self.assertEqual(
             total_acc, task1_acc + task2_acc, 'Task accuracy is averaged incorrectly',
+        )
+
+    def test_multitasking_metrics_macro(self):
+        valid, test = testing_utils.train_model(
+            {
+                'task': 'integration_tests:candidate,'
+                'integration_tests:multiturnCandidate',
+                'model': 'random_candidate',
+                'num_epochs': 0.5,
+                'aggregate_micro': False,
+            }
+        )
+
+        task1_acc = valid['integration_tests:candidate/accuracy']
+        task2_acc = valid['integration_tests:multiturnCandidate/accuracy']
+        total_acc = valid['accuracy']
+        self.assertEqual(
+            total_acc,
+            0.5 * (task1_acc.value() + task2_acc.value()),
+            'Task accuracy is averaged incorrectly',
+        )
+
+        valid, test = testing_utils.train_model(
+            {
+                'task': 'integration_tests:candidate,'
+                'integration_tests:multiturnCandidate',
+                'model': 'random_candidate',
+                'num_epochs': 0.5,
+                'aggregate_micro': False,
+            }
+        )
+        task1_acc = valid['integration_tests:candidate/accuracy']
+        task2_acc = valid['integration_tests:multiturnCandidate/accuracy']
+        total_acc = valid['accuracy']
+        # metrics should be averaged equally across tasks
+        self.assertEqual(
+            total_acc,
+            0.5 * (task1_acc.value() + task2_acc.value()),
+            'Task accuracy is averaged incorrectly',
         )
 
 


### PR DESCRIPTION
**Patch description**
Bring back support for macro averaging, which was lost in the metrics.

After discussion during the team meeting, I continued to look at the code more and more and determined that I still did not like the proposed solution of mismatching metrics during train/eval time (which was one of the major motivations of user level metrics). As such, I've implemented proper macro averaging as a higher level metric.

The only part I'm really unhappy about is carving out the exception for SumMetric. It's a bit annoying because `exs` is a critical metric that must be reported, and we don't want that averaged per-task, we want it summed.

**Testing steps**
Manual testing. New CI. Long CI of older things. @klshuster  can we run a test with your dodeca models (just point me to the model files in chat and a task mixture)

~Running locally, I think there might be a hang around when using with multiprocessing train.~ Resolved.