### PR TITLE
Global parlai command line launcher

### DIFF
--- a/bin/parlai
+++ b/bin/parlai
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import parlai.scripts.parlai_exe as parlai
+
+if __name__ == '__main__':
+    parlai.Parlai()

--- a/parlai/scripts/convert_data_to_parlai_format.py
+++ b/parlai/scripts/convert_data_to_parlai_format.py
@@ -64,7 +64,8 @@ def dump_data(opt):
 
 
 class ConvertDataToParlaiFormat:
-    def main():
+    @classmethod
+    def main(cls, *args, **kwargs):
         random.seed(42)
         # Get command line arguments
         parser = ParlaiParser()

--- a/parlai/scripts/convert_data_to_parlai_format.py
+++ b/parlai/scripts/convert_data_to_parlai_format.py
@@ -63,39 +63,40 @@ def dump_data(opt):
     fw.close()
 
 
-def main():
-    random.seed(42)
-    # Get command line arguments
-    parser = ParlaiParser()
-    parser.add_argument(
-        '-n',
-        '--num-examples',
-        default=-1,
-        type=int,
-        help='Total number of exs to convert, -1 to convert \
-                                all examples',
-    )
-    parser.add_argument(
-        '-of',
-        '--outfile',
-        default=None,
-        type=str,
-        help='Output file where to save, by default will be \
-                                created in /tmp',
-    )
-    parser.add_argument(
-        '-if',
-        '--ignore-fields',
-        default='id',
-        type=str,
-        help='Ignore these fields from the message (returned\
-                                with .act() )',
-    )
-    parser.add_argument('-ltim', '--log-every-n-secs', type=float, default=2)
-    parser.set_defaults(datatype='train:stream')
-    opt = parser.parse_args()
-    dump_data(opt)
+class ConvertDataToParlaiFormat:
+    def main():
+        random.seed(42)
+        # Get command line arguments
+        parser = ParlaiParser()
+        parser.add_argument(
+            '-n',
+            '--num-examples',
+            default=-1,
+            type=int,
+            help='Total number of exs to convert, -1 to convert \
+                                    all examples',
+        )
+        parser.add_argument(
+            '-of',
+            '--outfile',
+            default=None,
+            type=str,
+            help='Output file where to save, by default will be \
+                                    created in /tmp',
+        )
+        parser.add_argument(
+            '-if',
+            '--ignore-fields',
+            default='id',
+            type=str,
+            help='Ignore these fields from the message (returned\
+                                    with .act() )',
+        )
+        parser.add_argument('-ltim', '--log-every-n-secs', type=float, default=2)
+        parser.set_defaults(datatype='train:stream')
+        opt = parser.parse_args()
+        dump_data(opt)
 
 
 if __name__ == '__main__':
-    main()
+    ConvertDataToParlaiFormat.main()

--- a/parlai/scripts/parlai_exe.py
+++ b/parlai/scripts/parlai_exe.py
@@ -3,26 +3,25 @@ import importlib
 import os
 import sys
 
+
 def display_image():
     if os.environ.get('PARLAI_DISPLAY_LOGO') == 'OFF':
         return
     logo = colorize('ParlAI - Dialogue Research Platform', 'labels')
     print(logo)
-          
+
+
 def Parlai():
     if len(sys.argv) > 1:
         command = sys.argv[1]
     else:
         print("no command given")
         exit()
-        
-    map = {
-        'train': 'train_model',
-        'eval': 'eval_model'
-    }
+
+    map = {'train': 'train_model', 'eval': 'eval_model'}
     if command in map:
         command = map[command]
-        
+
     try:
         module_name = "parlai.scripts.%s" % command
         module = importlib.import_module(module_name)
@@ -33,8 +32,9 @@ def Parlai():
         exit()
 
     display_image()
-    sys.argv = sys.argv[1:]     # remove parlai arg
+    sys.argv = sys.argv[1:]  # remove parlai arg
     model_class.main()
+
 
 if __name__ == '__main__':
     Parlai()

--- a/parlai/scripts/parlai_exe.py
+++ b/parlai/scripts/parlai_exe.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """
-Global parlAI command line launcher
+Global parlAI command line launcher.
 """
 from parlai.utils.strings import colorize, name_to_classname
 import importlib

