### PR TITLE
[ACUTE] Pull internal acute types

### DIFF
--- a/parlai/mturk/tasks/acute_eval/analysis.py
+++ b/parlai/mturk/tasks/acute_eval/analysis.py
@@ -255,7 +255,7 @@ class AcuteAnalyzer(object):
                 continue
             for r_idx, task_data in enumerate(data['task_data']):
                 response_data = data['response']['task_data'][r_idx]
-                if response_data is None:
+                if response_data is None or not response_data:
                     continue
                 response = self._extract_response_data(
                     data, task_data, hit, response_data

--- a/parlai/mturk/tasks/acute_eval/fast_eval.py
+++ b/parlai/mturk/tasks/acute_eval/fast_eval.py
@@ -27,7 +27,7 @@ try:
         CONFIG as internal_conf,
     )
     from parlai_internal.projects.fast_acute.fast_eval import (
-        ACUTE_EVAL_TYPES as internal_types
+        ACUTE_EVAL_TYPES as internal_types,
     )
 
     CONFIG.update(internal_conf)

--- a/parlai/mturk/tasks/acute_eval/fast_eval.py
+++ b/parlai/mturk/tasks/acute_eval/fast_eval.py
@@ -26,11 +26,15 @@ try:
     from parlai_internal.projects.fast_acute.model_configs import (
         CONFIG as internal_conf,
     )
+    from parlai_internal.projects.fast_acute.fast_eval import (
+        ACUTE_EVAL_TYPES as internal_types
+    )
 
     CONFIG.update(internal_conf)
 except ImportError:
     # No access to internal
     pass
+    internal_types = None
 
 from typing import Dict, Any, List, Tuple, Set
 from itertools import combinations
@@ -58,6 +62,10 @@ ACUTE_EVAL_TYPES = {
         's2_choice': 'I would prefer to talk to <Speaker 2>',
     },
 }
+if internal_types:
+    ACUTE_EVAL_TYPES.update(
+        {k: v for k, v in internal_types.items() if k not in ACUTE_EVAL_TYPES}
+    )
 EXAMPLE_PATH = os.path.join(
     os.path.dirname(parlai_filepath), 'mturk/tasks/acute_eval/example'
 )


### PR DESCRIPTION
**Patch description**
Allow fast-acute to pull in `ACUTE_TYPES` from internal.

Also make `analysis.py` more robust to bad HITs (sometimes `response_data` isn't none but just an empty dict)

**Testing steps**
Ran `fast_eval.py` locally