### PR TITLE
Update narrativeqa data checksum because of upstream change

### DIFF
--- a/parlai/tasks/narrative_qa/build.py
+++ b/parlai/tasks/narrative_qa/build.py
@@ -17,7 +17,7 @@ RESOURCES = [
     DownloadableFile(
         'https://github.com/deepmind/narrativeqa/archive/master.zip',
         'narrative_qa.zip',
-        '9f6c484664394e0275944a4630a3de6294ba839162765d2839cc3d31a0b47a0e',
+        'd9fc92d5f53409f845ba44780e6689676d879c739589861b4805064513d1476b',
     )
 ]
 


### PR DESCRIPTION
They fixed some URLs so now their "master" is a different zip 🤷‍♀️