--- a/parlai/scripts/parlai_exe.py
+++ b/parlai/scripts/parlai_exe.py
@@ -26,14 +26,29 @@ def Parlai():
         print("no command given")
         exit()
 
-    map = {'train': 'train_model', 'eval': 'eval_model'}
-    if command in map:
-        command = map[command]
+    # List of mappings from a command name to the script to import and class to call.
+    maps = {
+        'train': ('parlai.scripts.train_model', 'TrainModel'),
+        'eval': ('parlai.scripts.eval_model', 'EvalModel'),
+    }
+    try:
+        # Add user-specified script mappings from parlai_internal, if available.
+        module_name = "parlai_internal.scripts.parlai_scripts"
+        module = importlib.import_module(module_name)
+        model_class = getattr(module, 'get_script_mappings')
+        model_class(maps)
+    except ImportError:
+        pass
+
+    if command in maps:
+        class_name = name_to_classname(maps[command][1])
+        script = maps[command][0]
+    else:
+        script = "parlai.scripts.%s" % command
+        class_name = name_to_classname(command)
 
     try:
-        module_name = "parlai.scripts.%s" % command
-        module = importlib.import_module(module_name)
-        class_name = name_to_classname(command)
+        module = importlib.import_module(script)
         model_class = getattr(module, class_name)
     except ImportError:
         print(command + " not found")

