### PR TITLE
Fix overridden parameters in create_agent_from_model_filename

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -272,7 +272,7 @@ def create_agent_from_model_file(model_file, opt_overides=None):
     opt['model_file'] = model_file
     if opt_overides is None:
         opt_overides = {}
-    opt['overrride'] = opt_overides
+    opt['override'] = opt_overides
     return create_agent_from_opt_file(opt)
 
 


### PR DESCRIPTION
**Patch description**
Due to a bug, the helper function `create_agent_from_model_file` wasn't working properly.

**Testing steps**
Manual testing.