### PR TITLE
Use AWS versions of cached EDPersonaTopicifierTeacher data

### DIFF
--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -150,7 +150,7 @@ class EDPersonaTopicifierTeacher(EmpatheticDialoguesTeacher):
             '--recompile-persona-topic-data',
             type='bool',
             default=cls.RECOMPILE_DEFAULT,
-            help='Re-compile data with ConvAI2 personas and WoW topics added',
+            help='Re-compile data with ConvAI2 personas and WoW topics added. Only useful for demonstrating how data was produced.',
         )
 
     def __init__(self, opt, shared=None):
@@ -166,8 +166,8 @@ class EDPersonaTopicifierTeacher(EmpatheticDialoguesTeacher):
             or self.opt.get('prepend', -1) > 0
         ):
             raise NotImplementedError(
-                'Using remove-political-convos, deepmoji, fasttextloc, or prepend not '
-                'supported with this teacher.'
+                'Removing political conversations or using deepmoji, fasttextloc, or '
+                'prepend not supported with this teacher.'
             )
 
         # Running over all examples is really slow because the process of finding a WoW

--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -30,18 +30,30 @@ from .build import build
 ##################################################
 
 
-def raw_data_path(opt):
+def raw_data_path(opt: Opt) -> str:
     # Build the data if it doesn't exist.
     build(opt)
     dt = opt['datatype'].split(':')[0]
     return os.path.join(opt['datapath'], 'blended_skill_talk', dt + '.json')
 
 
-def _processed_data_path(opt):
+def _processed_data_path(opt: Opt) -> str:
     # Build the data if it doesn't exist.
     build(opt)
     dt = opt['datatype'].split(':')[0]
     return os.path.join(opt['datapath'], 'blended_skill_talk', dt + '.txt')
+
+
+def _cached_data_path(opt: Opt, experiencer_side_only: bool) -> str:
+    # Build the data if it doesn't exist.
+    build(opt)
+    dt = opt['datatype'].split(':')[0]
+    side_string = 'experiencer_only' if experiencer_side_only else 'both_sides'
+    return os.path.join(
+        opt['datapath'],
+        'blended_skill_talk',
+        f'ed_persona_topicifier__{dt}__{side_string}.json',
+    )
 
 
 class BlendedSkillTalkTeacher(ParlAIDialogTeacher):
@@ -128,6 +140,16 @@ class EDPersonaTopicifierTeacher(EmpatheticDialoguesTeacher):
     Adds persona and WoW topic to ED context strings.
     """
 
+    @classmethod
+    def add_cmdline_args(cls, argparser):
+        agent = argparser.add_argument_group('EDPersonaTopicifierTeacher arguments')
+        agent.add_argument(
+            '--recompile-persona-topic-data',
+            type='bool',
+            default=False,
+            help='Re-compile data with ConvAI2 personas and WoW topics added',
+        )
+
     def __init__(self, opt, shared=None):
         self.persona_topicifier = PersonaTopicifier(
             opt=opt, should_have_personas=False, should_have_topics=False
@@ -146,26 +168,26 @@ class EDPersonaTopicifierTeacher(EmpatheticDialoguesTeacher):
             )
 
         # Running over all examples is really slow because the process of finding a WoW
-        # topic is expensive, so let's cache data with personas and topics
-        side_string = 'experiencer_only' if self.experiencer_side_only else 'both_sides'
-        self.cached_data_path = os.path.join(
-            self.opt['datapath'],
-            'empatheticdialogues',
-            'persona_topicifier',
-            f'{self.datatype.split(":")[0]}__{side_string}.json',
-        )
-        os.makedirs(os.path.dirname(self.cached_data_path), exist_ok=True)
-        if not os.path.isfile(self.cached_data_path):
-            warn_once(
-                f'Cached data file at {self.cached_data_path} not found! Creating...'
+        # topic is expensive, so let's load cached data with personas and topics unless
+        # --recompile-persona-topic-data is True
+        if opt['recompile_persona_topic_data']:
+            self.data_path = (
+                _cached_data_path(
+                    opt=self.opt, experiencer_side_only=self.experiencer_side_only
+                )
+                + '.recompiled'
             )
+            warn_once(f'Compiling data file for {self.data_path}.')
             self.persona_topic_data = self._compile_data()
-            warn_once(f'Saving data to {self.cached_data_path}.')
-            with open(self.cached_data_path, 'w') as f_write:
+            warn_once(f'Saving data to {self.data_path}.')
+            with open(self.data_path, 'w') as f_write:
                 json.dump(self.persona_topic_data, f_write)
         else:
-            warn_once(f'Loading cached data from {self.cached_data_path}.')
-            with open(self.cached_data_path, 'r') as f_read:
+            self.data_path = _cached_data_path(
+                opt=self.opt, experiencer_side_only=self.experiencer_side_only
+            )
+            warn_once(f'Loading cached data from {self.data_path}.')
+            with open(self.data_path, 'r') as f_read:
                 self.persona_topic_data = json.load(f_read)
 
     def _compile_data(self) -> List[List[dict]]:

--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -142,6 +142,7 @@ class EDPersonaTopicifierTeacher(EmpatheticDialoguesTeacher):
 
     @classmethod
     def add_cmdline_args(cls, argparser):
+        EmpatheticDialoguesTeacher.add_cmdline_args(argparser)
         agent = argparser.add_argument_group('EDPersonaTopicifierTeacher arguments')
         agent.add_argument(
             '--recompile-persona-topic-data',

--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -135,13 +135,14 @@ class EDPersonaTopicifierTeacher(EmpatheticDialoguesTeacher):
         super().__init__(opt, shared=shared)
 
         if (
-            self.opt.get('deepmoji') is not None
+            self.remove_political_convos is True
+            or self.opt.get('deepmoji') is not None
             or self.opt.get('fasttextloc') is not None
             or self.opt.get('prepend', -1) > 0
         ):
             raise NotImplementedError(
-                'Using deepmoji, fasttextloc, or prepend not supported with this '
-                'teacher.'
+                'Using remove-political-convos, deepmoji, fasttextloc, or prepend not '
+                'supported with this teacher.'
             )
 
         # Running over all examples is really slow because the process of finding a WoW

--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -140,6 +140,8 @@ class EDPersonaTopicifierTeacher(EmpatheticDialoguesTeacher):
     Adds persona and WoW topic to ED context strings.
     """
 
