### PR TITLE
Copy specific file extensions to the website.

### DIFF
--- a/website/postprocess_docs.py
+++ b/website/postprocess_docs.py
@@ -6,13 +6,13 @@
 
 import os
 
-NEEDLE3 = '<title>ParlAI Documentation &mdash; ParlAI  documentation</title>'
+NEEDLE3 = '&mdash; ParlAI  documentation</title>'
 REPLACEMENT3 = """
-<title>ParlAI Documentation &mdash; ParlAI  documentation</title>
+&mdash; ParlAI Documentation</title>
 <link rel="shortcut icon" type="image/png" href="/static/img/favicon-32x32.png" sizes="32x32"/>
 <link rel="shortcut icon" type="image/png" href="/static/img/favicon-16x16.png" sizes="16x16"/>
 <link rel="shortcut icon" type="image/png" href="/static/img/favicon-96x96.png" sizes="96x96"/>
-"""  # noqa: E501
+""".strip()  # noqa: E501
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Patch description**
Copy specific file extensions to the parl.ai static website. This will help us distribute some auxiliary files that we don't just host on git (like .html files).

**Testing steps**
Build website should pass, and then a few minutes after this merges, we should be able to see https://parl.ai/projects/wizard_of_wikipedia/parrot.png