### PR TITLE
[Acute Eval] Bug fix 

### DIFF
--- a/parlai/mturk/tasks/acute_eval/run.py
+++ b/parlai/mturk/tasks/acute_eval/run.py
@@ -353,7 +353,7 @@ class AcuteEvaluator(object):
             worker_data['conversations_seen'].extend(
                 self._get_dialogue_ids(self.desired_tasks[t])
             )
-            task_data.extend(self.desired_tasks[t])
+            task_data.append(self.desired_tasks[t])
 
         return task_data
 


### PR DESCRIPTION
**Patch description**
Bug fix for when the number of HITs exceeds the number of conversations to be completed. We `top_up_extra_data` so that the user still has a HIT to complete. However, there was an `extend` instead of an `append` here, causing bugs down the line.