### PR TITLE
DREAM and C3 Datasets

### DIFF
--- a/parlai/tasks/c3/__init__.py
+++ b/parlai/tasks/c3/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/parlai/tasks/c3/agents.py
+++ b/parlai/tasks/c3/agents.py
@@ -5,28 +5,19 @@
 # LICENSE file in the root directory of this source tree.
 
 from .build import build
-from parlai.core.teachers import FixedDialogTeacher
-from parlai.tasks.dream.agents import setup_data, num_examples, get
+from parlai.tasks.dream.agents import DREAMTeacher
 import os
 
 
-class C3Teacher(FixedDialogTeacher):
+class C3Teacher(DREAMTeacher):
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
-        build(opt)
-        jsons_path = os.path.join(opt['datapath'], 'C3')
         self.id = 'c3'
-        self.episodes = setup_data(opt, jsons_path)
-        self.reset()
 
-    def num_examples(self):
-        return num_examples(self.episodes)
-
-    def num_episodes(self):
-        return len(self.episodes)
-
-    def get(self, episode_idx, entry_idx=0):
-        return get(self.id, self.episodes, entry_idx)
+    def setup_data(self):
+        build(self.opt)
+        jsons_path = os.path.join(self.opt['datapath'], 'C3')
+        return self.setup_helper(jsons_path)
 
 
 class DefaultTeacher(C3Teacher):

--- a/parlai/tasks/c3/agents.py
+++ b/parlai/tasks/c3/agents.py
@@ -5,16 +5,28 @@
 # LICENSE file in the root directory of this source tree.
 
 from .build import build
-from parlai.tasks.dream.agents import BaseMultipleChoiceTeacher
+from parlai.core.teachers import FixedDialogTeacher
+from parlai.tasks.dream.agents import setup_data, num_examples, get
 import os
 
 
-class C3Teacher(BaseMultipleChoiceTeacher):
+class C3Teacher(FixedDialogTeacher):
     def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
         build(opt)
         jsons_path = os.path.join(opt['datapath'], 'C3')
         self.id = 'c3'
-        super().__init__(opt, jsons_path, shared)
+        self.episodes = setup_data(opt, jsons_path)
+        self.reset()
+
+    def num_examples(self):
+        return num_examples(self.episodes)
+
+    def num_episodes(self):
+        return len(self.episodes)
+
+    def get(self, episode_idx, entry_idx=0):
+        return get(self.id, self.episodes, entry_idx)
 
 
 class DefaultTeacher(C3Teacher):

--- a/parlai/tasks/c3/agents.py
+++ b/parlai/tasks/c3/agents.py
@@ -4,11 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.teachers import FixedDialogTeacher
 from .build import build
 from parlai.tasks.dream.agents import BaseMultipleChoiceTeacher
 import os
-import json
 
 
 def _path(opt):

--- a/parlai/tasks/c3/agents.py
+++ b/parlai/tasks/c3/agents.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from parlai.core.teachers import FixedDialogTeacher
+from .build import build
+from parlai.tasks.dream.agents import BaseMultipleChoiceTeacher
+import os
+import json
+
+
+def _path(opt):
+    # build the data if it does not exist
+    build(opt)
+
+    # set up path to data (specific to each dataset)
+    jsons_path = os.path.join(opt['datapath'], 'C3')
+    return jsons_path
+
+
+class C3Teacher(BaseMultipleChoiceTeacher):
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, _path, shared)
+        self.id = 'c3'
+
+
+class DefaultTeacher(C3Teacher):
+    pass

--- a/parlai/tasks/c3/agents.py
+++ b/parlai/tasks/c3/agents.py
@@ -9,19 +9,12 @@ from parlai.tasks.dream.agents import BaseMultipleChoiceTeacher
 import os
 
 
-def _path(opt):
-    # build the data if it does not exist
-    build(opt)
-
-    # set up path to data (specific to each dataset)
-    jsons_path = os.path.join(opt['datapath'], 'C3')
-    return jsons_path
-
-
 class C3Teacher(BaseMultipleChoiceTeacher):
     def __init__(self, opt, shared=None):
-        super().__init__(opt, _path, shared)
+        build(opt)
+        jsons_path = os.path.join(opt['datapath'], 'C3')
         self.id = 'c3'
+        super().__init__(opt, jsons_path, shared)
 
 
 class DefaultTeacher(C3Teacher):

