### PR TITLE
Enable pytorch 1.5.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,8 @@ setupcuda: &setupcuda
     working_directory: ~/
     command: |
       # download and install nvidia drivers, cuda, etc
-      wget --quiet --no-clobber -P ~/nvidia-downloads 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-430.40.run'
-      time sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-430.40.run --no-drm -q --ui=none
+      wget --quiet --no-clobber -P ~/nvidia-downloads 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-440.64.run'
+      time sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-440.64.run --no-drm -q --ui=none
       echo "Done installing NVIDIA drivers."
       pyenv versions
       nvidia-smi
@@ -244,13 +244,13 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
-      - restore_cache:
-          key: nvidia-downloads-v4
+        # - restore_cache:
+        #     key: nvidia-downloads-v4
       - <<: *setupcuda
-      - save_cache:
-          key: nvidia-downloads-v4
-          paths:
-            - "~/nvidia-downloads/"
+        # - save_cache:
+        #     key: nvidia-downloads-v4
+        #     paths:
+        #       - "~/nvidia-downloads/"
       - restore_cache:
           key: deps-v07-gpu15-{{ checksum "requirements.txt" }}
       - <<: *setup
@@ -275,13 +275,13 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
-      - restore_cache:
-          key: nvidia-downloads-v4
+        # - restore_cache:
+        #     key: nvidia-downloads-v4
       - <<: *setupcuda
-      - save_cache:
-          key: nvidia-downloads-v4
-          paths:
-            - "~/nvidia-downloads/"
+        # - save_cache:
+        #     key: nvidia-downloads-v4
+        #     paths:
+        #       - "~/nvidia-downloads/"
       - restore_cache:
           key: deps-v07-gpu14-{{ checksum "requirements.txt" }}
       - <<: *setup
@@ -306,13 +306,13 @@ jobs:
     steps:
       - checkout
       - <<: *fixgit
-      - restore_cache:
-          key: nvidia-downloads-v4
+        # - restore_cache:
+        #     key: nvidia-downloads-v4
       - <<: *setupcuda
-      - save_cache:
-          key: nvidia-downloads-v4
-          paths:
-            - "~/nvidia-downloads/"
+        # - save_cache:
+        #     key: nvidia-downloads-v4
+        #     paths:
+        #       - "~/nvidia-downloads/"
       - restore_cache:
           key: deps-v07-nightly-{{ checksum "requirements.txt" }}
       - <<: *setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,12 +146,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v5-osx-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-osx-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchcpuosx
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-osx-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-osx-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -173,12 +173,12 @@ jobs:
           command: circleci tests split --split-by=timings --timings-type=classname
       - <<: *fixgit
       - restore_cache:
-          key: deps-v5-ut36-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut36-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchcpu
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-ut36-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut36-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -197,12 +197,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v5-ut38-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut38-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchcpu
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-ut38-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut38-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -221,12 +221,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v5-ut37-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut37-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchcpu
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-ut37-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut37-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -252,12 +252,12 @@ jobs:
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v5-gpu15-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-gpu15-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchgpu15
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-gpu15-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-gpu15-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -283,12 +283,12 @@ jobs:
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v5-gpu14-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-gpu14-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchgpu14
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-gpu14-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-gpu14-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -314,12 +314,12 @@ jobs:
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v5-nightly-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-nightly-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchgpu14
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-nightly-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v5-nightly-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -341,11 +341,11 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-mturk-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v4-mturk-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - save_cache:
-          key: deps-v4-mturk-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v4-mturk-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -363,7 +363,7 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-bw-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v4-bw-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
@@ -374,7 +374,7 @@ jobs:
             pip install s3cmd
             sudo apt-get install linkchecker
       - save_cache:
-          key: deps-v4-bw-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v4-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -394,12 +394,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-dw-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v4-dw-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-v4-dw-testing1-{{ checksum "requirements.txt" }}
+          key: deps-v4-dw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,12 +146,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v5-osx-{{ checksum "requirements.txt" }}
+          key: deps-v07-osx-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchcpuosx
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-osx-{{ checksum "requirements.txt" }}
+          key: deps-v07-osx-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -173,12 +173,12 @@ jobs:
           command: circleci tests split --split-by=timings --timings-type=classname
       - <<: *fixgit
       - restore_cache:
