### PR TITLE
[WoW] change empty knowledge to dummy knowledge

### DIFF
--- a/projects/wizard_of_wikipedia/generator/agents.py
+++ b/projects/wizard_of_wikipedia/generator/agents.py
@@ -174,7 +174,7 @@ class EndToEndAgent(_GenericWizardAgent):
 
         if 'checked_sentence' not in obs:
             # interactive time. we're totally on our own
-            obs_know = [k.strip() for k in obs.get('knowledge', '').split('\n')]
+            obs_know = [k.strip() for k in obs.get('knowledge', 'no_passages_used').split('\n')]
             obs_know = [k for k in obs_know if k]
             obs['knowledge_parsed'] = obs_know
             return obs['knowledge_parsed']
@@ -183,7 +183,7 @@ class EndToEndAgent(_GenericWizardAgent):
             obs['title'], TOKEN_KNOWLEDGE, obs['checked_sentence']
         )
         # grab all the nonempty knowledge
-        obs_know = [k.strip() for k in obs.get('knowledge', '').split('\n')]
+        obs_know = [k.strip() for k in obs.get('knowledge', 'no_passages_used').split('\n')]
         obs_know = [k for k in obs_know if k]
 
         # we want the correct knowledge to always be in index 0

--- a/projects/wizard_of_wikipedia/generator/agents.py
+++ b/projects/wizard_of_wikipedia/generator/agents.py
@@ -174,7 +174,9 @@ class EndToEndAgent(_GenericWizardAgent):
 
         if 'checked_sentence' not in obs:
             # interactive time. we're totally on our own
-            obs_know = [k.strip() for k in obs.get('knowledge', 'no_passages_used').split('\n')]
+            obs_know = [
+                k.strip() for k in obs.get('knowledge', 'no_passages_used').split('\n')
+            ]
             obs_know = [k for k in obs_know if k]
             obs['knowledge_parsed'] = obs_know
             return obs['knowledge_parsed']
@@ -183,7 +185,9 @@ class EndToEndAgent(_GenericWizardAgent):
             obs['title'], TOKEN_KNOWLEDGE, obs['checked_sentence']
         )
         # grab all the nonempty knowledge
-        obs_know = [k.strip() for k in obs.get('knowledge', 'no_passages_used').split('\n')]
+        obs_know = [
+            k.strip() for k in obs.get('knowledge', 'no_passages_used').split('\n')
+        ]
         obs_know = [k for k in obs_know if k]
 
         # we want the correct knowledge to always be in index 0


### PR DESCRIPTION
Used to fail before if evaluating on a non-WoW task---now runs eval on that, though it still doesn't do interactive 🤷‍♀️