### PR TITLE
Fix broken link in chat service tutorial.

### DIFF
--- a/docs/source/tutorial_chat_service.md
+++ b/docs/source/tutorial_chat_service.md
@@ -150,4 +150,5 @@ See **Browser** above for an example implementation of a websockets-based chat s
 
 ### Adding a New Chat Service
 
-For full instructions on adding a new chat service to ParlAI, please read [here](https://github.com/facebookresearch/ParlAI/tree/master/parlai/chat_service/README.md).
+For full instructions on adding a new chat service to ParlAI, please read [here](https://github.com/facebookresearch/ParlAI/tree/master/parlai/chat_service/).
+


### PR DESCRIPTION
**Patch description**
Fixes #2564. Weirdly, I found the URL in the markdown correct, but the docs were rendering it wrong. As a work around, I just use the folder since that displays the readme at the bottom.

**Testing steps**
Local testing