-          key: deps-v5-ut36-{{ checksum "requirements.txt" }}
+          key: deps-v07-ut36-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchcpu
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-ut36-{{ checksum "requirements.txt" }}
+          key: deps-v07-ut36-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -197,12 +197,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v5-ut38-{{ checksum "requirements.txt" }}
+          key: deps-v07-ut38-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchcpu
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-ut38-{{ checksum "requirements.txt" }}
+          key: deps-v07-ut38-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -221,12 +221,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v5-ut37-{{ checksum "requirements.txt" }}
+          key: deps-v07-ut37-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchcpu
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-ut37-{{ checksum "requirements.txt" }}
+          key: deps-v07-ut37-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -252,12 +252,12 @@ jobs:
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v5-gpu15-{{ checksum "requirements.txt" }}
+          key: deps-v07-gpu15-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchgpu15
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-gpu15-{{ checksum "requirements.txt" }}
+          key: deps-v07-gpu15-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -283,12 +283,12 @@ jobs:
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v5-gpu14-{{ checksum "requirements.txt" }}
+          key: deps-v07-gpu14-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installtorchgpu14
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-gpu14-{{ checksum "requirements.txt" }}
+          key: deps-v07-gpu14-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -314,12 +314,12 @@ jobs:
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v5-nightly-{{ checksum "requirements.txt" }}
+          key: deps-v07-nightly-{{ checksum "requirements.txt" }}
       - <<: *setup
-      - <<: *installtorchgpu14
+      - <<: *installtorchgpu15
       - <<: *installdeps
       - save_cache:
-          key: deps-v5-nightly-{{ checksum "requirements.txt" }}
+          key: deps-v07-nightly-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -341,11 +341,11 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-mturk-{{ checksum "requirements.txt" }}
+          key: deps-v07-mturk-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - save_cache:
-          key: deps-v4-mturk-{{ checksum "requirements.txt" }}
+          key: deps-v07-mturk-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -363,7 +363,7 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-bw-{{ checksum "requirements.txt" }}
+          key: deps-v07-bw-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
@@ -374,7 +374,7 @@ jobs:
             pip install s3cmd
             sudo apt-get install linkchecker
       - save_cache:
-          key: deps-v4-bw-{{ checksum "requirements.txt" }}
+          key: deps-v07-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -394,12 +394,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-dw-{{ checksum "requirements.txt" }}
+          key: deps-v07-dw-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-v4-dw-{{ checksum "requirements.txt" }}
+          key: deps-v07-dw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,8 @@ installtorchgpu15: &installtorchgpu15
       pip3 install --progress-bar off 'subword-nmt==0.3.7'
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off transformers
+      pip3 install --progress-bar off 'torchtext==0.6.0'
+      pip3 install --progress-bar off 'torchvision==0.6.0'
       python -c 'import torch; print("Torch version:", torch.__version__)'
       python -m torch.utils.collect_env
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,8 @@ setupcuda: &setupcuda
     working_directory: ~/
     command: |
       # download and install nvidia drivers, cuda, etc
-      wget --quiet --no-clobber -P ~/nvidia-downloads 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-440.64.run'
-      time sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-440.64.run --no-drm -q --ui=none
+        wget --quiet --no-clobber -P ~/nvidia-downloads 'http://us.download.nvidia.com/tesla/440.64.00/NVIDIA-Linux-x86_64-440.64.00.run'
+      time sudo /bin/bash ~/nvidia-downloads/NVIDIA-Linux-x86_64-440.64.00.run --no-drm -q --ui=none
       echo "Done installing NVIDIA drivers."
       pyenv versions
       nvidia-smi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,13 @@ installtorchgpu15: &installtorchgpu15
       python -c 'import torch; print("Torch version:", torch.__version__)'
       python -m torch.utils.collect_env
 
+installtorchcpuosx: &installtorchcpuosx
+  run:
+    name: Install torch CPU and dependencies
+    command: |
+      pip3 install --progress-bar off torch
+      python -c 'import torch; print("Torch version:", torch.__version__)'
+      python -m torch.utils.collect_env
 
 installtorchcpu: &installtorchcpu
   run:
@@ -141,7 +148,7 @@ jobs:
       - restore_cache:
           key: deps-v5-osx-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
