### PR TITLE
Allow DialogTeacher's setup_data to emit non-tuple

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -781,7 +781,7 @@ class DialogData(object):
             if 'labels' in entry and isinstance(entry['labels'], str):
                 entry['labels'] = (entry['labels'],)
             table = entry.copy()
-        elif isinstance(entry, Tuple):
+        elif isinstance(entry, (Tuple, List)):
             table = {}
             if entry[0] is not None:
                 table['text'] = entry[0]
@@ -800,7 +800,7 @@ class DialogData(object):
                     table['image'] = img
         else:
             raise TypeError(
-                f"items out of setup_data should be Dict, Message, or Tuple. "
+                f"items out of setup_data should be dict, Message, list, or tuple. "
                 f"Got {type(entry)})"
             )
 

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -660,7 +660,7 @@ class DialogData(object):
             self.image_loader = ImageLoader(opt)
             self.data = []
             self._load(data_loader, opt['datafile'])
-            self.cands = None if cands is None else set(sys.intern(c) for c in cands)
+            self.cands = None if cands is None else set(c for c in cands)
 
         self.addedCands = []
         self.copied_cands = False
@@ -693,57 +693,7 @@ class DialogData(object):
                 episode = []
                 last_cands = None
 
-            # intern all strings so we don't store them more than once
-            # TODO: clean up the if .. sys.intern else None by refactoring
-            new_entry = []
-            if len(entry) > 0:
-                # process text if available
-                if entry[0] is not None:
-                    new_entry.append(sys.intern(entry[0]))
-                else:
-                    new_entry.append(None)
-                # TODO: unindent all of these one level.
-                if len(entry) > 1:
-                    # process labels if available
-                    if entry[1] is None:
-                        new_entry.append(None)
-                    elif hasattr(entry[1], '__iter__') and type(entry[1]) is not str:
-                        # TODO: this could use the abc collections
-                        # make sure iterable over labels, not single string
-                        new_entry.append(tuple(sys.intern(e) for e in entry[1]))
-                    elif isinstance(entry[1], str):
-                        new_entry.append((sys.intern(entry[1]),))
-                    else:
-                        raise TypeError(f"{entry[1]} is not list or str")
-                if len(entry) > 2:
-                    # process reward if available
-                    if entry[2] is not None:
-                        new_entry.append(entry[2])
-                    else:
-                        new_entry.append(None)
-                if len(entry) > 3:
-                    # process label candidates if available
-                    if entry[3] is None:
-                        new_entry.append(None)
-                    elif last_cands and entry[3] is last_cands:
-                        # if cands are shared, say "same" so we
-                        # don't store them again
-                        # TODO: This is bad, and it's not actually used anywhere
-                        # DEPRECATIONDAY: make this more rational
-                        new_entry.append(sys.intern('same as last time'))
-                    elif hasattr(entry[3], '__iter__') and type(entry[3]) is not str:
-                        # make sure iterable over candidates, not single string
-                        last_cands = entry[3]
-                        new_entry.append(tuple(sys.intern(e) for e in entry[3]))
-                    else:
-                        raise TypeError(
-                            'Must provide iterable over label candidates, '
-                            'not a single string.'
-                        )
-                if len(entry) > 4 and entry[4] is not None:
-                    new_entry.append(sys.intern(entry[4]))
-
-            episode.append(tuple(new_entry))
+            episode.append(entry)
 
         if len(episode) > 0:
             yield tuple(episode)
@@ -818,29 +768,32 @@ class DialogData(object):
                     'Labels are converted to eval_labels automatically. Please do not '
                     'set them in setup_data.'
                 )
-            if 'label' in entry:
-                # for convenience, rename to the labels convention automatically
-                label = entry.pop('label')
-                entry['labels'] = [label]
             if 'episode_done' in entry:
                 raise KeyError(
                     "episode_done is set automatically for you. Please don't set it "
                     "in setup_data."
                 )
+            if 'label' in entry:
+                # for convenience, rename to the labels convention automatically
+                label = entry.pop('label')
+                assert isinstance(label, str)
+                entry['labels'] = (label,)
+            if 'labels' in entry and isinstance(entry['labels'], str):
+                entry['labels'] = (entry['labels'],)
             table = entry.copy()
         elif isinstance(entry, Tuple):
             table = {}
             if entry[0] is not None:
                 table['text'] = entry[0]
