### PR TITLE
Add Opt load/save utilities

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -43,7 +43,7 @@ This module also provides a utility method:
 from parlai.core.build_data import modelzoo_path
 from parlai.core.loader import load_agent_module
 from parlai.core.loader import register_agent  # noqa: F401
-from parlai.core.opt import Opt, load_opt_file
+from parlai.core.opt import Opt
 from parlai.utils.misc import warn_once
 import copy
 import os
@@ -202,7 +202,7 @@ def compare_init_model_opts(opt: Opt, curr_opt: Opt):
     optfile = opt['init_model'] + '.opt'
     if not os.path.isfile(optfile):
         return
-    init_model_opt = load_opt_file(optfile)
+    init_model_opt = Opt.load_file(optfile)
 
     extra_opts = {}
     different_opts = {}
@@ -291,7 +291,7 @@ def create_agent_from_opt_file(opt: Opt):
     model_file = opt['model_file']
     optfile = model_file + '.opt'
     if os.path.isfile(optfile):
-        new_opt = load_opt_file(optfile)
+        new_opt = Opt.load_file(optfile)
         # TODO we need a better way to say these options are never copied...
         if 'datapath' in new_opt:
             # never use the datapath from an opt dump

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -202,7 +202,7 @@ def compare_init_model_opts(opt: Opt, curr_opt: Opt):
     optfile = opt['init_model'] + '.opt'
     if not os.path.isfile(optfile):
         return
-    init_model_opt = Opt.load_file(optfile)
+    init_model_opt = Opt.load(optfile)
 
     extra_opts = {}
     different_opts = {}
@@ -291,7 +291,7 @@ def create_agent_from_opt_file(opt: Opt):
     model_file = opt['model_file']
     optfile = model_file + '.opt'
     if os.path.isfile(optfile):
-        new_opt = Opt.load_file(optfile)
+        new_opt = Opt.load(optfile)
         # TODO we need a better way to say these options are never copied...
         if 'datapath' in new_opt:
             # never use the datapath from an opt dump

--- a/parlai/core/opt.py
+++ b/parlai/core/opt.py
@@ -13,6 +13,17 @@ import json
 import pickle
 import traceback
 
