### PR TITLE
Remove value error in HuggingFace BPE Tokenizer to work with dict.lower

### DIFF
--- a/parlai/utils/bpe.py
+++ b/parlai/utils/bpe.py
@@ -706,6 +706,8 @@ class HuggingFaceBpeHelper(BPEHelper):
                 'Please install HuggingFace tokenizer with: pip install tokenizers'
             )
 
+        if self.lower:
+            warn_once('Are you sure you want to lower case your BPE dictionary?')
         if self.maxtokens > 0 or self.minfreq > 0:
             raise ValueError(
                 'You should not filter vocabulary with using --dict-tokenizer bytelevelbpe'

--- a/parlai/utils/bpe.py
+++ b/parlai/utils/bpe.py
@@ -706,10 +706,6 @@ class HuggingFaceBpeHelper(BPEHelper):
                 'Please install HuggingFace tokenizer with: pip install tokenizers'
             )
 
-        if self.lower:
-            raise ValueError(
-                'Only use --dict-lower false with --dict-tokenizer bytelevelbpe'
-            )
         if self.maxtokens > 0 or self.minfreq > 0:
             raise ValueError(
                 'You should not filter vocabulary with using --dict-tokenizer bytelevelbpe'


### PR DESCRIPTION
**Patch description**
The Hugging face bpe tokenizer works with dict.lower. The `ValueError` here should be removed. 
1. The ParlAI hugging face bpe tokenizer will just load and sync its dict with the saved hugging face bpe files. Dict.lower will not create any issue in this case.
2. Based on testing with some models we have already.  
