### PR TITLE
[Chat Services] Chat service agent data persistence

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,12 +170,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-osx-{{ checksum "requirements.txt" }}
+          key: deps-v5-osx-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchcpuosx
       - save_cache:
-          key: deps-v4-osx-{{ checksum "requirements.txt" }}
+          key: deps-v5-osx-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -197,12 +197,12 @@ jobs:
           command: circleci tests split --split-by=timings --timings-type=classname
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-ut36-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut36-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchcpu
       - save_cache:
-          key: deps-v4-ut36-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut36-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -221,12 +221,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-ut38-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut38-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchcpu
       - save_cache:
-          key: deps-v4-ut38-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut38-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -245,12 +245,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-ut37-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut37-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchcpu
       - save_cache:
-          key: deps-v4-ut37-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut37-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -276,12 +276,12 @@ jobs:
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v4-gpu13-{{ checksum "requirements.txt" }}
+          key: deps-v5-gpu13-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu13
       - save_cache:
-          key: deps-v4-gpu13-{{ checksum "requirements.txt" }}
+          key: deps-v5-gpu13-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -307,12 +307,12 @@ jobs:
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v4-gpu14-{{ checksum "requirements.txt" }}
+          key: deps-v5-gpu14-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-v4-gpu14-{{ checksum "requirements.txt" }}
+          key: deps-v5-gpu14-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -338,12 +338,12 @@ jobs:
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v4-nightly-{{ checksum "requirements.txt" }}
+          key: deps-v5-nightly-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-v4-nightly-{{ checksum "requirements.txt" }}
+          key: deps-v5-nightly-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/parlai/chat_service/core/agents.py
+++ b/parlai/chat_service/core/agents.py
@@ -21,7 +21,7 @@ class ChatServiceAgent(Agent, ABC):
         self.id = receiver_id
         self.task_id = task_id
         self.acted_packets = {}
-        self.data = {}
+        self._data = {}
         self.msg_queue = Queue()
         self.observed_packets = {}
         self.message_request_time = None
@@ -29,6 +29,14 @@ class ChatServiceAgent(Agent, ABC):
         self.message_partners = []
         # initialize stored data
         self.set_stored_data()
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        self._data.update(value)
 
     @abstractmethod
     def observe(self, act):

--- a/parlai/chat_service/core/agents.py
+++ b/parlai/chat_service/core/agents.py
@@ -32,10 +32,25 @@ class ChatServiceAgent(Agent, ABC):
 
     @property
     def data(self):
+        """
+        ChatServiceAgent data property.
+        """
         return self._data
 
     @data.setter
     def data(self, value):
+        """
+        Setter for ChatServiceAgent.data.
+
+        The data within a ChatServiceAgent is persistent, in the sense that keys
+        _cannot_ be removed from the data. This is important to ensure persistence
+        of agent state across various parts of the ChatService pipeline.
+
+        To ensure this property, we call `agent._data.update(value)` when explicitly
+        setting the `data` property of an agent. This protects against cases where,
+        e.g., the `__init__` function sets a property for the agent, and then
+        later someone manually sets `agent.data = new_data`.
+        """
         self._data.update(value)
 
     @abstractmethod

--- a/parlai/chat_service/services/messenger/agents.py
+++ b/parlai/chat_service/services/messenger/agents.py
@@ -20,6 +20,7 @@ class MessengerAgent(ChatServiceAgent):
         self.disp_id = 'NewUser'
         self.message_partners = []
         self.page_id = page_id
+        self.data['allow_images'] = opt.get('allow_images', False)
 
     def observe(self, act):
         """

--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -234,22 +234,23 @@ class MessengerManager(ChatServiceManager):
         """
         Set up socket to start communicating to workers.
         """
-        if not self.bypass_server_setup:
-            shared_utils.print_and_log(
-                logging.INFO, 'Local: Setting up WebSocket...', should_print=True
-            )
+        if self.bypass_server_setup:
+            return
+
+        shared_utils.print_and_log(
+            logging.INFO, 'Local: Setting up WebSocket...', should_print=True
+        )
 
         self.app_token = self.get_app_token()
         self.sender = MessageSender(self.app_token)
 
         # Set up receive
-        if not self.bypass_server_setup:
-            socket_use_url = self.server_url
-            if self.opt['local']:  # skip some hops for local stuff
-                socket_use_url = 'https://localhost'
-            self.socket = ChatServiceMessageSocket(
-                socket_use_url, self.port, self._handle_webhook_event
-            )
+        socket_use_url = self.server_url
+        if self.opt['local']:  # skip some hops for local stuff
+            socket_use_url = 'https://localhost'
+        self.socket = ChatServiceMessageSocket(
+            socket_use_url, self.port, self._handle_webhook_event
+        )
         shared_utils.print_and_log(
             logging.INFO, 'done with websocket', should_print=True
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pexpect==4.7.0
 Pillow>=6.2.0
 py-gfm==0.1.4
 py-rouge==1.1
+pyyaml==3.13
 pyzmq==18.1.0
 regex==2019.8.19
 recommonmark==0.6.0

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-import parlai.utils.testing as testing_utils
 from parlai.chat_service.core.shared_utils import WorldConfig
 from parlai.chat_service.services.messenger.agents import MessengerAgent
 from parlai.chat_service.services.messenger.messenger_manager import MessengerManager
@@ -29,14 +28,12 @@ OPT = {
                 task_name='MessengerEchoTaskWorld',
                 max_time_in_pool=180,
                 agents_required=1,
-                backup_task=None
+                backup_task=None,
             )
         },
-        'additional_args': {
-            'page_id': PAGE_ID
-        }
+        'additional_args': {'page_id': PAGE_ID},
     },
-    'bypass_server_setup': True
+    'bypass_server_setup': True,
 }
 
 
@@ -44,6 +41,7 @@ class TestChatServiceAgent(unittest.TestCase):
     """
     Tests for chat service agent functionality.
     """
+
     def _get_args(self):
         parser = ParlaiParser(False, False)
         parser.add_parlai_data_path()
@@ -52,8 +50,8 @@ class TestChatServiceAgent(unittest.TestCase):
 
     def test_data_persistence(self):
         """
