### PR TITLE
Fix IR Baseline: update DictionaryAgent.freqs() to .freq

### DIFF
--- a/parlai/agents/ir_baseline/ir_baseline.py
+++ b/parlai/agents/ir_baseline/ir_baseline.py
@@ -356,8 +356,8 @@ class IrBaselineAgent(Agent):
         rw = rep['words']
         used = {}
         for w in words:
-            if len(self.dictionary.freqs()) > 0:
-                rw[w] = 1.0 / (1.0 + math.log(1.0 + self.dictionary.freqs()[w]))
+            if len(self.dictionary.freq) > 0:
+                rw[w] = 1.0 / (1.0 + math.log(1.0 + self.dictionary.freq[w]))
             else:
                 if w not in stopwords:
                     rw[w] = 1


### PR DESCRIPTION
**Patch description**
Fixes issue https://github.com/facebookresearch/ParlAI/issues/2555

**Testing steps**
`python examples/eval_model.py -t babi:task10k:1 -m ir_baseline` works again

**Logs**
```
$ python examples/eval_model.py -t babi:task10k:1 -m ir_baseline
WARNING: model_file unset but model has a `load` function.
[ optional arguments: ]
[  aggregate_micro: False ]
[  display_examples: False ]
[  log_every_n_secs: 2 ]
[  metrics: default ]
[  num_examples: -1 ]
[  report_filename:  ]
[  save_format: conversations ]
[  save_world_logs: False ]
[ Main ParlAI Arguments: ]
[  batchsize: 1 ]
[  datapath: /Users/louismartin/private/dev/ParlAI/data ]
[  datatype: valid ]
[  download_path: /Users/louismartin/private/dev/ParlAI/downloads ]
[  dynamic_batching: None ]
[  hide_labels: False ]
[  image_mode: raw ]
[  init_opt: None ]
[  multitask_weights: [1] ]
[  numthreads: 1 ]
[  show_advanced_args: False ]
[  task: babi:task10k:1 ]
[ ParlAI Model Arguments: ]
[  dict_class: None ]
[  init_model: None ]
[  model: ir_baseline ]
[  model_file: None ]
[ World Logging: ]
[  log_keep_fields: all ]
[ Tensorboard Arguments: ]
[  tensorboard_log: False ]
[ ParlAI Image Preprocessing Arguments: ]
[  image_cropsize: 224 ]
[  image_size: 256 ]
[ IrBaseline Arguments: ]
[  history_size: 1 ]
[  label_candidates_file: None ]
[  length_penalty: 0.5 ]
[ Evaluating task babi:task10k:1 using datatype valid. ]
[creating task(s): babi:task10k:1]
[loading fbdialog data:/Users/louismartin/private/dev/ParlAI/data/bAbI/tasks_1-20_v1-2/en-valid-10k-nosf/qa1_valid.txt]
[ Finished evaluating tasks ['babi:task10k:1'] using datatype valid ]
    accuracy   bleu-4  exs    f1  hits@1  hits@10  hits@100  hits@5
       .4650 4.65e-10 1000 .4650   .4650        1         1   .9610
```