+    RECOMPILE_DEFAULT = False
+
     @classmethod
     def add_cmdline_args(cls, argparser):
         EmpatheticDialoguesTeacher.add_cmdline_args(argparser)
@@ -147,7 +149,7 @@ class EDPersonaTopicifierTeacher(EmpatheticDialoguesTeacher):
         agent.add_argument(
             '--recompile-persona-topic-data',
             type='bool',
-            default=False,
+            default=cls.RECOMPILE_DEFAULT,
             help='Re-compile data with ConvAI2 personas and WoW topics added',
         )
 
@@ -171,7 +173,7 @@ class EDPersonaTopicifierTeacher(EmpatheticDialoguesTeacher):
         # Running over all examples is really slow because the process of finding a WoW
         # topic is expensive, so let's load cached data with personas and topics unless
         # --recompile-persona-topic-data is True
-        if opt['recompile_persona_topic_data']:
+        if opt.get('recompile_persona_topic_data', self.RECOMPILE_DEFAULT):
             self.data_path = (
                 _cached_data_path(
                     opt=self.opt, experiencer_side_only=self.experiencer_side_only

--- a/parlai/tasks/blended_skill_talk/build.py
+++ b/parlai/tasks/blended_skill_talk/build.py
@@ -29,12 +29,36 @@ RESOURCES = [
         '47cdb6cbee0516ca7400be35fa07761339b86c6c026425bf5dba00e5534e8182',
         zipped=False,
     ),
+    build_data.DownloadableFile(
+        'http://parl.ai/downloads/blended_skill_talk/ed_persona_topicifier__train__both_sides.json',
+        'ed_persona_topicifier__train__both_sides.json',
+        'fooooo',
+        zipped=False,
+    ),
+    build_data.DownloadableFile(
+        'http://parl.ai/downloads/blended_skill_talk/ed_persona_topicifier__train__experiencer_only.json',
+        'ed_persona_topicifier__train__experiencer_only.json',
+        'fooooo',
+        zipped=False,
+    ),
+    build_data.DownloadableFile(
+        'http://parl.ai/downloads/blended_skill_talk/ed_persona_topicifier__valid__experiencer_only.json',
+        'ed_persona_topicifier__valid__experiencer_only.json',
+        'foooo',
+        zipped=False,
+    ),
+    build_data.DownloadableFile(
+        'http://parl.ai/downloads/blended_skill_talk/ed_persona_topicifier__test__experiencer_only.json',
+        'ed_persona_topicifier__test__experiencer_only.json',
+        'fooooo',
+        zipped=False,
+    ),
 ]
 
 
 def build(opt):
     dpath = os.path.join(opt['datapath'], 'blended_skill_talk')
-    version = 'v1.2'
+    version = 'v1.3'
 
     if not build_data.built(dpath, version_string=version):
         print('[building data: ' + dpath + ']')

--- a/parlai/tasks/blended_skill_talk/build.py
+++ b/parlai/tasks/blended_skill_talk/build.py
@@ -32,25 +32,25 @@ RESOURCES = [
     build_data.DownloadableFile(
         'http://parl.ai/downloads/blended_skill_talk/ed_persona_topicifier__train__both_sides.json',
         'ed_persona_topicifier__train__both_sides.json',
-        'fooooo',
+        'ff2ea7c5fcb0449890d57a629cc3e8794ab95ac6db1057bf58d540c2b576e4cc',
         zipped=False,
     ),
     build_data.DownloadableFile(
         'http://parl.ai/downloads/blended_skill_talk/ed_persona_topicifier__train__experiencer_only.json',
         'ed_persona_topicifier__train__experiencer_only.json',
-        'fooooo',
+        '751f0ba2f421a11eee2bfc896d60ab70d669093c3a5f6cb30e8d202133a90ec7',
         zipped=False,
     ),
     build_data.DownloadableFile(
         'http://parl.ai/downloads/blended_skill_talk/ed_persona_topicifier__valid__experiencer_only.json',
         'ed_persona_topicifier__valid__experiencer_only.json',
-        'foooo',
+        '15d5412f5990a8a9c892305009d8597a737322aafe878b03ec71143703b25ba0',
         zipped=False,
     ),
     build_data.DownloadableFile(
         'http://parl.ai/downloads/blended_skill_talk/ed_persona_topicifier__test__experiencer_only.json',
         'ed_persona_topicifier__test__experiencer_only.json',
-        'fooooo',
+        '2604e977787be0b5edc54561f7ce8a54c40758d235a3fee262fe20fe36b8cd15',
         zipped=False,
     ),
 ]

--- a/tests/tasks/test_blended_skill_talk.py
+++ b/tests/tasks/test_blended_skill_talk.py
@@ -196,12 +196,10 @@ class TestBlendedSkillTalkTeacher(unittest.TestCase):
 
 class TestPersonaTopicifierTeachers(unittest.TestCase):
     """
-    Test two PersonaTopicifier teachers.
+    Test PersonaTopicifier teachers.
 
-    Check the contents of the first example of two teachers in which ConvAI2 personas
-    and WoW topics are added to contexts. We don't check
-    blended_skill_talk:EDPersonaTopicifier because, the first time that is run, it
-    requires a caching step that takes roughly an hour.
+    Check the contents of the first example of teachers in which ConvAI2 personas and
+    WoW topics are added to contexts.
     """
 
     def test_check_examples(self):
@@ -238,6 +236,22 @@ class TestPersonaTopicifierTeachers(unittest.TestCase):
                         'editing photos takesa lot of work .',
                         'you must be very fast . hunting is one of my favorite hobbies .',
                     ),
