### PR TITLE
Updating MTurk world saving to work with Mephisto agents.

### DIFF
--- a/parlai/mturk/core/worlds.py
+++ b/parlai/mturk/core/worlds.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from parlai.core.worlds import World
+from parlai.mturk.core.agents import MTurkAgent
 
 
 class MTurkDataWorld(World):
@@ -17,19 +18,22 @@ class MTurkDataWorld(World):
         save_data = {'custom_data': custom_data, 'worker_data': {}}
 
         for agent in workers:
-            messages = agent.get_messages()
-            # filter out peer feedback
-            save_messages = [m for m in messages if m.get('text') != '[PEER_REVIEW]']
-            save_data['worker_data'][agent.worker_id] = {
-                'worker_id': agent.worker_id,
-                'agent_id': agent.id,
-                'assignment_id': agent.assignment_id,
-                'messages': save_messages,
-                'given_feedback': agent.feedback,
-            }
+            if isinstance(agent, MTurkAgent):
+                messages = agent.get_messages()
+                # filter out peer feedback
+                save_messages = [
+                    m for m in messages if m.get('text') != '[PEER_REVIEW]'
+                ]
+                save_data['worker_data'][agent.worker_id] = {
+                    'worker_id': agent.worker_id,
+                    'agent_id': agent.id,
+                    'assignment_id': agent.assignment_id,
+                    'messages': save_messages,
+                    'given_feedback': agent.feedback,
+                }
 
         # In simple pairing case, attach the feedback right here
-        if len(workers) == 2:
+        if len(workers) == 2 and all([isinstance(w, MTurkAgent) for w in workers]):
             data = save_data['worker_data']
             a_0 = workers[0]
             a_1 = workers[1]


### PR DESCRIPTION
**Patch description**
Looking forward to the OSS release of Mephisto in the near future, this is some of the prep work required to allow existing tasks to run seamlessly while we're in a state of transition. In this case Mephisto's ParlAI agents only extend `Agent` and not `MTurkAgent`, and thus don't have the same methods. We still want to be able to `prep_save_data` to get the custom data that users specify, but we don't need the `worker_data` as Mephisto is responsible for keeping track of this on a per-assignment basis anyways.

**Testing:**
Launched a sandbox task, seemed to save - @dianaglzrico can you do a quick pilot of your task on this branch?