### PR TITLE
Fix rare cases of distributed evaluation failures

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -641,15 +641,16 @@ class DialogData(object):
     """
 
     def __init__(self, opt, data_loader=None, cands=None, shared=None, **kwargs):
-        # self.data is a list of episodes
-        # each episode is a tuple of entries
-        # each entry is a tuple of values for the action/observation table
+        # in case we need to shard the dataset
         self.rank = get_rank()
         self.num_workers = num_workers()
         self.is_distributed_and_is_eval = is_distributed() and any(
             x in opt['datatype'] for x in ('valid', 'test', 'train:evalmode')
         )
 
+        # self.data is a list of episodes
+        # each episode is a tuple of entries
+        # each entry is a tuple of values for the action/observation table
         if shared:
             self.image_loader = shared.get('image_loader', None)
             self.data = shared.get('data', [])


### PR DESCRIPTION
**Patch description**
Noticed that we were violating our self_observe invariant checks (and thus an exception being raised) for non-streaming teachers, but only in some very strange cases.  I actually found it very difficult to isolate in a test, but it appears like some datasets may not have been respecting the get() override or similar. I switched to stratifying the data the same way we do for streaming, which might even save a little bit of RAM anyway.

**Testing steps**
CI. Manual testing.