### PR TITLE
Colors in terminal display

### DIFF
--- a/parlai/agents/local_human/local_human.py
+++ b/parlai/agents/local_human/local_human.py
@@ -12,7 +12,7 @@ Example: python examples/eval_model.py -m local_human -t babi:Task1k:1 -dt valid
 from parlai.core.agents import Agent
 from parlai.core.message import Message
 from parlai.utils.misc import display_messages, load_cands
-
+from parlai.utils.strings import colorize
 
 class LocalHumanAgent(Agent):
     def add_cmdline_args(argparser):
@@ -40,7 +40,7 @@ class LocalHumanAgent(Agent):
         self.episodeDone = False
         self.finished = False
         self.fixedCands_txt = load_cands(self.opt.get('local_human_candidates_file'))
-        print("Enter [DONE] if you want to end the episode, [EXIT] to quit.\n")
+        print(colorize("Enter [DONE] if you want to end the episode, [EXIT] to quit.", 'highlight'))
 
     def epoch_done(self):
         return self.finished
@@ -57,7 +57,7 @@ class LocalHumanAgent(Agent):
     def act(self):
         reply = Message()
         reply['id'] = self.getID()
-        reply_text = input("Enter Your Message: ")
+        reply_text = input(colorize("Enter Your Message:", 'field') + ' ')
         reply_text = reply_text.replace('\\n', '\n')
         if self.opt.get('single_turn', False):
             reply_text += '[DONE]'

--- a/parlai/agents/local_human/local_human.py
+++ b/parlai/agents/local_human/local_human.py
@@ -14,6 +14,7 @@ from parlai.core.message import Message
 from parlai.utils.misc import display_messages, load_cands
 from parlai.utils.strings import colorize
 
