### PR TITLE
Don't write metrics to file

### DIFF
--- a/parlai/utils/conversations.py
+++ b/parlai/utils/conversations.py
@@ -318,7 +318,7 @@ class Conversations:
                         if save_keys != 'all':
                             save_keys_lst = save_keys.split(',')
                         else:
-                            save_keys_lst = ex.keys()
+                            save_keys_lst = [key for key in ex.keys() if key != 'metrics']
                         for key in save_keys_lst:
                             turn[key] = ex.get(key, '')
                         turn['id'] = ex_id

--- a/parlai/utils/conversations.py
+++ b/parlai/utils/conversations.py
@@ -318,7 +318,9 @@ class Conversations:
                         if save_keys != 'all':
                             save_keys_lst = save_keys.split(',')
                         else:
-                            save_keys_lst = [key for key in ex.keys() if key != 'metrics']
+                            save_keys_lst = [
+                                key for key in ex.keys() if key != 'metrics'
+                            ]
                         for key in save_keys_lst:
                             turn[key] = ex.get(key, '')
                         turn['id'] = ex_id

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -225,7 +225,7 @@ class TestEvalModel(unittest.TestCase):
                 num_examples=5,
                 display_examples=False,
                 save_world_logs=True,
-                report_filename=save_report
+                report_filename=save_report,
             )
 
             opt = parser.parse_args([], print_args=False)

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 from parlai.scripts.eval_model import setup_args
 
+import os
 import unittest
 import parlai.utils.testing as testing_utils
 
@@ -209,6 +210,26 @@ class TestEvalModel(unittest.TestCase):
                     500,
                     f'train:evalmode failed with bs {bs} and teacher {teacher}',
                 )
+
+    def test_save_report(self):
+        """
+        Test that we can save report from eval model.
+        """
+        with testing_utils.tempdir() as tmpdir:
+            save_report = os.path.join(tmpdir, 'report')
+            parser = setup_args()
+            parser.set_defaults(
+                task='integration_tests',
+                model='repeat_label',
+                datatype='valid',
+                num_examples=5,
+                display_examples=False,
+                save_world_logs=True,
+                report_filename=save_report
+            )
+
+            opt = parser.parse_args([], print_args=False)
+            valid, test = testing_utils.eval_model(opt)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Patch description**
I experienced some bugs with writing metrics to file since they are not JSON serializable. I did not see a clean way to make them JSON serializable since they are not dicts. Instead, I opted to:
- not save metrics to conversations
- when logging reports, convert metrics to their value first.

**Testing steps**
I wrote a test that will test saving eval_model reports. The test fails before these changes and passes afterwards.