### PR TITLE
[TRA] opts

### DIFF
--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -286,7 +286,7 @@ class TorchRankerAgent(TorchAgent):
             return
 
         # Override eval_candidates to interactive_candidates
-        self.eval_candidates = self.opt['interactive_candidates']
+        self.eval_candidates = self.opt.get('interactive_candidates', 'fixed')
         if self.eval_candidates == 'fixed':
             # Set fixed candidates path if it does not exist
             if self.fixed_candidates_path is None or self.fixed_candidates_path == '':


### PR DESCRIPTION
**Patch description**
Another opts bug:

Cause: When you call `create_agent`, add_model_subargs is only called if `'datapath'` is not in opt.

This is a temporary fix to unblock anyway with this. But I think we should always be calling `add_model_subargs` if they were not called already.