+
 class LocalHumanAgent(Agent):
     def add_cmdline_args(argparser):
         """
@@ -40,7 +41,12 @@ class LocalHumanAgent(Agent):
         self.episodeDone = False
         self.finished = False
         self.fixedCands_txt = load_cands(self.opt.get('local_human_candidates_file'))
-        print(colorize("Enter [DONE] if you want to end the episode, [EXIT] to quit.", 'highlight'))
+        print(
+            colorize(
+                "Enter [DONE] if you want to end the episode, [EXIT] to quit.",
+                'highlight',
+            )
+        )
 
     def epoch_done(self):
         return self.finished

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -122,6 +122,7 @@ class World(object):
             ignore_fields=self.opt.get('display_ignore_fields', ''),
             prettify=self.opt.get('display_prettify', False),
             max_len=self.opt.get('max_display_len', 1000),
+            verbose=self.opt.get('display_verbose', False),
         )
 
     def episode_done(self):

--- a/parlai/scripts/display_data.py
+++ b/parlai/scripts/display_data.py
@@ -34,11 +34,11 @@ def setup_args(parser=None):
     parser.add_argument('-mdl', '--max-display-len', type=int, default=1000)
     parser.add_argument('--display-ignore-fields', type=str, default='agent_reply')
     parser.add_argument(
-        '-s',
+        '-v',
         '--display-verbose',
-        default=True,
-        action='store_false',
-        help='Simple converational view, does not show other message fields.',
+        default=False,
+        action='store_true',
+        help='If false, simple converational view, does not show other message fields.',
     )
 
     parser.set_defaults(datatype='train:stream')

--- a/parlai/scripts/display_data.py
+++ b/parlai/scripts/display_data.py
@@ -33,11 +33,17 @@ def setup_args(parser=None):
     parser.add_argument('-n', '-ne', '--num-examples', type=int, default=10)
     parser.add_argument('-mdl', '--max-display-len', type=int, default=1000)
     parser.add_argument('--display-ignore-fields', type=str, default='agent_reply')
-    parser.add_argument('-s','--simple', default=False, action='store_true',
-                        help='Simple converational view, does not show other message fields.')
-   
+    parser.add_argument(
+        '-s',
+        '--simple',
+        default=False,
+        action='store_true',
+        help='Simple converational view, does not show other message fields.',
+    )
+
     parser.set_defaults(datatype='train:stream')
     return parser
+
 
 def simple_display(opt, world, turn):
     if opt['batchsize'] > 1:
@@ -51,7 +57,8 @@ def simple_display(opt, world, turn):
     labels = act.get('labels', act.get('eval_labels', ['[no labels field]']))
     labels = '|'.join(labels)
     print('\t' + colorize(labels, 'labels_nobold'))
-        
+
+
 def display_data(opt):
     # create repeat label agent and assign it to the specified task
     agent = RepeatLabelAgent(opt)
@@ -67,11 +74,11 @@ def display_data(opt):
         if opt['simple']:
             simple_display(opt, world, turn)
             turn += 1
-            if (world.get_acts()[0]['episode_done']):
+            if world.get_acts()[0]['episode_done']:
                 turn = 0
         else:
             print(world.display())
-                
+
         if world.epoch_done():
             print('EPOCH DONE')
             break
@@ -85,9 +92,8 @@ def display_data(opt):
         )
     except Exception:
         pass
-    
 
-    
+
 if __name__ == '__main__':
     random.seed(42)
 

--- a/parlai/scripts/display_data.py
+++ b/parlai/scripts/display_data.py
@@ -35,9 +35,9 @@ def setup_args(parser=None):
     parser.add_argument('--display-ignore-fields', type=str, default='agent_reply')
     parser.add_argument(
         '-s',
-        '--simple',
-        default=False,
-        action='store_true',
+        '--display-verbose',
+        default=True,
+        action='store_false',
         help='Simple converational view, does not show other message fields.',
     )
 
@@ -50,13 +50,15 @@ def simple_display(opt, world, turn):
         raise RuntimeError('Simple view only support batchsize=1')
     act = world.get_acts()[0]
     if turn == 0:
-        text = "     NEW EPISODE: " + act.get('id', "[no agent id]") + "            "
+        text = (
+            "    - - - NEW EPISODE: " + act.get('id', "[no agent id]") + " - - -       "
+        )
         print(colorize(text, 'highlight'))
     text = act.get('text', '[no text field]')
     print(colorize(text, 'text'))
     labels = act.get('labels', act.get('eval_labels', ['[no labels field]']))
     labels = '|'.join(labels)
-    print('\t' + colorize(labels, 'labels_nobold'))
+    print('   ' + colorize(labels, 'labels'))
 
 
 def display_data(opt):
@@ -71,13 +73,13 @@ def display_data(opt):
 
         # NOTE: If you want to look at the data from here rather than calling
         # world.display() you could access world.acts[0] directly, see simple_display above.
-        if opt['simple']:
+        if opt['display_verbose']:
+            print(world.display() + '\n~~')
+        else:
             simple_display(opt, world, turn)
             turn += 1
             if world.get_acts()[0]['episode_done']:
                 turn = 0
-        else:
-            print(world.display())
 
         if world.epoch_done():
             print('EPOCH DONE')

--- a/parlai/scripts/interactive.py
+++ b/parlai/scripts/interactive.py
@@ -67,13 +67,12 @@ def interactive(opt, print_parser=None):
 
     # Create model and assign it to the specified task
     agent = create_agent(opt, requireModelExists=True)
-    human_agent = LocalHumanAgent(opt)
-    world = create_task(opt, [human_agent, agent])
-
     if print_parser:
         # Show arguments after loading model
         print_parser.opt = agent.opt
         print_parser.print_args()
+    human_agent = LocalHumanAgent(opt)
+    world = create_task(opt, [human_agent, agent])
 
     # Show some example dialogs:
     while True:

--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -32,10 +32,11 @@ class EmpatheticDialoguesTeacher(FixedDialogTeacher):
             opt.get('train_experiencer_only', DEFAULT_TRAIN_EXPERIENCER_ONLY)
             and self.datatype == 'train'
         ) or self.datatype != 'train'
-        print(
-            f'[EmpatheticDialoguesTeacher] Only use experiencer side? '
-            f'{self.experiencer_side_only}, datatype: {self.datatype}'
-        )
+        if not shared:
+            print(
+                f'[EmpatheticDialoguesTeacher] Only use experiencer side? '
+                f'{self.experiencer_side_only}, datatype: {self.datatype}'
+            )
         self.remove_political_convos = opt.get(
             'remove_political_convos', DEFAULT_REMOVE_POLITICAL_CONVOS
         )

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -401,8 +401,14 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         }
         for k, v in state_dict['state'].items():
             if k in id_map:
+                # make sure when we copy the original state back, we make sure
+                # that original state is on the correct device
                 param = id_map[k]
-                self.optimizer.state[param] = v
+                like_device_v = {
+                    j: w.to(param.device) if torch.is_tensor(w) else w
+                    for j, w in v.items()
+                }
+                self.optimizer.state[param] = like_device_v
 
     @property
     def loss_scale(self):

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -401,14 +401,7 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         }
         for k, v in state_dict['state'].items():
             if k in id_map:
-                # make sure when we copy the original state back, we make sure
-                # that original state is on the correct device
                 param = id_map[k]
-                like_device_v = {
-                    j: w.to(param.device) if torch.is_tensor(w) else w
-                    for j, w in v.items()
-                }
-                self.optimizer.state[param] = like_device_v
 
     @property
     def loss_scale(self):

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -402,6 +402,7 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         for k, v in state_dict['state'].items():
             if k in id_map:
                 param = id_map[k]
+                self.optimizer.state[param] = v
 
     @property
     def loss_scale(self):

--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -759,9 +759,6 @@ def display_messages(
             continue
         agent_id = msg.get('id', '[no id field]')
         if verbose:
-            # lines.append(colorize(
-            #    '- - - - - - - Msg: ' + agent_id + ' - - - - - - - - - -', 'highlight2'
-            # ))
             lines.append(colorize('[id]:', 'field') + ' ' + colorize(agent_id, 'id'))
 
         if msg.get('episode_done'):

--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -757,7 +757,11 @@ def display_messages(
             # are ignoring the agent reply.
             continue
         agent_id = msg.get('id', '[no id field]')
-        lines.append(colorize('- - - - - - - Msg: ' + agent_id + ' - - - - - - - - - -', 'highlight'))
+        lines.append(
+            colorize(
+                '- - - - - - - Msg: ' + agent_id + ' - - - - - - - - - -', 'highlight'
+            )
+        )
         if msg.get('episode_done'):
             episode_done = True
         # Possibly indent the text (for the second speaker, if two).
@@ -780,11 +784,16 @@ def display_messages(
             lines.append(f'[ image ]: {msg["image"]}')
         if msg.get('text', ''):
             text = clip_text(msg['text'], max_len)
-            lines.append(space + colorize('[text]:', 'field') + ' ' + colorize(text, 'text'))
+            lines.append(
+                space + colorize('[text]:', 'field') + ' ' + colorize(text, 'text')
+            )
         for field in {'labels', 'eval_labels', 'label_candidates', 'text_candidates'}:
             if msg.get(field) and field not in ignore_fields_:
-                string = '{}{} {}'.format(space, colorize('[' + field + ']:', 'field'),
-                                           colorize(_ellipse(msg[field]), field))
+                string = '{}{} {}'.format(
+                    space,
+                    colorize('[' + field + ']:', 'field'),
+                    colorize(_ellipse(msg[field]), field),
+                )
                 lines.append(string)
         # Handling this separately since we need to clean up the raw output before displaying.
         token_loss_line = _token_losses_line(msg, ignore_fields_, space)
@@ -792,7 +801,9 @@ def display_messages(
             lines.append(token_loss_line)
 
     if episode_done:
-        lines.append(colorize('- - - - - - - END OF EPISODE - - - - - - - - - -', 'highlight2'))
+        lines.append(
+            colorize('- - - - - - - END OF EPISODE - - - - - - - - - -', 'highlight2')
+        )
 
     return '\n'.join(lines)
 

--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -721,6 +721,7 @@ def display_messages(
     prettify: bool = False,
     ignore_fields: str = '',
     max_len: int = 1000,
+    verbose: bool = False,
 ) -> Optional[str]:
     """
     Return a string describing the set of messages provided.
