### PR TITLE
Restore steamrollered colors, via style choice

### DIFF
--- a/parlai/scripts/detect_offensive_language.py
+++ b/parlai/scripts/detect_offensive_language.py
@@ -110,8 +110,8 @@ def detect(opt, printargs=None, print_parser=None):
         world.parley()
         stats['bad_words'] = []
         for a in world.acts:
-            text = a.get('text', '')
-            classify(text, stats)
+            #text = a.get('text', '')
+            #classify(text, stats)
             labels = a.get('labels', a.get('eval_labels', ''))
             for l in labels:
                 classify(l, stats)

--- a/parlai/scripts/detect_offensive_language.py
+++ b/parlai/scripts/detect_offensive_language.py
@@ -110,8 +110,8 @@ def detect(opt, printargs=None, print_parser=None):
         world.parley()
         stats['bad_words'] = []
         for a in world.acts:
-            #text = a.get('text', '')
-            #classify(text, stats)
+            text = a.get('text', '')
+            classify(text, stats)
             labels = a.get('labels', a.get('eval_labels', ''))
             for l in labels:
                 classify(l, stats)

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -79,12 +79,32 @@ def colorize(text, style):
 
     if colorstyle is None or colorstyle.lower() == 'steamroller':
         BLUE = '\033[1;94m'
-        BOLD_LIGHT_GRAY = '\033[1m'
-        LIGHT_GRAY = '\033[0m'
+        BOLD_LIGHT_GRAY_NOBK = '\033[1m'
+        LIGHT_GRAY_NOBK = '\033[0m'
         MAGENTA = '\033[0;95m'
-        HIGHLIGHT_RED = '\033[1;31m'
-        HIGHLIGHT_BLUE = '\033[0;34m'
+        HIGHLIGHT_RED_NOBK = '\033[1;31m'
+        HIGHLIGHT_BLUE_NOBK = '\033[0;34m'
         RESET = '\033[0;0m'
+        if style == 'highlight':
+            return HIGHLIGHT_RED_NOBK + text + RESET
+        if style == 'highlight2':
+            return HIGHLIGHT_BLUE_NOBK + text + RESET
+        elif style == 'text':
+            return LIGHT_GRAY_NOBK + text + RESET
+        elif style == 'bold_text':
+            return BOLD_LIGHT_GRAY_NOBK + text + RESET
+        elif style == 'labels' or style == 'eval_labels':
+            return BLUE + text + RESET
+        elif style == 'label_candidates':
+            return LIGHT_GRAY_NOBK + text + RESET
+        elif style == 'id':
+            return LIGHT_GRAY_NOBK + text + RESET
+        elif style == 'text2':
+            return MAGENTA + text + RESET
+        elif style == 'field':
+            return HIGHLIGHT_BLUE_NOBK + text + RESET
+        else:
+            return MAGENTA + text + RESET
 
     if colorstyle.lower() == 'spermwhale':
         BLUE = '\033[1;94m'
@@ -94,24 +114,26 @@ def colorize(text, style):
         HIGHLIGHT_RED = '\033[1;37;41m'
         HIGHLIGHT_BLUE = '\033[1;37;44m'
         RESET = '\033[0;0m'
+        if style == 'highlight':
+            return HIGHLIGHT_RED + text + RESET
+        if style == 'highlight2':
+            return HIGHLIGHT_BLUE + text + RESET
+        elif style == 'text':
+            return LIGHT_GRAY + text + RESET
+        elif style == 'bold_text':
+            return BOLD_LIGHT_GRAY + text + RESET
+        elif style == 'labels' or style == 'eval_labels':
+            return BLUE + text + RESET
+        elif style == 'label_candidates':
+            return LIGHT_GRAY + text + RESET
+        elif style == 'id':
+            return LIGHT_GRAY + text + RESET
+        elif style == 'text2':
+            return MAGENTA + text + RESET
+        elif style == 'field':
+            return HIGHLIGHT_BLUE + text + RESET
+        else:
+            return MAGENTA + text + RESET
 
