### PR TITLE
Added --host and --port parameter to client.py and interactive_web.py

### DIFF
--- a/parlai/chat_service/services/browser_chat/client.py
+++ b/parlai/chat_service/services/browser_chat/client.py
@@ -132,7 +132,7 @@ def on_close(ws):
 def _run_browser():
     host = opt.get('host', 'localhost')
     serving_port = opt.get('serving_port', 8080)
-    
+
     httpd = HTTPServer((host, serving_port), BrowserHandler)
 
     print('Please connect to the link: http://{}:{}/'.format(host, serving_port))
@@ -163,12 +163,18 @@ def setup_args():
         '--port', default=35496, type=int, help='Port used by the web socket (run.py)'
     )
     parser_grp.add_argument(
-        '--host', default='localhost', type=str, help='Host from which allow requests, use 0.0.0.0 to allow all IPs'
+        '--host',
+        default='localhost',
+        type=str,
+        help='Host from which allow requests, use 0.0.0.0 to allow all IPs',
     )
     parser_grp.add_argument(
-        '--serving_port', default=8080, type=int, help='Port used to configure the server'
+        '--serving_port',
+        default=8080,
+        type=int,
+        help='Port used to configure the server',
     )
-    
+
     return parser.parse_args()
 
 

--- a/parlai/chat_service/services/browser_chat/client.py
+++ b/parlai/chat_service/services/browser_chat/client.py
@@ -130,9 +130,12 @@ def on_close(ws):
 
 
 def _run_browser():
-    httpd = HTTPServer(('localhost', 8080), BrowserHandler)
+    host = opt.get('host', 'localhost')
+    serving_port = opt.get('serving_port', 8080)
+    
+    httpd = HTTPServer((host, serving_port), BrowserHandler)
 
-    print('Please connect to the link: http://{}:{}/'.format('localhost', 8080))
+    print('Please connect to the link: http://{}:{}/'.format(host, serving_port))
 
     SHARED['wb'] = httpd
 
@@ -157,8 +160,15 @@ def setup_args():
     parser = ParlaiParser(False, False)
     parser_grp = parser.add_argument_group('Browser Chat')
     parser_grp.add_argument(
-        '--port', default=35496, type=int, help='Port to run the browser chat server'
+        '--port', default=35496, type=int, help='Port used by the web socket (run.py)'
     )
+    parser_grp.add_argument(
+        '--host', default='localhost', type=str, help='Host from which allow requests, use 0.0.0.0 to allow all IPs'
+    )
+    parser_grp.add_argument(
+        '--serving_port', default=8080, type=int, help='Port used to configure the server'
+    )
+    
     return parser.parse_args()
 
 

--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -18,6 +18,7 @@ import json
 
 HOST_NAME = 'localhost'
 PORT = 8080
+
 SHARED: Dict[Any, Any] = {}
 STYLE_SHEET = "https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.4/css/bulma.css"
 FONT_AWESOME = "https://use.fontawesome.com/releases/v5.3.1/js/all.js"
@@ -231,6 +232,10 @@ def setup_interactive(shared):
     """
     parser = setup_args()
     parser.add_argument('--port', type=int, default=PORT, help='Port to listen on.')
+    parser.add_argument(
+        '--host', default=HOST_NAME, type=str, help='Host from which allow requests, use 0.0.0.0 to allow all IPs'
+    )
+   
     SHARED['opt'] = parser.parse_args(print_args=False)
 
     SHARED['opt']['task'] = 'parlai.agents.local_human.local_human:LocalHumanAgent'
@@ -249,8 +254,8 @@ def setup_interactive(shared):
 if __name__ == '__main__':
     opt = setup_interactive(SHARED)
     MyHandler.protocol_version = 'HTTP/1.0'
-    httpd = HTTPServer((HOST_NAME, opt['port']), MyHandler)
-    print('http://{}:{}/'.format(HOST_NAME, opt['port']))
+    httpd = HTTPServer((opt['host'], opt['port']), MyHandler)
+    print('http://{}:{}/'.format(opt['host'], opt['port']))
 
     try:
         httpd.serve_forever()

--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -233,9 +233,12 @@ def setup_interactive(shared):
     parser = setup_args()
     parser.add_argument('--port', type=int, default=PORT, help='Port to listen on.')
     parser.add_argument(
-        '--host', default=HOST_NAME, type=str, help='Host from which allow requests, use 0.0.0.0 to allow all IPs'
+        '--host',
+        default=HOST_NAME,
+        type=str,
+        help='Host from which allow requests, use 0.0.0.0 to allow all IPs',
     )
-   
+
     SHARED['opt'] = parser.parse_args(print_args=False)
 
     SHARED['opt']['task'] = 'parlai.agents.local_human.local_human:LocalHumanAgent'


### PR DESCRIPTION
**Patch description**
The files client.py and interactive_web.py by default are just handling requests by localhost and port 8080, I added two new parameters: --host to both and --serving_port to client.py, if --host is 0.0.0.0 then the server will run allowing all incoming IPs, the defaults for both parameters are 'localhost' and 8080 respectively, if they're not specified then the behavior will be the same as before.

**Usage:**
python ~/ParlAI/parlai/chat_service/services/browser_chat/client.py --port 8080 --host 0.0.0.0 --serving_port 80

python ~/ParlAI/parlai/scripts/interactive_web.py -t skill -mf modelfile --host 0.0.0.0 --port 80

**Example log**
In this example the server will now allow any IP from the internet and will be listening in port 80
```
~/ParlAI/parlai/chat_service/services/browser_chat$ sudo python3 client.py --port 8081 --serving_port 80 --host 0.0.0.0
[ Browser Chat: ] 
[  host: 0.0.0.0 ]
[  port: 8081 ]
[  serving_port: 80 ]
[ Current ParlAI commit: 066f02d17dc71855733594b6643ea7a8a6b58efb ]
Connecting to port:  8081
Please connect to the link: http://0.0.0.0:80/
```