-      - <<: *installtorchcpu
+      - <<: *installtorchcpuosx
       - <<: *installdeps
       - save_cache:
           key: deps-v5-osx-testing1-{{ checksum "requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ installtorchgpu14: &installtorchgpu14
   run:
     name: Install torch GPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch==1.4.0'
+      pip3 install --progress-bar off 'torch==1.5.0'
       pip3 install --progress-bar off 'subword-nmt==0.3.7'
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off 'torchtext==0.5.0'
@@ -88,11 +88,11 @@ installtorchgpu14: &installtorchgpu14
       python -m torch.utils.collect_env
 
 
-installtorchgpu13: &installtorchgpu13
+installtorchgpu15: &installtorchgpu15
   run:
     name: Install torch GPU and dependencies
     command: |
-      pip3 install --progress-bar off 'torch==1.3.1'
+      pip3 install --progress-bar off 'torch==1.5.0'
       pip3 install --progress-bar off 'subword-nmt==0.3.7'
       pip3 install --progress-bar off pytorch-pretrained-bert
       pip3 install --progress-bar off transformers
@@ -104,7 +104,7 @@ installtorchcpuosx: &installtorchcpuosx
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off torch
+      pip3 install --progress-bar off torch==1.5.0+cpu
       python -c 'import torch; print("Torch version:", torch.__version__)'
       python -m torch.utils.collect_env
 
@@ -112,7 +112,7 @@ installtorchcpu: &installtorchcpu
   run:
     name: Install torch CPU and dependencies
     command: |
-      pip3 install --progress-bar off torch==1.4.0+cpu torchtext==0.5.0 torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      pip3 install --progress-bar off torch==1.5.0+cpu torchtext==0.6.0 torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
       python -c 'import torch; print("Torch version:", torch.__version__)'
       python -m torch.utils.collect_env
 
@@ -147,12 +147,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v5-osx-{{ checksum "requirements.txt" }}
+          key: deps-v5-osx-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
-      - <<: *installdeps
       - <<: *installtorchcpuosx
+      - <<: *installdeps
       - save_cache:
-          key: deps-v5-osx-{{ checksum "requirements.txt" }}
+          key: deps-v5-osx-testing1-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -174,12 +174,12 @@ jobs:
           command: circleci tests split --split-by=timings --timings-type=classname
       - <<: *fixgit
       - restore_cache:
-          key: deps-v5-ut36-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut36-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
-      - <<: *installdeps
       - <<: *installtorchcpu
+      - <<: *installdeps
       - save_cache:
-          key: deps-v5-ut36-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut36-testing1-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -198,12 +198,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v5-ut38-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut38-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
-      - <<: *installdeps
       - <<: *installtorchcpu
+      - <<: *installdeps
       - save_cache:
-          key: deps-v5-ut38-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut38-testing1-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -222,12 +222,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v5-ut37-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut37-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
-      - <<: *installdeps
       - <<: *installtorchcpu
+      - <<: *installdeps
       - save_cache:
-          key: deps-v5-ut37-{{ checksum "requirements.txt" }}
+          key: deps-v5-ut37-testing1-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -238,7 +238,7 @@ jobs:
       - store_test_results:
           path: test-results
 
-  unittests_gpu13:
+  unittests_gpu15:
     <<: *gpu
     working_directory: ~/ParlAI
     parallelism: 8
@@ -253,17 +253,17 @@ jobs:
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v5-gpu13-{{ checksum "requirements.txt" }}
+          key: deps-v5-gpu15-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
-      - <<: *installdeps
       - <<: *installtorchgpu13
+      - <<: *installdeps
       - save_cache:
-          key: deps-v5-gpu13-{{ checksum "requirements.txt" }}
+          key: deps-v5-gpu15-testing1-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
       - run:
-          name: Unit tests (GPU; pytorch 1.3)
+          name: Unit tests (GPU; pytorch 1.5)
           command: coverage run -m pytest --junitxml=test-results/junit.xml -m unit -v
       - <<: *codecov
       - store_test_results:
@@ -284,12 +284,12 @@ jobs:
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v5-gpu14-{{ checksum "requirements.txt" }}
+          key: deps-v5-gpu14-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
-      - <<: *installdeps
       - <<: *installtorchgpu14
+      - <<: *installdeps
       - save_cache:
-          key: deps-v5-gpu14-{{ checksum "requirements.txt" }}
+          key: deps-v5-gpu14-testing1-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -315,21 +315,21 @@ jobs:
           paths:
             - "~/nvidia-downloads/"
       - restore_cache:
-          key: deps-v5-nightly-{{ checksum "requirements.txt" }}
+          key: deps-v5-nightly-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
-      - <<: *installdeps
       - <<: *installtorchgpu14
+      - <<: *installdeps
       - save_cache:
-          key: deps-v5-nightly-{{ checksum "requirements.txt" }}
+          key: deps-v5-nightly-testing1-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
       - run:
-          name: Nightly GPU tests
+          name: Nightly GPU tests (GPU; pytorch 1.5)
           no_output_timeout: 60m
           command: coverage run -m pytest --junitxml=test-results/junit.xml -m nightly_gpu -v
       - run:
-          name: Quickstart unit tests (GPU; pytorch 1.4)
+          name: Quickstart unit tests (GPU; pytorch 1.5)
           command: sh tests/test_quickstart.sh
       - <<: *codecov
       - store_test_results:
@@ -342,11 +342,11 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-mturk-{{ checksum "requirements.txt" }}
+          key: deps-v4-mturk-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - save_cache:
-          key: deps-v4-mturk-{{ checksum "requirements.txt" }}
+          key: deps-v4-mturk-testing1-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -364,7 +364,7 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-bw-{{ checksum "requirements.txt" }}
+          key: deps-v4-bw-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
@@ -375,7 +375,7 @@ jobs:
             pip install s3cmd
             sudo apt-get install linkchecker
       - save_cache:
-          key: deps-v4-bw-{{ checksum "requirements.txt" }}
+          key: deps-v4-bw-testing1-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -395,12 +395,12 @@ jobs:
       - checkout
       - <<: *fixgit
       - restore_cache:
-          key: deps-v4-dw-{{ checksum "requirements.txt" }}
+          key: deps-v4-dw-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
       - <<: *installdeps
       - <<: *installtorchgpu14
       - save_cache:
-          key: deps-v4-dw-{{ checksum "requirements.txt" }}
+          key: deps-v4-dw-testing1-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,14 +100,6 @@ installtorchgpu15: &installtorchgpu15
       python -m torch.utils.collect_env
 
 
-installtorchcpuosx: &installtorchcpuosx
-  run:
-    name: Install torch CPU and dependencies
-    command: |
-      pip3 install --progress-bar off torch==1.5.0+cpu
-      python -c 'import torch; print("Torch version:", torch.__version__)'
-      python -m torch.utils.collect_env
-
 installtorchcpu: &installtorchcpu
   run:
     name: Install torch CPU and dependencies
@@ -149,7 +141,7 @@ jobs:
       - restore_cache:
           key: deps-v5-osx-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
-      - <<: *installtorchcpuosx
+      - <<: *installtorchcpu
       - <<: *installdeps
       - save_cache:
           key: deps-v5-osx-testing1-{{ checksum "requirements.txt" }}
@@ -255,7 +247,7 @@ jobs:
       - restore_cache:
           key: deps-v5-gpu15-testing1-{{ checksum "requirements.txt" }}
       - <<: *setup
-      - <<: *installtorchgpu13
+      - <<: *installtorchgpu15
       - <<: *installdeps
       - save_cache:
           key: deps-v5-gpu15-testing1-{{ checksum "requirements.txt" }}
@@ -466,7 +458,7 @@ workflows:
   version: 2
   commit:
     jobs:
-      - unittests_gpu13
+      - unittests_gpu15
       - unittests_gpu14
       - unittests_38
       - unittests_37

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,14 +69,14 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cache/pip
-          key: pip-torch131cpu-v1-${{ hashFiles('**/requirements.txt') }}
+          key: pip-torch150cpu-v1-${{ hashFiles('**/requirements.txt') }}
         id: cache
       - name: install dependencies
         run: |
           pip install -q -r requirements.txt
           pip install -q mypy mypy-extensions
           pip install -q git+https://github.com/numpy/numpy-stubs.git
-          pip install -q torch==1.3.1+cpu torchvision==0.4.2+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install -q torch==1.5.0+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - name: mypy
         run: |
           set -eux

--- a/docs/source/tutorial_quick.rst
+++ b/docs/source/tutorial_quick.rst
@@ -38,7 +38,7 @@ Now let's try to train a model on it (even on your laptop, this should train fas
 .. code-block:: bash
 
   # train MemNN using batch size 1 and 4 threads for 5 epochs
-  python examples/train_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -bs 1 -nt 4 -eps 5 -m memnn --no-cuda
+  python examples/train_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -bs 8 -eps 5 -m memnn --no-cuda
 
 Let's print some of its predictions to make sure it's working.
 

--- a/docs/source/tutorial_quick.rst
+++ b/docs/source/tutorial_quick.rst
@@ -37,7 +37,7 @@ Now let's try to train a model on it (even on your laptop, this should train fas
 
 .. code-block:: bash
 
-  # train MemNN using batch size 1 and 4 threads for 5 epochs
+  # train MemNN using batch size 8 for 5 epochs
   python examples/train_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -bs 8 -eps 5 -m memnn --no-cuda
 
 Let's print some of its predictions to make sure it's working.

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -48,7 +48,13 @@ import time
 from typing import List, Dict, Any, Union
 
 try:
-    from torch.multiprocessing import Process, Value, Condition, Semaphore
+    from torch.multiprocessing import (
+        Process,
+        Value,
+        Condition,
+        Semaphore,
+        set_start_method,
+    )
 except ImportError:
     from multiprocessing import Process, Value, Semaphore, Condition  # noqa: F401
 
@@ -1356,6 +1362,16 @@ class HogwildWorld(World):
     """
 
     def __init__(self, opt: Opt, world):
+        from packaging import version
+        import torch
+
+        if version.parse(torch.__version__) >= version.parse('1.5.0'):
+            raise RuntimeError(
+                'Hogwild no longer works in pytorch 1.5 or newer. You can downgrade '
+                'to pytorch 1.4, but it would be better to migrate away from hogwild. '
+                'Please file a GitHub issue if you find a migration untenable.'
+            )
+
         super().__init__(opt)
         self.inner_world = world
         self.numthreads = opt['numthreads']

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -48,13 +48,7 @@ import time
 from typing import List, Dict, Any, Union
 
 try:
-    from torch.multiprocessing import (
-        Process,
-        Value,
-        Condition,
-        Semaphore,
-        set_start_method,
-    )
+    from torch.multiprocessing import Process, Value, Condition, Semaphore
 except ImportError:
     from multiprocessing import Process, Value, Semaphore, Condition  # noqa: F401
 

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -98,7 +98,7 @@ def skipUnlessTorchVersion(version):
 
         target = packaging.version.parse(version)
         skip = packaging.version.parse(torch.__version__) < target
-    reason = 'Test requires pytorch {version} or newer'
+    reason = f'Test requires pytorch {version} or newer'
     return unittest.skipIf(skip, reason)
 
 
@@ -111,7 +111,7 @@ def skipIfTorchVersion(version):
 
         target = packaging.version.parse(version)
         skip = packaging.version.parse(torch.__version__) >= target
-    reason = 'Test requires pytorch OLDER than {version}'
+    reason = f'Test requires pytorch OLDER than {version}'
 
     return unittest.skipIf(skip, reason)
 

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -89,15 +89,31 @@ def skipIfCircleCI(testfn, reason='Test disabled in CircleCI'):
     return unittest.skipIf(is_this_circleci(), reason)(testfn)
 
 
-def skipUnlessTorch14(testfn, reason='Test requires pytorch 1.4+'):
+def skipUnlessTorchVersion(version):
     skip = False
     if not TORCH_AVAILABLE:
         skip = True
     else:
-        from packaging import version
+        import packaging.version
 
-        skip = version.parse(torch.__version__) < version.parse('1.4.0')
-    return unittest.skipIf(skip, reason)(testfn)
+        target = packaging.version.parse(version)
+        skip = packaging.version.parse(torch.__version__) < target
+    reason = 'Test requires pytorch {version} or newer'
+    return unittest.skipIf(skip, reason)
+
+
+def skipIfTorchVersion(version):
+    skip = False
+    if not TORCH_AVAILABLE:
+        skip = True
+    else:
+        import packaging.version
+
+        target = packaging.version.parse(version)
+        skip = packaging.version.parse(torch.__version__) >= target
+    reason = 'Test requires pytorch OLDER than {version}'
+
+    return unittest.skipIf(skip, reason)
 
 
 class retry(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ flake8-bugbear==19.8.0
 gitdb2==2.0.5
 GitPython==3.0.3
 h5py==2.10.0
-joblib>=0.14.0
+joblib==0.14.1
 nltk==3.4.5
 numpy>=1.16.0
 pytest==5.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+torch>=1.4.1
 boto3==1.9.246
 botocore==1.12.246
 docutils==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ flake8==3.7.8
 flake8-bugbear==19.8.0
 gitdb2==2.0.5
 GitPython==3.0.3
-h5py==2.10.0
 joblib==0.14.1
+h5py==2.10.0
 nltk==3.4.5
 numpy>=1.16.0
 pytest==5.3.2

--- a/tests/test_hogwild.py
+++ b/tests/test_hogwild.py
@@ -15,6 +15,7 @@ BATCHSIZE_CHOICES = [1, 8]
 
 
 @testing_utils.skipIfGPU
+@testing_utils.skipIfTorchVersion(version="1.5.0")
 class TestHogwild(unittest.TestCase):
     """
     Check that hogwild is doing the right number of examples.
@@ -33,7 +34,7 @@ class TestHogwild(unittest.TestCase):
         )
         for nt in NUM_THREADS_CHOICES:
             for bs in BATCHSIZE_CHOICES:
-                opt['num_threads'] = nt
+                opt['numthreads'] = nt
                 opt['batchsize'] = bs
 
                 valid, test = testing_utils.train_model(opt)
@@ -49,12 +50,34 @@ class TestHogwild(unittest.TestCase):
         )
         for nt in NUM_THREADS_CHOICES:
             for bs in BATCHSIZE_CHOICES:
