### PR TITLE
More ergonomic progress logs in eval_model, etc.

### DIFF
--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -9,6 +9,7 @@ File for miscellaneous utility functions and constants.
 
 from collections import deque, OrderedDict
 from typing import Union, Optional, Set, Any, Dict, List, Tuple
+from datetime import timedelta
 import math
 import random
 import time
@@ -292,23 +293,24 @@ class TimeLogger:
             done = done.value()
         self.tot_time += self.timer.time()
         self.timer.reset()
-        log = {}
-        log['exs'] = done
+        report['exs'] = done
         if total > 0:
-            log['%done'] = done / total
-            if log["%done"] > 0:
-                time_left = self.tot_time / log['%done'] - self.tot_time
-                log['time_left'] = str(int(time_left)) + 's'
-            z = '%.2f' % (100 * log['%done'])
-            log['%done'] = str(z) + '%'
+            progress = done / total
+            seconds_left = max(0, self.tot_time / progress - self.tot_time)
+            eta = timedelta(seconds=int(seconds_left + 0.5))
+        else:
+            progress = 0
+            eta = "unknown"
+        elapsed = timedelta(seconds=int(self.tot_time))
 
+        text = (
+            f'{progress:.1%} complete ({done:,d} / {total:,d}), '
+            f'{elapsed} elapsed, {eta} eta'
+        )
         if report:
-            log = {**report, **log}
-
-        int_time = int(self.tot_time)
-        report_s = nice_report(log)
-        text = f'{int_time}s elapsed:\n{report_s}'
-        return text, log
+            report_s = nice_report(report)
+            text = f'{text}\n{report_s}'
+        return text, report
 
 
 class AttrDict(dict):


### PR DESCRIPTION
**Patch description**
Change the progress logger to be a bit more ergonomic. Report time in hours/minutes/seconds instead of only seconds. Don't roll up the % done and eta into the report, (rather put them in the log)

**Testing steps**
Manual testing. CI to ensure nothing breaks.

**Logs**
Eval model before:
```
09:17:54 | 27s elapsed:
    %done accuracy   bleu-4  exs     f1 gpu_mem  loss   ppl time_left token_acc  tpb
    4.77%        0 .0009798  372 .03271   .9254 5.394 220.1      541s     .1712 4972
```



Eval model after:
```
09:20:59 | 4.8% complete (372 / 7,801), 0:00:27 elapsed, 0:09:04 eta
    accuracy   bleu-4  exs     f1  gpu_mem  loss   ppl  token_acc  tpb
           0 .0009798  372 .03271    .9254 5.394 220.1      .1712 4972
```
