### PR TITLE
Adding passing of Agent.data to ChatService for internal parity

### DIFF
--- a/parlai/chat_service/core/chat_service_manager.py
+++ b/parlai/chat_service/core/chat_service_manager.py
@@ -37,6 +37,7 @@ class AgentState:
         self.active_agent = overworld_agent
         self.task_id_to_agent: Dict[str, ChatServiceAgent] = {}
         self.onboard_data = None
+        self.data = {}
         self.stored_data: Dict[str, Any] = {}
         self.time_in_pool: Dict[str, float] = {}
 
@@ -667,6 +668,7 @@ class ChatServiceManager(ABC):
             for agent in agents:
                 self.after_agent_removed(agent.id)
                 agent_state = self.get_agent_state(agent.id)
+                agent_state.data = agent.data
                 next_task = agent.data.get("next_task")
                 log_utils.print_and_log(logging.INFO, "Next task: {}".format(next_task))
                 if next_task is None:
@@ -719,6 +721,7 @@ class ChatServiceManager(ABC):
                         for state in agent_states:
                             agent = self._create_agent(task_id, state.get_id())
                             agent.onboard_data = state.onboard_data
+                            agent.data = state.data
                             state.assign_agent_to_task(agent, task_id)
                             state.set_active_agent(agent)
                             agents.append(agent)

--- a/parlai/chat_service/core/world_runner.py
+++ b/parlai/chat_service/core/world_runner.py
@@ -184,6 +184,7 @@ class ChatServiceWorldRunner:
                     agent_state.assign_agent_to_task(agent, onboard_id)
                     _, onboard_data = self._run_world(task, onboard_type, [agent])
                     agent_state.onboard_data = onboard_data
+                    agent_state.data = agent.data
                 self.manager.add_agent_to_pool(agent_state, world_type)
                 log_utils.print_and_log(logging.INFO, 'onboarding/overworld complete')
 

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -162,7 +162,7 @@ class WebsocketManager(ChatServiceManager):
         self.app = self._make_app()
         self.app.listen(self.port)
         # Must use a tornado callback to run the main loop
-        callback_time = utils.THREAD_MEDIUM_SLEEP * 10
+        callback_time = utils.THREAD_MEDIUM_SLEEP * 1000
         tornado.ioloop.PeriodicCallback(
             callback=self._manager_loop_fn, callback_time=callback_time
         ).start()

--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -117,6 +117,7 @@ class WebsocketManager(ChatServiceManager):
                     for state in agent_states:
                         agent = self._create_agent(task_id, state.get_id())
                         agent.onboard_data = state.onboard_data
+                        agent.data = state.data
                         state.assign_agent_to_task(agent, task_id)
                         state.set_active_agent(agent)
                         agents.append(agent)
@@ -161,7 +162,7 @@ class WebsocketManager(ChatServiceManager):
         self.app = self._make_app()
         self.app.listen(self.port)
         # Must use a tornado callback to run the main loop
-        callback_time = utils.THREAD_MEDIUM_SLEEP * 1000
+        callback_time = utils.THREAD_MEDIUM_SLEEP * 10
         tornado.ioloop.PeriodicCallback(
             callback=self._manager_loop_fn, callback_time=callback_time
         ).start()


### PR DESCRIPTION
**Patch description**
Internally we set contents of an agent's data between worlds. Externally we only supported this via `onboard_data`, which lets an onboarding world return data that is put in the agent later. This proved too restrictive for some of our internal chats, and so we added passing of the `agent.data` field. 

This PR introduces the same mechanic to the open source version (essentially being straight better than `onboard_data`), but I've retained the old mechanic to make minimal changes.

**Testing steps**
Tested with the LIGHT worlds, which aren't yet public yet. Suffice to say, I can send data from one world to another world via the agent.data field.