-                opt['num_threads'] = nt
+                opt['numthreads'] = nt
                 opt['batchsize'] = bs
 
                 valid, test = testing_utils.eval_model(opt)
                 self.assertEqual(valid['exs'], NUM_EXS)
                 self.assertEqual(test['exs'], NUM_EXS)
+
+
+@testing_utils.skipUnlessTorchVersion(version="1.5.0")
+class TestHogwildAntiquated(unittest.TestCase):
+    """
+    Test that hogwild throws an error on pytorch 1.5 plus.
+    """
+
+    def test_errors(self):
+        opt = dict(
+            task='integration_tests:repeat:{}'.format(1),
+            model='repeat_label',
+            display_examples=False,
+            num_epochs=1,
+        )
+        for nt in NUM_THREADS_CHOICES:
+            for bs in BATCHSIZE_CHOICES:
+                opt['numthreads'] = nt
+                opt['batchsize'] = bs
+
+                with self.assertRaises(RuntimeError):
+                    testing_utils.train_model(opt)
 
 
 if __name__ == '__main__':

--- a/tests/test_image_seq2seq.py
+++ b/tests/test_image_seq2seq.py
@@ -53,7 +53,7 @@ EVAL_ARGS = {
 }
 
 
-@testing_utils.skipUnlessTorch14
+@testing_utils.skipUnlessTorchVersion(version="1.4.0")
 class TestImageSeq2Seq(unittest.TestCase):
     """
     Unit tests for the ImageSeq2Seq Agent.

--- a/tests/test_image_seq2seq.py
+++ b/tests/test_image_seq2seq.py
@@ -70,7 +70,7 @@ class TestImageSeq2Seq(unittest.TestCase):
         args.update(TEXT_ARGS)
         valid, test = testing_utils.train_model(args)
         self.assertLessEqual(
-            valid['ppl'], 1.5, f'failed to train image_seq2seq on text task'
+            valid['ppl'], 1.5, 'failed to train image_seq2seq on text task'
         )
 
     @testing_utils.retry(ntries=3)
@@ -87,7 +87,7 @@ class TestImageSeq2Seq(unittest.TestCase):
 
         valid, test = testing_utils.train_model(args)
         self.assertLessEqual(
-            valid['ppl'], 6.6, f'failed to train image_seq2seq on image task'
+            valid['ppl'], 6.6, 'failed to train image_seq2seq on image task'
         )
 
     @testing_utils.retry(ntries=3)
@@ -102,7 +102,7 @@ class TestImageSeq2Seq(unittest.TestCase):
 
         valid, test = testing_utils.train_model(args)
         self.assertLessEqual(
-            valid['ppl'], 5.0, f'failed to train image_seq2seq on image+text task',
+            valid['ppl'], 5.0, 'failed to train image_seq2seq on image+text task',
         )
 
 

--- a/tests/test_memnn.py
+++ b/tests/test_memnn.py
@@ -74,7 +74,6 @@ class TestMemnn(unittest.TestCase):
         self.assertGreater(valid['hits@1'], 0.95)
         self.assertGreater(test['hits@1'], 0.95)
 
-    @unittest.skip
     def test_backcomp(self):
         """
         Tests that the memnn model files continue to works over time.

