### PR TITLE
Truncate file path as task name

### DIFF
--- a/parlai/tasks/fromfile/agents.py
+++ b/parlai/tasks/fromfile/agents.py
@@ -7,9 +7,10 @@
 # This task simply loads the specified file: useful for quick tests without
 # setting up a new task.
 
-from parlai.core.teachers import FbDialogTeacher, ParlAIDialogTeacher
-
 import copy
+import os
+
+from parlai.core.teachers import FbDialogTeacher, ParlAIDialogTeacher
 
 
 class FbformatTeacher(FbDialogTeacher):
@@ -81,7 +82,9 @@ class ParlaiformatTeacher(ParlAIDialogTeacher):
             datafile += "_" + self.opt['datatype'].split(':')[0] + '.txt'
         if shared is None:
             self._setup_data(datafile)
-        self.id = datafile
+        # Truncate datafile to just the immediate enclosing folder name and file name
+        dirname, basename = os.path.split(datafile)
+        self.id = os.path.join(os.path.split(dirname)[1], basename)
         self.reset()
 
 


### PR DESCRIPTION
**Patch description**
When creating a task from a file, truncate the task name to just the immediate enclosing folder name and file name of the file path

**Testing steps**
```
CUDA_VISIBLE_DEVICES=0,1 python examples/display_data.py \
-t "fromfile:fromfile_datapath=/private/home/ems/GitHub/facebookresearch/ParlAI/data/internal;blended_skill_talk_retrieval_cached/valid.txt"
```