### PR TITLE
Label to text teacher

### DIFF
--- a/parlai/tasks/wrapper/README.md
+++ b/parlai/tasks/wrapper/README.md
@@ -1,0 +1,2 @@
+Teachers that wrap around other teachers.
+- `LabelToTextTeacher`: teacher that will shift the label of a message into the message's text field for the specified task

--- a/parlai/tasks/wrapper/agents.py
+++ b/parlai/tasks/wrapper/agents.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """
-Generalized and miscellaneous teachers.
+Teachers that wrap around other ones.
 """
 
 import copy

--- a/parlai/tasks/wrapper/agents.py
+++ b/parlai/tasks/wrapper/agents.py
@@ -4,7 +4,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """
-Teachers that wrap around other ones.
+Teachers that wrap around other teachers, for instance, to modify message fields while
+keeping the examples/episodes the same.
+
+This is useful when working with agents that expect examples to be in a certain format,
+for instance a classifier that classifies the "text" field of a message. The meta-
+teachers in this module can be used to avoid writing several different nearly identical
+variants of different teachers: for instance, if you want to flatten examples and strip
+away all but the previous utterance in the 'text' field for several different teachers,
+it would be much easier to do so with one teacher in this module than with a brand new
+teacher for each of the original teachers.
 """
 
 import copy
@@ -54,6 +63,8 @@ class LabelToTextTeacher(Teacher):
 
     def num_episodes(self):
         """
+        Return the number of episodes.
+
         Because the dataset is flattened, there will be one episode per example.
         """
         return self.task.num_examples()