+# these keys are automatically removed upon save. This is a rather blunt hammer.
+# It's preferred you indicate this at option definiton time.
+__AUTOCLEAN_KEYS = [
+    "override",
+    "batchindex",
+    "download_path",
+    "datapath",
+    "batchindex",
+    "interactive_mode",
+]
+
 
 class Opt(dict):
     """
@@ -80,6 +91,24 @@ class Opt(dict):
             return '\n'.join(changes)
         else:
             return f'No history for {key}'
+
+    def save(self, filename: str) -> None:
+        """
+        Save the opt to disk.
+
+        Attempts to 'clean up' any residual values automatically.
+        """
+        # start with a shallow copy
+        dct = dict(self)
+
+        # clean up some things we probably don't want to save
+        for key in __AUTOCLEAN_KEYS:
+            if key in dct:
+                del dct[key]
+
+        with open(filename, 'w', encoding='utf-8') as handle:
+            json.dump(dct, handle=f, indent=4)
+            handle.write('\n')
 
     @classmethod
     def load_file(cls, optfile: str) -> Opt:

--- a/parlai/core/opt.py
+++ b/parlai/core/opt.py
@@ -23,6 +23,7 @@ __AUTOCLEAN_KEYS__: List[str] = [
     "download_path",
     "datapath",
     "batchindex",
+    # we don't save interactive mode, it's only decided by scripts or CLI
     "interactive_mode",
 ]
 
@@ -110,6 +111,7 @@ class Opt(dict):
 
         with open(filename, 'w', encoding='utf-8') as f:
             json.dump(dct, fp=f, indent=4)
+            # extra newline for convenience of working with jq
             f.write('\n')
 
     @classmethod

--- a/parlai/core/opt.py
+++ b/parlai/core/opt.py
@@ -81,17 +81,17 @@ class Opt(dict):
         else:
             return f'No history for {key}'
 
-
-def load_opt_file(optfile: str) -> Opt:
-    """
-    Load an Opt from disk.
-    """
-    try:
-        # try json first
-        with open(optfile, 'r') as t_handle:
-            opt = json.load(t_handle)
-    except UnicodeDecodeError:
-        # oops it's pickled
-        with open(optfile, 'rb') as b_handle:
-            opt = pickle.load(b_handle)
-    return Opt(opt)
+    @classmethod
+    def load_file(cls, optfile: str) -> Opt:
+        """
+        Load an Opt from disk.
+        """
+        try:
+            # try json first
+            with open(optfile, 'r') as t_handle:
+                opt = json.load(t_handle)
+        except UnicodeDecodeError:
+            # oops it's pickled
+            with open(optfile, 'rb') as b_handle:
+                opt = pickle.load(b_handle)
+        return cls(opt)

--- a/parlai/core/opt.py
+++ b/parlai/core/opt.py
@@ -13,9 +13,11 @@ import json
 import pickle
 import traceback
 
+from typing import List
+
 # these keys are automatically removed upon save. This is a rather blunt hammer.
 # It's preferred you indicate this at option definiton time.
-__AUTOCLEAN_KEYS = [
+__AUTOCLEAN_KEYS__: List[str] = [
     "override",
     "batchindex",
     "download_path",
@@ -102,25 +104,28 @@ class Opt(dict):
         dct = dict(self)
 
         # clean up some things we probably don't want to save
-        for key in __AUTOCLEAN_KEYS:
+        for key in __AUTOCLEAN_KEYS__:
             if key in dct:
                 del dct[key]
 
-        with open(filename, 'w', encoding='utf-8') as handle:
-            json.dump(dct, handle=f, indent=4)
-            handle.write('\n')
+        with open(filename, 'w', encoding='utf-8') as f:
+            json.dump(dct, fp=f, indent=4)
+            f.write('\n')
 
     @classmethod
-    def load_file(cls, optfile: str) -> Opt:
+    def load_file(cls, optfile: str) -> 'Opt':
         """
         Load an Opt from disk.
         """
         try:
             # try json first
             with open(optfile, 'r') as t_handle:
-                opt = json.load(t_handle)
+                dct = json.load(t_handle)
         except UnicodeDecodeError:
             # oops it's pickled
             with open(optfile, 'rb') as b_handle:
-                opt = pickle.load(b_handle)
-        return cls(opt)
+                dct = pickle.load(b_handle)
+        for key in __AUTOCLEAN_KEYS__:
+            if key in dct:
+                del dct[key]
+        return cls(dct)

--- a/parlai/core/opt.py
+++ b/parlai/core/opt.py
@@ -113,7 +113,7 @@ class Opt(dict):
             f.write('\n')
 
     @classmethod
-    def load_file(cls, optfile: str) -> 'Opt':
+    def load(cls, optfile: str) -> 'Opt':
         """
         Load an Opt from disk.
         """

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -26,7 +26,7 @@ import parlai.utils.logging as logging
 from parlai.core.build_data import modelzoo_path
 from parlai.core.loader import load_teacher_module, load_agent_module, load_world_module
 from parlai.tasks.tasks import ids_to_tasks
-from parlai.core.opt import Opt, load_opt_file
+from parlai.core.opt import Opt
 
 from typing import List, Optional
 
@@ -123,7 +123,7 @@ def get_model_name(opt):
             model_file = modelzoo_path(opt.get('datapath'), model_file)
             optfile = model_file + '.opt'
             if os.path.isfile(optfile):
-                new_opt = load_opt_file(optfile)
+                new_opt = Opt.load_file(optfile)
                 model = new_opt.get('model', None)
     return model
 
@@ -868,7 +868,7 @@ class ParlaiParser(argparse.ArgumentParser):
         Called before args are parsed; ``_load_opts`` is used for actually overriding
         opts after they are parsed.
         """
-        new_opt = load_opt_file(optfile)
+        new_opt = Opt.load_file(optfile)
         for key, value in new_opt.items():
             # existing command line parameters take priority.
             if key not in parsed or parsed[key] is None:
@@ -876,7 +876,7 @@ class ParlaiParser(argparse.ArgumentParser):
 
     def _load_opts(self, opt):
         optfile = opt.get('init_opt')
-        new_opt = load_opt_file(optfile)
+        new_opt = Opt.load_file(optfile)
         for key, value in new_opt.items():
             # existing command line parameters take priority.
             if key not in opt:

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -123,7 +123,7 @@ def get_model_name(opt):
             model_file = modelzoo_path(opt.get('datapath'), model_file)
             optfile = model_file + '.opt'
             if os.path.isfile(optfile):
-                new_opt = Opt.load_file(optfile)
+                new_opt = Opt.load(optfile)
                 model = new_opt.get('model', None)
     return model
 
@@ -868,7 +868,7 @@ class ParlaiParser(argparse.ArgumentParser):
         Called before args are parsed; ``_load_opts`` is used for actually overriding
         opts after they are parsed.
         """
-        new_opt = Opt.load_file(optfile)
+        new_opt = Opt.load(optfile)
         for key, value in new_opt.items():
             # existing command line parameters take priority.
             if key not in parsed or parsed[key] is None:
@@ -876,7 +876,7 @@ class ParlaiParser(argparse.ArgumentParser):
 
     def _load_opts(self, opt):
         optfile = opt.get('init_opt')
-        new_opt = Opt.load_file(optfile)
+        new_opt = Opt.load(optfile)
         for key, value in new_opt.items():
             # existing command line parameters take priority.
             if key not in opt:

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1788,19 +1788,10 @@ class TorchAgent(ABC, Agent):
             if states:  # anything found to save?
                 with open(path, 'wb') as write:
                     torch.save(states, write)
-
                 # save opt file
-                with open(path + '.opt', 'w', encoding='utf-8') as handle:
-                    if hasattr(self, 'model_version'):
-                        self.opt['model_version'] = self.model_version()
-                    saved_opts = deepcopy(self.opt)
-                    if 'interactive_mode' in saved_opts:
-                        # We do not save the state of interactive mode, it is only decided
-                        # by scripts or command line.
-                        del saved_opts['interactive_mode']
-                    json.dump(saved_opts, handle, indent=4)
-                    # for convenience of working with jq, make sure there's a newline
-                    handle.write('\n')
+                if hasattr(self, 'model_version'):
+                    self.opt['model_version'] = self.model_version()
+                self.opt.save(path + '.opt')
 
     def load_state_dict(self, state_dict):
         """

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -21,9 +21,7 @@ See below for documentation on each specific tool.
 
 from typing import Dict, Any, Union, List, Tuple, Optional
 from abc import ABC, abstractmethod
-from copy import deepcopy
 from collections import deque
-import json
 import random
 import os
 import torch

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import unittest
+import parlai.utils.testing as testing_utils
+from parlai.core.opt import Opt
+
+"""
+Test Opt and related mechanisms.
+"""
+
+
+class TestOpt(unittest.TestCase):
+    def test_save_load(self):
+        o = Opt({'a': 3, 'b': 'foo'})
+        with testing_utils.tempdir() as tmpdir:
+            fn = os.path.join(tmpdir, "opt")
+            o.save(fn)
+            o2 = Opt.load(fn)
+            assert o == o2
+
+    def test_save_withignore(self):
+        o = Opt({'a': 3, 'b': 'foo', 'override': {'a': 3}})
+        with testing_utils.tempdir() as tmpdir:
+            fn = os.path.join(tmpdir, "opt")
+            o.save(fn)
+            o2 = Opt.load(fn)
+            assert o != o2
+            assert 'override' not in o2


### PR DESCRIPTION
**Patch description**
Bundles these methods with Opt just for cleanliness. Corresponding internal changes upgrades old references.

Also adds a backstop for items that SHOULDN'T be saved or loaded from disk.

Although this may seem like a naming nit, centralizing the functionality will help keep attempts at #2177 clean.

Fixes #2172.

**Testing steps**
CI.