### PR TITLE
Speed up some unit tests

### DIFF
--- a/parlai/agents/test_agents/test_agents.py
+++ b/parlai/agents/test_agents/test_agents.py
@@ -121,3 +121,39 @@ class MockTorchAgent(TorchAgent):
                 for i in range(len(batch.text_vec))
             ]
         )
+
+
+class SilentTorchAgent(TorchAgent):
+    """
+    Use MockDict instead of regular DictionaryAgent.
+    """
+
+    @staticmethod
+    def dictionary_class():
+        """
+        Replace normal dictionary class with mock one.
+        """
+        return MockDict
+
+    def __init__(self, opt, shared=None):
+        self.model = self.build_model()
+        self.criterion = self.build_criterion()
+        super().__init__(opt, shared)
+
+    def build_model(self):
+        return torch.nn.Module()
+
+    def build_criterion(self):
+        return torch.nn.NLLLoss()
+
+    def train_step(self, batch):
+        """
+        Null output.
+        """
+        return Output()
+
+    def eval_step(self, batch):
+        """
+        Null output.
+        """
+        return Output()

--- a/tests/test_dynamicbatching.py
+++ b/tests/test_dynamicbatching.py
@@ -13,18 +13,21 @@ from parlai.tasks.integration_tests.agents import NUM_TEST, EXAMPLE_SIZE
 
 _TASK = 'integration_tests:variable_length'
 _DEFAULT_OPTIONS = {
-    'batchsize': 8,
+    'dict_file': 'zoo:unittest/transformer_generator2/model.dict',
+    'batchsize': 16,
     'dynamic_batching': 'full',
-    'optimizer': 'adamax',
+    'optimizer': 'sgd',
     'learningrate': 7e-3,
     'num_epochs': 1,
     'n_layers': 1,
     'n_heads': 1,
-    'ffn_size': 32,
-    'embedding_size': 32,
+    'ffn_size': 4,
+    'embedding_size': 4,
     'truncate': 8,
     'model': 'transformer/generator',
     'task': _TASK,
+    'skip_generation': True,
+    'candidates': 'batch',
 }
 
 

--- a/tests/test_dynamicbatching.py
+++ b/tests/test_dynamicbatching.py
@@ -12,22 +12,33 @@ import parlai.utils.testing as testing_utils
 from parlai.tasks.integration_tests.agents import NUM_TEST, EXAMPLE_SIZE
 
 _TASK = 'integration_tests:variable_length'
+
+# we don't need a real agent, since we're only checking the number examples
+# is correct
 _DEFAULT_OPTIONS = {
     'dict_file': 'zoo:unittest/transformer_generator2/model.dict',
+    'dict_tokenizer': 'space',
     'batchsize': 16,
     'dynamic_batching': 'full',
-    'optimizer': 'sgd',
-    'learningrate': 7e-3,
     'num_epochs': 1,
+    'truncate': 8,
+    'model': 'parlai.agents.test_agents.test_agents:SilentTorchAgent',
+    'task': _TASK,
+}
+
+_RANKER_OPTIONS = {
+    'dict_file': 'zoo:unittest/transformer_generator2/model.dict',
+    'dict_tokenizer': 'space',
+    'batchsize': 32,
+    'num_epochs': 0.1,
     'n_layers': 1,
     'n_heads': 1,
+    'candidates': 'batch',
     'ffn_size': 4,
     'embedding_size': 4,
-    'truncate': 8,
-    'model': 'transformer/generator',
     'task': _TASK,
-    'skip_generation': True,
-    'candidates': 'batch',
+    'truncate': 8,
+    'model': 'transformer/ranker',
 }
 
 
@@ -58,13 +69,13 @@ class TestDynamicBatching(unittest.TestCase):
             testing_utils.eval_model(model='repeat_label', task=_TASK)
 
     def test_ranking(self):
