### PR TITLE
Fix bad math in stochastic balancing

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -1844,7 +1844,7 @@ class MultiTaskTeacher(Teacher):
         self.task_choices = range(len(self.tasks))
         weights = self.opt.get('multitask_weights', [1])
         if weights == 'stochastic':
-            weights = [t.num_examples() for t in self.tasks]
+            weights = [t.num_episodes() for t in self.tasks]
         sum = 0
         for i in self.task_choices:
             if len(weights) > i:

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -611,7 +611,7 @@ class MultiWorld(World):
         self.task_choices = range(len(self.worlds))
         weights = self.opt.get('multitask_weights', [1])
         if weights == 'stochastic':
-            weights = [w.num_examples() for w in self.worlds]
+            weights = [w.num_episodes() for w in self.worlds]
         sum = 0
         for i in self.task_choices:
             if len(weights) > i:

--- a/tests/test_multiworld.py
+++ b/tests/test_multiworld.py
@@ -21,6 +21,7 @@ class Teacher1(DialogTeacher):
 
     def setup_data(self, datafile):
         for i in range(100):
+            yield (str(i), str(i)), False
             yield (str(i), str(i)), True
 
 
@@ -55,8 +56,8 @@ class TestMultiworld(unittest.TestCase):
 
         report = world.report()
         ratio = report['teacher1/exs'].value() / report['teacher2/exs'].value()
-        assert ratio > 1 / 1.2
-        assert ratio < 1.2
+        assert ratio > 1.7
+        assert ratio < 2.3
 
     @testing_utils.retry(ntries=10)
     def test_stochastic(self):
@@ -77,5 +78,5 @@ class TestMultiworld(unittest.TestCase):
         report = world.report()
         # stochastic so wide range
         ratio = report['teacher1/exs'].value() / report['teacher2/exs'].value()
-        assert ratio > 8
-        assert ratio < 12
+        assert ratio > 18
+        assert ratio < 22


### PR DESCRIPTION
**Patch description**
Realized last second that I made a mistake. A modification to the test confirms my mistake: we perform sampling at the episode level, so we need to use num episodes to determine sampling ratio.

**Testing steps**
Adjusted CI.