### PR TITLE
Use packaging.version to parse PyTorch version.

### DIFF
--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -94,10 +94,9 @@ def skipUnlessTorch14(testfn, reason='Test requires pytorch 1.4+'):
     if not TORCH_AVAILABLE:
         skip = True
     else:
-        version = torch.__version__.replace('+cpu', '').split('.')  # type: ignore
-        version_ = tuple(int(x) for x in version)  # type: ignore
-        if version_ < (1, 4, 0):
-            skip = True
+        from packaging import version
+
+        skip = version.parse(torch.__version__) < version.parse('1.4.0')
     return unittest.skipIf(skip, reason)(testfn)
 
 


### PR DESCRIPTION
**Patch description**

The existing version parsing doesn't handle all the wackiness of
Python version strings. This comes up when you build PyTorch
from source, which appends the commit hash, or use a different build,
which may add different suffixes (like `1.4.1.post2`).

Fortunately, the 'packaging.version' package can parse and compare
PEP 440 and legacy version strings. It's part of setuptools, so it's
included in standard Python installations.

**Testing steps**

1. Build and install PyTorch 1.4.1 from source
2. ```pytest -m unit```

