### PR TITLE
Light task: small mods

### DIFF
--- a/parlai/tasks/light_dialog/agents.py
+++ b/parlai/tasks/light_dialog/agents.py
@@ -172,6 +172,10 @@ class SimpleTeacher(DefaultTeacher):
         agent.add_argument('--light_use_clip_cands', type=int, default=10000)
         agent.add_argument('--light_use_speech_prefix', type='bool', default=False)
 
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
+        self.id += '_' + self.opt['light_label_type']
+
 
 class SimpleMultiTeacher(DefaultTeacher):
     def add_cmdline_args(argparser):
@@ -228,6 +232,10 @@ class SimpleMultiTeacher(DefaultTeacher):
         agent.add_argument('--light_use_cands', type=int, default=20)
         agent.add_argument('--light_use_clip_cands', type=int, default=10000)
         agent.add_argument('--light_use_speech_prefix', type='bool', default=False)
+
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
+        self.id += '_' + self.opt['light_label_type']
 
 
 class SelfchatTeacher(SimpleTeacher):

--- a/parlai/tasks/light_dialog/worlds.py
+++ b/parlai/tasks/light_dialog/worlds.py
@@ -22,7 +22,7 @@ class InteractiveSimpleWorld(InteractiveBaseWorld):
             '--add-task-string',
             type='bool',
             default=False,
-            help='Add _task_speech to text input to model or not'
+            help='Add _task_speech to text input to model or not',
         )
 
     def init_contexts(self):
@@ -55,7 +55,7 @@ class InteractiveSimpleWorld(InteractiveBaseWorld):
 
         else:
             task_name = ''
-            
+
         a1_persona = (
             task_name
             + p['_setting_name']

--- a/parlai/tasks/light_dialog/worlds.py
+++ b/parlai/tasks/light_dialog/worlds.py
@@ -15,6 +15,16 @@ import os
 
 
 class InteractiveSimpleWorld(InteractiveBaseWorld):
+    @staticmethod
+    def add_cmdline_args(argparser):
+        parser = argparser.add_argument_group('LIGHT Interactive World')
+        parser.add_argument(
+            '--add-task-string',
+            type='bool',
+            default=False,
+            help='Add _task_speech to text input to model or not'
+        )
+
     def init_contexts(self):
         # Create Light data so we can assign personas.
         light_opt = self.opt.copy()
@@ -40,8 +50,14 @@ class InteractiveSimpleWorld(InteractiveBaseWorld):
         for t in txt:
             p[t.split(' ')[0]] = t
 
+        if self.opt['add_task_string']:
+            task_name = ' _task_speech\n'
+
+        else:
+            task_name = ''
+            
         a1_persona = (
-            ' _task_speech\n'
+            task_name
             + p['_setting_name']
             + '\n'
             + p['_setting_desc']
@@ -56,7 +72,7 @@ class InteractiveSimpleWorld(InteractiveBaseWorld):
         )
 
         a2_persona = (
-            ' _task_speech\n'
+            task_name
             + p['_setting_name']
             + '\n'
             + p['_setting_desc']


### PR DESCRIPTION
- make task name make it clear which label task, this makes eval able to differentiate the different tasks when multitasking
- in the new 4 way multitasking variant we don't give the task name in the input text to the model, so we now have a flag to turn that off 