### PR TITLE
[Dodeca] Image Chat Generation Task

### DIFF
--- a/parlai/tasks/image_chat/agents.py
+++ b/parlai/tasks/image_chat/agents.py
@@ -70,6 +70,7 @@ class ImageChatTeacher(FixedDialogTeacher):
         else:
             self.image_loader = ImageLoader(opt)
             self._setup_data(self.data_path, personalities_data_path)
+        self.num_exs = sum(len(d['dialog']) for d in self.data)
         self.reset()
 
     @staticmethod
@@ -129,7 +130,7 @@ class ImageChatTeacher(FixedDialogTeacher):
         return len(self.data)
 
     def num_examples(self) -> int:
-        return sum(len(d['dialog']) for d in self.data)
+        return self.num_exs
 
     def submit_load_request(self, image_id: str):  # type: ignore
         img_path = os.path.join(self.image_path, '{}.jpg'.format(image_id))
@@ -235,9 +236,6 @@ class GenerationTeacher(ImageChatTeacher):
 
     def num_episodes(self) -> int:
         return self.num_eps
-
-    def num_examples(self) -> int:
-        return sum([len(d['dialog']) for d in self.data])
 
     def get(self, episode_idx: int, entry_idx: int = 0):
         entry_idx *= 2

--- a/parlai/tasks/image_chat/agents.py
+++ b/parlai/tasks/image_chat/agents.py
@@ -203,9 +203,6 @@ class GenerationTeacher(ImageChatTeacher):
     """
 
     def __init__(self, opt: Opt, shared: TShared = None):
-        if opt.get('datasplit', '100k') != '100k':
-            print('Warning: teacher only has 100k datasplit')
-            opt['datasplit'] = '100k'
         if not shared:
             self.idx_to_ep = {}
         else:

--- a/parlai/tasks/image_chat/agents.py
+++ b/parlai/tasks/image_chat/agents.py
@@ -13,16 +13,28 @@ An example is given as follows:
            'label': <comment/response>,
           }
 """
-from parlai.core.teachers import FixedDialogTeacher
-from parlai.core.image_featurizers import ImageLoader
-from torch.utils.data import Dataset
-from .build import build
-
 import json
 import os
+from typing import Tuple
+
+from parlai.core.message import Message
+from parlai.core.opt import Opt
+from parlai.core.teachers import FixedDialogTeacher
+from parlai.core.image_featurizers import ImageLoader
+from parlai.utils.typing import TShared
+from .build import build
 
 
-def _path(opt):
+def _path(opt: Opt) -> Tuple[str, str, str]:
+    """
+    Return appropriate datapaths.
+
+    :param opt:
+        options
+
+    :return (data path, personalities path, image_path):
+        path to data, personalities, and images
+    """
     build(opt)
     dt = opt['datatype'].split(':')[0]
     if dt in ['train', 'valid', 'test']:
@@ -40,82 +52,6 @@ def _path(opt):
     return data_path, personalities_data_path, image_path
 
 
-class DefaultDataset(Dataset):
-    """
-    A Pytorch Dataset.
-    """
-
-    def __init__(self, opt):
-        self.opt = opt
-        opt['image_load_task'] = 'image_chat'
-        self.image_mode = opt.get('image_mode', 'no_image_model')
-        self.datatype = self.opt.get('datatype')
-        self.training = self.datatype.startswith('train')
-        self.include_image = opt.get('include_image')
-        self.include_personality = opt.get('include_personality')
-        self.num_cands = opt.get('num_cands')
-        data_path, personalities_data_path, self.image_path = _path(opt)
-        self.image_loader = ImageLoader(opt)
-        self._setup_data(data_path, personalities_data_path)
-
-    @staticmethod
-    def add_cmdline_args(argparser):
-        ImageChatTeacher.add_cmdline_args(argparser)
-
-    def _setup_data(self, data_path, personalities_data_path):
-        print('loading: ' + data_path)
-        with open(data_path) as f:
-            self.data = json.load(f)
-        with open(personalities_data_path) as f:
-            self.personalities = json.load(f)
-
-    def __getitem__(self, index):
-        data = self.data[index]
-        dialog = data['dialog']
-        personality = dialog[-1][0]
-        text = ''
-        if len(dialog) > 1:
-            text = '\n'.join((dialog[0][1], dialog[1][1]))
-        if self.include_personality:
-            text += personality
-        label = dialog[-1][1]
-        image = self.get_image(data['image_hash'])
-
-        ep = {
-            'text': text,
-            'episode_done': True,
-            'image': image if self.include_image else None,
-        }
-
-        if self.opt.get('extract_image', False):
-            ep['image_id'] = data['image_hash']
-            return ep
-        if not self.opt['datatype'].startswith('test'):
-            ep['labels'] = [label]
-        if not self.training:
-            ep['label_candidates'] = data['candidates'][-1][self.num_cands]
-
-        return (index, ep)
-
-    def __len__(self):
-        return self.num_episodes()
-
-    def get_image(self, image_id):
-        im_path = os.path.join(self.image_path, '{}.jpg'.format(image_id))
-        return self.image_loader.load(im_path)
-
-    def num_episodes(self):
-        return len(self.data)
-
-    def num_examples(self):
-        return self.num_episodes()
-
-    def num_images(self):
-        if not hasattr(self, 'num_imgs'):
-            self.num_imgs = len({d['image_num'] for d in self.data})
-        return self.num_imgs
-
-
 class ImageChatTeacher(FixedDialogTeacher):
     """
     Provides the personality in the `text` field, and response in the `labels` field.
@@ -124,14 +60,14 @@ class ImageChatTeacher(FixedDialogTeacher):
     command line argument.
     """
 