-            if len(entry) > 1:
-                if entry[1] is not None:
-                    table['labels'] = entry[1]
-            if len(entry) > 2:
-                if entry[2] is not None:
-                    table['reward'] = entry[2]
-            if len(entry) > 3:
-                if entry[3] is not None:
-                    table['label_candidates'] = entry[3]
+            if len(entry) > 1 and entry[1] is not None:
+                l = entry[1]
+                if isinstance(l, str):
+                    l = (l,)
+                table['labels'] = l
+            if len(entry) > 2 and entry[2] is not None:
+                table['reward'] = entry[2]
+            if len(entry) > 3 and entry[3] is not None:
+                table['label_candidates'] = entry[3]
             if len(entry) > 4 and entry[4] is not None:
                 img = self.image_loader.load(entry[4])
                 if img is not None:

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -49,7 +49,6 @@ from multiprocessing import Value, Lock
 from threading import Thread
 import queue
 import random
-import sys
 import time
 import os
 import torch
@@ -686,12 +685,10 @@ class DialogData(object):
         """
 
         episode = []
-        last_cands = None
         for entry, new in data_loader:
             if new and len(episode) > 0:
                 yield tuple(episode)
                 episode = []
-                last_cands = None
 
             episode.append(entry)
 

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -442,25 +442,27 @@ class BadExampleTeacher(CandidateTeacher):
             case = newget.case
             if case == 0:
                 # empty string input
-                item['text'] = ''
+                item.force_set('text', '')
             elif case == 1:
                 # not text input
                 del item['text']
             elif case == 2:
                 # empty string label
-                item['labels'] = ['']
+                item.force_set('labels', [''])
             elif case == 3:
                 # no label
                 del item['labels']
             elif case == 4:
                 # no label candidates
-                item['label_candidates'] = []
+                item.force_set('label_candidates', [])
             elif case == 5:
                 # extra empty string in labels
-                item['label_candidates'] = list(item['label_candidates']) + ['']
+                item.force_set(
+                    'label_candidates', list(item['label_candidates']) + ['']
+                )
             elif case == 6:
                 # label candidates doesn't have the label
-                item['label_candidates'] = list(item['label_candidates'])
+                item.force_set('label_candidates', list(item['label_candidates']))
                 item['label_candidates'].remove(item['labels'][0])
             elif case == 7:
                 # no label candidates field

--- a/tests/test_teachers.py
+++ b/tests/test_teachers.py
@@ -14,6 +14,7 @@ import unittest
 from parlai.utils import testing as testing_utils
 import regex as re
 from parlai.core.teachers import DialogTeacher
+from parlai.core.message import Message
 from parlai.core.opt import Opt
 from parlai.core.loader import register_teacher
 
@@ -136,9 +137,30 @@ class TupleDialogTeacher(DialogTeacher):
         super().__init__(opt, shared)
 
     def setup_data(self, datafile):
-        for i in range(2):
+        for i in range(3):
             for j in range(1, 4):
                 yield (str(j), str(j * 2)), j == 1
+
+
+class DictDialogTeacher(DialogTeacher):
+    def __init__(self, opt, shared=None):
+        opt['datafile'] = 'mock'
+        super().__init__(opt, shared)
+
+    def setup_data(self, datafile):
+        for i in range(3):
+            for j in range(1, 4):
+                m = {'text': str(i)}
+                label = str(j * 2)
+                if i == 0:
+                    m['label'] = label
+                elif i == 1:
+                    m['labels'] = [labels]
+                elif i == 2:
+                    m['labels'] = [labels]
+                    m = Message(m)
+
+                yield m, j == 1
 
 
 class TestDialogTeacher(unittest.TestCase):
@@ -160,7 +182,14 @@ class TestDialogTeacher(unittest.TestCase):
         self._verify_act(teacher.act(), 2, 4, False)
         self._verify_act(teacher.act(), 3, 6, True)
 
+        self._verify_act(teacher.act(), 1, 2, False)
+        self._verify_act(teacher.act(), 2, 4, False)
+        self._verify_act(teacher.act(), 3, 6, True)
+
         assert teacher.epoch_done()
+
+    def test_tuple_teacher(self):
+        self._test_iterate(DictDialogTeacher)
 
     def test_tuple_teacher(self):
         self._test_iterate(TupleDialogTeacher)


### PR DESCRIPTION
**Patch description**
Making DialogTeacher a bit more friendly for highly custom teachers, which have more than just text/label. Built in some safety checks, and making it "do the right thing" if you give it "label" instead of "labels".

**Testing steps**
New CI, old CI, CI CI CI