### PR TITLE
Fix loading optimizer state from disk when using --fp16-impl mem_eff

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -957,7 +957,7 @@ class TorchAgent(ABC, Agent):
             # finally, try to actually load the optimizer state
             try:
                 self.optimizer.load_state_dict(optim_states)
-            except ValueError:
+            except (ValueError, KeyError):
                 warn_once(
                     'WARNING: not loading optim state since model params changed.'
                 )

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -401,8 +401,14 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         }
         for k, v in state_dict['state'].items():
             if k in id_map:
+                # make sure when we copy the original state back, we make sure
+                # that original state is on the correct device
                 param = id_map[k]
-                self.optimizer.state[param] = v
+                like_device_v = {
+                    j: w.to(param.device) if torch.is_tensor(w) else w
+                    for j, w in v.items()
+                }
+                self.optimizer.state[param] = like_device_v
 
     @property
     def loss_scale(self):

--- a/tests/test_mem_efficient_fp16.py
+++ b/tests/test_mem_efficient_fp16.py
@@ -51,7 +51,51 @@ class TestMemEfficientFP16(unittest.TestCase):
                 )
             )
 
-    def test_resuming(self):
+    def test_resuming_adam(self):
+        """
+        Test resuming without FP16.
+        """
+        with testing_utils.tempdir() as tmpdir:
+            model_file = os.path.join(tmpdir, 'model')
+
+            valid1, test1 = testing_utils.train_model(
+                dict(
+                    model_file=model_file,
+                    task='integration_tests:candidate',
+                    model='transformer/ranker',
+                    optimizer='adam',
+                    fp16=True,
+                    fp16_impl='mem_efficient',
+                    learningrate=7e-3,
+                    batchsize=32,
+                    num_epochs=1,
+                    n_layers=1,
+                    n_heads=1,
+                    ffn_size=32,
+                    embedding_size=32,
+                    warmup_updates=1,
+                    lr_scheduler='invsqrt',
+                )
+            )
+
+            valid2, test2 = testing_utils.train_model(
+                dict(
+                    model_file=model_file,
+                    task='integration_tests:candidate',
+                    model='transformer/ranker',
+                    num_epochs=2,
+                    fp16=True,
+                )
+            )
+
+            # make sure the number of updates is being tracked correctly
+            self.assertGreater(
+                valid2['total_train_updates'],
+                valid1['total_train_updates'],
+                'Number of updates is not increasing',
+            )
+
+    def test_resuming_fp32(self):
         """
         Test resuming without FP16.
         """

--- a/tests/test_mem_efficient_fp16.py
+++ b/tests/test_mem_efficient_fp16.py
@@ -27,7 +27,7 @@ class TestMemEfficientFP16(unittest.TestCase):
                 fp16_impl='mem_efficient',
                 learningrate=7e-3,
                 batchsize=32,
-                num_epochs=1,
+                num_epochs=0.25,
                 n_layers=1,
                 n_heads=1,
                 ffn_size=32,
@@ -51,9 +51,11 @@ class TestMemEfficientFP16(unittest.TestCase):
                 )
             )
 
-    def test_resuming_adam(self):
+    # we don't currently install apex in CircleCI for a variety of reasons
+    @testing_utils.skipIfCircleCI
+    def test_resuming_apex2memeff(self):
         """
-        Test resuming without FP16.
+        Test switching from memory efficient fp16 to apex fp16
         """
         with testing_utils.tempdir() as tmpdir:
             model_file = os.path.join(tmpdir, 'model')
@@ -65,10 +67,10 @@ class TestMemEfficientFP16(unittest.TestCase):
                     model='transformer/ranker',
                     optimizer='adam',
                     fp16=True,
-                    fp16_impl='mem_efficient',
+                    fp16_impl='apex',
                     learningrate=7e-3,
                     batchsize=32,
-                    num_epochs=1,
+                    num_epochs=0.25,
                     n_layers=1,
                     n_heads=1,
                     ffn_size=32,
@@ -83,7 +85,99 @@ class TestMemEfficientFP16(unittest.TestCase):
                     model_file=model_file,
                     task='integration_tests:candidate',
                     model='transformer/ranker',
