### PR TITLE
Fixed NucleusSampling masking

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -1534,10 +1534,9 @@ class NucleusSampling(TreeSearch):
         # for the probabilities in order to compute the CDF.
         probs = torch.softmax(logprobs, dim=-1)
         sprobs, sinds = probs.sort(dim=-1, descending=True)
-        # The subtraction here is so that we always include the first word to
-        # go over p. For example, if the most probable token has a prob of 0.5, and
-        # p = 0.3, then we need still need to include that first token.
-        mask = (sprobs.cumsum(dim=-1) - sprobs[:, :1]) >= self.p
+        # The subtraction here is to get the exclusive prefix sum,
+        # to guarantee the first element is not masked
+        mask = (sprobs.cumsum(dim=-1) - sprobs[:, :]) >= self.p
         sprobs[mask] = 0
         sprobs.div_(sprobs.sum(dim=-1).unsqueeze(1))
         choices = torch.multinomial(sprobs, 1)[:, 0]

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -1536,7 +1536,7 @@ class NucleusSampling(TreeSearch):
         sprobs, sinds = probs.sort(dim=-1, descending=True)
         # The subtraction here is to get the exclusive prefix sum,
         # to guarantee the first element is not masked
-        mask = (sprobs.cumsum(dim=-1) - sprobs[:, :]) >= self.p
+        mask = (sprobs.cumsum(dim=-1) - sprobs) >= self.p
         sprobs[mask] = 0
         sprobs.div_(sprobs.sum(dim=-1).unsqueeze(1))
         choices = torch.multinomial(sprobs, 1)[:, 0]


### PR DESCRIPTION
**Patch description**
Fixes NucleusSampling incorrect masking.
It currently subtracts the first element from the inclusive prefix sum, instead of using the exclusive prefix sum.

**Example**
Suppose `self.p = 0.5` and `sprobs = [[0.6, 0.2, 0.2]]`.
Current behavior makes `mask = [[False, False, False]]`
New correct behavior makes `mask = [[False, True, True]]`

**Testing steps**
Examples similar to above can be tested by running e.g.
`python parlai/scripts/self_chat.py -mf zoo:blender/blender_90M/model --inference nucleus --topp 0.5 --beam-size 1` and observing/printing the values of `sprobs` and `mask`.