### PR TITLE
[Chat Service] Fix yaml warning

### DIFF
--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -14,7 +14,6 @@ import os
 
 from parlai.core.agents import create_agent
 import parlai.chat_service.utils.logging as log_utils
-import parlai.chat_service.utils.misc as utils
 import parlai.chat_service.utils.server as server_utils
 from parlai.chat_service.services.messenger.agents import MessengerAgent
 from parlai.chat_service.core.socket import ChatServiceMessageSocket

--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -81,7 +81,7 @@ class MessengerManager(ChatServiceManager):
         """
         Initialize logging settings from the opt.
         """
-        utils.set_is_debug(self.opt['is_debug'])
+        log_utils.set_is_debug(self.opt['is_debug'])
         log_utils.set_log_level(self.opt['log_level'])
 
     def mark_removed(self, agent_id, pageid):

--- a/parlai/chat_service/utils/config.py
+++ b/parlai/chat_service/utils/config.py
@@ -36,7 +36,7 @@ def parse_configuration_file(config_path):
     result = {}
     result["configs"] = {}
     with open(config_path) as f:
-        cfg = yaml.load(f.read())
+        cfg = yaml.load(f.read(), Loader=yaml.FullLoader)
         # get world path
         result["world_path"] = cfg.get("world_module")
         if not result["world_path"]:

--- a/parlai/chat_service/utils/logging.py
+++ b/parlai/chat_service/utils/logging.py
@@ -17,6 +17,12 @@ logging_enabled = True
 debug = True
 log_level = logging.ERROR
 
+
+def set_is_debug(is_debug):
+    global debug
+    debug = is_debug
+
+
 if logging_enabled:
     logging.basicConfig(
         filename=str(time.time()) + '.log',

--- a/parlai/chat_service/utils/misc.py
+++ b/parlai/chat_service/utils/misc.py
@@ -14,11 +14,6 @@ from enum import Enum
 THREAD_MEDIUM_SLEEP = 0.3
 
 
-def set_is_debug(is_debug):
-    global debug
-    debug = is_debug
-
-
 class TaskState:
     """
     Wrapper for an agent running on a Worker.


### PR DESCRIPTION
**Patch description**
Apparently `yaml.load` is unsafe and deprecated (per [this page](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)). Update to fix that

Also addressing a comment from @JackUrb on #2493 where `set_is_debug` was in the wrong file.

**Testing steps**
Tested locally