-                    num_epochs=2,
+                    fp16_impl='mem_efficient',
+                    num_epochs=0.5,
+                    fp16=True,
+                )
+            )
+
+            # make sure the number of updates is being tracked correctly
+            self.assertGreater(
+                valid2['total_train_updates'],
+                valid1['total_train_updates'],
+                'Number of updates is not increasing',
+            )
+
+    # we don't currently install apex in CircleCI for a variety of reasons
+    @testing_utils.skipIfCircleCI
+    def test_resuming_memeff2apex(self):
+        """
+        Test switching from memory efficient fp16 to apex fp16
+        """
+        with testing_utils.tempdir() as tmpdir:
+            model_file = os.path.join(tmpdir, 'model')
+
+            valid1, test1 = testing_utils.train_model(
+                dict(
+                    model_file=model_file,
+                    task='integration_tests:candidate',
+                    model='transformer/ranker',
+                    optimizer='adam',
+                    fp16=True,
+                    fp16_impl='mem_efficient',
+                    learningrate=7e-3,
+                    batchsize=32,
+                    num_epochs=0.25,
+                    n_layers=1,
+                    n_heads=1,
+                    ffn_size=32,
+                    embedding_size=32,
+                    warmup_updates=1,
+                    lr_scheduler='invsqrt',
+                )
+            )
+
+            valid2, test2 = testing_utils.train_model(
+                dict(
+                    model_file=model_file,
+                    task='integration_tests:candidate',
+                    model='transformer/ranker',
+                    fp16_impl='apex',
+                    num_epochs=0.5,
+                    fp16=True,
+                )
+            )
+
+            # make sure the number of updates is being tracked correctly
+            self.assertGreater(
+                valid2['total_train_updates'],
+                valid1['total_train_updates'],
+                'Number of updates is not increasing',
+            )
+
+    def test_resuming_adam(self):
+        """
+        Test resuming a memory efficient fp16 model from disk.
+        """
+        with testing_utils.tempdir() as tmpdir:
+            model_file = os.path.join(tmpdir, 'model')
+
+            valid1, test1 = testing_utils.train_model(
+                dict(
+                    model_file=model_file,
+                    task='integration_tests:candidate',
+                    model='transformer/ranker',
+                    optimizer='adam',
+                    fp16=True,
+                    fp16_impl='mem_efficient',
+                    learningrate=7e-3,
+                    batchsize=32,
+                    num_epochs=0.25,
+                    n_layers=1,
+                    n_heads=1,
+                    ffn_size=32,
+                    embedding_size=32,
+                    warmup_updates=1,
+                    lr_scheduler='invsqrt',
+                )
+            )
+
+            valid2, test2 = testing_utils.train_model(
+                dict(
+                    model_file=model_file,
+                    task='integration_tests:candidate',
+                    model='transformer/ranker',
+                    num_epochs=0.5,
                     fp16=True,
                 )
             )
@@ -112,7 +206,7 @@ class TestMemEfficientFP16(unittest.TestCase):
                     fp16_impl='mem_efficient',
                     learningrate=7e-3,
                     batchsize=32,
-                    num_epochs=1,
+                    num_epochs=0.25,
                     n_layers=1,
                     n_heads=1,
                     ffn_size=32,
@@ -127,7 +221,7 @@ class TestMemEfficientFP16(unittest.TestCase):
                     model_file=model_file,
                     task='integration_tests:candidate',
                     model='transformer/ranker',
-                    num_epochs=1,
+                    num_epochs=0.5,
                     fp16=False,
                 )
             )

--- a/tests/test_mem_efficient_fp16.py
+++ b/tests/test_mem_efficient_fp16.py
@@ -55,7 +55,7 @@ class TestMemEfficientFP16(unittest.TestCase):
     @testing_utils.skipIfCircleCI
     def test_resuming_apex2memeff(self):
         """
-        Test switching from memory efficient fp16 to apex fp16
+        Test switching from memory efficient fp16 to apex fp16.
         """
         with testing_utils.tempdir() as tmpdir:
             model_file = os.path.join(tmpdir, 'model')
@@ -102,7 +102,7 @@ class TestMemEfficientFP16(unittest.TestCase):
     @testing_utils.skipIfCircleCI
     def test_resuming_memeff2apex(self):
         """
-        Test switching from memory efficient fp16 to apex fp16
+        Test switching from memory efficient fp16 to apex fp16.
         """
         with testing_utils.tempdir() as tmpdir:
             model_file = os.path.join(tmpdir, 'model')


### PR DESCRIPTION
**Patch description**
Fixes a bug when loading memory efficient fp16 optimizers off of disk. The memory efficient fp16 optimizer keeps fp32 states for the weights, and hacks around a pytorch cast by keeping the original state dict. Since the original state dict was loaded on CPU, this would cause a mismatch of devices. Anything that changed the optimizer, switched to fp32, or switched to apex fp16, wasn't affected, since they didn't have this special code path resuming tensors.

This patch ensures that all tensors of the state are moved to the same device as the corresponding parameter weights.

Also prevents a crash on switching between memeff and apex fp16. This is a bit more finicky, but at least it won't crash now.

**Testing steps**
Manual testing with a command that @jaseweston gave. New integration tests that failed before this patch, and passes after.