### PR TITLE
Make docs match code (redownload=False)

### DIFF
--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -150,7 +150,7 @@ def download(url, path, fname, redownload=False, num_retries=5):
     Download file using `requests`.
 
     If ``redownload`` is set to false, then will not download tar file again if it is
-    present (default ``True``).
+    present (default ``False``).
     """
     outfile = os.path.join(path, fname)
     download = not os.path.isfile(outfile) or redownload


### PR DESCRIPTION
The docstring said the default was True was but it's actually False. 🤷‍♀️