### PR TITLE
transformer classif default bug

### DIFF
--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -347,7 +347,7 @@ class TransformerClassifierAgent(TorchClassifierAgent):
             help='load model from base transformer ranking model '
             '(used for pretraining)',
         )
-        parser.set_params(reduction_type='first')
+        parser.set_defaults(reduction_type='first')
 
     def build_model(self):
         num_classes = len(self.class_list)


### PR DESCRIPTION
This was causing the reduction_type to be incorrect by default when e.g. using eval_model.
Found by the roller.