### PR TITLE
add ability to specify the datapath for the offensive language strings

### DIFF
--- a/parlai/utils/safety.py
+++ b/parlai/utils/safety.py
@@ -44,6 +44,7 @@ class OffensiveLanguageClassifier:
             model='transformer/classifier',
             model_file='zoo:dialogue_safety/single_turn/model',
             print_scores=True,
+        )
         safety_opt = parser.parse_args([], print_args=False)
         return create_agent(safety_opt)
 

--- a/parlai/utils/safety.py
+++ b/parlai/utils/safety.py
@@ -44,7 +44,6 @@ class OffensiveLanguageClassifier:
             model='transformer/classifier',
             model_file='zoo:dialogue_safety/single_turn/model',
             print_scores=True,
-        )
         safety_opt = parser.parse_args([], print_args=False)
         return create_agent(safety_opt)
 
@@ -77,17 +76,14 @@ class OffensiveStringMatcher:
     https://github.com/LDNOOBW.
     """
 
-    def __init__(self):
+    def __init__(self, datapath: str = None):
         """
         Get data from external sources and build data representation.
         """
         import parlai.core.build_data as build_data
-        from parlai.core.params import ParlaiParser
         from parlai.core.dict import DictionaryAgent
 
         self.tokenize = DictionaryAgent.split_tokenize
-
-        parser = ParlaiParser(False, False)
 
         def _path():
             # Build the data if it doesn't exist.
@@ -114,7 +110,12 @@ class OffensiveStringMatcher:
                 # Mark the data as built.
                 build_data.mark_done(dpath, version)
 
-        self.datapath = os.path.join(parser.parlai_home, 'data')
+        if datapath is None:
+            from parlai.core.params import ParlaiParser
+            parser = ParlaiParser(False, False)
+            self.datapath = os.path.join(parser.parlai_home, 'data')
+        else:
+            self.datapath = datapath
         self.datafile = _path()
 
         # store a token trie: e.g.

--- a/parlai/utils/safety.py
+++ b/parlai/utils/safety.py
@@ -113,6 +113,7 @@ class OffensiveStringMatcher:
 
         if datapath is None:
             from parlai.core.params import ParlaiParser
+
             parser = ParlaiParser(False, False)
             self.datapath = os.path.join(parser.parlai_home, 'data')
         else:


### PR DESCRIPTION
**Patch description**
For an internal project, it was required to specify a different datapath. This syncs those changes.

**Testing steps**
```
λ python -m parlai.scripts.safe_interactive -mf /path/to/model
```

