### PR TITLE
Add gnorm metric logging when gradient clipping < 0

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -52,7 +52,7 @@ from parlai.core.metrics import (
     GlobalFixedMetric,
 )
 from parlai.utils.distributed import is_primary_worker
-from parlai.utils.torch import argsort, padded_tensor
+from parlai.utils.torch import argsort, compute_grad_norm, padded_tensor
 
 
 class Batch(AttrDict):
@@ -1999,15 +1999,7 @@ class TorchAgent(ABC, Agent):
             )
         else:
             parameters = self.model.parameters()
-            if isinstance(parameters, torch.Tensor):
-                parameters = [parameters]
-            parameters = list(filter(lambda p: p.grad is not None, parameters))
-            norm_type = 2.0
-            total_norm = 0
-            for p in parameters:
-                param_norm = p.grad.data.norm(norm_type)
-                total_norm += param_norm.item() ** norm_type
-            grad_norm = total_norm ** (1. / norm_type)
+            grad_norm = compute_grad_norm(parameters)
             self.global_metrics.add('gnorm', GlobalAverageMetric(grad_norm))
 
         if self.fp16:

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -229,6 +229,7 @@ def argsort(keys: List[Any], *lists: List[List[Any]], descending: bool = False):
 def compute_grad_norm(parameters, norm_type=2.0):
     """
     Compute norm over gradients of model parameters.
+
     Mostly taken from the body of torch.nn.utils.clip_grad_norm_
 
     :param parameters:
@@ -237,7 +238,6 @@ def compute_grad_norm(parameters, norm_type=2.0):
 
     :param norm_type
         type of p-norm to use
-
     """
     if isinstance(parameters, torch.Tensor):
         parameters = [parameters]

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -241,7 +241,7 @@ def compute_grad_norm(parameters, norm_type=2.0):
     """
     if isinstance(parameters, torch.Tensor):
         parameters = [parameters]
-    parameters = list(filter(lambda p: p.grad is not None, parameters))
+    parameters = [p.grad for p in parameters if p is not None]
     total_norm = 0
     for p in parameters:
         param_norm = p.grad.data.norm(norm_type)

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -230,12 +230,9 @@ def compute_grad_norm(parameters, norm_type=2.0):
     """
     Compute norm over gradients of model parameters.
 
-    Mostly taken from the body of torch.nn.utils.clip_grad_norm_
-
     :param parameters:
         the model parameters for gradient norm calculation. Iterable of
         Tensors or single Tensor
-
     :param norm_type:
         type of p-norm to use
 

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -236,8 +236,11 @@ def compute_grad_norm(parameters, norm_type=2.0):
         the model parameters for gradient norm calculation. Iterable of
         Tensors or single Tensor
 
-    :param norm_type
+    :param norm_type:
         type of p-norm to use
+
+    :returns:
+        the computed gradient norm
     """
     if isinstance(parameters, torch.Tensor):
         parameters = [parameters]

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -246,7 +246,7 @@ def compute_grad_norm(parameters, norm_type=2.0):
     for p in parameters:
         param_norm = p.grad.data.norm(norm_type)
         total_norm += param_norm.item() ** norm_type
-    return total_norm ** (1. / norm_type)
+    return total_norm ** (1.0 / norm_type)
 
 
 class IdentityLayer(torch.nn.Module):

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -226,6 +226,29 @@ def argsort(keys: List[Any], *lists: List[List[Any]], descending: bool = False):
     return output
 
 
+def compute_grad_norm(parameters, norm_type=2.0):
+    """
+    Compute norm over gradients of model parameters.
+    Mostly taken from the body of torch.nn.utils.clip_grad_norm_
+
+    :param parameters:
+        the model parameters for gradient norm calculation. Iterable of
+        Tensors or single Tensor
+
+    :param norm_type
+        type of p-norm to use
+
+    """
+    if isinstance(parameters, torch.Tensor):
+        parameters = [parameters]
+    parameters = list(filter(lambda p: p.grad is not None, parameters))
+    total_norm = 0
+    for p in parameters:
+        param_norm = p.grad.data.norm(norm_type)
+        total_norm += param_norm.item() ** norm_type
+    return total_norm ** (1. / norm_type)
+
+
 class IdentityLayer(torch.nn.Module):
     """
     Identity layer module.


### PR DESCRIPTION
**Patch description**
Patch for #1977
Show gnorm in metrics even when gradient clipping isn't set

**Testing steps**
Ran train_model with --gradient_clip -1, verified that gnorm is printed.
Command:
`python examples/train_model.py -m transformer/generator -t convai2 -mf /tmp/tg --gradient_clip -1 -lr 1e-10`
Output:
<img width="682" alt="Screen Shot 2020-03-25 at 17 43 04" src="https://user-images.githubusercontent.com/7191484/77588581-84dbe080-6ec0-11ea-8adb-1681d9c3893e.png">
