### PR TITLE
[Display Data] don't force ordered

### DIFF
--- a/parlai/scripts/display_data.py
+++ b/parlai/scripts/display_data.py
@@ -61,10 +61,6 @@ def simple_display(opt, world, turn):
 
 
 def display_data(opt):
-    # force ordered data to prevent repeats
-    if 'ordered' not in opt['datatype']:
-        opt['datatype'] = opt['datatype'].split(':')[0] + ':ordered'
-
     # create repeat label agent and assign it to the specified task
     agent = RepeatLabelAgent(opt)
     world = create_task(opt, agent)


### PR DESCRIPTION
**Patch description**
`train:ordered` is the default for display data, but some teachers only work with streaming. We shouldn't FORCE `train:ordered` (it is set as default, but we should be able to override it).