### PR TITLE
Allow macroaverages with nonequal number of subreports.

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -508,7 +508,7 @@ def aggregate_named_reports(
 
     # reporters is a list of teachers or worlds
     m: Dict[str, Metric] = {}
-    macro_averages: Dict[str, List[Metric]] = {}
+    macro_averages: Dict[str, Dict[str, Metric]] = {}
     for task_id, task_report in named_reports.items():
         for each_metric, value in task_report.items():
             if value.is_global:

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -56,7 +56,7 @@ from parlai.core.agents import create_agents_from_shared
 from parlai.core.loader import load_task_module, load_world_module
 from parlai.core.metrics import aggregate_named_reports
 from parlai.core.opt import Opt
-from parlai.core.teachers import create_task_agent_from_taskname
+from parlai.core.teachers import Teacher, create_task_agent_from_taskname
 from parlai.utils.misc import Timer, display_messages
 from parlai.tasks.tasks import ids_to_tasks
 
@@ -612,7 +612,7 @@ class MultiWorld(World):
                 weight = 1
             self.cum_task_weights[i] = weight + sum
             sum += weight
-        task_ids = {}
+        task_ids: Dict[str, Teacher] = {}
         # Having overlap in teacher ids will cause issues for metrics aggregation.
         for each_world in self.worlds:
             world_id = each_world.getID()
@@ -625,7 +625,7 @@ class MultiWorld(World):
                     )
                 )
             else:
-                task_ids[world_id] = each_world.get_agents()[0]
+                task_ids[world_id] = each_world.get_task_agent()
 
     def num_examples(self):
         """

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -341,10 +341,10 @@ class PipelineHelper(object):
         self.__device_allocations['cuda:0'] += trainable_parameters(model) * 3
 
         model.apply(self._place_modulelist)
-        model._apply(self._move_rest_to_cuda0)
+        model._apply(self._move_rest_to_cuda0)  # type: ignore
         return model
 
-    def _move_rest_to_cuda0(self, parameter):
+    def _move_rest_to_cuda0(self, parameter: torch.Tensor):
         if parameter.device.type == 'cpu':
             return parameter.to('cuda:0')
         else:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -108,7 +108,7 @@ class TestMetric(unittest.TestCase):
         m2 = AverageMetric(3, 4)
 
         assert (m1 + m2) == AverageMetric(4, 7)
-        assert MacroAverageMetric([m1, m2]) == 0.5 * (1.0 / 3 + 3.0 / 4)
+        assert MacroAverageMetric([m1, m2], ['a', 'b']) == 0.5 * (1.0 / 3 + 3.0 / 4)
 
 
 class TestMetrics(unittest.TestCase):
@@ -236,6 +236,29 @@ class TestAggregators(unittest.TestCase):
         assert agg['b/sum'] == 4
         assert agg['b/fixed'] == 4
         assert 'b/global_avg' not in agg
+
+    def test_uneven_macro_aggrevation(self):
+        report1 = {
+            'avg': AverageMetric(1, 1),
+        }
+        report2 = {
+            'avg': AverageMetric(0, 1),
+        }
+        report3 = {
+            'avg': AverageMetric(0, 1),
+        }
+        agg1 = aggregate_named_reports(
+            {'a': report1, 'b': report2}, micro_average=False
+        )
+        agg2 = aggregate_named_reports({'a': {}, 'c': report3}, micro_average=False)
+
+        agg = aggregate_unnamed_reports([agg1, agg2])
+        assert agg1['avg'] == 0.5
+        assert agg2['avg'] == 0.0
+        assert agg['a/avg'] == 1.0
+        assert agg['b/avg'] == 0.0
+        assert agg['c/avg'] == 0.0
+        assert agg['avg'] == 1.0 / 3
 
     def test_micro_aggregation(self):
         report1 = {

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -108,7 +108,7 @@ class TestMetric(unittest.TestCase):
         m2 = AverageMetric(3, 4)
 
         assert (m1 + m2) == AverageMetric(4, 7)
-        assert MacroAverageMetric([m1, m2], ['a', 'b']) == 0.5 * (1.0 / 3 + 3.0 / 4)
+        assert MacroAverageMetric({'a': m1, 'b': m2}) == 0.5 * (1.0 / 3 + 3.0 / 4)
 
 
 class TestMetrics(unittest.TestCase):


### PR DESCRIPTION
**Patch description**
I was working on a large multitask setting with a very small batch size in a distributed setting. Very easily, some workers would work on different subsets of tasks, which would mess up this assertion I had left in the macro-averaging code.  So we support the mixed case properly now, but it slightly changes the API.

**Testing steps**
New test. CI. Manual testing.