### PR TITLE
[TCA] Truncate bug fix and README fix

### DIFF
--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -371,6 +371,11 @@ class TransformerClassifierAgent(TorchClassifierAgent):
             )
             obs['added_start_end'] = True
 
+        # check truncation after adding start end tokens
+        if obs.get('text_vec') is not None:
+            truncated_vec = self._check_truncate(obs['text_vec'], self.text_truncate, True)
+            obs.force_set('text_vec', torch.LongTensor(truncated_vec))
+
         return obs
 
     def score(self, batch):

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -373,7 +373,9 @@ class TransformerClassifierAgent(TorchClassifierAgent):
 
         # check truncation after adding start end tokens
         if obs.get('text_vec') is not None:
-            truncated_vec = self._check_truncate(obs['text_vec'], self.text_truncate, True)
+            truncated_vec = self._check_truncate(
+                obs['text_vec'], self.text_truncate, True
+            )
             obs.force_set('text_vec', torch.LongTensor(truncated_vec))
 
         return obs

--- a/projects/dialogue_safety/README.md
+++ b/projects/dialogue_safety/README.md
@@ -41,17 +41,17 @@ python examples/display_data.py -t dialogue_safety:multiturn --single-turn True
 
 Evaluate a pre-trained Transformer-based model on the test sets of rounds 1-3 or the **adversarial** task:
 ```bash
-python examples/eval_model.py -t dialogue_safety:adversarial --round 3 -dt test -mf zoo:dialogue_safety/single_turn/model -bs 40
+python examples/eval_model.py -t dialogue_safety:adversarial --round 3 -dt test -m transformer/classifier -mf zoo:dialogue_safety/single_turn/model -bs 40
 ```
 
 Evaluate the same pre-trained Transformer-based model on the test sets of rounds 1-3 or the **standard** task:
 ```bash
-python examples/eval_model.py -t dialogue_safety:standard --round 3 -dt test -mf zoo:dialogue_safety/single_turn/model -bs 40
+python examples/eval_model.py -t dialogue_safety:standard --round 3 -dt test -m transformer/classifier -mf zoo:dialogue_safety/single_turn/model -bs 40
 ```
 
 Interact with the single-turn model to see its classifications of your input in real time:
 ```bash
-python examples/interactive.py -mf zoo:dialogue_safety/single_turn/model --print-scores True --single-turn True
+python examples/interactive.py -mf zoo:dialogue_safety/single_turn/model -m transformer/classifier --print-scores True --single-turn True
 ```
 Here are some example outputs from the above script:
 ```bash


### PR DESCRIPTION
**Patch description**
Noticed a bug in Transformer Classifier agent where we add start/end *after* truncating. This leads to error with positional embeddings. We haven't observed this before, as we are usually loading a pre-trained ranker (with 1024 positional embeddings, which is usually much greater than the length to which we truncate). 

Also updated README of dialogue safety model to reflect new location of `transformer/classifer` module.

Solution is to just truncate after.