--- a/parlai/tasks/c3/build.py
+++ b/parlai/tasks/c3/build.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import parlai.core.build_data as build_data
+import os
+from parlai.core.build_data import DownloadableFile
+
+RESOURCES = [
+    DownloadableFile(
+        'https://raw.githubusercontent.com/nlpdata/c3/master/data/c3-d-train.json',
+        'train.json',
+        'baf81f327dee84c6f451c9a4dd662e6193c67473b8791ffb72cce75cdb528f20',
+        zipped=False,
+    ),
+    DownloadableFile(
+        'https://raw.githubusercontent.com/nlpdata/c3/master/data/c3-d-test.json',
+        'test.json',
+        'e9920491b31f9d00ecf31e51727b495dd6b0d05f4a96f273a343e81b6775a8f0',
+        zipped=False,
+    ),
+    DownloadableFile(
+        'https://raw.githubusercontent.com/nlpdata/c3/master/data/c3-d-dev.json',
+        'dev.json',
+        '8c7054930a40aeb288ad7c51c42fa93d54aef678ccab29c75d46a7432f4f6278',
+        zipped=False,
+    ),
+]
+
+
+def build(opt):
+    dpath = os.path.join(opt['datapath'], 'C3')
+    version = None
+
+    if not build_data.built(dpath, version_string=version):
+        print('[building data: ' + dpath + ']')
+        if build_data.built(dpath):
+            build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # Download the data.
+        for downloadable_file in RESOURCES:
+            downloadable_file.download_file(dpath)
+
+        build_data.mark_done(dpath, version_string=version)

--- a/parlai/tasks/c3/build.py
+++ b/parlai/tasks/c3/build.py
@@ -32,7 +32,7 @@ RESOURCES = [
 
 def build(opt):
     dpath = os.path.join(opt['datapath'], 'C3')
-    version = None
+    version = '1.0'
 
     if not build_data.built(dpath, version_string=version):
         print('[building data: ' + dpath + ']')

--- a/parlai/tasks/dream/__init__.py
+++ b/parlai/tasks/dream/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/parlai/tasks/dream/agents.py
+++ b/parlai/tasks/dream/agents.py
@@ -10,63 +10,67 @@ import os
 import json
 
 
-def setup_data(opt, jsons_path):
-    if opt['datatype'].startswith('test'):
-        dpath = os.path.join(jsons_path, 'test.json')
-    elif opt['datatype'].startswith('valid'):
-        dpath = os.path.join(jsons_path, 'dev.json')
-    else:
-        dpath = os.path.join(jsons_path, 'train.json')
-    episodes = []
-    with open(dpath) as f:
-        data = json.load(f)
-        for dialogue in data:
-            context = '\n'.join(dialogue[0])
-            qas = dialogue[1]
-            episodes.append({'context': context, 'qas': qas})
-    return episodes
-
-
-def num_examples(episodes):
-    examples = 0
-    for data in episodes:
-        examples += len(data['qas'])
-    return examples
-
-
-def get(tid, episodes, episode_idx, entry_idx=0):
-    episode = episodes[episode_idx]
-    entry = episode['qas'][entry_idx]['question']
-    if entry_idx == 0:
-        entry = episode['context'] + '\n' + entry
-    episode_done = entry_idx == len(episode['qas']) - 1
-    action = {
-        'id': tid,
-        'text': entry,
-        'episode_done': episode_done,
-        'labels': [episode['qas'][entry_idx]['answer']],
-        'label_candidates': episode['qas'][entry_idx]['choice'],
-    }
-    return action
-
-
 class DREAMTeacher(FixedDialogTeacher):
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
-        build(opt)
-        jsons_path = os.path.join(opt['datapath'], 'DREAM')
         self.id = 'dream'
-        self.episodes = setup_data(opt, jsons_path)
+        if shared is not None:
+            self.episodes = shared['episodes']
+        else:
+            self.episodes = self.setup_data()
         self.reset()
 
+    def share(self):
+        shared = super().share()
+        shared['episodes'] = self.episodes
+        return shared
+
+    def setup_data(self):
+        build(self.opt)
+        jsons_path = os.path.join(self.opt['datapath'], 'DREAM')
+        return self.setup_helper(jsons_path)
+
+    def setup_helper(self, jsons_path):
+        if self.opt['datatype'].startswith('test'):
+            dpath = os.path.join(jsons_path, 'test.json')
+        elif self.opt['datatype'].startswith('valid'):
+            dpath = os.path.join(jsons_path, 'dev.json')
+        elif self.opt['datatype'].startswith('train'):
+            dpath = os.path.join(jsons_path, 'train.json')
+        else:
+            raise ValueError('Datatype not train, test, or valid')
+        episodes = []
+        with open(dpath) as f:
+            data = json.load(f)
+            for dialogue in data:
+                context = '\n'.join(dialogue[0])
+                qas = dialogue[1]
+                episodes.append({'context': context, 'qas': qas})
+        return episodes
+
     def num_examples(self):
-        return num_examples(self.episodes)
+        examples = 0
+        for data in self.episodes:
+            examples += len(data['qas'])
+        return examples
 
     def num_episodes(self):
         return len(self.episodes)
 
     def get(self, episode_idx, entry_idx=0):
-        return get(self.id, self.episodes, entry_idx)
+        episode = self.episodes[episode_idx]
+        entry = episode['qas'][entry_idx]['question']
+        if entry_idx == 0:
+            entry = episode['context'] + '\n' + entry
+        episode_done = entry_idx == len(episode['qas']) - 1
+        action = {
+            'id': self.id,
+            'text': entry,
+            'episode_done': episode_done,
+            'labels': [episode['qas'][entry_idx]['answer']],
+            'label_candidates': episode['qas'][entry_idx]['choice'],
+        }
+        return action
 
 
 class DefaultTeacher(DREAMTeacher):

--- a/parlai/tasks/dream/agents.py
+++ b/parlai/tasks/dream/agents.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from parlai.core.teachers import FixedDialogTeacher
+from .build import build
+import os
+import json
+
+
+def _path(opt):
+    # build the data if it does not exist
+    build(opt)
+
+    # set up path to data (specific to each dataset)
+    jsons_path = os.path.join(opt['datapath'], 'DREAM')
+    return jsons_path
+
+
+class BaseMultipleChoiceTeacher(FixedDialogTeacher):
+    """
+    Base class for Dream and C3 Teachers
+    """
+
+    def __init__(self, opt, path_fn, shared=None):
+        super().__init__(opt, shared)
+        jsons_path = path_fn(opt)
+        self.episodes = self._setup_data(jsons_path)
+        self.reset()
+
+    def _setup_data(self, jsons_path):
+        if self.opt['datatype'].startswith('test'):
+            dpath = os.path.join(jsons_path, 'test.json')
+        elif self.opt['datatype'].startswith('valid'):
+            dpath = os.path.join(jsons_path, 'dev.json')
+        else:
+            dpath = os.path.join(jsons_path, 'train.json')
+        episodes = []
+        with open(dpath) as f:
+            data = json.load(f)
+            for dialogue in data:
+                context = '\n'.join(dialogue[0])
+                qas = dialogue[1]
+                episodes.append({'context': context, 'qas': qas})
+        return episodes
+
+    def num_examples(self):
+        examples = 0
+        for data in self.episodes:
+            examples += len(data['qas'])
+        return examples
+
+    def num_episodes(self):
+        return len(self.episodes)
+
+    def get(self, episode_idx, entry_idx=0):
+        episode = self.episodes[episode_idx]
+        entry = episode['qas'][entry_idx]['question']
+        if entry_idx == 0:
+            entry = episode['context'] + '\n' + entry
+        episode_done = entry_idx == len(episode['qas']) - 1
+        action = {
+            'id': self.id,
+            'text': entry,
+            'episode_done': episode_done,
+            'labels': [episode['qas'][entry_idx]['answer']],
+            'label_candidates': episode['qas'][entry_idx]['choice'],
+        }
+        return action
+
+
+class DREAMTeacher(BaseMultipleChoiceTeacher):
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, _path, shared)
+        self.id = 'dream'
+
+
+class DefaultTeacher(DREAMTeacher):
+    pass

