### PR TITLE
Skip the extra model step on [DONE] or [EXIT].

### DIFF
--- a/parlai/agents/local_human/local_human.py
+++ b/parlai/agents/local_human/local_human.py
@@ -75,13 +75,12 @@ class LocalHumanAgent(Agent):
         reply['episode_done'] = False
         reply['label_candidates'] = self.fixedCands_txt
         if '[DONE]' in reply_text:
-            reply.force_set('episode_done', True)
-            self.episodeDone = True
-            reply_text = reply_text.replace('[DONE]', '')
+            # let interactive know we're resetting
+            raise StopIteration
         reply['text'] = reply_text
         if '[EXIT]' in reply_text:
             self.finished = True
-            return {'episode_done': True}
+            raise StopIteration
         return reply
 
     def episode_done(self):

--- a/parlai/agents/safe_local_human/safe_local_human.py
+++ b/parlai/agents/safe_local_human/safe_local_human.py
@@ -119,9 +119,7 @@ class SafeLocalHumanAgent(LocalHumanAgent):
 
         # check for episode done
         if '[DONE]' in reply_text or self.opt.get('single_turn', False):
-            reply.force_set('episode_done', True)
-            self.episodeDone = True
-            reply_text = reply_text.replace('[DONE]', '')
+            raise StopIteration
 
         # set reply text
         reply['text'] = reply_text
@@ -129,5 +127,6 @@ class SafeLocalHumanAgent(LocalHumanAgent):
         # check if finished
         if '[EXIT]' in reply_text:
             self.finished = True
+            raise StopIteration
 
         return reply

--- a/parlai/scripts/interactive.py
+++ b/parlai/scripts/interactive.py
@@ -76,13 +76,11 @@ def interactive(opt, print_parser=None):
     world = create_task(opt, [human_agent, agent])
 
     # Show some example dialogs:
-    while True:
+    while not world.epoch_done():
         world.parley()
         if opt.get('display_examples'):
             print("---")
             print(world.display())
-        if world.epoch_done():
-            break
 
 
 class Interactive(ParlaiScript):

--- a/parlai/tasks/blended_skill_talk/worlds.py
+++ b/parlai/tasks/blended_skill_talk/worlds.py
@@ -80,7 +80,8 @@ class InteractiveWorld(InteractiveBaseWorld):
         if self.display_partner_persona:
             partner_persona = self.p2.replace('your persona:', 'partner\'s persona:')
             print(f"Your partner was playing the following persona:\n{partner_persona}")
-        print("[ Preparing new chat ... ]\n")
+        if not self.epoch_done():
+            print("\n[ Preparing new chat ... ]\n")
 
 
 class SelfChatWorld(SelfChatBaseWorld):

--- a/parlai/tasks/convai2/worlds.py
+++ b/parlai/tasks/convai2/worlds.py
@@ -80,7 +80,8 @@ class InteractiveWorld(InteractiveBaseWorld):
         if self.display_partner_persona:
             partner_persona = self.p2.replace('your persona:', 'partner\'s persona:')
             print(f"Your partner was playing the following persona:\n{partner_persona}")
-        print("[ Preparing new chat ... ]\n")
+        if not self.epoch_done():
+            print("[ Preparing new chat ... ]\n")
 
     def share(self):
         shared_data = super().share()

--- a/parlai/tasks/interactive/worlds.py
+++ b/parlai/tasks/interactive/worlds.py
@@ -60,7 +60,13 @@ class InteractiveWorld(DialogPartnerWorld):
                 {'id': 'context', 'text': self.p1, 'episode_done': False}
             )
             agents[0].observe(validate(context_act))
-        act = deepcopy(agents[0].act())
+        try:
+            act = deepcopy(agents[0].act())
+        except StopIteration:
+            self.reset()
+            self.finalize_episode()
+            self.turn_cnt = 0
+            return
         acts[0] = act
         if self.turn_cnt == 0 and self.p2 != '':
             # add the context on to the first message to agent 1


### PR DESCRIPTION
**Patch description**
Cosmetic change, preventing the model from observing/acting when the user types [DONE] or [EXIT].

**Testing steps**
Manual testing with safe interactive and interactive.