### PR TITLE
[BPE] Bug fix

### DIFF
--- a/parlai/utils/bpe.py
+++ b/parlai/utils/bpe.py
@@ -824,6 +824,7 @@ class SlowBytelevelBPE(Gpt2BpeHelper):
         """
         bpe_data = None
         json_path = ''
+        vocab_path = ''
         if self.opt.get('dict_loaded'):
             dfname = self.opt['dict_file']
             if os.path.isfile(f'{dfname}-merges.txt'):


### PR DESCRIPTION
**Patch description**
There was a situation where `vocab_path` could be used prior to its initialization; fixing that

**Testing Steps**
local testing & circle ci