### PR TITLE
Adding temperature decoding option

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -652,6 +652,23 @@ class TestTransformerGenerator(unittest.TestCase):
         self.assertEqual(agent.model.encoder.n_layers, 2)
         self.assertEqual(agent.model.decoder.n_layers, 2)
 
+    def test_temperature(self):
+        """
+        Test temperature.
+        """
+        # Just ensuring no crash.
+        testing_utils.eval_model(
+            dict(
+                task='integration_tests:multiturn_candidate',
+                model='transformer/generator',
+                model_file='zoo:unittest/transformer_generator2/model',
+                batchsize=32,
+                inference='beam',
+                beam_size=5,
+                temperature=0.99,
+            )
+        )
+
 
 class TestLearningRateScheduler(unittest.TestCase):
     """


### PR DESCRIPTION
**Patch description**
Basing this change on the definition of temperature in https://arxiv.org/pdf/1503.02531.pdf and the implementation found in fairseq: https://github.com/pytorch/fairseq/blob/master/fairseq/sequence_generator.py#L573-L574

**Testing steps**
Add breakpoint and verify temperature is applied to the pre-softmax logits.
```
λ python parlai/scripts/self_chat.py -mf /path/to/model   --skip-generation False --beam-block-ngram 1 --beam-context-block-ngram 1 --inference topk --topk 4 --selfchat-max-turns 6 --num-self-chats 1 -d True --beam-size 2 --temperature 100
...
[creating task(s): self_chat]
   [context]: __SILENCE__
> /private/home/spoff/ParlAI/parlai/core/torch_generator_agent.py(896)_generate()
-> if self.temperature != 1.0:
(Pdb) F.log_softmax(score, dim=-1)
tensor([[[-1.6266e+01, -6.5504e+04, -8.9844e+00,  ..., -1.6250e+01,
          -1.6266e+01, -1.6250e+01],
         [-1.6266e+01, -6.5504e+04, -8.9844e+00,  ..., -1.6250e+01,
          -1.6266e+01, -1.6250e+01]]], device='cuda:0', dtype=torch.float16)
(Pdb) F.log_softmax(score.div(self.temperature), dim=-1)
tensor([[[ -10.9297, -666.0000,  -10.8594,  ...,  -10.9297,  -10.9297,
           -10.9297],
         [ -10.9297, -666.0000,  -10.8594,  ...,  -10.9297,  -10.9297,
           -10.9297]]], device='cuda:0', dtype=torch.float16)
(Pdb) n
> /private/home/spoff/ParlAI/parlai/core/torch_generator_agent.py(897)_generate()
-> score.div_(self.temperature)
(Pdb) n
> /private/home/spoff/ParlAI/parlai/core/torch_generator_agent.py(898)_generate()
-> score = F.log_softmax(score, dim=-1)
(Pdb) n
> /private/home/spoff/ParlAI/parlai/core/torch_generator_agent.py(899)_generate()
-> for i, b in enumerate(beams):
(Pdb) score
tensor([[[ -10.9297, -666.0000,  -10.8594,  ...,  -10.9297,  -10.9297,
           -10.9297],
         [ -10.9297, -666.0000,  -10.8594,  ...,  -10.9297,  -10.9297,
           -10.9297]]], device='cuda:0', dtype=torch.float16)
```