--- a/parlai/utils/teachers.py
+++ b/parlai/utils/teachers.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Generalized and miscellaneous teachers.
+"""
+
+import copy
+import random
+from typing import List
+
+from parlai.core.agents import Agent, create_agent_from_shared
+from parlai.core.metrics import aggregate_named_reports
+from parlai.core.opt import Opt
+from parlai.core.teachers import create_task_agent_from_taskname, Teacher
+
+
+class LabelToTextTeacher(Teacher):
+    """
+    Teacher that will shift message['labels'][0] into message['text'] for whatever task
+    is specified with --label-to-text-task.
+    """
+
+    @classmethod
+    def add_cmdline_args(cls, argparser):
+        # Teacher has no args, and so we don't add them
+        parser = argparser.add_argument_group('LabelToText args')
+        parser.add_argument(
+            '-l2t-task' '--label-to-text-task',
+            type=str,
+            help='The task whose labels will get shifted into the text field',
+        )
+
+    def __init__(self, opt: Opt, shared=None):
+        if ',' in opt['task']:
+            raise ValueError('LabelToTextTeacher cannot be used with multiple tasks!')
+        self.id = opt['task']
+        if shared and 'task' in shared:
+            # TODO: revise from here
+            self.task = create_agent_from_shared(shared['task'])
+        else:
+            tasks = opt['task'].split(',')
+            for k in tasks:
+                k = k.strip()
+                if k:
+                    opt_singletask = copy.deepcopy(opt)
+                    opt_singletask['task'] = k
+                    self.tasks = create_task_agent_from_taskname(opt_singletask)
+        self.task_idx = -1
+        self.new_task = True
+        self.random = opt.get('datatype') == 'train'
+        # Make multi-task task probabilities.
+        self.cum_task_weights = [1] * len(self.tasks)
+        self.task_choices = range(len(self.tasks))
+        weights = self.opt.get('multitask_weights', [1])
+        sum = 0
+        for i in self.task_choices:
+            if len(weights) > i:
+                weight = weights[i]
+            else:
+                weight = 1
+            self.cum_task_weights[i] = weight + sum
+            sum += weight
+
+    def num_examples(self):
+        """
+        Return the number of examples.
+        """
+        if not hasattr(self, 'num_exs'):
+            # num_examples is sum of all examples in all tasks
+            tasks_num_exs = [t.num_examples() for t in self.tasks]
+            if any(num is None for num in tasks_num_exs):
+                self.num_exs = None
+            else:
+                self.num_exs = sum(tasks_num_exs)
+        return self.num_exs
+
+    def num_episodes(self):
+        """
+        Return the number of episodes.
+        """
+        if not hasattr(self, 'num_eps'):
+            # num_episodes is sum of all num_episodes in all tasks
+            tasks_num_eps = [t.num_episodes() for t in self.tasks]
+            if any(num is None for num in tasks_num_eps):
+                self.num_eps = None
+            else:
+                self.num_eps = sum(tasks_num_eps)
+        return self.num_eps
+
+    def observe(self, observation):
+        """
+        Make an observation.
+        """
+        return self.tasks[self.task_idx].observe(observation)
+
+    def act(self):
+        """
+        Act on the previous observation.
+        """
+        if self.new_task:
+            self.new_task = False
+            if self.random:
+                # select random teacher
+                self.task_idx = random.choices(
+                    self.task_choices, cum_weights=self.cum_task_weights
+                )[0]
+            else:
+                # do at most one full loop looking for unfinished task
+                for _ in range(len(self.tasks)):
+                    self.task_idx = (self.task_idx + 1) % len(self.tasks)
+                    if not self.tasks[self.task_idx].epoch_done():
+                        # if this task has examples ready, break
+                        break
+                if self.tasks[self.task_idx].epoch_done():
+                    # all tasks are done, so return empty action table
+                    return {'episode_done': True}
+        t = self.tasks[self.task_idx].act()
+        if t['episode_done']:
+            self.new_task = True
+        return t
+
+    def epoch_done(self):
+        """
+        Return whether all subtasks are completed.
+        """
+        for t in self.tasks:
+            if not t.epoch_done():
+                return False
+        return True
+
+    # return transformed metrics showing total examples and accuracy if avail.
+    def report(self):
+        """
+        Report aggregated metrics across all subtasks.
+        """
+        return aggregate_named_reports(
+            {t.getID(): t.report() for t in self.tasks},
+            micro_average=self.opt.get('aggregate_micro', False),
+        )
+
+    def reset(self):
+        """
+        Reset all subtasks.
+        """
+        for t in self.tasks:
+            t.reset()
+
+    def reset_metrics(self):
+        """
+        Reset metrics for each subtask.
+        """
+        for t in self.tasks:
+            t.reset_metrics()
+
+    def save(self):
+        """
+        Save the subtask.
+        """
+        self.task.save()
+
+    def share(self):
+        """
+        Share the subtask.
+        """
+        shared = {}
+        shared['task'] = self.task.share()
+        return shared
+
+    def shutdown(self):
+        """
+        Shutdown the subagent.
+        """
+        self.task.shutdown()
+
+    def update_counters(self):
+        self.task.update_counters()

--- a/parlai/utils/teachers.py
+++ b/parlai/utils/teachers.py
@@ -17,8 +17,10 @@ from parlai.core.teachers import create_task_agent_from_taskname, Teacher
 class LabelToTextTeacher(Teacher):
     """
     Teacher that will shift message['labels'][0] into message['text'] for whatever task
-    is specified with --label-to-text-task. Because the dialogue history is effectively
-    overwritten by this action, all episodes will be flattened into one example each.
+    is specified with --label-to-text-task.
+
+    Because the dialogue history is effectively overwritten by this action, all episodes
+    will be flattened into one example each.
     """
 
     @classmethod

--- a/parlai/utils/teachers.py
+++ b/parlai/utils/teachers.py
@@ -67,16 +67,19 @@ class LabelToTextTeacher(Teacher):
         Act on the previous observation.
         """
         act = self.task.act()
-        if 'labels' in act:
-            use_eval_labels = False
-            labels = act['labels']
-        else:
-            use_eval_labels = True
-            labels = act['eval_labels']
-        assert len(labels) == 1
         new_act = copy.deepcopy(act)