-    if style == 'highlight':
-        return HIGHLIGHT_RED + text + RESET
-    if style == 'highlight2':
-        return HIGHLIGHT_BLUE + text + RESET
-    elif style == 'text':
-        return LIGHT_GRAY + text + RESET
-    elif style == 'bold_text':
-        return BOLD_LIGHT_GRAY + text + RESET
-    elif style == 'labels' or style == 'eval_labels':
-        return BLUE + text + RESET
-    elif style == 'label_candidates':
-        return LIGHT_GRAY + text + RESET
-    elif style == 'id':
-        return LIGHT_GRAY + text + RESET
-    elif style == 'text2':
-        return MAGENTA + text + RESET
-    elif style == 'field':
-        return HIGHLIGHT_BLUE + text + RESET
-    else:
-        return MAGENTA + text + RESET
+    # No colorstyle specified/found.
+    return text

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -6,6 +6,7 @@
 """
 Utility functions and classes for handling text strings.
 """
+import os
 import sys as _sys
 
 
@@ -70,15 +71,30 @@ def colorize(text, style):
         USE_COLORS = True
     except NameError:
         USE_COLORS = _sys.stdout.isatty()
-    BLUE = '\033[1;94m'
-    BOLD_LIGHT_GRAY = '\033[1m'
-    LIGHT_GRAY = '\033[0m'
-    MAGENTA = '\033[0;95m'
-    HIGHLIGHT_RED = '\033[1;31m'
-    HIGHLIGHT_BLUE = '\033[0;34m'
-    RESET = '\033[0;0m'
+
     if not USE_COLORS:
         return text
+    
+    colorstyle = os.environ.get('PARLAI_COLORSTYLE')
+
+    if colorstyle == None or colorstyle.lower() == 'steamroller':
+        BLUE = '\033[1;94m'
+        BOLD_LIGHT_GRAY = '\033[1m'
+        LIGHT_GRAY = '\033[0m'
+        MAGENTA = '\033[0;95m'
+        HIGHLIGHT_RED = '\033[1;31m'
+        HIGHLIGHT_BLUE = '\033[0;34m'
+        RESET = '\033[0;0m'
+
+    if colorstyle.lower() == 'spermwhale':
+        BLUE = '\033[1;94m'
+        BOLD_LIGHT_GRAY = '\033[1;37;40m'
+        LIGHT_GRAY = '\033[0;37;40m'
+        MAGENTA = '\033[0;95m'
+        HIGHLIGHT_RED = '\033[1;37;41m'
+        HIGHLIGHT_BLUE = '\033[1;37;44m'
+        RESET = '\033[0;0m'
+
     if style == 'highlight':
         return HIGHLIGHT_RED + text + RESET
     if style == 'highlight2':

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -74,7 +74,7 @@ def colorize(text, style):
 
     if not USE_COLORS:
         return text
-    
+
     colorstyle = os.environ.get('PARLAI_COLORSTYLE')
 
     if colorstyle == None or colorstyle.lower() == 'steamroller':

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -77,7 +77,7 @@ def colorize(text, style):
 
     colorstyle = os.environ.get('PARLAI_COLORSTYLE')
 
-    if colorstyle == None or colorstyle.lower() == 'steamroller':
+    if colorstyle is None or colorstyle.lower() == 'steamroller':
         BLUE = '\033[1;94m'
         BOLD_LIGHT_GRAY = '\033[1m'
         LIGHT_GRAY = '\033[0m'


### PR DESCRIPTION
Color choices I wrote were steamrollered in this PR: https://github.com/facebookresearch/ParlAI/pull/2570/files

So that I can get back the colors I like, I added:
export PARLAI_COLORSTYLE="spermwhale" to get my choices, defaults to Steamroller choices.
Each of us can add their own in there too...