### PR TITLE
nucleus -inf overflow

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -1134,8 +1134,10 @@ class TreeSearch(object):
         #  check new hypos for eos label, if we have some, add to finished
         for hypid in range(self.beam_size):
             if self.outputs[-1][hypid] == self.eos:
-                if (self.scores[hypid] == neginf(self.scores.dtype)
-                    or self.scores[hypid].item() == -math.inf):
+                if (
+                    self.scores[hypid] == neginf(self.scores.dtype)
+                    or self.scores[hypid].item() == -math.inf
+                ):
                     continue
                 #  this is finished hypo, adding to finished
                 eostail = _HypothesisTail(


### PR DESCRIPTION
**Patch description**
When a score for an EOS token in any given hypothesis overflowed to `-inf` in NucleusSampling, it would be added to the final list of hypotheses. This doesn't happen that often for small beam widths, but I was experimenting with a large beam width (20) which triggered this 100% of the time.

Exception:
```
Traceback (most recent call last):
  File "parlai/scripts/self_chat.py", line 124, in <module> 
    self_chat(parser.parse_args(print_args=False))
  File "parlai/scripts/self_chat.py", line 102, in self_chat  
    _run_self_chat_episode(opt, world, logger) 
  File "parlai/scripts/self_chat.py", line 71, in _run_self_chat_episode  
    world.parley()  
  File "/private/home/spoff/ParlAI/parlai/tasks/self_chat/worlds.py", line 164, in parley  
    acts[0] = agents[0].act()  
  File "/private/home/spoff/ParlAI/parlai/core/torch_agent.py", line 1830, in act  
    response = self.batch_act([self.observation])[0] 
  File "/private/home/spoff/ParlAI/parlai/core/torch_agent.py", line 1880, in batch_act  
    output = self.eval_step(batch) 
  File "/private/home/spoff/ParlAI/parlai/core/torch_generator_agent.py", line 722, in eval_step  
    beam_preds_scores, _ = self._generate(batch, self.beam_size, maxlen) 
  File "/private/home/spoff/ParlAI/parlai/core/torch_generator_agent.py", line 907, in _generate  
    n_best_beam_preds_scores = [b.get_rescored_finished() for b in beams] 
  File "/private/home/spoff/ParlAI/parlai/core/torch_generator_agent.py", line 907, in <listcomp> 
    n_best_beam_preds_scores = [b.get_rescored_finished() for b in beams] 
  File "/private/home/spoff/ParlAI/parlai/core/torch_generator_agent.py", line 1250, in get_rescored_finished  
    with score {score.item():.2f}'
AssertionError: TreeSearch returned a finalized hypo with multiple end tokens             with score -inf
```

Isolating the scores for a given hypothesis over time:
```
(Pdb) [s[14].item() for s in self.all_scores]                                                                          
[0.0, -3.404296875, -4.5625, -4.8515625, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -65504.0, -inf, -inf, -inf]
```

Demonstrating the overflow:
```
(Pdb) scores                                                                 
tensor([ -5.8594,  -4.3906,  -1.9766,  -5.9258,  -5.1406,  -8.7500,  -0.1957,
         -2.9043,  -6.9258,  -0.8604,  -5.4023,  -5.0156,  -0.9146,  -0.2678,
         -2.0957,  -5.3750,  -4.9219, -16.6406,  -3.2578, -11.7656],         
       device='cuda:0', dtype=torch.float16) 
(Pdb) prior_scores                                                           
tensor([-65504.0000, -65504.0000, -65504.0000, -65504.0000, -65504.0000,     
        -65504.0000,   -194.6250, -65504.0000, -65504.0000, -65504.0000,     
        -65504.0000, -65504.0000, -65504.0000, -65504.0000, -65504.0000,     
        -65504.0000, -65504.0000, -65504.0000, -65504.0000, -65504.0000],    
       device='cuda:0', dtype=torch.float16)                                 
(Pdb) prior_scores + -14                                                     
tensor([-65504.0000, -65504.0000, -65504.0000, -65504.0000, -65504.0000,     
        -65504.0000,   -208.6250, -65504.0000, -65504.0000, -65504.0000,     
        -65504.0000, -65504.0000, -65504.0000, -65504.0000, -65504.0000,     
        -65504.0000, -65504.0000, -65504.0000, -65504.0000, -65504.0000],    
       device='cuda:0', dtype=torch.float16)                                 
(Pdb) prior_scores + -15                                                     
tensor([-65504.0000, -65504.0000, -65504.0000, -65504.0000, -65504.0000,     
        -65504.0000,   -209.6250, -65504.0000, -65504.0000, -65504.0000,     
        -65504.0000, -65504.0000, -65504.0000, -65504.0000, -65504.0000,     
        -65504.0000, -65504.0000, -65504.0000, -65504.0000, -65504.0000],    
       device='cuda:0', dtype=torch.float16)                                 
(Pdb) prior_scores + -16                                                     
tensor([     -inf,      -inf,      -inf,      -inf,      -inf,      -inf,    
        -210.6250,      -inf,      -inf,      -inf,      -inf,      -inf,    
             -inf,      -inf,      -inf,      -inf,      -inf,      -inf,    
             -inf,      -inf], device='cuda:0', dtype=torch.float16) 
```

**Testing steps**
Re-run the same command that failed:
```
λ python parlai/scripts/self_chat.py -mf /path/to/model   --skip-generation False --beam-block-ngram 1 --beam-context-block-ngram 1 --inference nucleus --topp 0.9 --selfchat
-max-turns 6 --num-self-chats 2 -d True --beam-size 20
[ warning: overriding opt['skip_generation'] to False (previously: True )]
[ warning: overriding opt['beam_block_ngram'] to 1 (previously: None )]
[ warning: overriding opt['beam_context_block_ngram'] to 1 (previously: None )]
[ warning: overriding opt['inference'] to nucleus (previously: greedy )]
[ warning: overriding opt['topp'] to 0.9 (previously: None )]
[ warning: overriding opt['selfchat_max_turns'] to 6 (previously: None )]
[ warning: overriding opt['num_self_chats'] to 2 (previously: None )]
[ warning: overriding opt['display_examples'] to True (previously: False )]
[ warning: overriding opt['beam_size'] to 20 (previously: 1 )]
[ Using CUDA ]
Dictionary: loading dictionary from /path/to/model.dict
[ num words =  54944 ]
[TransformerGenerator: full interactive mode on.]
Total parameters: 87508992
Trainable parameters:  87508992
[ Loading existing model params from /path/to/model ]
/private/home/spoff/ParlAI/parlai/nn/lr_scheduler.py:398: UserWarning: --lr-scheduler invsqrt requires a value for --invsqrt-lr-decay-gamma. Defaulting to set gamma to --warmup-updates value for backwards
  '--lr-scheduler invsqrt requires a value for '
[creating task(s): self_chat]
   [context]: __SILENCE__
[TransformerGenerator_1]: ヽ ༼ ຈل ͜ ຈ ༽ __unk__
   [TransformerGenerator_2]: done
[TransformerGenerator_1]: upvoted please return
   [TransformerGenerator_2]: up you go !
[TransformerGenerator_1]: thanks
   [TransformerGenerator_2]: no problem
[TransformerGenerator_1]: thx
   [TransformerGenerator_2]: np
[TransformerGenerator_1]: + 1
   [TransformerGenerator_2]: & # x200b ;
-- end of episode --
   [context]: __SILENCE__
[TransformerGenerator_1]: __unk__
   [TransformerGenerator_2]: goodbye
[TransformerGenerator_1]: oof
   [TransformerGenerator_2]: owie
[TransformerGenerator_1]: my bones
   [TransformerGenerator_2]: r / bonehurtingjuice
[TransformerGenerator_1]: ew
   [TransformerGenerator_2]: thank mr skeltal
[TransformerGenerator_1]: doot
   [TransformerGenerator_2]: dootsy
-- end of episode --
 [ Conversations saved to file: /tmp/TransformerGenerator_selfchat.jsonl ]
[ Writing metadata to file /tmp/TransformerGenerator_selfchat.metadata ]
```

Run it with fp32 to sanity check:
```
λ python parlai/scripts/self_chat.py -mf /path/to/model  --skip-generation False --beam-block-ngram 1 --beam-context-block-ngram 1 --inference nucleus --topp 0.9 --selfchat-max-turns 6 --num-self-chats 2 -d True --beam-size 20 --fp16 False
[ warning: overriding opt['skip_generation'] to False (previously: True )]
[ warning: overriding opt['beam_block_ngram'] to 1 (previously: None )]
[ warning: overriding opt['beam_context_block_ngram'] to 1 (previously: None )]
[ warning: overriding opt['inference'] to nucleus (previously: greedy )]
[ warning: overriding opt['topp'] to 0.9 (previously: None )]
[ warning: overriding opt['selfchat_max_turns'] to 6 (previously: None )]
[ warning: overriding opt['num_self_chats'] to 2 (previously: None )]
[ warning: overriding opt['display_examples'] to True (previously: False )]
[ warning: overriding opt['beam_size'] to 20 (previously: 1 )]
[ warning: overriding opt['fp16'] to False (previously: True )]
[ Using CUDA ]
Dictionary: loading dictionary from /path/to/model.dict
[ num words =  54944 ]
[TransformerGenerator: full interactive mode on.]
Total parameters: 87508992
Trainable parameters:  87508992
[ Loading existing model params from /path/to/model ]
/private/home/spoff/ParlAI/parlai/nn/lr_scheduler.py:398: UserWarning: --lr-scheduler invsqrt requires a value for --invsqrt-lr-decay-gamma. Defaulting to set gamma to --warmup-updates value for backwards
  '--lr-scheduler invsqrt requires a value for '
[creating task(s): self_chat]
   [context]: __SILENCE__
[TransformerGenerator_1]: thank you !
   [TransformerGenerator_2]: no problem
[TransformerGenerator_1]: : )
   [TransformerGenerator_2]: __unk__
[TransformerGenerator_1]: happy cake day
   [TransformerGenerator_2]: thanks
[TransformerGenerator_1]: np
   [TransformerGenerator_2]: have a good one
[TransformerGenerator_1]: ty
   [TransformerGenerator_2]: your welcome
-- end of episode --
   [context]: __SILENCE__
[TransformerGenerator_1]: thanks .
   [TransformerGenerator_2]: np
[TransformerGenerator_1]: : )
   [TransformerGenerator_2]: < 3
[TransformerGenerator_1]: __unk__
   [TransformerGenerator_2]: ❤ ️
[TransformerGenerator_1]: 😉
   [TransformerGenerator_2]: 👍
[TransformerGenerator_1]: goodbye
   [TransformerGenerator_2]: r / wholesomeouija
-- end of episode --
 [ Conversations saved to file: /tmp/TransformerGenerator_selfchat.jsonl ]
[ Writing metadata to file /tmp/TransformerGenerator_selfchat.metadata ]
```