### PR TITLE
[Bug Fix]Display data should add :ordered properly

### DIFF
--- a/parlai/scripts/display_data.py
+++ b/parlai/scripts/display_data.py
@@ -62,8 +62,8 @@ def simple_display(opt, world, turn):
 
 def display_data(opt):
     # force ordered data to prevent repeats
-    if 'ordered' not in opt['datatype']:
-        opt['datatype'] = opt['datatype'].split(':')[0] + ':ordered'
+    if 'ordered' not in opt['datatype'] and 'train' in opt['datatype']:
+        opt['datatype'] = f"{opt['datatype']}:ordered"
 
     # create repeat label agent and assign it to the specified task
     agent = RepeatLabelAgent(opt)


### PR DESCRIPTION
**Patch description**
The previous code forces display_data to have ordered in opt, this logic breaks for valid, test. Also breaks for train:stream
**Testing steps**
display_data with any chunk teacher.