--- a/parlai/tasks/dream/agents.py
+++ b/parlai/tasks/dream/agents.py
@@ -10,23 +10,13 @@ import os
 import json
 
 
-def _path(opt):
-    # build the data if it does not exist
-    build(opt)
-
-    # set up path to data (specific to each dataset)
-    jsons_path = os.path.join(opt['datapath'], 'DREAM')
-    return jsons_path
-
-
 class BaseMultipleChoiceTeacher(FixedDialogTeacher):
     """
     Base class for Dream and C3 Teachers.
     """
 
-    def __init__(self, opt, path_fn, shared=None):
+    def __init__(self, opt, jsons_path, shared=None):
         super().__init__(opt, shared)
-        jsons_path = path_fn(opt)
         self.episodes = self._setup_data(jsons_path)
         self.reset()
 
@@ -73,8 +63,10 @@ class BaseMultipleChoiceTeacher(FixedDialogTeacher):
 
 class DREAMTeacher(BaseMultipleChoiceTeacher):
     def __init__(self, opt, shared=None):
-        super().__init__(opt, _path, shared)
+        build(opt)
+        jsons_path = os.path.join(opt['datapath'], 'DREAM')
         self.id = 'dream'
+        super().__init__(opt, jsons_path, shared)
 
 
 class DefaultTeacher(DREAMTeacher):

--- a/parlai/tasks/dream/agents.py
+++ b/parlai/tasks/dream/agents.py
@@ -21,7 +21,7 @@ def _path(opt):
 
 class BaseMultipleChoiceTeacher(FixedDialogTeacher):
     """
-    Base class for Dream and C3 Teachers
+    Base class for Dream and C3 Teachers.
     """
 
     def __init__(self, opt, path_fn, shared=None):

