### PR TITLE
Test Interactive and Self-Chat

### DIFF
--- a/parlai/agents/local_human/local_human.py
+++ b/parlai/agents/local_human/local_human.py
@@ -38,8 +38,12 @@ class LocalHumanAgent(Agent):
         super().__init__(opt)
         self.id = 'localHuman'
         self.episodeDone = False
+        self.finished = False
         self.fixedCands_txt = load_cands(self.opt.get('local_human_candidates_file'))
-        print("Enter [DONE] if you want to end the episode.\n")
+        print("Enter [DONE] if you want to end the episode, [EXIT] to quit.\n")
+
+    def epoch_done(self):
+        return self.finished
 
     def observe(self, msg):
         print(
@@ -64,6 +68,8 @@ class LocalHumanAgent(Agent):
             self.episodeDone = True
             reply_text = reply_text.replace('[DONE]', '')
         reply['text'] = reply_text
+        if '[EXIT]' in reply_text:
+            self.finished = True
         return reply
 
     def episode_done(self):

--- a/parlai/tasks/convai2/worlds.py
+++ b/parlai/tasks/convai2/worlds.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 from parlai.core.worlds import create_task
 from parlai.core.worlds import DialogPartnerWorld, validate
-from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
+from parlai.agents.fixed_response.fixed_response import FixedResponseAgent
 from parlai.tasks.self_chat.worlds import SelfChatWorld as SelfChatBaseWorld
 
 import random
@@ -24,7 +24,7 @@ def load_personas(opt):
         convai2_opt['datatype'] = 'train:evalmode'
     convai2_opt['interactive_task'] = False
     convai2_opt['selfchat_task'] = False
-    convai2_agent = RepeatLabelAgent(convai2_opt)
+    convai2_agent = FixedResponseAgent({'fixed_response': None})
     convai2_world = create_task(convai2_opt, convai2_agent)
     personas = set()
     while not convai2_world.epoch_done():

--- a/tests/test_interative.py
+++ b/tests/test_interative.py
@@ -1,11 +1,13 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # http://google.com
 # LICENSE file in the root directory of this source tree.
 
-"""Tests that interactive.py is behaving well."""
+"""
+Tests that interactive.py is behaving well.
+"""
 
 import unittest
 from unittest import mock

--- a/tests/test_interative.py
+++ b/tests/test_interative.py
@@ -6,3 +6,52 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests that interactive.py is behaving well."""
+
+import unittest
+from unittest import mock
+import parlai.scripts.interactive as interactive
+
+
+class FakeInput(object):
+    def __init__(self, max_turns=2):
+        self.max_turns = max_turns
+        self.turn = 0
+
+    def __call__(self, prompt=""):
+        self.turn += 1
+        if self.turn <= self.max_turns:
+            return f'Turn {self.turn}'
+        else:
+            return '[EXIT]'
+
+
+class TestInteractive(unittest.TestCase):
+    def setUp(self):
+        # override input() with our fake, deterministic output
+        patcher = mock.patch('builtins.input', new=FakeInput())
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_repeat(self):
+        pp = interactive.setup_args()
+        opt = pp.parse_args(['-m', 'repeat_query'], print_args=False)
+        interactive.interactive(opt)
+
+
+class TestInteractiveConvai2(unittest.TestCase):
+    def setUp(self):
+        # override input() with our fake, deterministic output
+        patcher = mock.patch('builtins.input', new=FakeInput())
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_repeat(self):
+        pp = interactive.setup_args()
+        opt = pp.parse_args(
+            ['-m', 'repeat_query', '-t', 'convai2', '-dt', 'valid'], print_args=False
+        )
+        interactive.interactive(opt)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_self_chat.py
+++ b/tests/test_self_chat.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+import parlai.scripts.self_chat as self_chat
+
+
+class TestSelfChat(unittest.TestCase):
+    def test_vanilla(self):
+        pp = self_chat.setup_args()
+        opt = pp.parse_args(['-m', 'fixed_response', '--fixed-response', 'hi'])
+        self_chat.self_chat(opt)
+
+    def test_convai2(self):
+        pp = self_chat.setup_args()
+        opt = pp.parse_args(
+            [
+                '-m',
+                'fixed_response',
+                '--fixed-response',
+                'hi',
+                '-t',
+                'convai2',
+                '-dt',
+                'valid',
+            ]
+        )
+        self_chat.self_chat(opt)


### PR DESCRIPTION
**Patch description**
We have a big hole in our testing around interactive and self chat talks. This creates some new tests for this.

A few changes:
- Support setting epoch_done in `local_human`, to signal to the world "hey, we're done here."
- Switch from `repeat_label` to `fixed_response` when collecting the personas. By using a `None` response, I skip the evaluation metrics, which gives a nice speed up
- Just use a fixed response for self chat. In the future, I think I would like to test the interactive mode of a few different agents (cc @jaseweston).

**Testing steps**
CI of new unit tests. Hopefully we see some good improvements in code coverage.