-        self._test_correct_processed(
-            NUM_TEST, model='transformer/ranker', datatype='train'
+        testing_utils.train_model(
+            Opt(datatype='train', dynamic_batching='full', **_RANKER_OPTIONS)
         )
 
     def test_ranking_streaming(self):
-        self._test_correct_processed(
-            NUM_TEST, model='transformer/ranker', datatype='train:stream'
+        testing_utils.train_model(
+            Opt(datatype='train:stream', dynamic_batching='full', **_RANKER_OPTIONS)
         )
 
     def test_training(self):
@@ -114,13 +125,15 @@ class TestBatchSort(unittest.TestCase):
             testing_utils.eval_model(model='repeat_label', task=_TASK)
 
     def test_ranking(self):
-        self._test_correct_processed(
-            NUM_TEST, model='transformer/ranker', datatype='train'
+        testing_utils.train_model(
+            Opt(datatype='train', dynamic_batching='batchsort', **_RANKER_OPTIONS)
         )
 
     def test_ranking_streaming(self):
-        self._test_correct_processed(
-            NUM_TEST, model='transformer/ranker', datatype='train:stream'
+        testing_utils.train_model(
+            Opt(
+                datatype='train:stream', dynamic_batching='batchsort', **_RANKER_OPTIONS
+            )
         )
 
     def test_training(self):

--- a/tests/test_mem_efficient_fp16.py
+++ b/tests/test_mem_efficient_fp16.py
@@ -16,7 +16,7 @@ class TestMemEfficientFP16(unittest.TestCase):
     Test memory efficient FP16 implementation.
     """
 
-    @testing_utils.retry()
+    @testing_utils.retry(ntries=3)
     def test_adam(self):
         valid, _ = testing_utils.train_model(
             dict(
@@ -36,7 +36,7 @@ class TestMemEfficientFP16(unittest.TestCase):
                 lr_scheduler='invsqrt',
             )
         )
-        self.assertGreaterEqual(valid['hits@1'], 0.4)
+        self.assertGreaterEqual(valid['hits@1'], 0.1)
 
     def test_unsupported(self):
         with self.assertRaises(RuntimeError):
@@ -68,7 +68,7 @@ class TestMemEfficientFP16(unittest.TestCase):
                     fp16_impl='mem_efficient',
                     learningrate=7e-3,
                     batchsize=32,
-                    num_epochs=1,
+                    num_epochs=0.1,
                     n_layers=1,
                     n_heads=1,
                     ffn_size=32,
@@ -83,7 +83,7 @@ class TestMemEfficientFP16(unittest.TestCase):
                     model_file=model_file,
                     task='integration_tests:candidate',
                     model='transformer/ranker',
-                    num_epochs=1,
+                    num_epochs=0.25,
                     fp16=False,
                 )
             )

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -25,7 +25,7 @@ class TestSeq2Seq(unittest.TestCase):
                 model='seq2seq',
                 learningrate=LR,
                 batchsize=BATCH_SIZE,
-                num_epochs=NUM_EPOCHS,
+                num_epochs=3,
                 numthreads=1,
                 embeddingsize=16,
                 hiddensize=16,
@@ -34,6 +34,7 @@ class TestSeq2Seq(unittest.TestCase):
                 gradient_clip=1.0,
                 dropout=0.0,
                 lookuptable='all',
+                skip_generation=True,
                 rank_candidates=True,
             )
         )

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -19,7 +19,7 @@ from collections import deque
 SKIP_TESTS = False
 try:
     from parlai.core.torch_agent import Output
-    from parlai.agents.test_agents.dummy_torch_agent import MockTorchAgent, MockDict
+    from parlai.agents.test_agents.test_agents import MockTorchAgent, MockDict
     import torch
 except ImportError:
     SKIP_TESTS = True
@@ -991,7 +991,7 @@ class TestTorchAgent(unittest.TestCase):
             return {
                 'task': 'integration_tests',
                 'init_model': init_mf,
-                'model': 'parlai.agents.test_agents.dummy_torch_agent:MockTorchAgent',
+                'model': 'parlai.agents.test_agents.test_agents:MockTorchAgent',
                 'model_file': mf,
                 'num_epochs': 3,
                 'validation_every_n_epochs': 1,

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -526,6 +526,7 @@ class TestTransformerGenerator(unittest.TestCase):
                 numthreads=1,
                 no_cuda=True,
                 embedding_size=16,
+                skip_generation=True,
                 hiddensize=16,
             )
         )

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -496,22 +496,18 @@ class TestTransformerGenerator(unittest.TestCase):
         """
         Tests that the generator model files work over time.
         """
-        valid, test = testing_utils.eval_model(
+        _, test = testing_utils.eval_model(
             dict(
                 task='integration_tests:multiturn_candidate',
                 model='transformer/generator',
                 model_file='zoo:unittest/transformer_generator2/model',
                 dict_file='zoo:unittest/transformer_generator2/model.dict',
-                rank_candidates=True,
+                rank_candidates=False,
                 batch_size=64,
-            )
+            ),
+            skip_valid=True,
         )
 
-        self.assertGreaterEqual(valid['hits@1'], 0.95)
-        self.assertLessEqual(valid['ppl'], 1.01)
-        self.assertGreaterEqual(valid['accuracy'], 0.99)
-        self.assertGreaterEqual(valid['f1'], 0.99)
-        self.assertGreaterEqual(test['hits@1'], 0.95)
         self.assertLessEqual(test['ppl'], 1.01)
         self.assertGreaterEqual(test['accuracy'], 0.99)
         self.assertGreaterEqual(test['f1'], 0.99)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -552,15 +552,14 @@ class TestTransformerGenerator(unittest.TestCase):
                 beam_size=1,
                 variant='xlm',
                 activation='gelu',
+                skip_generation=True,
                 n_segments=8,  # doesn't do anything but still good to test
                 adam_eps=1e-6,  # just to test another flag simultaneously
             )
         )
 
         self.assertLessEqual(valid['ppl'], 1.30)
-        self.assertGreaterEqual(valid['bleu-4'], 0.90)
         self.assertLessEqual(test['ppl'], 1.30)
-        self.assertGreaterEqual(test['bleu-4'], 0.90)
 
     @testing_utils.retry(ntries=3)
     def test_prelayernorm(self):
@@ -583,13 +582,12 @@ class TestTransformerGenerator(unittest.TestCase):
                 beam_size=1,
                 variant='prelayernorm',
                 activation='gelu',
+                skip_generation=True,
             )
         )
 
         self.assertLessEqual(valid['ppl'], 1.30)
-        self.assertGreaterEqual(valid['bleu-4'], 0.90)
         self.assertLessEqual(test['ppl'], 1.30)
-        self.assertGreaterEqual(test['bleu-4'], 0.90)
 
     def test_compute_tokenized_bleu(self):
         """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,14 +98,16 @@ class TestUtils(unittest.TestCase):
         opt = Opt(opt)
         opt['x'] += 1
         opt['x'] = 10
-        history = opt.history['x']
-        self.assertEqual(history[0][1], 1, 'History not set properly')
-        self.assertEqual(history[1][1], 10, 'History not set properly')
+        self.assertEqual(opt.history[0][0], 'x', 'History not set properly')
+        self.assertEqual(opt.history[0][1], 1, 'History not set properly')
+        self.assertEqual(opt.history[1][0], 'x', 'History not set properly')
+        self.assertEqual(opt.history[1][1], 10, 'History not set properly')
 
         opt_copy = deepcopy(opt)
-        history = opt_copy.history['x']
-        self.assertEqual(history[0][1], 1, 'Deepcopy history not set properly')
-        self.assertEqual(history[1][1], 10, 'Deepcopy history not set properly')
+        self.assertEqual(opt_copy.history[0][1], 1, 'Deepcopy history not set properly')
+        self.assertEqual(
+            opt_copy.history[1][1], 10, 'Deepcopy history not set properly'
+        )
 
 
 class TestStrings(unittest.TestCase):


### PR DESCRIPTION
**Patch description**
- I noticed that deepcopying opts was taking as much as 50% of some of our tests, especially ones like dynamic batching, where we create so many world copies. This is because we deep copy the history and the list of deepcopies, and this just grows and grows. We can make this cheaper by not having opt.history be a dict of mutable lists.
- Various small hyperparameter changes in some tests, shortcuts, skip_generation, batch candidates, etc.

**Testing steps**
CI