### PR TITLE
Don't require pre-built dictionaries.

### DIFF
--- a/parlai/agents/hugging_face/dict.py
+++ b/parlai/agents/hugging_face/dict.py
@@ -64,6 +64,12 @@ class HuggingFaceDictionaryAgent(DictionaryAgent, ABC):
 
 
 class Gpt2DictionaryAgent(HuggingFaceDictionaryAgent):
+    def is_prebuilt(self):
+        """
+        Indicates whether the dictionary is fixed, and does not require building.
+        """
+        return True
+
     def get_tokenizer(self, opt):
         """
         Instantiate tokenizer.

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -324,6 +324,12 @@ class DictionaryAgent(Agent):
             if opt.get('dict_file'):
                 self.save_path = opt['dict_file']
 
+    def is_prebuilt(self):
+        """
+        Indicates whether the dictionary is fixed, and does not require building.
+        """
+        return self.tokenizer in ['gpt2', 'bytelevelbpe']
+
     def add_token(self, word):
         """
         Add a single token to the dictionary.

--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -328,7 +328,7 @@ class DictionaryAgent(Agent):
         """
         Indicates whether the dictionary is fixed, and does not require building.
         """
-        return self.tokenizer in ['gpt2', 'bytelevelbpe']
+        return self.tokenizer == 'gpt2'
 
     def add_token(self, word):
         """

--- a/parlai/scripts/build_dict.py
+++ b/parlai/scripts/build_dict.py
@@ -78,9 +78,6 @@ def build_dict(opt, skip_if_built=False):
         logging.debug("dictionary already built.")
         return None
 
-    if is_distributed():
-        raise ValueError('Dictionaries should be pre-built before distributed train.')
-
     if opt.get('dict_class'):
         # Custom dictionary class
         dictionary = str2class(opt['dict_class'])(opt)
@@ -88,10 +85,13 @@ def build_dict(opt, skip_if_built=False):
         # Default dictionary class
         dictionary = DictionaryAgent(opt)
 
-    if os.path.isfile(opt['dict_file']):
+    if os.path.isfile(opt['dict_file']) or dictionary.is_prebuilt():
         # Dictionary already built, return loaded dictionary agent
         logging.debug("dictionary already built.")
         return dictionary
+
+    if is_distributed():
+        raise ValueError('Dictionaries should be pre-built before distributed train.')
 
     ordered_opt = copy.deepcopy(opt)
     cnt = 0

--- a/parlai/scripts/build_dict.py
+++ b/parlai/scripts/build_dict.py
@@ -85,7 +85,9 @@ def build_dict(opt, skip_if_built=False):
         # Default dictionary class
         dictionary = DictionaryAgent(opt)
 
-    if os.path.isfile(opt['dict_file']) or dictionary.is_prebuilt():
+    if os.path.isfile(opt['dict_file']) or (
+        hasattr(dictionary, 'is_prebuilt') and dictionary.is_prebuilt()
+    ):
         # Dictionary already built, return loaded dictionary agent
         logging.debug("dictionary already built.")
         return dictionary


### PR DESCRIPTION
**Patch description**
For certain specialized models/tokenizers, the dictionary is fixed ahead of time, especially like GPT-2. In these instances, we don't necessarily need to mandate they be built ahead of time in distributed mode. This adds a new field to dictionaries indicating whether this is the case.

**Testing steps**
Manual testing. CI.