### PR TITLE
Trigger BST data download in interactive mode

### DIFF
--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -25,7 +25,14 @@ from .build import build
 ##################################################
 
 
-def _path(opt):
+def raw_data_path(opt):
+    # Build the data if it doesn't exist.
+    build(opt)
+    dt = opt['datatype'].split(':')[0]
+    return os.path.join(opt['datapath'], 'blended_skill_talk', dt + '.json')
+
+
+def _processed_data_path(opt):
     # Build the data if it doesn't exist.
     build(opt)
     dt = opt['datatype'].split(':')[0]
@@ -35,7 +42,7 @@ def _path(opt):
 class BlendedSkillTalkTeacher(ParlAIDialogTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
-        opt['parlaidialogteacher_datafile'] = _path(opt)
+        opt['parlaidialogteacher_datafile'] = _processed_data_path(opt)
         super().__init__(opt, shared)
 
 

--- a/parlai/tasks/blended_skill_talk/worlds.py
+++ b/parlai/tasks/blended_skill_talk/worlds.py
@@ -6,17 +6,15 @@
 
 import json
 import random
-import os
 
+from parlai.tasks.blended_skill_talk.agents import raw_data_path
 from parlai.tasks.interactive.worlds import InteractiveWorld as InteractiveBaseWorld
 from parlai.tasks.self_chat.worlds import SelfChatWorld as SelfChatBaseWorld
 
 
 def load_personas(opt):
     print('[ loading personas.. ]')
-    fname = os.path.join(
-        opt['datapath'], 'blended_skill_talk', opt['datatype'].split(':')[0] + '.json'
-    )
+    fname = raw_data_path(opt)
     with open(fname) as json_file:
         data = json.load(json_file)
     contexts = []


### PR DESCRIPTION
**Patch description**
Trigger download of the BST data files even when running in interactive mode.

**Testing steps**
- Tested that data can be downloaded correctly when running interactive mode:
```
rm -rf data/blended_skill_talk
python examples/interactive.py -m repeat_label -t blended_skill_talk
```
- Tested that data can be downloaded correctly when displaying data:
```
rm -rf data/blended_skill_talk
python examples/display_data.py -t blended_skill_talk
```