-    def __init__(self, opt, shared=None):
+    def __init__(self, opt: Opt, shared: TShared = None):
         super().__init__(opt, shared)
         self.opt = opt
         self.image_mode = opt.get('image_mode', 'no_image_model')
         self.data_path, personalities_data_path, self.image_path = _path(opt)
         self.datatype = opt.get('datatype').split(':')[0]
         self.include_personality = opt.get('include_personality')
-        self.include_image = opt.get('include_image')
+        self.include_image = opt.get('include_image') and opt.get('load_images')
         self.num_cands = opt.get('num_cands')
         if shared and 'data' in shared:
             self.data = shared['data']
@@ -165,6 +101,12 @@ class ImageChatTeacher(FixedDialogTeacher):
             'via the provided download script)',
         )
         agent.add_argument(
+            '--load-images',
+            type='bool',
+            default=True,
+            help='Specify whether to load images'
+        )
+        agent.add_argument(
             '--num-cands',
             type=str,
             default='100',
@@ -172,7 +114,10 @@ class ImageChatTeacher(FixedDialogTeacher):
             help='how many candidates to provide agent',
         )
 
-    def _setup_data(self, data_path, personalities_data_path):
+    def _setup_data(self, data_path: str, personalities_data_path: str):
+        """
+        Load the data.
+        """
         print('loading: ' + data_path)
         with open(data_path) as f:
             self.data = json.load(f)
@@ -180,22 +125,25 @@ class ImageChatTeacher(FixedDialogTeacher):
             self.personalities = json.load(f)
 
     def reset(self):
+        """
+        Override to Reset self.example.
+        """
         super().reset()
         self.example = None
 
-    def num_episodes(self):
+    def num_episodes(self) -> int:
         return len(self.data)
 
-    def num_examples(self):
+    def num_examples(self) -> int:
         return sum(len(d['dialog']) for d in self.data)
 
-    def submit_load_request(self, image_id):
+    def submit_load_request(self, image_id: str):
         img_path = os.path.join(self.image_path, '{}.jpg'.format(image_id))
         self.data_loader.request_load(
             self.receive_data, self.image_loader.load, (img_path,)
         )
 
-    def get(self, episode_idx, entry_idx=0):
+    def get(self, episode_idx: int, entry_idx: int = 0):
         data = self.data[episode_idx]
         personality, text = data['dialog'][entry_idx]
         episode_done = entry_idx == len(data['dialog']) - 1
@@ -212,7 +160,7 @@ class ImageChatTeacher(FixedDialogTeacher):
 
         return action
 
