### PR TITLE
Filter political conversations out of EmpatheticDialogues

### DIFF
--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-from typing import List
+from typing import Any, List
 
 import numpy as np
 
@@ -182,8 +182,10 @@ class EmpatheticDialoguesTeacher(FixedDialogTeacher):
         )
 
     def _select_dialogues_to_add(
-        self, experiencer_text_dialogue: List[list], responder_text_dialogue: List[list]
-    ) -> List[List[list]]:
+        self,
+        experiencer_text_dialogue: List[List[Any]],
+        responder_text_dialogue: List[List[Any]],
+    ) -> List[List[List[Any]]]:
         """
         Return conversation halves to add to self.data.
 

--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -143,6 +143,9 @@ class EmpatheticDialoguesTeacher(FixedDialogTeacher):
                     for f in gettop:
                         ft_cand = f.split("_")[-1] + " " + ft_cand
 
+                # Check if either the text or label are marked as being political
+                is_political = '<POLITICAL>' in cparts[7] or '<POLITICAL>' in sparts[7]
+
                 dialogue_parts = [
                     contextt,
                     label,
@@ -153,6 +156,7 @@ class EmpatheticDialoguesTeacher(FixedDialogTeacher):
                     ft_ctx,
                     ft_cand,
                     inline_label_candidates,
+                    is_political,
                 ]
 
                 if int(sparts[1]) % 2 == 0:
@@ -183,22 +187,22 @@ class EmpatheticDialoguesTeacher(FixedDialogTeacher):
         """
         Return conversation halves to add to self.data.
 
-        Given lists corresponding to the conversation turns from both sides of the conversation, return only the list(s) that will be added to self.data.
+        Given lists corresponding to the conversation turns from both sides of the
+        conversation, return only the list(s) that will be added to self.data.
+        Optionally filter by side of the conversation or by whether the conversation
+        contains any political language.
         """
-        selected_dialogues = []
-        if len(experiencer_text_dialogue) > 0:
-            if not (
-                self.remove_political_convos
-                and self.is_political(experiencer_text_dialogue)
-            ):
+        if self.remove_political_convos and any(
+            [turn[9] for turn in experiencer_text_dialogue + responder_text_dialogue]
+        ):
+            return []
+        else:
+            selected_dialogues = []
+            if len(experiencer_text_dialogue) > 0:
                 selected_dialogues.append(experiencer_text_dialogue)
-        if len(responder_text_dialogue) > 0 and not self.experiencer_side_only:
-            if not (
-                self.remove_political_convos
-                and self.is_political(responder_text_dialogue)
-            ):
+            if len(responder_text_dialogue) > 0 and not self.experiencer_side_only:
                 selected_dialogues.append(responder_text_dialogue)
-        return selected_dialogues
+            return selected_dialogues
 
     def get(self, episode_idx, entry_idx=0):
         ep = self.data[episode_idx]


### PR DESCRIPTION
**Patch description**
Allows filtering conversations marked with a "<POLITICAL>" tag out of EmpatheticDialogues. Use `--remove-political-convos` to trigger this. Useful for safety filtering

**Testing steps**
```
python examples/display_data.py -t empathetic_dialogues
python examples/display_data.py -t empathetic_dialogues --remove-political-convos True
```

train set, before filtering:
[ loaded 39057 episodes with a total of 64636 examples ]
train set, after:
[ loaded 38851 episodes with a total of 64313 examples ]


valid, before:
[ loaded 2769 episodes with a total of 5738 examples ]
valid, after:
[ loaded 2768 episodes with a total of 5736 examples ]


test, before:
[ loaded 2547 episodes with a total of 5259 examples ]
test, after:
[ loaded 2542 episodes with a total of 5249 examples ]

"datasets" CI check: `python tests/datatests/test_new_tasks.py` passes.