### PR TITLE
CircleCI robust to too much parallelism; testing speedups

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,7 @@ We use this to split up tests into different circleci runs.
 import os
 import pathlib
 import random
+from pytest import ExitCode
 
 
 # TODO: rename the folders nicer so they make more sense, maybe even have
@@ -57,3 +58,14 @@ def pytest_collection_modifyitems(config, items):
     config.hook.pytest_deselected(items=deselected)
     for d in deselected:
         items.remove(d)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """
+    Ensure that pytest doesn't report failure when no tests are collected.
+
+    This can sometimes happen due to the way we distribute tests across multiple circle
+    nodes.
+    """
+    if exitstatus == ExitCode.NO_TESTS_COLLECTED:
+        session.exitstatus = ExitCode.OK


### PR DESCRIPTION
**Patch description**
Nightly GPU CI started failing due to some deleted tests, and now one of the nodes gets assigned 0 tests. This is just bad luck, and will change next time we have a node.

We could change the shuffle seed, but I am inclined to make sure that it just doesn't report a failure because it found 0 nodes. 

**Testing steps**
```
$ pytest -m fakeselector
================================ test session starts =================================
platform linux -- Python 3.7.4, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /private/home/roller/working/parlai, inifile: pytest.ini, testpaths: tests
plugins: subtests-0.2.1, requests-mock-1.7.0
collected 274 items / 274 deselected

======================== 274 deselected, 3 warnings in 2.99s =========================
$ echo $?
0
```