### PR TITLE
[TGA] Beam blacklist

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -73,7 +73,7 @@ class SearchBlacklist(object):
 
     def _add_literal(self, phrase_literal: str):
         if phrase_literal in self._phrases:
-            continue
+            return
         ngram = self.dict.txt2vec(phrase_literal)
         self._phrases.add(phrase_literal)
         logging.debug(f"Adding '{phrase_literal}' to the beam blacklist {ngram}")

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -971,15 +971,27 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         """
         phrases = set()
         for phrase in self._get_blocked_phrases():
+            phrase = phrase.strip()
+            if not phrase:
+                # paranoia
+                continue
             phrases.add(phrase)
+            phrases.add(phrase + "s")
             phrases.add(phrase.lower())
+            phrases.add(phrase.lower() + "s")
             phrases.add(phrase.upper())
+            phrases.add(phrase.upper() + "S")
             phrases.add(phrase.title())
+            phrases.add(phrase.title() + "S")
+            phrases.add(phrase[0].upper() + phrase[1:])
+            phrases.add(phrase[0].upper() + phrase[1:] + "s")
+            phrases.add(phrase[0].upper() + phrase[1:].lower())
+            phrases.add(phrase[0].upper() + phrase[1:].lower() + "s")
 
         ngrams_blacklist = []
         for phrase in phrases:
             ngram = self.dict.txt2vec(phrase)
-            logging.info(f"Adding '{phrase}' to the blacklist {ngram}")
+            logging.debug(f"Adding '{phrase}' to the beam blacklist {ngram}")
             ngrams_blacklist.append(ngram)
 
         return ngrams_blacklist

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -72,6 +72,8 @@ class SearchBlacklist(object):
         self._phrase_ngrams = {}
 
     def _add_literal(self, phrase_literal: str):
+        if phrase_literal in self._phrases:
+            continue
         ngram = self.dict.txt2vec(phrase_literal)
         self._phrases.add(phrase_literal)
         logging.debug(f"Adding '{phrase_literal}' to the beam blacklist {ngram}")

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -351,6 +351,24 @@ class TestTransformerGenerator(unittest.TestCase):
                     skip_generation=False,
                 )
             )
+
+            with open(os.path.join(tmpdir, 'blacklist.txt'), 'w') as f:
+                f.write("38\n62\n")
+
+            valid_beam_block3, _ = testing_utils.eval_model(
+                dict(
+                    task='integration_tests:repeat_words',
+                    model_file=mf,
+                    dict_file=df,
+                    batch_size=1,
+                    inference='beam',
+                    beam_size=5,
+                    beam_blacklist_filename=os.path.join(tmpdir, 'blacklist.txt'),
+                    skip_generation=False,
+                ),
+                skip_test=True,
+            )
+
         self.assertLessEqual(valid['ppl'], 1.30)
         self.assertGreaterEqual(valid['f1'], 0.80)
         self.assertGreaterEqual(valid['bleu-4'], 0.5)
@@ -369,6 +387,10 @@ class TestTransformerGenerator(unittest.TestCase):
         self.assertLessEqual(valid_beam_block2['bleu-4'], 1e-6)
         self.assertLessEqual(test_beam_block2['f1'], 0.6)
         self.assertLessEqual(test_beam_block2['bleu-4'], 1e-6)
+
+        # Beam Block blacklist
+        self.assertLess(valid_beam_block3['bleu-4'], valid['bleu-4'])
+        self.assertLess(valid_beam_block3['f1'], valid['f1'])
 
     @testing_utils.retry(ntries=3)
     def test_beamsearch_contextblocking(self):


### PR DESCRIPTION
**Patch description**
Add the ability to hard-blacklist ngrams in the beam search. Adds a new optional argument that points to a filename. If specified, the filename is expected to be a text file, with one phrase per line. The system tokenizes the strings, so no need to pre-convert to tokens.

**Testing steps**
Manual testing. New test in CI.