@@ -757,11 +758,12 @@ def display_messages(
             # are ignoring the agent reply.
             continue
         agent_id = msg.get('id', '[no id field]')
-        lines.append(
-            colorize(
-                '- - - - - - - Msg: ' + agent_id + ' - - - - - - - - - -', 'highlight'
-            )
-        )
+        if verbose:
+            # lines.append(colorize(
+            #    '- - - - - - - Msg: ' + agent_id + ' - - - - - - - - - -', 'highlight2'
+            # ))
+            lines.append(colorize('[id]:', 'field') + ' ' + colorize(agent_id, 'id'))
+
         if msg.get('episode_done'):
             episode_done = True
         # Possibly indent the text (for the second speaker, if two).
@@ -784,9 +786,21 @@ def display_messages(
             lines.append(f'[ image ]: {msg["image"]}')
         if msg.get('text', ''):
             text = clip_text(msg['text'], max_len)
-            lines.append(
-                space + colorize('[text]:', 'field') + ' ' + colorize(text, 'text')
-            )
+            if index == 0:
+                style = 'bold_text'
+            else:
+                style = 'labels'
+            if verbose:
+                lines.append(
+                    space + colorize('[text]:', 'field') + ' ' + colorize(text, style)
+                )
+            else:
+                lines.append(
+                    space
+                    + colorize("[" + agent_id + "]:", 'field')
+                    + ' '
+                    + colorize(text, style)
+                )
         for field in {'labels', 'eval_labels', 'label_candidates', 'text_candidates'}:
             if msg.get(field) and field not in ignore_fields_:
                 string = '{}{} {}'.format(
@@ -802,7 +816,7 @@ def display_messages(
 
     if episode_done:
         lines.append(
-            colorize('- - - - - - - END OF EPISODE - - - - - - - - - -', 'highlight2')
+            colorize('- - - - - - - END OF EPISODE - - - - - - - - - -', 'highlight')
         )
 
     return '\n'.join(lines)

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -89,17 +89,18 @@ def colorize(text, style):
     if style == 'highlight2':
         return HIGHLIGHT_BLUE + text + RESET
     elif style == 'text':
-        return BLUE + text + RESET
-    elif style == 'labels' or style == 'eval_labels':
-        return BOLD_LIGHT_GRAY + text + RESET
-    elif style == 'labels_nobold':
         return LIGHT_GRAY + text + RESET
+    elif style == 'bold_text':
+        return BOLD_LIGHT_GRAY + text + RESET
+    elif style == 'labels' or style == 'eval_labels':
+        return BLUE + text + RESET
     elif style == 'label_candidates':
+        return LIGHT_GRAY + text + RESET
+    elif style == 'id':
         return LIGHT_GRAY + text + RESET
     elif style == 'text2':
         return MAGENTA + text + RESET
     elif style == 'field':
-        # return RED + text + RESET
         return HIGHLIGHT_BLUE + text + RESET
     else:
         return MAGENTA + text + RESET

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -65,21 +65,12 @@ def uppercase(string: str) -> str:
 
 def colorize(text, style):
     USE_COLORS = _sys.stdout.isatty()
-    RED = '\033[1;91m'
     BLUE = '\033[1;94m'
-    DARK_BLUE = '\033[0;37;40m\033[1;34;40m'
-    RED = '\033[0;91m'
-    YELLOW = '\033[0;93m'
-    GREEN = '\033[1;92m'
-    CYAN = '\033[1;96m'
-    GREEN = '\033[1;32;40m'
     BOLD_LIGHT_GRAY = '\033[1;37;40m'
     LIGHT_GRAY = '\033[0;37;40m'
-    WHITE = '\033[1;37m'
     MAGENTA = '\033[0;95m'
     HIGHLIGHT_RED = '\033[1;37;41m'
     HIGHLIGHT_BLUE = '\033[1;37;44m'
-    BOLD = '\033[1m'
     RESET = '\033[0;0m'
     if not USE_COLORS:
         return text

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -8,6 +8,7 @@ Utility functions and classes for handling text strings.
 """
 import sys as _sys
 
+
 def normalize_reply(text: str, version=1) -> str:
     """
     Standardize the capitalization and punctuation spacing of the input text.
@@ -67,7 +68,7 @@ def colorize(text, style):
     RED = '\033[1;91m'
     BLUE = '\033[1;94m'
     DARK_BLUE = '\033[0;37;40m\033[1;34;40m'
-    #DARK_BLUE = '\033[1;34;40m'
+    # DARK_BLUE = '\033[1;34;40m'
     RED = '\033[0;91m'
     YELLOW = '\033[0;93m'
     GREEN = '\033[1;92m'
@@ -87,18 +88,18 @@ def colorize(text, style):
         return HIGHLIGHT_RED + text + RESET
     if style == 'highlight2':
         return HIGHLIGHT_BLUE + text + RESET
-    elif style == 'text': 
+    elif style == 'text':
         return BLUE + text + RESET
-    elif style == 'labels' or style == 'eval_labels': 
+    elif style == 'labels' or style == 'eval_labels':
         return BOLD_LIGHT_GRAY + text + RESET
     elif style == 'labels_nobold':
         return LIGHT_GRAY + text + RESET
     elif style == 'label_candidates':
         return LIGHT_GRAY + text + RESET
-    elif style == 'text2': 
-        return MAGENTA + text + RESET 
-    elif style == 'field': 
-        #return RED + text + RESET
+    elif style == 'text2':
+        return MAGENTA + text + RESET
+    elif style == 'field':
+        # return RED + text + RESET
         return HIGHLIGHT_BLUE + text + RESET
     else:
         return MAGENTA + text + RESET

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -68,7 +68,6 @@ def colorize(text, style):
     RED = '\033[1;91m'
     BLUE = '\033[1;94m'
     DARK_BLUE = '\033[0;37;40m\033[1;34;40m'
-    # DARK_BLUE = '\033[1;34;40m'
     RED = '\033[0;91m'
     YELLOW = '\033[0;93m'
     GREEN = '\033[1;92m'

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -6,7 +6,7 @@
 """
 Utility functions and classes for handling text strings.
 """
-
+import sys as _sys
 
 def normalize_reply(text: str, version=1) -> str:
     """
@@ -60,3 +60,45 @@ def uppercase(string: str) -> str:
         return string
     else:
         return string[0].upper() + string[1:]
+
+
+def colorize(text, style):
+    USE_COLORS = _sys.stdout.isatty()
+    RED = '\033[1;91m'
+    BLUE = '\033[1;94m'
+    DARK_BLUE = '\033[0;37;40m\033[1;34;40m'
+    #DARK_BLUE = '\033[1;34;40m'
+    RED = '\033[0;91m'
+    YELLOW = '\033[0;93m'
+    GREEN = '\033[1;92m'
+    CYAN = '\033[1;96m'
+    GREEN = '\033[1;32;40m'
+    BOLD_LIGHT_GRAY = '\033[1;37;40m'
+    LIGHT_GRAY = '\033[0;37;40m'
+    WHITE = '\033[1;37m'
+    MAGENTA = '\033[0;95m'
+    HIGHLIGHT_RED = '\033[1;37;41m'
+    HIGHLIGHT_BLUE = '\033[1;37;44m'
+    BOLD = '\033[1m'
+    RESET = '\033[0;0m'
+    if not USE_COLORS:
+        return text
+    if style == 'highlight':
+        return HIGHLIGHT_RED + text + RESET
+    if style == 'highlight2':
+        return HIGHLIGHT_BLUE + text + RESET
+    elif style == 'text': 
+        return BLUE + text + RESET
+    elif style == 'labels' or style == 'eval_labels': 
+        return BOLD_LIGHT_GRAY + text + RESET
+    elif style == 'labels_nobold':
+        return LIGHT_GRAY + text + RESET
+    elif style == 'label_candidates':
+        return LIGHT_GRAY + text + RESET
+    elif style == 'text2': 
+        return MAGENTA + text + RESET 
+    elif style == 'field': 
+        #return RED + text + RESET
+        return HIGHLIGHT_BLUE + text + RESET
+    else:
+        return MAGENTA + text + RESET

--- a/tests/test_display_data.py
+++ b/tests/test_display_data.py
@@ -17,7 +17,7 @@ class TestDisplayData(unittest.TestCase):
         Does display_data reach the end of the loop?
         """
         str_output, _, _ = testing_utils.display_data(
-            {'num_examples': 1, 'task': 'babi:task1k:1'}
+            {'num_examples': 1, 'task': 'babi:task1k:1', 'display_verbose': True}
         )
 
         self.assertGreater(len(str_output), 0, "Output is empty")

--- a/tests/test_display_data.py
+++ b/tests/test_display_data.py
@@ -21,7 +21,7 @@ class TestDisplayData(unittest.TestCase):
         )
 
         self.assertGreater(len(str_output), 0, "Output is empty")
-        self.assertIn("[babi:task1k:1]:", str_output, "Babi task did not print")
+        self.assertIn("babi:task1k:1", str_output, "Babi task did not print")
         self.assertIn("~~", str_output, "Example output did not complete")
 
 

--- a/tests/test_teachers.py
+++ b/tests/test_teachers.py
@@ -32,6 +32,7 @@ class TestAbstractImageTeacher(unittest.TestCase):
                 'task': 'integration_tests:ImageTeacher',
                 'datapath': data_path,
                 'image_mode': image_mode,
+                'display_verbose': True
             }
             output = testing_utils.display_data(opt)
             train_labels = re.findall(r"\[labels: .*\]", output[0])
@@ -66,7 +67,7 @@ class TestParlAIDialogTeacher(unittest.TestCase):
             fp = os.path.join(tmpdir, "goodfile.txt")
             with open(fp, "w") as f:
                 f.write('id:test_file\ttext:input\tlabels:good label\n\n')
-            opt = {'task': 'fromfile', 'fromfile_datapath': fp}
+            opt = {'task': 'fromfile', 'fromfile_datapath': fp, 'display_verbose': True}
             testing_utils.display_data(opt)
 
     def test_bad_fileformat(self):
@@ -77,7 +78,7 @@ class TestParlAIDialogTeacher(unittest.TestCase):
             fp = os.path.join(tmpdir, "badfile.txt")
             with open(fp, "w") as f:
                 f.write('id:test_file\ttext:input\teval_labels:bad label\n\n')
-            opt = {'task': 'fromfile', 'fromfile_datapath': fp}
+            opt = {'task': 'fromfile', 'fromfile_datapath': fp, 'display_verbose': True}
             with self.assertRaises(ValueError):
                 testing_utils.display_data(opt)
 

--- a/tests/test_teachers.py
+++ b/tests/test_teachers.py
@@ -35,9 +35,9 @@ class TestAbstractImageTeacher(unittest.TestCase):
                 'display_verbose': True
             }
             output = testing_utils.display_data(opt)
-            train_labels = re.findall(r"\[labels: .*\]", output[0])
-            valid_labels = re.findall(r"\[eval_labels: .*\]", output[1])
-            test_labels = re.findall(r"\[eval_labels: .*\]", output[2])
+            train_labels = re.findall(r"\[labels\].*\n", output[0])
+            valid_labels = re.findall(r"\[eval_labels\].*\n", output[1])
+            test_labels = re.findall(r"\[eval_labels\].*\n", output[2])
 
             for i, lbls in enumerate([train_labels, valid_labels, test_labels]):
                 self.assertGreater(len(lbls), 0, 'DisplayData failed')

--- a/tests/test_teachers.py
+++ b/tests/test_teachers.py
@@ -32,7 +32,7 @@ class TestAbstractImageTeacher(unittest.TestCase):
                 'task': 'integration_tests:ImageTeacher',
                 'datapath': data_path,
                 'image_mode': image_mode,
-                'display_verbose': True
+                'display_verbose': True,
             }
             output = testing_utils.display_data(opt)
             train_labels = re.findall(r"\[labels\].*\n", output[0])


### PR DESCRIPTION
Affects display_data, display_model, selfchat, interactive, and more by adding colors to world.display()

py examples/display_data.py -t convai2 -dt valid -s

<img width="597" alt="Screen Shot 2020-03-28 at 6 57 44 PM" src="https://user-images.githubusercontent.com/11068664/77835752-316acc00-7126-11ea-96ca-69f0137781e1.png">


py examples/display_data.py -t convai2 -dt valid 

<img width="854" alt="Screen Shot 2020-03-28 at 6 58 15 PM" src="https://user-images.githubusercontent.com/11068664/77835751-30399f00-7126-11ea-8ee5-506c39ef1987.png">

py parlai/scripts/self_chat.py -t convai2 -dt valid -m fixed_response

<img width="693" alt="Screen Shot 2020-03-28 at 6 58 26 PM" src="https://user-images.githubusercontent.com/11068664/77835749-2fa10880-7126-11ea-8535-ccc2aa9e064e.png">

py examples/interactive.py -t convai2 -m fixed_response

<img width="421" alt="Screen Shot 2020-03-28 at 6 58 41 PM" src="https://user-images.githubusercontent.com/11068664/77835748-2fa10880-7126-11ea-9752-6d59543acf96.png">
