### PR TITLE
[TriviaQA] no-evidence, union

### DIFF
--- a/parlai/tasks/triviaqa/agents.py
+++ b/parlai/tasks/triviaqa/agents.py
@@ -24,11 +24,10 @@ class WebTeacher(DialogTeacher):
     def __init__(self, opt, shared=None):
         if not hasattr(self, 'prefix'):
             self.prefix = ''
-            if opt['datatype'].startswith('train'):
-                self.suffix = 'train'
-            else:
-                self.suffix = 'dev'
+            self.suffix = 'train' if opt['datatype'].startswith('train') else 'dev'
 
+        if "no_evidence" not in self.__dict__:
+            self.no_evidence = False
         qa_dir, self.evidence_dir = _path(opt)
         opt['datafile'] = os.path.join(
             qa_dir, self.prefix + 'web-' + self.suffix + '.json'
@@ -45,17 +44,20 @@ class WebTeacher(DialogTeacher):
             answers = datapoint['Answer']['Aliases']
             evidence_list = datapoint['SearchResults']
 
-            if len(evidence_list) == 0:
-                continue
+            if self.no_evidence:
+                yield (question, answers), True
+            else:
+                if len(evidence_list) == 0:
+                    continue
 
-            for evidence_item in evidence_list:
-                evidence_file_path = os.path.join(
-                    self.evidence_dir, 'web', evidence_item['Filename']
-                )
-                with open(evidence_file_path) as evidence_file:
-                    evidence = 'Title: %s\n' % evidence_item['Title']
-                    evidence += evidence_file.read()
-                    yield (evidence + '\n' + question, answers), True
+                for evidence_item in evidence_list:
+                    evidence_file_path = os.path.join(
+                        self.evidence_dir, 'web', evidence_item['Filename']
+                    )
+                    with open(evidence_file_path) as evidence_file:
+                        evidence = 'Title: %s\n' % evidence_item['Title']
+                        evidence += evidence_file.read()
+                        yield (evidence + '\n' + question, answers), True
 
 
 class VerifiedWebTeacher(WebTeacher):
@@ -70,15 +72,20 @@ class VerifiedWebTeacher(WebTeacher):
         super().__init__(opt, shared)
 
 
+class NoEvidenceWebTeacher(WebTeacher):
+    def __init__(self, opt, shared=None):
+        self.no_evidence = True
+        super().__init__(opt, shared)
+
+
 class WikipediaTeacher(DialogTeacher):
     def __init__(self, opt, shared=None):
         if not hasattr(self, 'prefix'):
             self.prefix = ''
-            if opt['datatype'].startswith('train'):
-                self.suffix = 'train'
-            else:
-                self.suffix = 'dev'
+            self.suffix = 'train' if opt['datatype'].startswith('train') else 'dev'
 
+        if "no_evidence" not in self.__dict__:
+            self.no_evidence = False
         qa_dir, self.evidence_dir = _path(opt)
         opt['datafile'] = os.path.join(
             qa_dir, self.prefix + 'wikipedia-' + self.suffix + '.json'
@@ -96,19 +103,22 @@ class WikipediaTeacher(DialogTeacher):
             answers = datapoint['Answer']['Aliases']
             evidence_list = datapoint['EntityPages']
 
-            if len(evidence_list) == 0:
-                continue
+            if self.no_evidence:
+                yield (question, answers), True
+            else:
+                if len(evidence_list) == 0:
+                    continue
 
-            evidence = ''
-            for evidence_item in evidence_list:
-                evidence_file_path = os.path.join(
-                    self.evidence_dir, 'wikipedia', evidence_item['Filename']
-                )
-                with open(evidence_file_path) as evidence_file:
-                    evidence += 'Title: %s\n' % evidence_item['Title']
-                    evidence += evidence_file.read() + '\n\n'
+                evidence = ''
+                for evidence_item in evidence_list:
+                    evidence_file_path = os.path.join(
+                        self.evidence_dir, 'wikipedia', evidence_item['Filename']
+                    )
+                    with open(evidence_file_path) as evidence_file:
+                        evidence += 'Title: %s\n' % evidence_item['Title']
+                        evidence += evidence_file.read() + '\n\n'
 
-            yield (evidence + question, answers), True
+                yield (evidence + question, answers), True
 
 
 class VerifiedWikipediaTeacher(WikipediaTeacher):
@@ -123,11 +133,40 @@ class VerifiedWikipediaTeacher(WikipediaTeacher):
         super().__init__(opt, shared)
 
 
+class NoEvidenceWikipediaTeacher(WikipediaTeacher):
+    def __init__(self, opt, shared=None):
+        self.no_evidence = True
+        super().__init__(opt, shared)
+
+
 class VerifiedTeacher(MultiTaskTeacher):
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
         opt['task'] = 'triviaqa:VerifiedWikipedia,triviaqa:VerifiedWeb'
         super().__init__(opt, shared)
+
+
+class NoEvidenceUnionTeacher(DialogTeacher):
+    def __init__(self, opt, shared=None):
+        if not hasattr(self, 'prefix'):
+            self.prefix = ''
+            self.suffix = 'train' if opt['datatype'].startswith('train') else 'dev'
+
+        qa_dir, self.evidence_dir = _path(opt)
+        opt['datafile'] = os.path.join(
+            qa_dir, self.prefix + 'union-noevidence-' + self.suffix + '.json'
+        )
+        self.id = 'triviaqa'
+        super().__init__(opt, shared)
+
+    def setup_data(self, path):
+        print('loading: ' + path)
+        with open(path) as data_file:
+            data = json.load(data_file)['Data']
+        for datapoint in data:
+            question = datapoint['Question']
+            answers = datapoint['Answer']['Aliases']
+            yield (question, answers), True
 
 
 class DefaultTeacher(MultiTaskTeacher):

--- a/parlai/tasks/triviaqa/agents.py
+++ b/parlai/tasks/triviaqa/agents.py
@@ -26,7 +26,7 @@ class WebTeacher(DialogTeacher):
             self.prefix = ''
             self.suffix = 'train' if opt['datatype'].startswith('train') else 'dev'
 
-        if "no_evidence" not in self.__dict__:
+        if not hasattr(self, 'no_evidence'):
             self.no_evidence = False
         qa_dir, self.evidence_dir = _path(opt)
         opt['datafile'] = os.path.join(
@@ -84,7 +84,7 @@ class WikipediaTeacher(DialogTeacher):
             self.prefix = ''
             self.suffix = 'train' if opt['datatype'].startswith('train') else 'dev'
 
-        if "no_evidence" not in self.__dict__:
+        if not hasattr(self, 'no_evidence'):
             self.no_evidence = False
         qa_dir, self.evidence_dir = _path(opt)
         opt['datafile'] = os.path.join(
@@ -154,7 +154,7 @@ class NoEvidenceUnionTeacher(DialogTeacher):
 
         qa_dir, self.evidence_dir = _path(opt)
         opt['datafile'] = os.path.join(
-            qa_dir, self.prefix + 'union-noevidence-' + self.suffix + '.json'
+            qa_dir, self.prefix + 'noevidence-union-' + self.suffix + '.json'
         )
         self.id = 'triviaqa'
         super().__init__(opt, shared)

--- a/parlai/tasks/triviaqa/build.py
+++ b/parlai/tasks/triviaqa/build.py
@@ -7,6 +7,7 @@
 # Download and build the data if it does not exist.
 
 import parlai.core.build_data as build_data
+import json
 import os
 from parlai.core.build_data import DownloadableFile
 
@@ -21,7 +22,7 @@ RESOURCES = [
 
 def build(opt):
     dpath = os.path.join(opt['datapath'], 'TriviaQA')
-    version = None
+    version = "2.0"
 
     if not build_data.built(dpath, version_string=version):
         print('[building data: ' + dpath + ']')
@@ -33,6 +34,30 @@ def build(opt):
         # Download the data.
         for downloadable_file in RESOURCES:
             downloadable_file.download_file(dpath)
+
+        # Make *-union-noevidence-*.json
+        for section in ["verified-{}-dev.json", "{}-train.json", "{}-dev.json"]:
+            section = os.path.join(dpath, "qa", section)
+            q2as = {}
+            with open(section.format("web")) as data_file:
+                for datapoint in json.load(data_file)['Data']:
+                    question = datapoint['Question']
+                    answers = datapoint['Answer']['Aliases']
+                    assert question not in q2as
+                    q2as[question] = answers
+            with open(section.format("wikipedia")) as data_file:
+                for datapoint in json.load(data_file)['Data']:
+                    question = datapoint['Question']
+                    answers = datapoint['Answer']['Aliases']
+                    if question not in q2as:
+                        q2as[question] = answers
+                    else:
+                        q2as[question] += answers
+            with open(section.format("union-noevidence"), "wt") as data_file:
+                json.dump({"Data": [
+                    {"Question": question, "Answer": {"Aliases": answers}}
+                    for question, answers in q2as.items()
+                ]}, data_file)
 
         # Mark the data as built.
         build_data.mark_done(dpath, version_string=version)

--- a/parlai/tasks/triviaqa/build.py
+++ b/parlai/tasks/triviaqa/build.py
@@ -54,10 +54,15 @@ def build(opt):
                     else:
                         q2as[question] += answers
             with open(section.format("union-noevidence"), "wt") as data_file:
-                json.dump({"Data": [
-                    {"Question": question, "Answer": {"Aliases": answers}}
-                    for question, answers in q2as.items()
-                ]}, data_file)
+                json.dump(
+                    {
+                        "Data": [
+                            {"Question": question, "Answer": {"Aliases": answers}}
+                            for question, answers in q2as.items()
+                        ]
+                    },
+                    data_file,
+                )
 
         # Mark the data as built.
         build_data.mark_done(dpath, version_string=version)

--- a/parlai/tasks/triviaqa/build.py
+++ b/parlai/tasks/triviaqa/build.py
@@ -22,7 +22,7 @@ RESOURCES = [
 
 def build(opt):
     dpath = os.path.join(opt['datapath'], 'TriviaQA')
-    version = "2.0"
+    version = "3"  # build changes, not upstream changes
 
     if not build_data.built(dpath, version_string=version):
         print('[building data: ' + dpath + ']')
@@ -53,7 +53,7 @@ def build(opt):
                         q2as[question] = answers
                     else:
                         q2as[question] += answers
-            with open(section.format("union-noevidence"), "wt") as data_file:
+            with open(section.format("noevidence-union"), "wt") as data_file:
                 json.dump(
                     {
                         "Data": [


### PR DESCRIPTION
Adds NoEvidence teachers for Web and Wikipedia sections and adds a NoEvidenceUnion teacher that (thanks to evidence-dropping) joins the two sections. This is different from the previous "union" that did multitasking because most questions in TriviaQA are shared between Web and Wikipedia. New build()-ing merges the two into a single json with combined answer sets that can then be used by the teacher---marked as version "2.0" to make sure we don't have stale files :)