### PR TITLE
Disable relative step flag in adafactor

### DIFF
--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -554,7 +554,9 @@ class Adafactor(torch.optim.Optimizer):
         beta1=None,
         weight_decay=0.0,
         scale_parameter=True,
-        relative_step=True,
+        # relative_step=True, TODO: enable it back. This leads lr decay to 0.
+        # Since for some schdulers, they only update lr per validation step.
+        # In such cases lr will keep decay every update.
         warmup_init=False,
     ):
         defaults = dict(
@@ -565,13 +567,16 @@ class Adafactor(torch.optim.Optimizer):
             beta1=beta1,
             weight_decay=weight_decay,
             scale_parameter=scale_parameter,
-            relative_step=relative_step,
+            relative_step=False,
             warmup_init=warmup_init,
         )
         super(Adafactor, self).__init__(params, defaults)
 
     def _get_lr(self, param_group, param_state):
         rel_step_sz = param_group['lr']
+        # TODO: enable it back. This leads lr decay to 0.
+        # Since for some schdulers, they only update lr per validation step.
+        # In such cases lr will keep decay every update.
         if param_group['relative_step']:
             min_step = (
                 1e-6 * param_state['step'] if param_group['warmup_init'] else 1e-2

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -553,10 +553,10 @@ class Adafactor(torch.optim.Optimizer):
         decay_rate=-0.8,
         beta1=None,
         weight_decay=0.0,
-        scale_parameter=True,
-        # relative_step=True, TODO: enable it back. This leads lr decay to 0.
+        # scale_parameter=True, TODO: enable it back. This leads lr decay to 0.
         # Since for some schdulers, they only update lr per validation step.
         # In such cases lr will keep decay every update.
+        # relative_step=True,
         warmup_init=False,
     ):
         defaults = dict(
@@ -566,7 +566,7 @@ class Adafactor(torch.optim.Optimizer):
             decay_rate=decay_rate,
             beta1=beta1,
             weight_decay=weight_decay,
-            scale_parameter=scale_parameter,
+            scale_parameter=False,
             relative_step=False,
             warmup_init=warmup_init,
         )


### PR DESCRIPTION
**Patch description**
A better version of #2443 
Some optimizers don't work with this relative step flag, because it decays LR at every training update, assuming a new LR will be set by the scheduler. However, it is not true for some schedulers like reduceonplateu, fixed LR, since they only update LR every validation. 
For these schedulers, LR go to 0 after a few training steps. 
**Testing steps**
```
 python examples/train_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -bs 1 -nt 1  -eps 5 -m memnn  -lr 5e-3 --optimizer adafactor
```
**Logs**
Before:
```
[ time:37.0s total_exs:25222 epochs:2.8 time_left:30.0s ]
    clip  exs  gnorm        lr  mean_loss  total_train_updates  tpb  updates
       1   22  404.1 1.565e-31      7.839                   22    1       22

[ time:48.0s total_exs:25244 epochs:2.8 time_left:38.0s ]
    clip  exs  gnorm  lr  mean_loss  total_train_updates  tpb  updates
       1   22    419   0      7.894                   44    1       22

[ time:58.0s total_exs:25266 epochs:2.81 time_left:46.0s ]
    clip  exs  gnorm  lr  mean_loss  total_train_updates  tpb  updates
       1   22    400   0       6.12                   66    1       22

[ time:68.0s total_exs:25288 epochs:2.81 time_left:54.0s ]
    clip  exs  gnorm  lr  mean_loss  total_train_updates  tpb  updates
       1   22  466.8   0      8.252                   88    1       22
```
After:
```    
clip  exs  gnorm    lr  mean_loss  total_train_updates  tpb  updates
   .9091   22  361.1 .0050      36.84                   22    1       22

[ time:48.0s total_exs:25244 epochs:2.8 time_left:38.0s ]
    clip  exs  gnorm    lr  mean_loss  total_train_updates  tpb  updates
       1   22  589.8 .0050      81.49                   44    1       22

[ time:58.0s total_exs:25267 epochs:2.81 time_left:46.0s ]
    clip  exs  gnorm    lr  mean_loss  total_train_updates  tpb  updates
   .9565   23  419.5 .0050      70.26                   67    1       23

[ time:68.0s total_exs:25290 epochs:2.81 time_left:54.0s ]
    clip  exs  gnorm    lr  mean_loss  total_train_updates  tpb  updates
   .7826   23  296.5 .0050      43.22                   90    1       23

[ time:78.0s total_exs:25312 epochs:2.81 time_left:62.0s ]
    clip  exs  gnorm    lr  mean_loss  total_train_updates  tpb  updates
       1   22    277 .0050      30.92                  112    1       22

