### PR TITLE
Ignore F541 f-string is missing placeholders

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,6 +9,7 @@ extend-ignore =
     E266
     W503
     F403
+    F541
 select = C,E,F,W,B,B950,RST,PAI,BLK
 
 max-line-length=80


### PR DESCRIPTION
**Patch description**
Recent version of flake added this error and I don't like it. I'm muting it.

Example:
```
parlai/core/teachers.py:1714:19: F541 f-string is missing placeholders
            print(f'No existing image features, attempting to build.')
                  ^
````

**Testing steps**
Ran flake8 after this and it passed.