-        new_act.force_set('text', labels[0])
-        new_act.force_set('eval_labels' if use_eval_labels else 'labels', [''])
+        if 'labels' in act:
+            labels = act['labels']
+            assert len(labels) == 1
+            new_act.force_set('text', labels[0])
+            new_act.force_set('labels', [''])
+        elif 'eval_labels' in act:
+            labels = act['eval_labels']
+            assert len(labels) == 1
+            new_act.force_set('text', labels[0])
+            new_act.force_set('eval_labels', [''])
+        else:
+            assert 'text' not in act and act['episode_done'] is True
         new_act.force_set('episode_done', True)  # Clear the dialogue history
         return new_act
 

--- a/parlai/utils/teachers.py
+++ b/parlai/utils/teachers.py
@@ -25,7 +25,7 @@ class LabelToTextTeacher(Teacher):
 
     @classmethod
     def add_cmdline_args(cls, argparser):
-        # Teacher has no args, and so we don't add them
+        # Teacher has no args
         parser = argparser.add_argument_group('LabelToText args')
         parser.add_argument(
             '-l2tt',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -134,40 +134,5 @@ class TestStrings(unittest.TestCase):
         assert string_utils.uppercase("tEst") == "TEst"
 
 
-class TestTeachers(unittest.TestCase):
-    def test_label_to_text_teacher(self):
-
-        # Set up regular teacher
-        kwargs = {'task': 'integration_tests:multiturn'}
-        parser = setup_args()
-        parser.set_defaults(**kwargs)
-        opt = parser.parse_args([])
-        agent = RepeatLabelAgent(opt)
-        regular_world = create_task(opt, agent)
-
-        # Set up label-to-text teacher
-        kwargs = {
-            'task': 'parlai.utils.teachers:labelToTextTeacher',
-            'label_to_text_task': 'integration_tests:multiturn',
-        }
-        parser = setup_args()
-        parser.set_defaults(**kwargs)
-        opt = parser.parse_args([])
-        agent = RepeatLabelAgent(opt)
-        label_to_text_world = create_task(opt, agent)
-
-        num_examples = 0
-        while num_examples < 5:
-            regular_world.parley()
-            regular_example = regular_world.get_acts()[0]
-            label_to_text_world.parley()
-            label_to_text_example = label_to_text_world.get_acts()[0]
-            self.assertEqual(
-                label_to_text_example['text'], regular_example['labels'][0]
-            )
-            self.assertEqual(label_to_text_example['labels'], [''])
-            num_examples += 1
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,16 +4,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import time
-import unittest
-from copy import deepcopy
-
-from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
 from parlai.core.opt import Opt
-from parlai.core.worlds import create_task
-from parlai.scripts.display_data import setup_args
 from parlai.utils.misc import Timer, round_sigfigs, set_namedtuple_defaults
 import parlai.utils.strings as string_utils
+from copy import deepcopy
+import time
+import unittest
 
 
 class TestUtils(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -162,8 +162,10 @@ class TestTeachers(unittest.TestCase):
             regular_example = regular_world.get_acts()[0]
             label_to_text_world.parley()
             label_to_text_example = label_to_text_world.get_acts()[0]
-            self.assertEqual(label_to_text_example['text'], regular_example['label'][0])
-            self.assertEqual(label_to_text_example['label'], [''])
+            self.assertEqual(
+                label_to_text_example['text'], regular_example['labels'][0]
+            )
+            self.assertEqual(label_to_text_example['labels'], [''])
             num_examples += 1
 
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
+from parlai.core.worlds import create_task
+from parlai.scripts.display_data import setup_args
+
+
+class TestWrapper(unittest.TestCase):
+    def test_label_to_text_teacher(self):
+
+        # Set up regular teacher
+        kwargs = {'task': 'integration_tests:multiturn'}
+        parser = setup_args()
+        parser.set_defaults(**kwargs)
+        opt = parser.parse_args([])
+        agent = RepeatLabelAgent(opt)
+        regular_world = create_task(opt, agent)
+
+        # Set up label-to-text teacher
+        kwargs = {
+            'task': 'wrapper:labelToTextTeacher',
+            'label_to_text_task': 'integration_tests:multiturn',
+        }
+        parser = setup_args()
+        parser.set_defaults(**kwargs)
+        opt = parser.parse_args([])
+        agent = RepeatLabelAgent(opt)
+        label_to_text_world = create_task(opt, agent)
+
+        num_examples = 0
+        while num_examples < 5:
+            regular_world.parley()
+            regular_example = regular_world.get_acts()[0]
+            label_to_text_world.parley()
+            label_to_text_example = label_to_text_world.get_acts()[0]
+            self.assertEqual(
+                label_to_text_example['text'], regular_example['labels'][0]
+            )
+            self.assertEqual(label_to_text_example['labels'], [''])
+            num_examples += 1
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_zootasks.py
+++ b/tests/test_zootasks.py
@@ -74,7 +74,7 @@ class TestZooAndTasks(unittest.TestCase):
             task_list,
             "parlai/tasks",
             "task",
-            ignore=['fromfile', 'interactive'],
+            ignore=['fromfile', 'interactive', 'wrapper'],
         )
 
     def test_zoolist(self):


### PR DESCRIPTION
**Patch description**
Teacher that will shift `message['labels'][0]` into `message['text']` for whatever task is specified with `--label-to-text-task`. Because the dialogue history is effectively overwritten by this action, all episodes will be flattened into one example each. I created this to classify labels of dataset examples using Dexter's new safety classifier, which was built to classify the "text" strings of dataset examples. The code used `MultiTaskTeacher` as an inspiration.

Hopefully this type of teacher can be abstracted in the future to support other types of teachers in which the examples are the same but the fields get modified in some way, without all of the boilerplate that this teacher contains.

I put this teacher in `parlai/tasks/wrapper/`, and I've added the `wrapper` folder to the list of folders that doesn't get an entry in `task_list.py`, alongside `fromfile` and `interactive`, because it's very general

**Testing steps**
Unit test: `python -m unittest tests.test_wrapper`

***test_new_tasks***
`python tests/datatests/test_new_tasks.py` fails with the following error:
```
Traceback (most recent call last):
  File "tests/datatests/test_new_tasks.py", line 64, in test_verify_data
    text, log = verify(opt, print_parser=False)
  File "/private/home/ems/GitHub/facebookresearch/ParlAI_dev/parlai/scripts/verify_data.py", line 63, in verify
    world = create_task(opt, agent)
  File "/private/home/ems/GitHub/facebookresearch/ParlAI_dev/parlai/core/worlds.py", line 1622, in create_task
    world = create_task_world(opt, user_agents, default_world=default_world)
  File "/private/home/ems/GitHub/facebookresearch/ParlAI_dev/parlai/core/worlds.py", line 1585, in create_task_world
    task_agents = _create_task_agents(opt)
  File "/private/home/ems/GitHub/facebookresearch/ParlAI_dev/parlai/core/worlds.py", line 1573, in _create_task_agents
    return create_task_agent_from_taskname(opt)
  File "/private/home/ems/GitHub/facebookresearch/ParlAI_dev/parlai/core/teachers.py", line 2212, in create_task_agent_from_taskname
    task_agents = teacher_class(opt)
  File "/private/home/ems/GitHub/facebookresearch/ParlAI_dev/parlai/tasks/wrapper/agents.py", line 47, in __init__
    self.task = create_task_agent_from_taskname(opt_singletask)[0]
  File "/private/home/ems/GitHub/facebookresearch/ParlAI_dev/parlai/core/teachers.py", line 2206, in create_task_agent_from_taskname
    'No task specified. Please select a task with ' + '--task {task_name}.'
RuntimeError: No task specified. Please select a task with --task {task_name}.
Got above exception in wrapper:LabelToTextTeacher
```
This is because the teacher won't run unless you specify a task (as my error message explains). However, I feel like this is justifiable behavior, because the point of this task is that it wraps around another task and modifies its message fields.