--- a/parlai/tasks/dream/build.py
+++ b/parlai/tasks/dream/build.py
@@ -32,7 +32,7 @@ RESOURCES = [
 
 def build(opt):
     dpath = os.path.join(opt['datapath'], 'DREAM')
-    version = None
+    version = '1.0'
 
     if not build_data.built(dpath, version_string=version):
         print('[building data: ' + dpath + ']')

--- a/parlai/tasks/dream/build.py
+++ b/parlai/tasks/dream/build.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import parlai.core.build_data as build_data
+import os
+from parlai.core.build_data import DownloadableFile
+
+RESOURCES = [
+    DownloadableFile(
+        'https://raw.githubusercontent.com/nlpdata/dream/master/data/train.json',
+        'train.json',
+        '90942ddea1b56231a0ad2097dc5f115ce1face1cfb86f029041e5bad38e68566',
+        zipped=False,
+    ),
+    DownloadableFile(
+        'https://raw.githubusercontent.com/nlpdata/dream/master/data/test.json',
+        'test.json',
+        'd96d7d0752f7eab1ea8f165a582430f35653c428d36633ab4d7f26fc14946c3a',
+        zipped=False,
+    ),
+    DownloadableFile(
+        'https://raw.githubusercontent.com/nlpdata/dream/master/data/dev.json',
+        'dev.json',
+        '9d5af2e580d809c73872a7dd43fe93d0b07c6f6086b04a9a9a1917603009d961',
+        zipped=False,
+    ),
+]
+
+
+def build(opt):
+    dpath = os.path.join(opt['datapath'], 'DREAM')
+    version = None
+
+    if not build_data.built(dpath, version_string=version):
+        print('[building data: ' + dpath + ']')
+        if build_data.built(dpath):
+            build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # Download the data.
+        for downloadable_file in RESOURCES:
+            downloadable_file.download_file(dpath)
+
+        build_data.mark_done(dpath, version_string=version)

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -1144,4 +1144,24 @@ task_list = [
             "<https://arxiv.org/abs/1911.03842>."
         ),
     },
+    {
+        "id": "DREAM",
+        "display_name": "DREAM",
+        "task": "dream",
+        "tags": ["All", "QA"],
+        "description": (
+            "A multiple-choice answering dataset based on multi-turn, multi-party dialogue."
+            "More information can be found at: <https://dataset.org/dream/>."
+        ),
+    },
+    {
+        "id": "C3",
+        "display_name": "C3",
+        "task": "c3",
+        "tags": ["All", "QA"],
+        "description": (
+            "A multiple-choice answering dataset in Chinese based on a prior passage."
+            "More information can be found at: <https://dataset.org/c3/>."
+        ),
+    },
 ]


### PR DESCRIPTION
**Patch description**
Adds DREAM dataset (https://dataset.org/dream/) and C3 datasets (https://dataset.org/c3/). The datasets answer multiple-choice questions given a conversation or text passage, respectively.

**Testing steps**
Run display_data with verbose tag, expect to see conversations with multiple choice answers as label_candidates.

**Logs**
*DREAM*
`python3 examples/display_data.py -t dream -v`
```
[id]: dream
[text]: W: Hello, this is TBC Television Studios. How can I help you?
M: Hello. I'm calling because I saw an ad in the campus newspaper. It said you wanted an assistant to work on your local news program.
W: Right. But you do realize that we just need volunteers. It's an unpaid position.
M: Oh, sure. I understand that. I just want to get some experience working for television news production after I get my degree.
W: I see. Well, you'll need to talk to Ms. Black. She is in charge of the program. But first, you'll need to come here to fill out an application form. Can you drop by the studio later today?
Where does the woman work?
[labels]: At a TV station.
[label_candidates]: At a university.|At a TV station.|At a newspaper office.
~~
[id]: dream
[text]: Why is the man applying for this position?
[labels]: He wants some working experience.
[label_candidates]: He needs a well-paid position.|He has recently lost another job.|He wants some working experience.

```

*C3*
`python3 examples/display_data.py -t dream -v`
```
~~
[id]: c3
[text]: 男：这件衣服我要了，在哪儿交钱?
女：前边右拐就有一个收银台，可以交现金，也可以刷卡。
他们最可能在什么地方?
[labels]: 商场
[label_candidates]: 医院|迪厅|商场|饭馆
```

**Other information**
The datasets share the same format, so if there's generally better way to share their agents methods besides having some methods in `dream/agents.py` I can change it to that. 

**Data tests (if applicable)**
```
python3 tests/datatests/test_new_tasks.py 
.
----------------------------------------------------------------------
Ran 1 test in 40.650s

OK

```