--- a/tests/test_memnn.py
+++ b/tests/test_memnn.py
@@ -46,6 +46,7 @@ class TestMemnn(unittest.TestCase):
         self.assertGreater(test['hits@1'], 0.95)
 
     @testing_utils.skipIfGPU
+    @testing_utils.skipIfTorchVersion("1.5.0")
     @testing_utils.retry()
     def test_labelcands_multi(self):
         """
@@ -73,6 +74,7 @@ class TestMemnn(unittest.TestCase):
         self.assertGreater(valid['hits@1'], 0.95)
         self.assertGreater(test['hits@1'], 0.95)
 
+    @unittest.skip
     def test_backcomp(self):
         """
         Tests that the memnn model files continue to works over time.

--- a/tests/test_quickstart.sh
+++ b/tests/test_quickstart.sh
@@ -9,11 +9,11 @@ set -e -x  # error and exit on any failure; print the commands being run
 
 # view a task & train a model
 python examples/display_data.py -t babi:task10k:1
-python examples/train_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -bs 1 -nt 4 -eps 5 -m memnn --no-cuda
+python examples/train_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -bs 8 -eps 5 -m memnn --no-cuda
 python examples/display_model.py -t babi:task10k:1 -mf /tmp/babi_memnn -ecands vocab
 
 # train a transformer on twitter
