### PR TITLE
[Beam block] upgrade opt bug fix

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -334,9 +334,10 @@ class TorchGeneratorAgent(TorchAgent, ABC):
 
         # 2020-06-03: Changing "blacklist" --> "blocklist"
         if 'beam_blacklist_filename' in opt_from_disk:
-            opt_from_disk['beam_block_list_filename'] = opt_from_disk[
-                'beam_blacklist_filename'
-            ]
+            if opt_from_disk['beam_blacklist_filename'] is not None:
+                opt_from_disk['beam_block_list_filename'] = opt_from_disk[
+                    'beam_blacklist_filename'
+                ]
             del opt_from_disk['beam_blacklist_filename']
 
         return opt_from_disk


### PR DESCRIPTION
**Patch description**
Don't override block list unless it is not None. I'm still not convinced this is the right solution, seems like an issue with opt overriding.