### PR TITLE
Catch a possible user error in reading ParlAI format data files.

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -1388,8 +1388,15 @@ class ParlAIDialogTeacher(FixedDialogTeacher):
         self.num_exs = 0
         eps = []
         with open(path, newline='\n') as read:
-            for line in read:
+            for line_no, line in enumerate(read, 1):
                 msg = str_to_msg(line.rstrip('\n'))
+                if 'eval_labels' in msg:
+                    raise ValueError(
+                        f"It looks like you've written eval_labels as a key in your "
+                        f"data file. This is not appropriate; labels will be converted "
+                        f"for you automatically. This is happening on Line {line_no} "
+                        f"in {path}. The line is:\n\t{line}"
+                    )
                 if msg:
                     self.num_exs += 1
                     eps.append(msg)

--- a/tests/test_teachers.py
+++ b/tests/test_teachers.py
@@ -57,5 +57,30 @@ class TestAbstractImageTeacher(unittest.TestCase):
         self._test_display_output('resnet152')
 
 
+class TestParlAIDialogTeacher(unittest.TestCase):
+    def test_good_fileformat(self):
+        """
+        Checks that we fail to load a dataset where the use specified eval_labels.
+        """
+        with testing_utils.tempdir() as tmpdir:
+            fp = os.path.join(tmpdir, "goodfile.txt")
+            with open(fp, "w") as f:
+                f.write('id:test_file\ttext:input\tlabels:good label')
+            opt = {'task': 'fromfile', 'fromfile_datapath': fp}
+            testing_utils.display_data(opt)
+
+    def test_bad_fileformat(self):
+        """
+        Checks that we fail to load a dataset where the use specified eval_labels.
+        """
+        with testing_utils.tempdir() as tmpdir:
+            fp = os.path.join(tmpdir, "badfile.txt")
+            with open(fp, "w") as f:
+                f.write('id:test_file\ttext:input\teval_labels:bad label')
+            opt = {'task': 'fromfile', 'fromfile_datapath': fp}
+            with self.assertRaises(ValueError):
+                testing_utils.display_data(opt)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Patch description**
Throw an error message when the user includes eval_labels in their data. This was a bug we accidentally hit, so best to ensure it doesn't happen again.

**Testing steps**
Manual creation of a test case. New unit tests.

**Logs**
```
Traceback (most recent call last):
  File "examples/display_data.py", line 23, in <module>
    display_data(opt)
  File "/private/home/roller/working/parlai/parlai/scripts/display_data.py", line 42, in display_data
    world = create_task(opt, agent)
  File "/private/home/roller/working/parlai/parlai/core/worlds.py", line 1599, in create_task
    world = create_task_world(opt, user_agents, default_world=default_world)
  File "/private/home/roller/working/parlai/parlai/core/worlds.py", line 1563, in create_task_world
    task_agents = _create_task_agents(opt)
  File "/private/home/roller/working/parlai/parlai/core/worlds.py", line 1551, in _create_task_agents
    return create_task_agent_from_taskname(opt)
  File "/private/home/roller/working/parlai/parlai/core/teachers.py", line 2215, in create_task_agent_from_taskname
    task_agents = teacher_class(opt)
  File "/private/home/roller/working/parlai/parlai/tasks/fromfile/agents.py", line 108, in __init__
    super().__init__(opt, shared)
  File "/private/home/roller/working/parlai/parlai/tasks/fromfile/agents.py", line 83, in __init__
    self._setup_data(datafile)
  File "/private/home/roller/working/parlai/parlai/core/teachers.py", line 1395, in _setup_data
    f"It looks like you've written eval_labels as a key in your "
ValueError: It looks like you've written eval_labels as a key in your data file. This is not appropriate; labels will be converted for you automatically. This is happening on Line 1 in foo. The line is:
        id:wizard_of_wikipedia  text:Science fiction    eval_labels:I think science fiction is an amazing genre for anything. Future science, technology, time travel, FTL travel, they're all such interesting concepts. 
```