### PR TITLE
[Rankers] Data parallel fix

### DIFF
--- a/parlai/agents/bert_ranker/bi_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/bi_encoder_ranker.py
@@ -3,7 +3,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from parlai.utils.distributed import is_distributed
 from parlai.core.torch_ranker_agent import TorchRankerAgent
 from parlai.utils.torch import padded_3d
 from parlai.zoo.bert.build import download

--- a/parlai/agents/bert_ranker/bi_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/bi_encoder_ranker.py
@@ -47,11 +47,6 @@ class BiEncoderRankerAgent(TorchRankerAgent):
 
         super().__init__(opt, shared)
         # it's easier for now to use DataParallel when
-        self.data_parallel = opt.get('data_parallel') and self.use_cuda
-        if self.data_parallel and shared is None:
-            self.model = torch.nn.DataParallel(self.model)
-        if is_distributed():
-            raise ValueError('Cannot combine --data-parallel and distributed mode')
         self.NULL_IDX = self.dict.pad_idx
         self.START_IDX = self.dict.start_idx
         self.END_IDX = self.dict.end_idx

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -3,7 +3,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from parlai.utils.distributed import is_distributed
 from parlai.utils.torch import concat_without_padding
 from parlai.core.torch_ranker_agent import TorchRankerAgent
 from parlai.zoo.bert.build import download
@@ -19,7 +18,6 @@ from .helpers import (
 )
 
 import os
-import torch
 
 
 class CrossEncoderRankerAgent(TorchRankerAgent):

--- a/parlai/agents/bert_ranker/cross_encoder_ranker.py
+++ b/parlai/agents/bert_ranker/cross_encoder_ranker.py
@@ -43,11 +43,6 @@ class CrossEncoderRankerAgent(TorchRankerAgent):
 
         super().__init__(opt, shared)
         # it's easier for now to use DataParallel when
-        self.data_parallel = opt.get('data_parallel') and self.use_cuda
-        if self.data_parallel and shared is None:
-            self.model = torch.nn.DataParallel(self.model)
-        if is_distributed():
-            raise ValueError('Cannot combine --data-parallel and distributed mode')
         self.clip = -1
         self.NULL_IDX = self.dict.pad_idx
         self.START_IDX = self.dict.start_idx

--- a/parlai/agents/transformer/crossencoder.py
+++ b/parlai/agents/transformer/crossencoder.py
@@ -17,6 +17,7 @@ class CrossencoderAgent(TorchRankerAgent):
     Equivalent of bert_ranker/crossencoder but does not rely on an external library
     (hugging face).
     """
+
     @classmethod
     def add_cmdline_args(cls, argparser):
         """

--- a/parlai/agents/transformer/crossencoder.py
+++ b/parlai/agents/transformer/crossencoder.py
@@ -17,18 +17,6 @@ class CrossencoderAgent(TorchRankerAgent):
     Equivalent of bert_ranker/crossencoder but does not rely on an external library
     (hugging face).
     """
-
-    def __init__(self, opt, shared=None):
-        super().__init__(opt, shared)
-        self.data_parallel = opt.get('data_parallel') and self.use_cuda
-        if self.data_parallel:
-            from parlai.utils.distributed import is_distributed
-
-            if is_distributed():
-                raise ValueError('Cannot combine --data-parallel and distributed mode')
-            if shared is None:
-                self.model = torch.nn.DataParallel(self.model)
-
     @classmethod
     def add_cmdline_args(cls, argparser):
         """


### PR DESCRIPTION
**Patch description**
A few ranking models broke from #2481 which moved the data parallel wrap up to Torch Ranker Agent. Result was that some models were being double wrapped in data parallel.