+                    'episode_done': False,
+                },
+            ),
+            (
+                "blended_skill_talk:EDPersonaTopicifier",
+                {
+                    'situation': 'I remember going to the fireworks with my best friend. There was a lot of people, but it only felt like us in the world.',
+                    'emotion': 'sentimental',
+                    'prepend_ctx': None,
+                    'prepend_cand': None,
+                    'deepmoji_ctx': None,
+                    'deepmoji_cand': None,
+                    'text': 'your persona: people hate that i obsess about the poor.\nyour persona: i like to make cellphone apps that would help heal our world.\nyour persona: i like to watch people pray together.\nyour persona: people don t like me too much but i like them anyways.\nAndroid (operating system)#Applications\nI remember going to see the fireworks with my best friend. It was the first time we ever spent time alone together. Although there was a lot of people, we felt like the only people in the world.',
+                    'labels': [
+                        'Was this a friend you were in love with, or just a best friend?'
+                    ],
                     'episode_done': False,
                 },
             ),
@@ -281,9 +295,7 @@ class TestPersonaTopicifierTeachers(unittest.TestCase):
 
 class TestBlendedSkillTalkInteractiveWorld(unittest.TestCase):
     @patch("parlai.tasks.blended_skill_talk.worlds._load_personas")
-    def test_share(
-        self, mock_load_personas,
-    ):
+    def test_share(self, mock_load_personas):
         test_personas = ['your persona:I live on a pirate\'s shoulder']
         with testing_utils.tempdir() as data_path:
             mock_load_personas.return_value = test_personas


### PR DESCRIPTION
**Patch description**
Use versions of cached EDPersonaTopicifierTeacher datafiles from AWS instead of having to compute and cache the datafile the first time that EDPersonaTopicifierTeacher is used, which takes ~45 min for the train set. Still allow the option of re-compiling the datafile with `--recompile-persona-topic-data True`.

**Testing steps**
- `python tests/tasks/test_blended_skill_talk.py` (EDPersonaTopicifierTeacher test added because it can now run quickly due to these cached files)
- Testing that all files are loaded correctly with `display_data.py`
- Checking that `display_data.py` output is the same for the test set with and without `--recompile-persona-topic-data True`
```
(py37) ems@devfair0229:~/GitHub/facebookresearch/ParlAI$ python tests/datatests/test_new_tasks.py
.
----------------------------------------------------------------------
Ran 1 test in 599.938s

OK
```