-    def next_example(self):
+    def next_example(self) -> Message:
         """
         Returns the next example from this dataset after starting to queue up the next
         example.
@@ -240,11 +188,111 @@ class ImageChatTeacher(FixedDialogTeacher):
         else:
             return ready
 
-    def share(self):
+    def share(self) -> TShared:
         shared = super().share()
         shared['data'] = self.data
         shared['image_loader'] = self.image_loader
         shared['personalities'] = self.personalities
+        return shared
+
+
+class GenerationTeacher(ImageChatTeacher):
+    """
+    GenerationTeacher - dialogues are split into two episodes, one from
+    each individual person's point of view.
+
+    Used in the #dodecaDialogue task. (see https://parl.ai/projects/dodecadialogue/)
+    """
+
+    def __init__(self, opt: Opt, shared: TShared = None):
+        if opt.get('datasplit', '100k') != '100k':
+            print('Warning: teacher only has 100k datasplit')
+            opt['datasplit'] = '100k'
+        if not shared:
+            self.idx_to_ep = {}
+        else:
+            self.idx_to_ep = shared['idx_to_ep']
+        self.prepend_personality = opt.get('prepend_personality', True)
+        self.include_dialogue_history = opt.get('include_dialogue_history', True)
+        super().__init__(opt, shared)
+        self.num_eps = len(self.data) + len(
+            [d for d in self.data if len(d['dialog']) > 1]
+        )
+
+    @staticmethod
+    def add_cmdline_args(argparser):
+        ImageChatTeacher.add_cmdline_args(argparser)
+        agent = argparser.add_argument_group('generation teacher arguments')
+        agent.add_argument(
+            '--prepend-personality',
+            type='bool',
+            default=True,
+            help='if true, always prepend first turn text with the personality',
+        )
+        agent.add_argument(
+            '--include-dialogue-history',
+            type='bool',
+            default=True,
+            help='if false, remove the dialogue history',
+        )
+
+    def num_episodes(self) -> int:
+        return self.num_eps
+
+    def num_examples(self) -> int:
+        return sum([len(d['dialog']) for d in self.data])
+
+    def get(self, episode_idx: int, entry_idx: int = 0):
+        entry_idx *= 2
+        first_turn = entry_idx == 0
+        if episode_idx >= len(self.data):
+            # Second time through dataset
+            data = self.data[self.idx_to_ep[episode_idx]]
+            entry_idx += 1
+        else:
+            data = self.data[episode_idx]
+
+        personality, label = data['dialog'][entry_idx]
+        if not self.include_personality:
+            personality = ''
+
+        if entry_idx > 0:
+            _, text = data['dialog'][entry_idx - 1]
+            if not self.include_dialogue_history:
+                text = ''
+            if first_turn and self.prepend_personality and self.include_personality:
+                text = '\n'.join([personality, text])
+        elif self.prepend_personality and self.include_personality:
+            text = personality
+        else:
+            text = ''
+
+        episode_done = entry_idx >= len(data['dialog']) - 2
+
+        action = {
+            'text': text,
+            'personality': personality,
+            'image_id': data['image_hash'],
+            'episode_done': episode_done,
+            'labels': [label],
+        }
+
+        if "candidates" in data:
+            action['label_candidates'] = data['candidates'][entry_idx][self.num_cands]
+
+        return action
+
+    def _setup_data(self, data_path: str, personalities_data_path: str):
+        super()._setup_data(data_path, personalities_data_path)
+        ep_idx = len(self.data)
+        for i, d in enumerate(self.data):
+            if len(d['dialog']) > 1:
+                self.idx_to_ep[ep_idx] = i
+                ep_idx += 1
+
+    def share(self):
+        shared = super().share()
+        shared['idx_to_ep'] = self.idx_to_ep
         return shared
 
 

--- a/parlai/tasks/image_chat/build.py
+++ b/parlai/tasks/image_chat/build.py
@@ -34,5 +34,9 @@ def build(opt):
 
         build_data.mark_done(dpath, version)
 
-    if not build_data.built(image_path, version) and not opt.get('yfcc_path') and opt.get('load_images'):
+    if (
+        not build_data.built(image_path, version)
+        and not opt.get('yfcc_path')
+        and opt.get('load_images')
+    ):
         download_images(opt, task='image_chat')

--- a/parlai/tasks/image_chat/build.py
+++ b/parlai/tasks/image_chat/build.py
@@ -34,5 +34,5 @@ def build(opt):
 
         build_data.mark_done(dpath, version)
 
-    if not build_data.built(image_path, version) and not opt.get('yfcc_path'):
+    if not build_data.built(image_path, version) and not opt.get('yfcc_path') and opt.get('load_images'):
         download_images(opt, task='image_chat')


### PR DESCRIPTION
**Patch description**
Open-sourcing Image Chat generation teacher. Added cmd-line arg for not loading the images at all (in case someone wants to just use the dialogue-only version of the task, and does not want to download the images).

Also removing the `Dataset` as we deprecated `PytorchDataTeacher`

**Testing steps**
display data as well as verify data

**Logs**
```
$ python examples/display_data.py -t image_chat:generation --load-images false
.
.
.
    - - - NEW EPISODE: image_chat:generation - - -
Appreciative (Grateful)
   home sweet home
in my big house
   Its a house, so like it
    - - - NEW EPISODE: image_chat:generation - - -
Discouraging
   How can you get any work done in such a disorganized office?
    - - - NEW EPISODE: image_chat:generation - - -
Empathetic
   I hope the person who made this made a lot of money
    - - - NEW EPISODE: image_chat:generation - - -
Erratic
   Is the street skewed or am I just kind of drunk?
I think you are drunk bro.
   Is it ok?  Are you mad?
    - - - NEW EPISODE: image_chat:generation - - -
Destructive
   This ugly box of a building should be torn down and turned into tombstones.
    - - - NEW EPISODE: image_chat:generation - - -
Escapist (Dreamer, Seeks Distraction)
   Oh to hit the road and just keep walking.
    - - - NEW EPISODE: image_chat:generation - - -
Whimsical (Playful, Fanciful)
   I can't wait to buy these shirts for my mom's birthday!
Your mom will have quite a surprise when she sees the shirts!
   she knows my jokster mentality
[ loaded 271322 episodes with a total of 355862 examples ]
```