### PR TITLE
Pass weight tensor into FP16SafeCrossEntropy

### DIFF
--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -41,7 +41,7 @@ class FP16SafeCrossEntropy(torch.nn.Module):
         # default ignore_index=-100 mimics pytorch's default in
         # torch.nn.functional.nll_loss
         super().__init__()
-        self.register_buffer('weight', weight)
+        self.register_buffer('weight', weight)  # type: ignore
         self.ignore_index = ignore_index
         self.reduction = reduction
 

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -6,10 +6,12 @@
 """
 Utility methods for mixed precision training.
 """
-from parlai.utils.misc import warn_once
 
-from itertools import chain
 import math
+from itertools import chain
+from typing import Optional
+
+from parlai.utils.misc import warn_once
 
 try:
     import torch
@@ -30,11 +32,16 @@ class FP16SafeCrossEntropy(torch.nn.Module):
     This avoids overflow in the softmax by doing the operation in FP32.
     """
 
-    def __init__(self, weight=None, ignore_index=-100, reduction='none'):
+    def __init__(
+        self,
+        weight: Optional[torch.Tensor] = None,
+        ignore_index: int = -100,
+        reduction: str = 'none',
+    ):
         # default ignore_index=-100 mimics pytorch's default in
         # torch.nn.functional.nll_loss
         super().__init__()
-        self.weight = weight
+        self.register_buffer('weight', weight)
         self.ignore_index = ignore_index
         self.reduction = reduction
 
@@ -266,11 +273,7 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         """
         List of compatible optimizers.
         """
-        return [
-            'adam',
-            'mem_eff_adam',
-            'adafactor',
-        ]
+        return ['adam', 'mem_eff_adam', 'adafactor']
 
     @property
     def params(self):

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -30,10 +30,11 @@ class FP16SafeCrossEntropy(torch.nn.Module):
     This avoids overflow in the softmax by doing the operation in FP32.
     """
 
-    def __init__(self, ignore_index=-100, reduction='none'):
+    def __init__(self, weight=None, ignore_index=-100, reduction='none'):
         # default ignore_index=-100 mimics pytorch's default in
         # torch.nn.functional.nll_loss
         super().__init__()
+        self.weight = weight
         self.ignore_index = ignore_index
         self.reduction = reduction
 
@@ -41,6 +42,7 @@ class FP16SafeCrossEntropy(torch.nn.Module):
         return F.nll_loss(
             F.log_softmax(scores, 1, dtype=torch.float32),
             targets,
+            weight=self.weight,
             ignore_index=self.ignore_index,
             reduction=self.reduction,
         )


### PR DESCRIPTION
**Patch description**
Allows for a vector of per-class weights to be passed into our FP16-safe cross entropy function (useful for classification loss)

**Testing steps**
Sweep I ran to test out this fix:
```
python -u examples/train_model.py --activation gelu --attention-dropout 0.0 --batchsize 128 --classes-from-file /checkpoint/parlai/projects/retrieve_st/sweeps_ems/s2020_03_12__retnref_with_style/personality_list.txt --dict-file /checkpoint/parlai/zoo/meena/20200319_meenav0data_tall_2.7B_adamoptimizer/20200319_13.3ppl_200kupdates/model.dict --dict-tokenizer bytelevelbpe --dropout 0.1 --embedding-size 2560 --ffn-size 10240 --fp16-impl mem_efficient --freeze-enc-dec-weights False --fp16 True --gradient-clip 0.1 --history-add-global-end-token end --history-size 2 --init-model /checkpoint/parlai/zoo/meena/20200319_meenav0data_tall_2.7B_adamoptimizer/20200319_13.3ppl_200kupdates/model --label-truncate 128 --log-every-n-secs 30 --lr-scheduler-patience 3 --lr-scheduler reduceonplateau --max-train-time 165887.99999999997 --model-parallel True --model parlai_internal.agents.retnref.retnref:GeneratorWithClassifierHeadAgent --n-decoder-layers 24 --n-encoder-layers 2 --n-heads 32 --n-positions 128 --optimizer adam --relu-dropout 0.0 --save-after-valid True --text-truncate 128 --truncate 128 --update-freq 2 --variant prelayernorm --warmup_updates 100 -lr 2e-06 -t internal:comment_battle:ImageDialogPersonalityClassifier -veps 0.25 -vmm max -vmt weighted_acc -vp 10000 --model-file /checkpoint/parlai/projects/retrieve_st/sweeps_ems/s2020_04_01__style_classifier/01_sweeps/000/2d1/model
```
