### PR TITLE
Standardize ParlAI script access

### DIFF
--- a/parlai/scripts/build_candidates.py
+++ b/parlai/scripts/build_candidates.py
@@ -26,7 +26,8 @@ import tempfile
 
 def setup_args(parser=None) -> ParlaiParser:
     # Get command line arguments
-    parser = ParlaiParser()
+    if not parser:
+        parser = ParlaiParser()
     parser.add_argument(
         '-n',
         '--num-examples',

--- a/parlai/scripts/build_candidates.py
+++ b/parlai/scripts/build_candidates.py
@@ -19,8 +19,31 @@ from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
 from parlai.core.worlds import create_task
 from parlai.utils.misc import TimeLogger
 import parlai.utils.logging as logging
+from parlai.scripts.script import ParlaiScript
 import random
 import tempfile
+
+
+def setup_args(parser=None) -> ParlaiParser:
+    # Get command line arguments
+    parser = ParlaiParser()
+    parser.add_argument(
+        '-n',
+        '--num-examples',
+        default=-1,
+        type=int,
+        help='Total number of exs to convert, -1 to convert all examples',
+    )
+    parser.add_argument(
+        '-of',
+        '--outfile',
+        default=None,
+        type=str,
+        help='Output file where to save, by default will be created in /tmp',
+    )
+    parser.add_argument('-ltim', '--log-every-n-secs', type=float, default=2)
+    parser.set_defaults(datatype='train:evalmode')
+    return parser
 
 
 def build_cands(opt):
@@ -69,29 +92,15 @@ def build_cands(opt):
     fw.close()
 
 
-def main():
-    random.seed(42)
-    # Get command line arguments
-    parser = ParlaiParser()
-    parser.add_argument(
-        '-n',
-        '--num-examples',
-        default=-1,
-        type=int,
-        help='Total number of exs to convert, -1 to convert all examples',
-    )
-    parser.add_argument(
-        '-of',
-        '--outfile',
-        default=None,
-        type=str,
-        help='Output file where to save, by default will be created in /tmp',
-    )
-    parser.add_argument('-ltim', '--log-every-n-secs', type=float, default=2)
-    parser.set_defaults(datatype='train:evalmode')
-    opt = parser.parse_args()
-    build_cands(opt)
+class BuildCandidates(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return build_cands(self.opt)
 
 
 if __name__ == '__main__':
-    main()
+    random.seed(42)
+    BuildCandidates.main()

--- a/parlai/scripts/build_dict.py
+++ b/parlai/scripts/build_dict.py
@@ -145,5 +145,14 @@ def build_dict(opt, skip_if_built=False):
     return dictionary
 
 
+class BuildDict(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args(hidden=False)
+
+    def run(self):
+        return build_dict(self.opt)
+
+
 if __name__ == '__main__':
-    build_dict(setup_args(hidden=False).parse_args())
+    BuildDict.main()

--- a/parlai/scripts/build_dict.py
+++ b/parlai/scripts/build_dict.py
@@ -21,6 +21,7 @@ from parlai.core.params import ParlaiParser, str2class
 from parlai.core.worlds import create_task
 from parlai.utils.misc import TimeLogger
 from parlai.utils.distributed import is_distributed
+from parlai.scripts.script import ParlaiScript
 import parlai.utils.logging as logging
 import copy
 import os

--- a/parlai/scripts/convert_data_to_fasttext_format.py
+++ b/parlai/scripts/convert_data_to_fasttext_format.py
@@ -66,10 +66,11 @@ def dump_data(opt):
     fw.close()
 
 
-def main():
-    random.seed(42)
+def setup_args(parser=None) -> ParlaiParser:
     # Get command line arguments
-    parser = ParlaiParser()
+    if not parser:
+        parser = ParlaiParser()
+    # Get command line arguments
     parser.add_argument(
         '-n',
         '--num-examples',
@@ -88,9 +89,16 @@ def main():
     )
     parser.add_argument('-ltim', '--log-every-n-secs', type=float, default=2)
     parser.set_defaults(datatype='train:ordered')
-    opt = parser.parse_args()
-    dump_data(opt)
+    return parser
 
+class ConvertDataToFastText(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return dump_data(self.opt)
 
 if __name__ == '__main__':
-    main()
+    random.seed(42)
+    ConvertDataToFastText.main()

--- a/parlai/scripts/convert_data_to_fasttext_format.py
+++ b/parlai/scripts/convert_data_to_fasttext_format.py
@@ -77,16 +77,14 @@ def setup_args(parser=None) -> ParlaiParser:
         '--num-examples',
         default=-1,
         type=int,
-        help='Total number of exs to convert, -1 to convert \
-                                all examples',
+        help='Total number of exs to convert, -1 to convert all examples',
     )
     parser.add_argument(
         '-of',
         '--outfile',
         default=None,
         type=str,
-        help='Output file where to save, by default will be \
-                                created in /tmp',
+        help='Output file where to save, by default will be created in /tmp',
     )
     parser.add_argument('-ltim', '--log-every-n-secs', type=float, default=2)
     parser.set_defaults(datatype='train:ordered')

--- a/parlai/scripts/convert_data_to_fasttext_format.py
+++ b/parlai/scripts/convert_data_to_fasttext_format.py
@@ -21,6 +21,7 @@ from parlai.utils.misc import TimeLogger
 import random
 import tempfile
 import parlai.utils.logging as logging
+from parlai.scripts.script import ParlaiScript
 
 
 def dump_data(opt):
@@ -91,6 +92,7 @@ def setup_args(parser=None) -> ParlaiParser:
     parser.set_defaults(datatype='train:ordered')
     return parser
 
+
 class ConvertDataToFastText(ParlaiScript):
     @classmethod
     def setup_args(cls):
@@ -98,6 +100,7 @@ class ConvertDataToFastText(ParlaiScript):
 
     def run(self):
         return dump_data(self.opt)
+
 
 if __name__ == '__main__':
     random.seed(42)

--- a/parlai/scripts/convert_data_to_parlai_format.py
+++ b/parlai/scripts/convert_data_to_parlai_format.py
@@ -19,6 +19,7 @@ from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
 from parlai.core.worlds import create_task
 from parlai.utils.misc import msg_to_str, TimeLogger
 import parlai.utils.logging as logging
+from parlai.scripts.script import ParlaiScript
 import random
 import tempfile
 
@@ -64,41 +65,46 @@ def dump_data(opt):
     fw.close()
 
 
-class ConvertDataToParlaiFormat:
-    @classmethod
-    def main(cls, *args, **kwargs):
-        random.seed(42)
-        # Get command line arguments
-        parser = ParlaiParser()
-        parser.add_argument(
-            '-n',
-            '--num-examples',
-            default=-1,
-            type=int,
-            help='Total number of exs to convert, -1 to convert \
-                                    all examples',
-        )
-        parser.add_argument(
-            '-of',
-            '--outfile',
-            default=None,
-            type=str,
-            help='Output file where to save, by default will be \
-                                    created in /tmp',
-        )
-        parser.add_argument(
-            '-if',
-            '--ignore-fields',
-            default='id',
-            type=str,
-            help='Ignore these fields from the message (returned\
-                                    with .act() )',
-        )
-        parser.add_argument('-ltim', '--log-every-n-secs', type=float, default=2)
-        parser.set_defaults(datatype='train:stream')
-        opt = parser.parse_args()
-        dump_data(opt)
+def setup_args():
+    # Get command line arguments
+    parser = ParlaiParser()
+    parser.add_argument(
+        '-n',
+        '--num-examples',
+        default=-1,
+        type=int,
+        help='Total number of exs to convert, -1 to convert \
+                                all examples',
+    )
+    parser.add_argument(
+        '-of',
+        '--outfile',
+        default=None,
+        type=str,
+        help='Output file where to save, by default will be \
+                                created in /tmp',
+    )
+    parser.add_argument(
+        '-if',
+        '--ignore-fields',
+        default='id',
+        type=str,
+        help='Ignore these fields from the message (returned\
+                                with .act() )',
+    )
+    parser.add_argument('-ltim', '--log-every-n-secs', type=float, default=2)
+    parser.set_defaults(datatype='train:stream')
+    return parser
 
+
+class ConvertDataToParlaiFormat(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return dump_data(self.opt)
 
 if __name__ == '__main__':
+    random.seed(42)
     ConvertDataToParlaiFormat.main()

--- a/parlai/scripts/convert_data_to_parlai_format.py
+++ b/parlai/scripts/convert_data_to_parlai_format.py
@@ -105,6 +105,7 @@ class ConvertDataToParlaiFormat(ParlaiScript):
     def run(self):
         return dump_data(self.opt)
 
+
 if __name__ == '__main__':
     random.seed(42)
     ConvertDataToParlaiFormat.main()

--- a/parlai/scripts/convert_data_to_parlai_format.py
+++ b/parlai/scripts/convert_data_to_parlai_format.py
@@ -73,24 +73,21 @@ def setup_args():
         '--num-examples',
         default=-1,
         type=int,
-        help='Total number of exs to convert, -1 to convert \
-                                all examples',
+        help='Total number of exs to convert, -1 to convert all examples',
     )
     parser.add_argument(
         '-of',
         '--outfile',
         default=None,
         type=str,
-        help='Output file where to save, by default will be \
-                                created in /tmp',
+        help='Output file where to save, by default will be created in tmp',
     )
     parser.add_argument(
         '-if',
         '--ignore-fields',
         default='id',
         type=str,
-        help='Ignore these fields from the message (returned\
-                                with .act() )',
+        help='Ignore these fields from the message (returned with .act() )',
     )
     parser.add_argument('-ltim', '--log-every-n-secs', type=float, default=2)
     parser.set_defaults(datatype='train:stream')

--- a/parlai/scripts/convo_render.py
+++ b/parlai/scripts/convo_render.py
@@ -333,13 +333,17 @@ def render_convo(opt):
                 file_handle = open(fname, "w")
                 file_handle.write(html_str)
                 if extension == "pdf":
-                    cmd = f"{CHROME_PATH} --headless --crash-dumps-dir=/tmp \
-                     --print-to-pdf=\"{output_file}\" {fname}"
+                    cmd = (
+                        f"{CHROME_PATH} --headless --crash-dumps-dir=/tmp"
+                        f"--print-to-pdf=\"{output_file}\" {fname}"
+                    )
                 else:
-                    cmd = f"{CHROME_PATH} --headless --hide-scrollbars \
-                    --crash-dumps-dir=/tmp \
-                     --window-size={opt['width'] * 100},{opt['height'] * 100} \
-                      --screenshot=\"{output_file}\" {fname}"
+                    cmd = (
+                        f"{CHROME_PATH} --headless --hide-scrollbars"
+                        f"--crash-dumps-dir=/tmp --window-size"
+                        f"={opt['width'] * 100},{opt['height'] * 100}"
+                        f"--screenshot=\"{output_file}\" {fname}"
+                    )
                 subprocess.run(
                     cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
                 )

--- a/parlai/scripts/convo_render.py
+++ b/parlai/scripts/convo_render.py
@@ -7,9 +7,10 @@
 import os
 import json
 import random
-import argparse
 import tempfile
 import subprocess
+from parlai.core.params import ParlaiParser
+from parlai.scripts.script import ParlaiScript
 
 # Constants
 END_OF_CONVO = "EOC"
@@ -207,38 +208,41 @@ def display_cli(conversations, alt_speaker, human_speaker):
             prBlueBG("%-15s: %s" % (speaker[:15], speech))
 
 
-def create_parser():
+def setup_args():
     """
     Creates a parser object with some pre-determined arguments.
     """
-    parser = argparse.ArgumentParser(
-        description="Process Conversation Rendering arguments"
+    parser = ParlaiParser(
+        add_parlai_args=True, description="Process Conversation Rendering arguments"
     )
-    parser.add_argument("input", help="Input file to read conversations from")
-    parser.add_argument(
+    conv_render = parser.add_argument_group('Conversation Rendering Arguments')
+    conv_render.add_argument(
+        "--input", "-i", help="Input file to read conversations from"
+    )
+    conv_render.add_argument(
         "--output",
         "-o",
         help="Output file to write conversations to. One of [.pdf, .png, .html] only",
     )
-    parser.add_argument(
+    conv_render.add_argument(
         "--width", "-wd", help="Width of output file", type=int, default=8
     )
-    parser.add_argument(
+    conv_render.add_argument(
         "--height", "-ht", help="Height of output file", type=int, default=10
     )
-    parser.add_argument(
+    conv_render.add_argument(
         "--user-icon",
         "-uic",
         help="Absolute Path/URL to user image icon",
         default=HUMAN_EMOJI_IMG,
     )
-    parser.add_argument(
+    conv_render.add_argument(
         "--alt-icon",
         "-aic",
         help="Absolute Path/URL to alternate image icon",
         default=ALT_EMOJI_IMG,
     )
-    parser.add_argument(
+    conv_render.add_argument(
         "--num-examples",
         "-ne",
         help="Number of conversations to render",
@@ -271,37 +275,36 @@ def check_icon_arg(src, default):
     return src
 
 
-def validate_args(args):
+def validate_args(opt):
     """
     Validate the cmdline args passed into the script.
 
-    :param args: The arguments of te parser
+    :param opt: The arguments of te parser
 
     :return: Returns extension of output file. None if no output file
     """
-    if not os.path.exists(args.input):
+    if not os.path.exists(opt['input']):
         raise IOError("Input File does not exist")
-    if args.output is None:
+    if opt['output'] is None:
         return None
-    extension = args.output.split(".")[-1]
+    extension = opt['output'].split(".")[-1]
     if extension not in ["html", "pdf", "png"]:
         raise Exception(
             "Extension not specified/supported. Specify one of '.html', '.pdf' or '.png' output files"
         )
-    args.user_icon = check_icon_arg(args.user_icon, HUMAN_EMOJI_IMG)
-    args.alt_icon = check_icon_arg(args.alt_icon, ALT_EMOJI_IMG)
+    opt['user_icon'] = check_icon_arg(opt['user_icon'], HUMAN_EMOJI_IMG)
+    opt['alt_icon'] = check_icon_arg(opt['alt_icon'], ALT_EMOJI_IMG)
     return extension
 
 
-if __name__ == "__main__":
-    parser = create_parser()
-    args = parser.parse_args()
-    extension = validate_args(args)
-    input_file, output_file = args.input, args.output
-    height, width = args.height, args.width
+def render_convo(opt):
+    # Run
+    extension = validate_args(opt)
+    input_file, output_file = opt['intput'], opt['output']
+    height, width = opt['height'], opt['width']
     alt_speaker = input_file.split('/')[-1][:-6]
 
-    dialogs = pre_process(input_file, args.num_examples, alt_speaker)
+    dialogs = pre_process(input_file, opt['num_examples'], alt_speaker)
 
     # Display on CLI
     if output_file is None:
@@ -315,8 +318,8 @@ if __name__ == "__main__":
             "Rendered HTML",
             alt_speaker,
             "human",
-            args.user_icon,
-            args.alt_icon,
+            opt['user_icon'],
+            opt['alt_icon'],
         )
         if extension == "html":
             # save to output
@@ -335,9 +338,22 @@ if __name__ == "__main__":
                 else:
                     cmd = f"{CHROME_PATH} --headless --hide-scrollbars \
                     --crash-dumps-dir=/tmp \
-                     --window-size={args.width * 100},{args.height * 100} \
+                     --window-size={opt['width'] * 100},{opt['height'] * 100} \
                       --screenshot=\"{output_file}\" {fname}"
                 subprocess.run(
                     cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
                 )
                 file_handle.close()
+
+
+class RenderConversation(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return render_convo(self.opt)
+
+
+if __name__ == '__main__':
+    RenderConversation.main()

--- a/parlai/scripts/data_stats.py
+++ b/parlai/scripts/data_stats.py
@@ -174,9 +174,11 @@ def verify(opt, printargs=None, print_parser=None):
         pass
     return report(world, counts, log_time)
 
+
 def obtain_stats(opt, parser):
     report_text, report_log = verify(opt, print_parser=parser)
     print(report_text.replace('\\n', '\n'))
+
 
 class DataStats(ParlaiScript):
     @classmethod
@@ -185,6 +187,7 @@ class DataStats(ParlaiScript):
 
     def run(self):
         return obtain_stats(self.opt, self.parser)
+
 
 if __name__ == '__main__':
     DataStats.main()

--- a/parlai/scripts/data_stats.py
+++ b/parlai/scripts/data_stats.py
@@ -18,6 +18,7 @@ from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
 from parlai.core.worlds import create_task
 from parlai.utils.misc import TimeLogger
 from parlai.core.dict import DictionaryAgent
+from parlai.scripts.script import ParlaiScript
 
 import parlai.utils.logging as logging
 
@@ -173,10 +174,17 @@ def verify(opt, printargs=None, print_parser=None):
         pass
     return report(world, counts, log_time)
 
+def obtain_stats(opt, parser):
+    report_text, report_log = verify(opt, print_parser=parser)
+    print(report_text.replace('\\n', '\n'))
+
+class DataStats(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return obtain_stats(self.opt, self.parser)
 
 if __name__ == '__main__':
-    parser = setup_args()
-    report_text, report_log = verify(
-        parser.parse_args(print_args=False), print_parser=parser
-    )
-    print(report_text.replace('\\n', '\n'))
+    DataStats.main()

--- a/parlai/scripts/detect_offensive_language.py
+++ b/parlai/scripts/detect_offensive_language.py
@@ -20,6 +20,7 @@ from parlai.core.worlds import create_task
 from parlai.utils.safety import OffensiveStringMatcher, OffensiveLanguageClassifier
 from parlai.utils.misc import TimeLogger
 import parlai.utils.logging as logging
+from parlai.scripts.script import ParlaiScript
 
 import random
 
@@ -131,6 +132,14 @@ def detect(opt, printargs=None, print_parser=None):
     return world.report()
 
 
+class DetectOffensive(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return detect(self.opt, print_parser=self.parser)
+
+
 if __name__ == '__main__':
-    parser = setup_args()
-    detect(parser.parse_args(print_args=False), print_parser=parser)
+    DetectOffensive.main()

--- a/parlai/scripts/distributed_train.py
+++ b/parlai/scripts/distributed_train.py
@@ -42,14 +42,6 @@ from parlai.scripts.script import ParlaiScript
 
 
 def setup_args():
-    # double check we're using SLURM
-    node_list = os.environ.get('SLURM_JOB_NODELIST')
-    if node_list is None:
-        raise RuntimeError(
-            'Does not appear to be in a SLURM environment. '
-            'You should not call this script directly; see launch_distributed.py'
-        )
-
     parser = single_train.setup_args()
     parser.add_distributed_training_args()
     parser.add_argument('--port', type=int, default=61337, help='TCP port number')
@@ -97,4 +89,11 @@ class DistributedTrain(ParlaiScript):
 
 
 if __name__ == '__main__':
+    # double check we're using SLURM
+    node_list = os.environ.get('SLURM_JOB_NODELIST')
+    if node_list is None:
+        raise RuntimeError(
+            'Does not appear to be in a SLURM environment. '
+            'You should not call this script directly; see launch_distributed.py'
+        )
     DistributedTrain.main(print_args=(os.environ['SLURM_PROCID'] == '0'))

--- a/parlai/scripts/distributed_train.py
+++ b/parlai/scripts/distributed_train.py
@@ -95,4 +95,4 @@ if __name__ == '__main__':
         raise RuntimeError(
             'Does not appear to be in a SLURM environment. You should not call this script directly; see launch_distributed.py'
         )
-    DistributedTrain.main(print_args=(os.environ['SLURM_PROCID'] == '0'))
+    DistributedTrain.main()

--- a/parlai/scripts/distributed_train.py
+++ b/parlai/scripts/distributed_train.py
@@ -85,14 +85,16 @@ class DistributedTrain(ParlaiScript):
         return setup_args()
 
     def run(self):
+        # double check we're using SLURM
+        node_list = os.environ.get('SLURM_JOB_NODELIST')
+        if node_list is None:
+            raise RuntimeError(
+                'Does not appear to be in a SLURM environment. '
+                'You should not call this script directly; '
+                'see launch_distributed.py'
+            )
         return dist_train(self.opt)
 
 
 if __name__ == '__main__':
-    # double check we're using SLURM
-    node_list = os.environ.get('SLURM_JOB_NODELIST')
-    if node_list is None:
-        raise RuntimeError(
-            'Does not appear to be in a SLURM environment. You should not call this script directly; see launch_distributed.py'
-        )
     DistributedTrain.main()

--- a/parlai/scripts/distributed_train.py
+++ b/parlai/scripts/distributed_train.py
@@ -93,7 +93,6 @@ if __name__ == '__main__':
     node_list = os.environ.get('SLURM_JOB_NODELIST')
     if node_list is None:
         raise RuntimeError(
-            'Does not appear to be in a SLURM environment. '
-            'You should not call this script directly; see launch_distributed.py'
+            'Does not appear to be in a SLURM environment. You should not call this script directly; see launch_distributed.py'
         )
     DistributedTrain.main(print_args=(os.environ['SLURM_PROCID'] == '0'))

--- a/parlai/scripts/distributed_train.py
+++ b/parlai/scripts/distributed_train.py
@@ -48,7 +48,7 @@ def setup_args():
     return parser
 
 
-def dist_train(opt):
+def dist_train(opt, node_list):
     # We can determine the init method automatically for Slurm.
     try:
         # Figure out the main host, and which rank we are.
@@ -93,7 +93,7 @@ class DistributedTrain(ParlaiScript):
                 'You should not call this script directly; '
                 'see launch_distributed.py'
             )
-        return dist_train(self.opt)
+        return dist_train(self.opt, node_list)
 
 
 if __name__ == '__main__':

--- a/parlai/scripts/eval_ppl.py
+++ b/parlai/scripts/eval_ppl.py
@@ -39,6 +39,7 @@ from parlai.core.params import ParlaiParser
 from parlai.utils.misc import Timer, round_sigfigs, no_lock
 from parlai.utils.thread import SharedTable
 from parlai.core.worlds import create_task, World
+from parlai.scripts.script import ParlaiScript
 
 import copy
 import math
@@ -252,8 +253,14 @@ def eval_ppl(opt, build_dict=None, dict_file=None):
         )
 
 
+class EvalPPL(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return eval_ppl(self.opt, dict_file=self.opt.get('dict_file'))
+
+
 if __name__ == '__main__':
-    parser = setup_args()
-    # try with --numthreads N to go fast
-    opt = parser.parse_args()
-    eval_ppl(opt, dict_file=opt.get('dict_file'))
+    EvalPPL.main()

--- a/parlai/scripts/eval_wordstat.py
+++ b/parlai/scripts/eval_wordstat.py
@@ -34,6 +34,7 @@ from parlai.utils.misc import TimeLogger
 from parlai.core.metrics import normalize_answer
 from parlai.core.logs import TensorboardLogger
 from collections import Counter
+from parlai.scripts.script import ParlaiScript
 
 import copy
 import numpy
@@ -278,6 +279,14 @@ def eval_wordstat(opt, print_parser=None):
     return report
 
 
+class EvalWordStat(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return eval_wordstat(self.opt, print_parser=self.parser)
+
+
 if __name__ == '__main__':
-    parser = setup_args()
-    eval_wordstat(parser.parse_args(print_args=False), print_parser=parser)
+    EvalWordStat.main()

--- a/parlai/scripts/extract_image_feature.py
+++ b/parlai/scripts/extract_image_feature.py
@@ -45,16 +45,15 @@ def setup_args(parser=None):
         '--dataset',
         type=str,
         default=None,
-        help='Pytorch Dataset; if specified, will save \
-                           the images in one hdf5 file according to how \
-                           they are returned by the specified dataset',
+        help='Pytorch Dataset; if specified, will save the images in one hdf5'
+        'file according to how they are returned by the specified dataset',
     )
     arg_group.add_argument(
         '-at',
         '--attention',
         action='store_true',
-        help='Whether to extract image features with attention \
-                           (Note - this is specifically for the mlb_vqa model)',
+        help='Whether to extract image features with attention'
+        '(Note - this is specifically for the mlb_vqa model)',
     )
     arg_group.add_argument(
         '--use-hdf5-extraction',

--- a/parlai/scripts/extract_image_feature.py
+++ b/parlai/scripts/extract_image_feature.py
@@ -31,6 +31,7 @@ from parlai.core.params import ParlaiParser
 from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
 from parlai.core.worlds import create_task
 import parlai.utils.logging as logging
+from parlai.scripts.script import ParlaiScript
 
 
 # TODO: this may not be adequately updated after deleting pytorch data teacher
@@ -223,5 +224,14 @@ def extract_feats(opt):
     logging.info("Finished extracting images")
 
 
+class ExtractImgFeatures(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return extract_feats(self.opt)
+
+
 if __name__ == '__main__':
-    extract_feats(setup_args().parse_args())
+    ExtractImgFeatures.main()

--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -13,6 +13,7 @@ from parlai.scripts.interactive import setup_args
 from parlai.core.agents import create_agent
 from parlai.core.worlds import create_task
 from typing import Dict, Any
+from parlai.scripts.script import ParlaiScript
 import parlai.utils.logging as logging
 
 import json
@@ -227,7 +228,7 @@ class MyHandler(BaseHTTPRequestHandler):
         self.wfile.write(response)
 
 
-def setup_interactive(shared):
+def setup_interweb_args(shared):
     """
     Build and parse CLI opts.
     """
@@ -239,8 +240,11 @@ def setup_interactive(shared):
         type=str,
         help='Host from which allow requests, use 0.0.0.0 to allow all IPs',
     )
+    return parser
 
-    SHARED['opt'] = parser.parse_args(print_args=False)
+
+def interactive_web(parser):
+    SHARED['opt'] = parser.opt
 
     SHARED['opt']['task'] = 'parlai.agents.local_human.local_human:LocalHumanAgent'
 
@@ -252,11 +256,6 @@ def setup_interactive(shared):
     # show args after loading model
     parser.opt = agent.opt
     parser.print_args()
-    return agent.opt
-
-
-if __name__ == '__main__':
-    opt = setup_interactive(SHARED)
     MyHandler.protocol_version = 'HTTP/1.0'
     httpd = HTTPServer((opt['host'], opt['port']), MyHandler)
     logging.info('http://{}:{}/'.format(opt['host'], opt['port']))
@@ -266,3 +265,16 @@ if __name__ == '__main__':
     except KeyboardInterrupt:
         pass
     httpd.server_close()
+
+
+class InteractiveWeb(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_interweb_args(SHARED)
+
+    def run(self):
+        return interactive_web(self.parser)
+
+
+if __name__ == '__main__':
+    InteractiveWeb.main()

--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -243,7 +243,7 @@ def setup_interweb_args(shared):
     return parser
 
 
-def interactive_web(parser):
+def interactive_web(opt, parser):
     SHARED['opt'] = parser.opt
 
     SHARED['opt']['task'] = 'parlai.agents.local_human.local_human:LocalHumanAgent'
@@ -273,7 +273,7 @@ class InteractiveWeb(ParlaiScript):
         return setup_interweb_args(SHARED)
 
     def run(self):
-        return interactive_web(self.parser)
+        return interactive_web(self.opt, self.parser)
 
 
 if __name__ == '__main__':

--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -25,6 +25,7 @@ import torch.distributed as dist
 import parlai.scripts.train_model as single_train
 import parlai.utils.distributed as distributed_utils
 import parlai.utils.logging as logging
+from parlai.scripts.script import ParlaiScript
 
 
 def multiprocess_train(
@@ -122,11 +123,15 @@ def setup_args():
     return parser
 
 
-def main():
-    opt = setup_args().parse_args()
-    port = random.randint(32000, 48000)
-    return launch_and_train(opt, port)
+class MultiProcessTrain(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        port = random.randint(32000, 48000)
+        return launch_and_train(self.opt, port)
 
 
 if __name__ == '__main__':
-    main()
+    MultiProcessTrain.main()

--- a/parlai/scripts/profile_interactive.py
+++ b/parlai/scripts/profile_interactive.py
@@ -8,6 +8,7 @@ Basic script which allows to profile interaction with a model using repeat_query
 avoid human interaction (so we can time it, only).
 """
 from parlai.core.params import ParlaiParser
+from parlai.scripts.script import ParlaiScript
 from parlai.core.agents import create_agent
 from parlai.core.worlds import create_task
 from parlai.agents.repeat_query.repeat_query import RepeatQueryAgent
@@ -93,7 +94,15 @@ def profile_interactive(opt, print_parser=None):
     print(s.getvalue())
 
 
+class ProfileInteractive(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return profile_interactive(self.opt, print_parser=self.parser)
+
+
 if __name__ == '__main__':
     random.seed(42)
-    parser = setup_args()
-    profile_interactive(parser.parse_args(print_args=False), print_parser=parser)
+    ProfileInteractive.main()

--- a/parlai/scripts/profile_train.py
+++ b/parlai/scripts/profile_train.py
@@ -18,6 +18,7 @@ see a few of them:
 """
 
 from parlai.core.params import ParlaiParser
+from parlai.scripts.script import ParlaiScript
 from parlai.scripts.train_model import setup_args as train_args
 from parlai.scripts.train_model import TrainLoop
 import parlai.utils.logging as logging
@@ -101,5 +102,14 @@ def profile(opt):
             pdb.set_trace()
 
 
+class ProfileTrain(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return profile(self.opt)
+
+
 if __name__ == '__main__':
-    profile(setup_args().parse_args())
+    ProfileTrain.main()

--- a/parlai/scripts/safe_interactive.py
+++ b/parlai/scripts/safe_interactive.py
@@ -9,6 +9,7 @@ trained model.
 """
 
 from parlai.core.params import ParlaiParser
+from parlai.scripts.script import ParlaiScript
 from parlai.core.agents import create_agent
 from parlai.core.worlds import create_task
 from parlai.agents.safe_local_human.safe_local_human import SafeLocalHumanAgent
@@ -79,7 +80,15 @@ def safe_interactive(opt, print_parser=None):
             break
 
 
+class SafeInteractive(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return safe_interactive(self.opt, print_parser=self.parser)
+
+
 if __name__ == '__main__':
     random.seed(42)
-    parser = setup_args()
-    safe_interactive(parser.parse_args(print_args=False), print_parser=parser)
+    SafeInteractive.main()

--- a/parlai/scripts/self_chat.py
+++ b/parlai/scripts/self_chat.py
@@ -11,6 +11,7 @@ from parlai.core.agents import create_agent
 from parlai.core.worlds import create_task
 from parlai.utils.world_logging import WorldLogger
 from parlai.utils.misc import TimeLogger
+from parlai.scripts.script import ParlaiScript
 import parlai.utils.logging as logging
 
 import math

--- a/parlai/scripts/self_chat.py
+++ b/parlai/scripts/self_chat.py
@@ -126,6 +126,15 @@ def self_chat(opt):
     return logger.get_logs()
 
 
+class SelfChat(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        self.parser.parse_args(print_args=False)
+        return self_chat(self.opt)
+
+
 if __name__ == '__main__':
-    parser = setup_args()
-    self_chat(parser.parse_args(print_args=False))
+    SelfChat.main()

--- a/parlai/scripts/self_chat.py
+++ b/parlai/scripts/self_chat.py
@@ -133,8 +133,7 @@ class SelfChat(ParlaiScript):
         return setup_args()
 
     def run(self):
-        self.parser.parse_args(print_args=False)
-        return self_chat(self.opt)
+        return self_chat(self.opt, print_args=False)
 
 
 if __name__ == '__main__':

--- a/parlai/scripts/verify_data.py
+++ b/parlai/scripts/verify_data.py
@@ -19,6 +19,7 @@ from parlai.core.message import Message
 from parlai.core.params import ParlaiParser
 from parlai.utils.misc import TimeLogger, warn_once
 from parlai.core.worlds import create_task
+from parlai.scripts.script import ParlaiScript
 import parlai.utils.logging as logging
 
 
@@ -134,9 +135,21 @@ def verify(opt, printargs=None, print_parser=None):
     return report(world, counts, log_time)
 
 
-if __name__ == '__main__':
-    parser = setup_args()
+def verify_data(opt, parser):
     report_text, report_log = verify(
         parser.parse_args(print_args=False), print_parser=parser
     )
     print(report_text)
+
+
+class VerifyData(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        return verify_data(self.opt, self.parser)
+
+
+if __name__ == '__main__':
+    VerifyData.main()


### PR DESCRIPTION
**Patch description**
Fix for one part of #2713 

**Testing steps**
Ensure CI doesn't break. Try checking ```--help``` works as intended for the upgraded scripts.

**Logs**
Example ```--help``` output for
```
 python -m parlai.scripts.interactive_web --help
```
```
usage: interactive_web.py [-h] [-o INIT_OPT] [-v] [-t TASK]
                          [-dt {train,train:stream,train:ordered,train:ordered:stream,train:stream:ordered,train:evalmode,train:evalmode:stream,train:evalmode:ordered,train:evalmode:ordered:stream,train:evalmode:stream:ordered,valid,valid:stream,test,test:stream}]
                          [-nt NUMTHREADS] [-bs BATCHSIZE]
                          [-dynb {batchsort,full,None}] [-dp DATAPATH]
                          [-m MODEL] [-mf MODEL_FILE] [-im INIT_MODEL]
                          [-d DISPLAY_EXAMPLES]
                          [--display-prettify DISPLAY_PRETTIFY]
                          [--display-ignore-fields DISPLAY_IGNORE_FIELDS]
                          [-it INTERACTIVE_TASK]
                          [--save-world-logs SAVE_WORLD_LOGS]
                          [-fixedCands LOCAL_HUMAN_CANDIDATES_FILE]
                          [--single-turn SINGLE_TURN] [--port PORT]
                          [--host HOST]

Interactive chat with a model

optional arguments:
  -h, --help
      show this help message and exit
  -d, --display-examples DISPLAY_EXAMPLES
  --display-prettify DISPLAY_PRETTIFY
      Set to use a prettytable when displaying examples with text candidates
      (default: False)
  --display-ignore-fields DISPLAY_IGNORE_FIELDS
      Do not display these fields (default: label_candidates,text_candidates)
  -it, --interactive-task INTERACTIVE_TASK
      Create interactive version of task (default: True)
  --save-world-logs SAVE_WORLD_LOGS
      Saves a jsonl file containing all of the task examples and model replies.
      Must also specify --report-filename. (default: False)
  --port PORT
      Port to listen on. (default: 8080)
  --host HOST
      Host from which allow requests, use 0.0.0.0 to allow all IPs (default:
      localhost)

Main ParlAI Arguments:
  -o, --init-opt INIT_OPT
      Path to json file of options. Note: Further Command-line arguments
      override file-based options. (default: None)
  -v, --show-advanced-args
      Show hidden command line options (advanced users only) (default: False)
  -t, --task TASK
      ParlAI task(s), e.g. "babi:Task1" or "babi,cbt" (default: interactive)
  -dt, --datatype {train,train:stream,train:ordered,train:ordered:stream,train:stream:ordered,train:evalmode,train:evalmode:stream,train:evalmode:ordered,train:evalmode:ordered:stream,train:evalmode:stream:ordered,valid,valid:stream,test,test:stream}
      choose from: train, train:ordered, valid, test. to stream data add
      ":stream" to any option (e.g., train:stream). by default: train is random
      with replacement, valid is ordered, test is ordered. (default: train)
  -nt, --numthreads NUMTHREADS
      number of threads. Used for hogwild if batchsize is 1, else for number of
      threads in threadpool loading, (default: 1)
  -bs, --batchsize BATCHSIZE
      batch size for minibatch training schemes (default: 1)
  -dynb, --dynamic-batching {batchsort,full,None}
      Use dynamic batching (default: None)
  -dp, --datapath DATAPATH
      path to datasets, defaults to {parlai_dir}/data (default: None)

ParlAI Model Arguments:
  -m, --model MODEL
      the model class name. can match parlai/agents/<model> for agents in that
      directory, or can provide a fully specified module for `from X import Y`
      via `-m X:Y` (e.g. `-m parlai.agents.seq2seq.seq2seq:Seq2SeqAgent`)
      (default: None)
  -mf, --model-file MODEL_FILE
      model file name for loading and saving models (default: None)
  -im, --init-model INIT_MODEL
      load model weights and dict from this file (default: None)

Local Human Arguments:
  -fixedCands, --local-human-candidates-file LOCAL_HUMAN_CANDIDATES_FILE
      File of label_candidates to send to other agent (default: None)
  --single-turn SINGLE_TURN
      If on, assumes single turn episodes. (default: False)

```

**Other information**
NA

**Data tests (if applicable)**
NA