### PR TITLE
[TorchClassifierAgent]Don't share optimizer if we don't have it

### DIFF
--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -193,7 +193,8 @@ class TorchClassifierAgent(TorchAgent):
         shared['class_list'] = self.class_list
         shared['class_weights'] = self.class_weights
         shared['model'] = self.model
-        shared['optimizer'] = self.optimizer
+        if hasattr(self, 'optimizer'):
+            shared['optimizer'] = self.optimizer
         return shared
 
     def _get_labels(self, batch):

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -708,6 +708,26 @@ class TestClassifier(unittest.TestCase):
         assert valid['accuracy'] > 0.97
         assert test['accuracy'] > 0.97
 
+    @testing_utils.skipUnlessGPU
+    def test_eval_classifier(self):
+        valid, _ = testing_utils.eval_model(
+            dict(
+                task='dialogue_safety:adversarial,dialogue_safety:standard',
+                model='transformer/classifier',
+                model_file='zoo:dialogue_safety/single_turn/model',
+                round=3,
+                batchsize=40,
+            ),
+            skip_test=True,
+        )
+        self.assertGreaterEqual(
+            valid['dialogue_safety:adversarial/accuracy'].value(), 0.96
+        )
+        self.assertGreaterEqual(
+            valid['dialogue_safety:standard/accuracy'].value(), 0.98
+        )
+        self.assertGreaterEqual(valid['accuracy'].value(), 0.97)
+
 
 class TestLearningRateScheduler(unittest.TestCase):
     """

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -708,26 +708,6 @@ class TestClassifier(unittest.TestCase):
         assert valid['accuracy'] > 0.97
         assert test['accuracy'] > 0.97
 
-    @testing_utils.skipUnlessGPU
-    def test_eval_classifier(self):
-        valid, _ = testing_utils.eval_model(
-            dict(
-                task='dialogue_safety:adversarial,dialogue_safety:standard',
-                model='transformer/classifier',
-                model_file='zoo:dialogue_safety/single_turn/model',
-                round=3,
-                batchsize=40,
-            ),
-            skip_test=True,
-        )
-        self.assertGreaterEqual(
-            valid['dialogue_safety:adversarial/accuracy'].value(), 0.96
-        )
-        self.assertGreaterEqual(
-            valid['dialogue_safety:standard/accuracy'].value(), 0.98
-        )
-        self.assertGreaterEqual(valid['accuracy'].value(), 0.97)
-
 
 class TestLearningRateScheduler(unittest.TestCase):
     """


### PR DESCRIPTION
**Patch description**
The current torch classifier agent is broken in eval since it tries to share optimizer even when `_should_initialize_optimizer` returns False. And this causes the agent to crash.
testing_utils.eval_model doesn't really catch this one thought.

**Testing steps**
```
py -m ipdb  examples/eval_model.py -t dialogue_safety:adversarial --round 3 -dt test -m transformer/classifier -mf zoo:dialogue_safety/single_turn/model -bs 40
```

**Logs**
```
3s elapsed:
    %done accuracy   bleu-4 class___notok___f1 class___notok___prec class___notok___recall class___ok___f1 class___ok___prec class___ok___recall exs    f1 gpu_mem  loss time_left tpb weighted_acc weighted_f1
    1.33%    .9250 9.25e-10              .5714                .6667                  .5000           .9589             .9459               .9722  40 .9250  .04928 .5148      260s 208        .7361       .9202
5s elapsed:
     %done accuracy    bleu-4 class___notok___f1 class___notok___prec class___notok___recall class___ok___f1 class___ok___prec class___ok___recall   exs    f1 gpu_mem  loss time_left   tpb weighted_acc weighted_f1
    46.67%    .9614 9.614e-10              .7874                .8403                  .7407           .9788             .9727               .9850  1400 .9614  .05358 .2244        6s 207.7        .8629       .9603
[ Finished evaluating tasks ['dialogue_safety:adversarial'] using datatype test ]
    accuracy   bleu-4  class___notok___f1  class___notok___prec  class___notok___recall  class___ok___f1  class___ok___prec  class___ok___recall  exs    f1  gpu_mem  loss  tpb  weighted_acc  weighted_f1
       .9620 9.62e-10               .8041                 .8298                   .7800            .9790              .9757                .9822 3000 .9620   .05359 .2151  208         .8811        .9615
```
It fails on master with :
```
[creating task(s): dialogue_safety:adversarial]
Traceback (most recent call last):
  File "/private/home/daju/.conda/envs/my_parlai/lib/python3.7/site-packages/ipdb/__main__.py", line 168, in main
    pdb._runscript(mainpyfile)
  File "/private/home/daju/.conda/envs/my_parlai/lib/python3.7/pdb.py", line 1570, in _runscript
    self.run(statement)
  File "/private/home/daju/.conda/envs/my_parlai/lib/python3.7/bdb.py", line 585, in run
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
  File "/private/home/daju/ParlAI/examples/eval_model.py", line 11, in <module>
    """
  File "/private/home/daju/ParlAI/parlai/scripts/eval_model.py", line 188, in eval_model
    task_report = _eval_single_world(opt, agent, task)
  File "/private/home/daju/ParlAI/parlai/scripts/eval_model.py", line 116, in _eval_single_world
    world = create_task(task_opt, agent)  # create worlds for tasks
  File "/private/home/daju/ParlAI/parlai/core/worlds.py", line 1636, in create_task
    world = BatchWorld(opt, world)
  File "/private/home/daju/ParlAI/parlai/core/worlds.py", line 839, in __init__
    shared = world.share()
  File "/private/home/daju/ParlAI/parlai/core/worlds.py", line 150, in share
    shared_data['agents'] = self._share_agents()
  File "/private/home/daju/ParlAI/parlai/core/worlds.py", line 168, in _share_agents
    shared_agents = [a.share() for a in self.agents]
  File "/private/home/daju/ParlAI/parlai/core/worlds.py", line 168, in <listcomp>
    shared_agents = [a.share() for a in self.agents]
  File "/private/home/daju/ParlAI/parlai/core/torch_classifier_agent.py", line 196, in share
    shared['optimizer'] = self.optimizer
AttributeError: 'TransformerClassifierAgent' object has no attribute 'optimizer'
Uncaught exception. Entering post mortem debugging
Running 'cont' or 'step' will restart the program
```