### PR TITLE
Raise errors when teachers have overlapped ids

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -612,10 +612,20 @@ class MultiWorld(World):
                 weight = 1
             self.cum_task_weights[i] = weight + sum
             sum += weight
-        task_ids = {w.getID() for w in self.worlds}
+        task_ids = {}
         # Having overlap in teacher ids will cause issues for metrics aggregation.
-        if len(task_ids) != len(self.worlds):
-            raise KeyError('Teachers have overlap in ids. Please fix.')
+        for each_world in self.worlds:
+            world_id = each_world.getID()
+            if world_id in task_ids:
+                raise KeyError(
+                    '{} and {} teachers have overlap in id {}.'.format(
+                        task_ids[world_id],
+                        each_world.get_agents()[0].__class__,
+                        world_id,
+                    )
+                )
+            else:
+                task_ids[world_id] = each_world.get_agents()[0]
 
     def num_examples(self):
         """

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -612,6 +612,10 @@ class MultiWorld(World):
                 weight = 1
             self.cum_task_weights[i] = weight + sum
             sum += weight
+        task_ids = {w.getID() for w in self.worlds}
+        # Having overlap in teacher ids will cause issues for metrics aggregation.
+        if len(task_ids) != len(self.worlds):
+            raise KeyError('Teachers have overlap in ids. Please fix.')
 
     def num_examples(self):
         """

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -617,7 +617,7 @@ class MultiWorld(World):
         for each_world in self.worlds:
             world_id = each_world.getID()
             if world_id in task_ids:
-                raise KeyError(
+                raise AssertionError(
                     '{} and {} teachers have overlap in id {}.'.format(
                         task_ids[world_id],
                         each_world.get_agents()[0].__class__,

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -41,7 +41,7 @@ class TestTrainModel(unittest.TestCase):
         task2_acc = valid['integration_tests:multiturnCandidate/accuracy']
         total_acc = valid['accuracy']
         self.assertEqual(
-            total_acc, task1_acc + task2_acc, 'Task accuracy is averaged incorrectly',
+            total_acc, task1_acc + task2_acc, 'Task accuracy is averaged incorrectly'
         )
 
         valid, test = testing_utils.train_model(
@@ -58,7 +58,7 @@ class TestTrainModel(unittest.TestCase):
         total_acc = valid['accuracy']
         # metrics should be averaged equally across tasks
         self.assertEqual(
-            total_acc, task1_acc + task2_acc, 'Task accuracy is averaged incorrectly',
+            total_acc, task1_acc + task2_acc, 'Task accuracy is averaged incorrectly'
         )
 
     def test_multitasking_metrics_macro(self):
@@ -99,6 +99,16 @@ class TestTrainModel(unittest.TestCase):
             0.5 * (task1_acc.value() + task2_acc.value()),
             'Task accuracy is averaged incorrectly',
         )
+
+    def test_multitasking_id_overlap(self):
+        with self.assertRaises(KeyError) as context:
+            testing_utils.train_model(
+                {'task': 'integration_tests,' 'integration_tests'}
+            )
+            self.assertTrue(
+                'teachers have overlap in id integration_tests.'
+                in str(context.exception)
+            )
 
 
 if __name__ == '__main__':

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -10,6 +10,8 @@ Basic tests that ensure train_model.py behaves in predictable ways.
 
 import unittest
 import parlai.utils.testing as testing_utils
+from parlai.core.worlds import create_task
+from parlai.core.params import ParlaiParser
 
 
 class TestTrainModel(unittest.TestCase):
@@ -101,10 +103,10 @@ class TestTrainModel(unittest.TestCase):
         )
 
     def test_multitasking_id_overlap(self):
-        with self.assertRaises(KeyError) as context:
-            testing_utils.train_model(
-                {'task': 'integration_tests,' 'integration_tests'}
-            )
+        with self.assertRaises(AssertionError) as context:
+            pp = ParlaiParser()
+            opt = pp.parse_args(['--task', 'integration_tests,integration_tests'])
+            self.world = create_task(opt, None)
             self.assertTrue(
                 'teachers have overlap in id integration_tests.'
                 in str(context.exception)


### PR DESCRIPTION
**Patch description**
Two task teachers might have the same id. And this causes problems for metrics aggregation, since we use teacher.id as keys for that. 
Having overlapped teacher.id will lead metrics reports getting overwritten. 
**Testing steps**
 py examples/train_model.py -t integration_tests,integration_tests -mf /tmp/hkhk

**Logs**
```
Traceback (most recent call last):
  File "examples/train_model.py", line 17, in <module>
    TrainLoop(opt).train()
  File "/private/home/daju/ParlAI/parlai/scripts/train_model.py", line 277, in __init__
    build_dict(opt, skip_if_built=True)
  File "/private/home/daju/ParlAI/parlai/scripts/build_dict.py", line 113, in build_dict
    world_dict = create_task(ordered_opt, dictionary)
  File "/private/home/daju/ParlAI/parlai/core/worlds.py", line 1624, in create_task
    world = MultiWorld(opt, user_agents, default_world=default_world)
  File "/private/home/daju/ParlAI/parlai/core/worlds.py", line 624, in __init__
    world_id,
KeyError: "<parlai.tasks.integration_tests.agents.DefaultTeacher object at 0x7f66249b3fd0> and <class 'parlai.tasks.integration_tests.agents.DefaultTeacher'> teachers have overlap in id integration_tests."
```