### PR TITLE
[Interactive] Fix for single turn

### DIFF
--- a/parlai/agents/local_human/local_human.py
+++ b/parlai/agents/local_human/local_human.py
@@ -70,9 +70,9 @@ class LocalHumanAgent(Agent):
             return {'episode_done': True}
 
         reply_text = reply_text.replace('\\n', '\n')
-        if self.opt.get('single_turn', False):
-            reply_text += '[DONE]'
         reply['episode_done'] = False
+        if self.opt.get('single_turn', False):
+            reply.force_set('episode_done', True)
         reply['label_candidates'] = self.fixedCands_txt
         if '[DONE]' in reply_text:
             # let interactive know we're resetting


### PR DESCRIPTION
**Patch description**
The flag `--single-turn` allows you to set `episode_done` True every turn. Useful for debugging or for models that aren't meant to iteratively build up history (like classifiers). Previous fix made it such that when you set `--single-turn True` you never see the model output. This sets `episode_done` to be True but without raising the StopIteration on the parley loop so that you still see the model reply.