### PR TITLE
Change length penalty to match NMT paper

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -1227,7 +1227,7 @@ class TreeSearch(object):
         for finished_item in self.finished:
             current_length = finished_item.timestep + 1
             # these weights are from Google NMT paper
-            length_penalty = math.pow((1 + current_length) / 6, self.length_penalty)
+            length_penalty = math.pow((5 + current_length) / 6, self.length_penalty)
             rescored_finished.append(
                 _HypothesisTail(
                     timestep=finished_item.timestep,


### PR DESCRIPTION
**Patch description**
I was reading the NMT paper to understand this length penalizing a little better, and realized we're not using the same constants they did. It kind of feels like we should use the constants they found to be optimal, or experiment with our own constants to find out what works best for dialog.

<img width="115" alt="Screen Shot 2020-03-16 at 10 55 20 PM" src="https://user-images.githubusercontent.com/1254056/76817798-38b2e100-67da-11ea-88f9-c99dc5e85913.png">

The basic behavior of this function is the same either way, though, so there's a good case to be made for favoring reproducibility over using the optimal constants by keeping what we have.

**Testing steps**
Plotted the final score, given hypothesis lengths from 1 to 15, an imaginary hypothesis score of -2.0, and a length penalty of 0.65:
<img width="380" alt="Screen Shot 2020-03-16 at 11 01 30 PM" src="https://user-images.githubusercontent.com/1254056/76817773-2b95f200-67da-11ea-87c1-235bca63b071.png">
