### PR TITLE
Make BST worlds faster to clone

### DIFF
--- a/parlai/tasks/blended_skill_talk/worlds.py
+++ b/parlai/tasks/blended_skill_talk/worlds.py
@@ -12,7 +12,13 @@ from parlai.tasks.interactive.worlds import InteractiveWorld as InteractiveBaseW
 from parlai.tasks.self_chat.worlds import SelfChatWorld as SelfChatBaseWorld
 
 
-def load_personas(opt):
+def get_contexts_data(opt, shared=None):
+    if shared and 'contexts_data' in shared:
+        return shared['contexts_data']
+    return _load_personas(opt=opt)
+
+
+def _load_personas(opt):
     print('[ loading personas.. ]')
     if opt.get('include_personas', True):
         print(
@@ -75,7 +81,7 @@ class InteractiveWorld(InteractiveBaseWorld):
         self.display_partner_persona = self.opt['display_partner_persona']
 
     def init_contexts(self, shared=None):
-        self.contexts_data = load_personas(self.opt)
+        self.contexts_data = get_contexts_data(self.opt, shared=shared)
 
     def get_contexts(self):
         random.seed()
@@ -89,6 +95,11 @@ class InteractiveWorld(InteractiveBaseWorld):
             print(f"Your partner was playing the following persona:\n{partner_persona}")
         if not self.epoch_done():
             print("\n[ Preparing new chat ... ]\n")
+
+    def share(self):
+        shared_data = super().share()
+        shared_data['contexts_data'] = self.contexts_data
+        return shared_data
 
 
 class SelfChatWorld(SelfChatBaseWorld):
@@ -108,9 +119,14 @@ class SelfChatWorld(SelfChatBaseWorld):
         )
 
     def init_contexts(self, shared=None):
-        self.contexts_data = load_personas(self.opt)
+        self.contexts_data = get_contexts_data(self.opt, shared=shared)
 
     def get_contexts(self):
         random.seed()
         p = random.choice(self.contexts_data)
         return [p[0], p[1]]
+
+    def share(self):
+        shared_data = super().share()
+        shared_data['contexts_data'] = self.contexts_data
+        return shared_data


### PR DESCRIPTION
**Patch description**
Same motivation and type of change as #2562.

Currently, if you duplicate a BlendedSkillTalk world, it will go through the process of loading the personas from disk again. This change adds the personas to the shared dict so that they don't need to be reloaded.

**Testing steps**
```
spoff@devfair0294:~/ParlAI(bst-share)
λ python -m unittest -v tests.tasks.test_blended_skill_talk.TestBlendedSkillTalkInteractiveWorld
test_share (tests.tasks.test_blended_skill_talk.TestBlendedSkillTalkInteractiveWorld) ... [ optional arguments: ] 
[  display_ignore_fields: agent_reply ]
[  display_verbose: False ]
[  max_display_len: 1000 ]
[  num_examples: 10 ]
[ Main ParlAI Arguments: ] 
[  batchsize: 1 ]
[  datapath: /tmp/tmpa3cxx2q6 ]
[  datatype: train:ordered ]
[  download_path: /private/home/spoff/ParlAI/downloads ]
[  dynamic_batching: None ]
[  hide_labels: False ]
[  image_mode: raw ]
[  init_opt: None ]
[  multitask_weights: [1] ]
[  numthreads: 1 ]
[  show_advanced_args: False ]
[  task: blended_skill_talk ]
[ ParlAI Model Arguments: ] 
[  dict_class: None ]
[  init_model: None ]
[  model: None ]
[  model_file: None ]
[ ParlAI Image Preprocessing Arguments: ] 
[  image_cropsize: 224 ]
[  image_size: 256 ]
[ BST Interactive World: ] 
[  display_partner_persona: True ]
[  include_initial_utterances: False ]
[  include_personas: True ]
[ Current ParlAI commit: 1f1822153e2f32a107a21bae414d0b012ea15608 ]
[ Current internal commit: c70d856c0bb33f53c2d1b26ed5ad85331416d7ed ]
ok

----------------------------------------------------------------------
Ran 1 test in 0.039s

OK
```