-pip3 install emoji unidecode
+python -m pip install emoji unidecode
 python examples/display_data.py -t twitter
 python examples/train_model.py -t twitter -mf /tmp/tr_twitter -m transformer/ranker -bs 10 -vtim 3600 -cands batch -ecands batch --data-parallel True --max-train-time 20 -nl 1 --dict-tokenizer split -emb random --ffn-size 128
 python examples/eval_model.py -t twitter -bs 50 -m legacy:seq2seq:0 -mf models:convai2/seq2seq/convai2_self_seq2seq_model --num-examples 1

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -100,6 +100,7 @@ class TestSeq2Seq(unittest.TestCase):
 
 class TestHogwildSeq2seq(unittest.TestCase):
     @testing_utils.skipIfGPU
+    @testing_utils.skipIfTorchVersion("1.5.0")
     def test_generation_multi(self):
         """
         This test uses a multi-turn task and multithreading.

--- a/tests/test_teachers.py
+++ b/tests/test_teachers.py
@@ -49,8 +49,8 @@ class TestAbstractImageTeacher(unittest.TestCase):
         """
         self._test_display_output('no_image_model')
 
-    @testing_utils.skipUnlessTorch14
     @testing_utils.skipUnlessGPU
+    @testing_utils.skipUnlessTorchVersion(version="1.4.0")
     def test_display_data_resnet(self):
         """
         Test that, with pre-loaded image features, all examples are different.

--- a/tests/test_threadutils.py
+++ b/tests/test_threadutils.py
@@ -12,6 +12,7 @@ import time
 
 
 @testing_utils.skipIfGPU
+@testing_utils.skipIfTorchVersion("1.5.0")
 class TestSharedTable(unittest.TestCase):
     """
     Make sure the package is alive.

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -871,7 +871,7 @@ class TestLearningRateScheduler(unittest.TestCase):
         )
 
 
-@testing_utils.skipUnlessTorch14
+@testing_utils.skipUnlessTorchVersion("1.4.0")
 class TestImagePolyencoder(unittest.TestCase):
     """
     Unit tests for the ImagePolyencoderAgent.


### PR DESCRIPTION
**Patch description**
pytorch 1.5 came out and broke our tests. This turns out to because our method for hogwild no longer works. Unfortunately, I think we're going to have to simply sunset hogwild, but this requires a lot of doc updates etc. The best way is to do this before 1.6, and for now just tell users that hogwild is 1.4 or earlier.

So in summary:
- Make the helper decorators for pytorch a little more usable.
- Upgrade the installation caches for CI
- Disable hogwild only when in 1.5.

**Testing steps**
Local testing, but CI requires a lot of updates.