### PR TITLE
Added WorldLogger functionality to interactive.py

### DIFF
--- a/parlai/scripts/interactive.py
+++ b/parlai/scripts/interactive.py
@@ -97,7 +97,7 @@ def interactive(opt, print_parser=None):
             # dump world acts to file
             world_logger.reset()  # add final acts to logs
             base_outfile = opt['report_filename'].split('.')[0]
-            outfile = base_outfile + f'_{task}_replies.jsonl'
+            outfile = f'{base_outfile}_{opt["task"]}_replies.jsonl'
             world_logger.write(outfile, world, file_format=opt['save_format'])
 
 

--- a/parlai/scripts/interactive.py
+++ b/parlai/scripts/interactive.py
@@ -88,17 +88,17 @@ def interactive(opt, print_parser=None):
     # Show some example dialogs:
     while not world.epoch_done():
         world.parley()
-        if world_logger is not None: 
+        if world_logger is not None:
             world_logger.log(world)
         if opt.get('display_examples'):
             print("---")
             print(world.display())
-        if world_logger is not None: 
-            # dump world acts to file 
-            world_logger.reset()  # add final acts to logs 
-            base_outfile = opt['report_filename'].split('.')[0] 
-            outfile = base_outfile + f'_{task}_replies.jsonl' 
-            world_logger.write(outfile, world, file_format=opt['save_format']) 
+        if world_logger is not None:
+            # dump world acts to file
+            world_logger.reset()  # add final acts to logs
+            base_outfile = opt['report_filename'].split('.')[0]
+            outfile = base_outfile + f'_{task}_replies.jsonl'
+            world_logger.write(outfile, world, file_format=opt['save_format'])
 
 
 class Interactive(ParlaiScript):

--- a/parlai/scripts/interactive.py
+++ b/parlai/scripts/interactive.py
@@ -22,6 +22,7 @@ from parlai.core.params import ParlaiParser
 from parlai.core.agents import create_agent
 from parlai.core.worlds import create_task
 from parlai.scripts.script import ParlaiScript
+from parlai.utils.world_logging import WorldLogger
 from parlai.agents.local_human.local_human import LocalHumanAgent
 
 import random
@@ -51,6 +52,13 @@ def setup_args(parser=None):
         default=True,
         help='Create interactive version of task',
     )
+    parser.add_argument(
+        '--save-world-logs',
+        type='bool',
+        default=False,
+        help='Saves a jsonl file containing all of the task examples and '
+        'model replies. Must also specify --report-filename.',
+    )
     parser.set_defaults(interactive_mode=True, task='interactive')
     LocalHumanAgent.add_cmdline_args(parser)
     return parser
@@ -73,14 +81,24 @@ def interactive(opt, print_parser=None):
         print_parser.opt = agent.opt
         print_parser.print_args()
     human_agent = LocalHumanAgent(opt)
+    # set up world logger
+    world_logger = WorldLogger(opt) if opt['save_world_logs'] else None 
     world = create_task(opt, [human_agent, agent])
 
     # Show some example dialogs:
     while not world.epoch_done():
         world.parley()
+        if world_logger is not None: 
+            world_logger.log(world)
         if opt.get('display_examples'):
             print("---")
             print(world.display())
+        if world_logger is not None: 
+            # dump world acts to file 
+            world_logger.reset()  # add final acts to logs 
+            base_outfile = opt['report_filename'].split('.')[0] 
+            outfile = base_outfile + f'_{task}_replies.jsonl' 
+            world_logger.write(outfile, world, file_format=opt['save_format']) 
 
 
 class Interactive(ParlaiScript):

--- a/parlai/scripts/interactive.py
+++ b/parlai/scripts/interactive.py
@@ -82,7 +82,7 @@ def interactive(opt, print_parser=None):
         print_parser.print_args()
     human_agent = LocalHumanAgent(opt)
     # set up world logger
-    world_logger = WorldLogger(opt) if opt['save_world_logs'] else None 
+    world_logger = WorldLogger(opt) if opt['save_world_logs'] else None
     world = create_task(opt, [human_agent, agent])
 
     # Show some example dialogs:


### PR DESCRIPTION
**Patch description**
Added WorldLogger functionality to interactive.py in order to save chat logs During interaction with the model.
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. -->

**Logs**
<!-- If applicable, please paste the command line from your testing: -->
```
!python -m parlai.scripts.interactive -t twitter -m seq2seq --save-world-logs True --report-filename /test/report_twitter_replies.jsonl
```

**Other information**
<!-- Any other information or context you would like to provide. -->

**Data tests (if applicable)**
If you added a new teacher, you will be asked to run
`python tests/datatests/test_new_tasks.py`. Please paste this log here.
