### PR TITLE
Fix a GPU leak

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -766,14 +766,16 @@ class DialogData(object):
         """
         return len(self.data)
 
-    @lru_cache(maxsize=1)
     def num_examples(self):
         """
         Return total number of entries available.
 
         Each episode has at least one entry, but might have many more.
         """
-        return sum(len(episode) for episode in self.data)
+        if hasattr(self, '_num_examples_cache'):
+            return self._num_examples_cache
+        self._num_examples_cache = sum(len(episode) for episode in self.data)
+        return self._num_examples_cache
 
     def get(self, episode_idx, entry_idx=0):
         """

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -40,7 +40,6 @@ from parlai.core.opt import Opt
 from parlai.utils.misc import AttrDict, no_lock, str_to_msg, warn_once
 from parlai.utils.distributed import get_rank, num_workers, is_distributed
 
-from functools import lru_cache
 from abc import ABC, abstractmethod
 
 import concurrent.futures

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -379,7 +379,6 @@ class DialogPartnerWorld(World):
             self.total_exs += metrics['exs'].value()
         return metrics
 
-    @lru_cache(maxsize=1)
     def num_examples(self):
         """
         Return number of examples.
@@ -1424,12 +1423,14 @@ class HogwildWorld(World):
         """
         return self.inner_world.getID()
 
-    @lru_cache(maxsize=1)
     def num_examples(self):
         """
         Return the number of examples.
         """
-        return self.inner_world.num_examples()
+        if hasattr(self, '_num_examples'):
+            return self._num_examples_cache
+        self._num_examples_cache = self.inner_world.num_examples()
+        return self._num_examples_cache
 
     def num_episodes(self):
         """

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -45,7 +45,6 @@ import copy
 import random
 import time
 
-from functools import lru_cache
 from typing import List, Dict, Any, Union
 
 try:


### PR DESCRIPTION
**Patch description**
When working with models that barely fit on the GPU, we can easily OOM when we load up the final 
validation model. The memory of the agent was not clearing correctly.

This insidious bug was due to `lru_cache` keeping a copy of the the world in memory, and therefore the agent, and therefore the model.

Fix is to manually cache the thing that was bound by the LRU cache, and manually clear the memory before we load validation.


**Testing steps**
Loading a large model before and after this fix. CI.