### PR TITLE
Force utf-8 encodings

### DIFF
--- a/parlai/tasks/blended_skill_talk/build.py
+++ b/parlai/tasks/blended_skill_talk/build.py
@@ -99,11 +99,11 @@ def _create_parlai_format(dpath: str):
         save_path = os.path.join(dpath, f'{datatype}.txt')
 
         print(f'Loading {load_path}.')
-        with open(load_path, 'r') as f_read:
+        with open(load_path, 'r', encoding='utf8') as f_read:
             data = json.load(f_read)
 
         print(f'Saving to {save_path}')
-        with open(save_path, 'w') as f_write:
+        with open(save_path, 'w', encoding='utf8') as f_write:
             for episode in data:
                 assert (
                     len(episode['dialog'])

--- a/parlai/utils/bpe.py
+++ b/parlai/utils/bpe.py
@@ -513,7 +513,7 @@ class Gpt2BpeHelper(BPEHelper):
         :return:
             encoder, mapping tokens to unicode reps
         """
-        with open(json_path, 'r') as f:
+        with open(json_path, 'r', encoding='utf8') as f:
             encoder = json.load(f)
         for each_token in encoder.keys():
             new_token = ''.join(


### PR DESCRIPTION
**Patch description**
Forcing utf-8 at the following positions allows me to run Parl.AI Blender under Windows 10 with Anaconda3 and does not negatively impact Linux support.

**Testing steps**
I tested across both Windows 10 and also Linux successfully.  

python3 parlai/scripts/interactive.py -t blended_skill_talk -mf zoo:blender/blender_90M/model

[context]: your persona: i live in pittsburgh.
your persona: i volunteer at an animal shelter.
Animal shelter
Enter Your Message: hi
[TransformerGenerator]: hello , how are you today ? i just got back from mountain climbing with my husband at telecom .

**Logs**


**Other information**
Windows 10 / Anaconda3 will work just fine with Parl.AI Blender with just these minor updates.

**Data tests (if applicable)**

