### PR TITLE
Render html formats and add arguments in analysis

### DIFF
--- a/parlai/mturk/tasks/acute_eval/analysis.py
+++ b/parlai/mturk/tasks/acute_eval/analysis.py
@@ -348,10 +348,12 @@ class AcuteAnalyzer(object):
         """
         return self.dataframe.groupby('worker')['run_id'].count().max()
 
-    def filter_by_dialog_length(self, is_debug=False):
+    def filter_by_dialogue_length(self, is_debug=False):
         """
-        Filter out matchup with one of the conversation shorter than self.min_dialogue_length
-        This applies to calculating sorted_win_frac_df and signficance_df, but not html visualizations of conversations.
+        Filter out matchup with one of the conversation shorter than
+        self.min_dialogue_length This applies to calculating sorted_win_frac_df and
+        signficance_df, but not html visualizations of conversations.
+
         :param is_debug: if True, print logs indicating the number of pairings filtered out due to short conversation.
             is_debug bool
         """
@@ -359,8 +361,8 @@ class AcuteAnalyzer(object):
         filter_list = {}
         for _, row in self.dataframe.iterrows():
             keep_row = True
-            for model_name, dialog_length in row['dialogue_lengths'].items():
-                if keep_row and dialog_length < self.min_dialogue_length:
+            for model_name, dialogue_length in row['dialogue_lengths'].items():
+                if keep_row and dialogue_length < self.min_dialogue_length:
                     keep_row = False
                     filter_list[model_name] = filter_list.get(model_name, 0) + 1
             if keep_row:
@@ -368,7 +370,7 @@ class AcuteAnalyzer(object):
         if is_debug:
             for model_name in filter_list:
                 print(
-                    f"For {self.run_id}: filter out {filter_list[model_name]} matchups due to {model_name} with dialog length shorter than {self.min_dialog_length}"
+                    f"For {self.run_id}: filter out {filter_list[model_name]} matchups due to {model_name} with dialogue length shorter than {self.min_dialogue_length}"
                 )
         return df
 
@@ -376,7 +378,7 @@ class AcuteAnalyzer(object):
         """
         Return the wins for each model by matchup.
         """
-        df_filtered = self.filter_by_dialog_length(True)
+        df_filtered = self.filter_by_dialogue_length(True)
         self.matchup_total_df = (
             df_filtered.groupby(['eval_choice_0', 'eval_choice_1'])['run_id']
             .count()
@@ -515,14 +517,18 @@ class AcuteAnalyzer(object):
                 <p class="toc_title">Model Pairs</p>\
                 <ul class="toc_list">'
             for matchup in matchups:
-                eval_question = table.loc[table['matchup'] == matchup, 'question'].iloc[0]
+                eval_question = table.loc[table['matchup'] == matchup, 'question'].iloc[
+                    0
+                ]
                 result += f"<li><a href='#{matchup}''>{matchup + '__on__' +eval_question}</a></li>"
             result += '</ul></div>'
             for matchup in matchups:
                 length = min(
                     self.max_matchups_html, len(table[table['matchup'] == matchup])
                 )
-                eval_question = table.loc[table['matchup'] == matchup, 'question'].iloc[0]
+                eval_question = table.loc[table['matchup'] == matchup, 'question'].iloc[
+                    0
+                ]
                 matchup_table = table[table['matchup'] == matchup][:length]
                 table_rows = [
                     _render_row(matchup.split('__vs__'), row, idx, cherry_pick)
@@ -531,7 +537,7 @@ class AcuteAnalyzer(object):
                 if cherry_pick:
                     table_body = f"<table border=1 frame=void rules=rows cellpadding='20'><tr><th>Pair Id</th><th>Comments</th><th>Winner Conversation</th><th>Loser Conversation</th><th>Reason</th></tr>{''.join(table_rows)}</table>"
                 else:
-                    table_body = f"<table border=1 frame=void rules=rows cellpadding='20'><tr><th>Pair Id</th><th>Winner Conversation</th><th>Loser Conversation</th><ths>Reason</th></tr>{''.join(table_rows)}</table>"
+                    table_body = f"<table border=1 frame=void rules=rows cellpadding='20'><tr><th>Pair Id</th><th>Winner Conversation</th><th>Loser Conversation</th><th>Reason</th></tr>{''.join(table_rows)}</table>"
                 result += f"<h2 id='{matchup}'><li><a href='#toc_container'>{matchup + '__on__' +eval_question}</a></li></h2><body>{table_body}</body>"
             return HTML(result)
 
@@ -560,7 +566,7 @@ class AcuteAnalyzer(object):
                 return "", "p>.05"
 
         output = []
-        df_filtered = self.filter_by_dialog_length()
+        df_filtered = self.filter_by_dialogue_length()
         for _, run_annotations in df_filtered.groupby('run_id'):
             question = list(run_annotations.question)[0]
             for matchup, annotations in run_annotations.groupby('matchup'):

--- a/parlai/mturk/tasks/acute_eval/analysis.py
+++ b/parlai/mturk/tasks/acute_eval/analysis.py
@@ -448,8 +448,7 @@ class AcuteAnalyzer(object):
         """
         matchups = list(self.dataframe.matchup.unique())
 
-        def _render_row(
-            matchup: List[str], row: pd.Series, row_id: int) -> str:
+        def _render_row(matchup: List[str], row: pd.Series, row_id: int) -> str:
             dialogues = {'winner_dialogue': '', 'loser_dialogue': ''}
             for d_key in dialogues:
                 result = []

--- a/parlai/mturk/tasks/acute_eval/analysis.py
+++ b/parlai/mturk/tasks/acute_eval/analysis.py
@@ -76,7 +76,7 @@ def setup_args():
         '--cherry-pick',
         type='bool',
         default=False,