-        Test to make sure that assigning the `data` attribute of
-        a MessengerAgent does not overwrite values already in `data`.
+        Test to make sure that assigning the `data` attribute of a MessengerAgent does
+        not overwrite values already in `data`.
         """
         opt = self._get_args()
         opt.update(OPT)
@@ -62,19 +60,12 @@ class TestChatServiceAgent(unittest.TestCase):
 
         self.assertEqual(agent.data, {'allow_images': False})
         agent.data = {'second_arg': False}
-        self.assertEqual(
-            agent.data,
-            {'allow_images': False, 'second_arg': False}
-        )
+        self.assertEqual(agent.data, {'allow_images': False, 'second_arg': False})
         agent.data['allow_images'] = True
-        self.assertEqual(
-            agent.data,
-            {'allow_images': True, 'second_arg': False}
-        ),
+        self.assertEqual(agent.data, {'allow_images': True, 'second_arg': False}),
         agent.data = {'third_arg': 1, 'second_arg': True}
         self.assertEqual(
-            agent.data,
-            {'allow_images': True, 'second_arg': True, 'third_arg': 1}
+            agent.data, {'allow_images': True, 'second_arg': True, 'third_arg': 1}
         )
 
 

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+import parlai.utils.testing as testing_utils
+from parlai.chat_service.core.shared_utils import WorldConfig
+from parlai.chat_service.services.messenger.agents import MessengerAgent
+from parlai.chat_service.services.messenger.messenger_manager import MessengerManager
+from parlai.core.params import ParlaiParser
+
+AGENT_ID = -1
+TASK_ID = 'test_task_1'
+PAGE_ID = 0
+# config taken from `chat_service/tasks/overworld_demo`
+OPT = {
+    'is_debug': True,
+    'config': {
+        'overworld': 'MessengerOverworld',
+        'world_path': 'parlai.chat_service.tasks.overworld_demo.worlds',
+        'max_workers': 2,
+        'task_name': 'overworld_demo',
+        'configs': {
+            'echo': WorldConfig(
+                world_name='echo',
+                onboarding_name='MessengerEchoOnboardWorld',
+                task_name='MessengerEchoTaskWorld',
+                max_time_in_pool=180,
+                agents_required=1,
+                backup_task=None
+            )
+        },
+        'additional_args': {
+            'page_id': PAGE_ID
+        }
+    },
+    'bypass_server_setup': True
+}
+
+
+class TestChatServiceAgent(unittest.TestCase):
+    """
+    Tests for chat service agent functionality.
+    """
+    def _get_args(self):
+        parser = ParlaiParser(False, False)
+        parser.add_parlai_data_path()
+        parser.add_messenger_args()
+        return parser.parse_args([])
+
+    def test_data_persistence(self):
+        """
+        Test to make sure that assigning the `data` attribute of
+        a MessengerAgent does not overwrite values already in `data`.
+        """
+        opt = self._get_args()
+        opt.update(OPT)
+        manager = MessengerManager(opt)
+        agent = MessengerAgent(opt, manager, AGENT_ID, TASK_ID, PAGE_ID)
+
+        self.assertEqual(agent.data, {'allow_images': False})
+        agent.data = {'second_arg': False}
+        self.assertEqual(
+            agent.data,
+            {'allow_images': False, 'second_arg': False}
+        )
+        agent.data['allow_images'] = True
+        self.assertEqual(
+            agent.data,
+            {'allow_images': True, 'second_arg': False}
+        ),
+        agent.data = {'third_arg': 1, 'second_arg': True}
+        self.assertEqual(
+            agent.data,
+            {'allow_images': True, 'second_arg': True, 'third_arg': 1}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Patch description**
I would like a `ChatServiceAgent`'s data to persist, even when directly assigned. This is very useful when instantiating a `ChatServiceAgent`, setting properties in the agent's data, and then subsequently assigning a new data dictionary to the agent's data (which does indeed happen).

**Testing steps**
Included unit test

**Logs**
```
$ python -m pytest -m unit tests/test_chat_service.py
============================================================================================================================= test session starts ==============================================================================================================================
platform linux -- Python 3.6.9, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini
plugins: requests-mock-1.7.0
collected 1 item

tests/test_chat_service.py .                                                                                                                                                                                                                                             [100%]

========================================================================================================================== slowest 10 test durations ===========================================================================================================================
1.70s call     tests/test_chat_service.py::TestChatServiceAgent::test_data_persistence

(0.00 durations hidden.  Use -vv to show these durations.)
======================================================================================================================== 1 passed, 5 warnings in 3.62s =========================================================================================================================
```