### PR TITLE
Self chat fixes

### DIFF
--- a/parlai/tasks/blended_skill_talk/worlds.py
+++ b/parlai/tasks/blended_skill_talk/worlds.py
@@ -95,7 +95,7 @@ class SelfChatWorld(SelfChatBaseWorld):
         parser.add_argument(
             '--include-initial-utterances',
             type='bool',
-            default=True,
+            default=False,
             help='Include context conversation at beginning or not',
         )
 

--- a/parlai/tasks/self_chat/worlds.py
+++ b/parlai/tasks/self_chat/worlds.py
@@ -139,7 +139,7 @@ class SelfChatWorld(DialogPartnerWorld):
                     'episode_done': False,
                     'id': 'context',
                 }
-                self.acts[1 - i] = context
+                self.acts[i] = context
                 self.agents[i].observe(validate(context))
             # clear contexts so they are only added once per episode
             self.contexts = None


### PR DESCRIPTION
**Patch description**
Change the act in which context is stored in self chat, so that it aligns with the agent to which the context is being shown.

For blended skill talk, we make `--include-initial-utterances` default to False.