--- a/parlai/scripts/parlai_exe.py
+++ b/parlai/scripts/parlai_exe.py
@@ -1,3 +1,11 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Global parlAI command line launcher
+"""
 from parlai.utils.strings import colorize, name_to_classname
 import importlib
 import os

--- a/parlai/scripts/parlai_exe.py
+++ b/parlai/scripts/parlai_exe.py
@@ -1,0 +1,45 @@
+from parlai.utils.strings import colorize, name_to_classname
+import importlib
+import sys
+
+def display_image():
+    if os.environ.get('PARLAI_DISPLAY_LOGO') = 'OFF':
+        return
+
+    image1 = (
+        "         \\              \n" +
+        " \\      (o>             \n" +
+        " (o>     //\   ")
+    image2 = "ParlAI    \n"
+    image3 = ("_(()_____V_/_________    \n" +
+        " ||      ||              \n" + 
+        "         ||              \n")
+    image1 = image1.replace('\\', "\\\\")
+    image1 = image1.replace('/\\\\', "/\\")
+    image = (colorize(image1, 'text')
+             + colorize(image2, 'bold_text')
+             + colorize(image3, 'text'))
+    print(image)
+          
+def Parlai():
+    if len(sys.argv) > 1:
+        command = sys.argv[1]
+    else:
+        print("no command given")
+        exit()
+        
+    try:
+        module_name = "parlai.scripts.%s" % command
+        module = importlib.import_module(module_name)
+        class_name = name_to_classname(sys.argv[1])
+        model_class = getattr(module, class_name)
+    except ImportError:
+        print(command + " not found")
+        exit()
+
+    display_image()
+    sys.argv = sys.argv[1:]     # remove parlai arg
+    model_class.main()
+
+if __name__ == '__main__':
+    Parlai()

--- a/parlai/scripts/parlai_exe.py
+++ b/parlai/scripts/parlai_exe.py
@@ -1,25 +1,13 @@
 from parlai.utils.strings import colorize, name_to_classname
 import importlib
+import os
 import sys
 
 def display_image():
-    if os.environ.get('PARLAI_DISPLAY_LOGO') = 'OFF':
+    if os.environ.get('PARLAI_DISPLAY_LOGO') == 'OFF':
         return
-
-    image1 = (
-        "         \\              \n" +
-        " \\      (o>             \n" +
-        " (o>     //\   ")
-    image2 = "ParlAI    \n"
-    image3 = ("_(()_____V_/_________    \n" +
-        " ||      ||              \n" + 
-        "         ||              \n")
-    image1 = image1.replace('\\', "\\\\")
-    image1 = image1.replace('/\\\\', "/\\")
-    image = (colorize(image1, 'text')
-             + colorize(image2, 'bold_text')
-             + colorize(image3, 'text'))
-    print(image)
+    logo = colorize('ParlAI - Dialogue Research Platform', 'labels')
+    print(logo)
           
 def Parlai():
     if len(sys.argv) > 1:
@@ -28,10 +16,17 @@ def Parlai():
         print("no command given")
         exit()
         
+    map = {
+        'train': 'train_model',
+        'eval': 'eval_model'
+    }
+    if command in map:
+        command = map[command]
+        
     try:
         module_name = "parlai.scripts.%s" % command
         module = importlib.import_module(module_name)
-        class_name = name_to_classname(sys.argv[1])
+        class_name = name_to_classname(command)
         model_class = getattr(module, class_name)
     except ImportError:
         print(command + " not found")

--- a/parlai/scripts/parlai_exe.py
+++ b/parlai/scripts/parlai_exe.py
@@ -20,17 +20,24 @@ def display_image():
 
 
 def Parlai():
-    if len(sys.argv) > 1:
+    # List of mappings from a command name to the script to import and class to call.
+    maps = {
+        'dd': ('parlai.scripts.display_data', 'DisplayData'),
+        'train': ('parlai.scripts.train_model', 'TrainModel'),
+        'eval': ('parlai.scripts.eval_model', 'EvalModel'),
+        'i': ('parlai.scripts.interactive', 'Interactive'),
+    }
+
+    if len(sys.argv) > 1 and sys.argv[1] != '--help':
         command = sys.argv[1]
     else:
         print("no command given")
+        print("\nMain ParlAI commands:")
+        for c in maps:
+            command = maps[c][0][maps[c][0].rfind('.') + 1 :]
+            print("  " + command + " (" + c + ")")
         exit()
 
-    # List of mappings from a command name to the script to import and class to call.
-    maps = {
-        'train': ('parlai.scripts.train_model', 'TrainModel'),
-        'eval': ('parlai.scripts.eval_model', 'EvalModel'),
-    }
     try:
         # Add user-specified script mappings from parlai_internal, if available.
         module_name = "parlai_internal.scripts.parlai_scripts"

--- a/parlai/scripts/parlai_exe.py
+++ b/parlai/scripts/parlai_exe.py
@@ -35,8 +35,7 @@ def Parlai():
         # Add user-specified script mappings from parlai_internal, if available.
         module_name = "parlai_internal.scripts.parlai_scripts"
         module = importlib.import_module(module_name)
-        model_class = getattr(module, 'get_script_mappings')
-        model_class(maps)
+        module.get_script_mappings(maps)
     except ImportError:
         pass
 

--- a/parlai/scripts/parlai_exe.py
+++ b/parlai/scripts/parlai_exe.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """
-Global parlAI command line launcher.
+Global ParlAI command line launcher.
 """
 from parlai.utils.strings import colorize, name_to_classname
 import importlib

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -63,6 +63,7 @@ def uppercase(string: str) -> str:
     else:
         return string[0].upper() + string[1:]
 
+
 def name_to_classname(name: str) -> str:
     words = name.split('_')
     class_name = ''
@@ -70,6 +71,7 @@ def name_to_classname(name: str) -> str:
         # capitalize the first letter
         class_name += w[0].upper() + w[1:]
     return class_name
+
 
 def colorize(text, style):
     try:

--- a/parlai/utils/strings.py
+++ b/parlai/utils/strings.py
@@ -63,6 +63,13 @@ def uppercase(string: str) -> str:
     else:
         return string[0].upper() + string[1:]
 
+def name_to_classname(name: str) -> str:
+    words = name.split('_')
+    class_name = ''
+    for w in words:
+        # capitalize the first letter
+        class_name += w[0].upper() + w[1:]
+    return class_name
 
 def colorize(text, style):
     try:

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ if __name__ == '__main__':
         long_description_content_type='text/markdown',
         url='http://parl.ai/',
         python_requires='>=3.6',
+        scripts=['bin/parlai'],
         packages=find_packages(
             exclude=('data', 'docs', 'examples', 'tests', 'parlai_internal',)
         ),


### PR DESCRIPTION
e.g.:

parlai display_data -t convai2

or

parlai dd -t convai2


see:

parlai --help

Main ParlAI commands:
  display_data (dd)
  train_model (train)
  eval_model (eval)
  interactive (i)

(but it will also try to run anything in parlai/scripts if it can,  or else look for a list of more user-defined scripts in parlai_internal/scripts/parlai_scripts)