-        help='whether the run is a sandbox run or not',
+        help='whether to include cherry-picking checkbox column',
     )
     return parser
 


### PR DESCRIPTION
**Patch description**
### New arguments in analysis.py
- ```--rounding-digit```: number of digits for rounding winrate (default is 2, but we might need more precision)
- ```--max-matchups-render```: max number of matchups to display per model pair in html files (default is 10 which could be smaller than we need in case of cherry-picking)
- ```--min-dialogue-length```: for filtering out short conversations when calculating the winrate.
- ```--annotate-convo```: whether to include cherry pick checkbox column

### Render conversations and reasons in a better format and in more details 
Motivations:
- Observation 1: turkers refer 'SPEAKER_1' and 'SPEAKER_2' a lot in their reasons but because in html we align conversations by winner/loser rather than the SPEAKERs' id, sometimes it can be confusing as to which bot/human the turker is refering to. 
- Observation 2: There is no horizontal line border between each matchup. 
- Observation 3: For acute-evals with multiple combos, it can get a bit exhausting to direct to the exact model pair one would like to read, and then redirect to another.

New features:

- Link SPEAKER id to the model namein the reason column.
- Add gorizontal border between matchups 
- Add checkbox for cherry/lemmon-picking
- Number the matchups for each model pair.
- Add table of contents (list of model pairs in the acute eval run) for convenience. Add hyperlink to direct to each model pair, and redirect to table of model pairs at the top of the html page.

**Logs**
` python parlai/mturk/tasks/acute_eval/analysis.py --is-sandbox False -id <RUN_ID> --rounding-digit 5 --min-dialogue-length 10 --max-matchups-html 100 --annotate-convoTrue`

```
For acute_eval_1587575040: filter out 8 matchups due to meena_human_as_model with dialogue length shorter than 14
For acute_eval_1587575040: filter out 6 matchups due to meena with dialogue length shorter than 14
/private/home/jingxu23/.conda/envs/conda_parlai/lib/python3.7/site-packages/numpy/core/fromnumeric.py:3335: RuntimeWarning: Mean of empty slice.
  out=out, **kwargs)
/private/home/jingxu23/.conda/envs/conda_parlai/lib/python3.7/site-packages/numpy/core/_methods.py:161: RuntimeWarning: invalid value encountered in double_scalars
  ret = ret.dtype.type(ret / rcount)

------------------------------------------------------------
 To visualize signficance result, try cat /checkpoint/parlai/qfunction_acute_evals/acute_eval_1587575040-results/acute_eval_1587575040.significance.csv | column -t -s, | less -S 
 ------------------------------------------------------------

------------------------------------------------------------
 To visualize grid result, try cat /checkpoint/parlai/qfunction_acute_evals/acute_eval_1587575040-results/acute_eval_1587575040.grid.csv | column -t -s, | less -S 
 ------------------------------------------------------------

------------------------------------------------------------
 To visualize only conversations with reasons provided, open /checkpoint/parlai/qfunction_acute_evals/acute_eval_1587575040-results/acute_eval_1587575040.reason.html in a browser 
 ------------------------------------------------------------

------------------------------------------------------------
 To visualize all conversations, open /checkpoint/parlai/qfunction_acute_evals/acute_eval_1587575040-results/acute_eval_1587575040.all.html in a browser 
 ------------------------------------------------------------

------------------------------------------------------------
 Here is the grid of results: 
 ------------------------------------------------------------
winner                   xxxxx  xxxxxxxxxxxxxxxxxxxxx  xxxxxxxxxxxxxxxxxxxxxx  xxxxxxxxxxxxxxxxxxxxxx
loser                                                                                                
xxxxx             NaN                    0.67                      NaN                   NaN
xxxxxxxxxxxxxx    0.33                   NaN                       0.56                  0.57
xxxxxxxxxxxxxx    NaN                    0.44                      NaN                   NaN
xxxxxxxxxxi       NaN                    0.43                      NaN                   NaN
/private/home/jingxu23/.conda/envs/conda_parlai/lib/python3.7/site-packages/numpy/core/fromnumeric.py:3335: RuntimeWarning: Mean of empty slice.
  out=out, **kwargs)
/private/home/jingxu23/.conda/envs/conda_parlai/lib/python3.7/site-packages/numpy/core/_methods.py:161: RuntimeWarning: invalid value encountered in double_scalars
  ret = ret.dtype.type(ret / rcount)

------------------------------------------------------------
 Here is each matchup with signficance measures: 
 ------------------------------------------------------------
                                                   question                                              matchup                   model1  numwins1  winrate1                  model2  numwins2  winrate2    sigf stars     p
0  Who would you prefer to talk to for a long conversation?                                  xxxxx__vs__xxxxxxxxxxxxx        xxxxxxxxxxxxx        72      0.56  xxxxxxxxxxxxx        56      0.44   p>.05        0.18
1  Who would you prefer to talk to for a long conversation?                                  xxxx__vs__xxxxxxxxxxxxx         xxxxxxxxxxxxx        48      0.33  xxxxxxxxxxxxx        99      0.67  p<.001   ***  0.00
2  Who would you prefer to talk to for a long conversation?                                  xxxxxx__vs__xxxxxxxxxxxxx       xxxxxxxxxxxxx        77      0.57  xxxxxxxxxxxxx        58      0.43   p>.05        0.12
```

reason.html:
![Screen Shot 2020-04-29 at 10 28 30 AM](https://user-images.githubusercontent.com/60988468/80608000-314f3c00-8a04-11ea-90b1-b56ab40b18dd.png)
