### PR TITLE
More ChatService internal parity

### DIFF
--- a/parlai/chat_service/core/chat_service_manager.py
+++ b/parlai/chat_service/core/chat_service_manager.py
@@ -673,7 +673,9 @@ class ChatServiceManager(ABC):
                 log_utils.print_and_log(logging.INFO, "Next task: {}".format(next_task))
                 if next_task is None:
                     self._launch_overworld(agent.id)
-                    agent_state.set_active_agent(agent_state.get_overworld_agent())
+                    overworld_agent = agent_state.get_overworld_agent()
+                    overworld_agent.data = agent_state.data
+                    agent_state.set_active_agent(overworld_agent)
                 elif next_task == self.EXIT_STR:
                     self._remove_agent(agent.id)
                 else:

--- a/parlai/chat_service/core/world_runner.py
+++ b/parlai/chat_service/core/world_runner.py
@@ -180,6 +180,7 @@ class ChatServiceWorldRunner:
                 if onboard_type:
                     onboard_id = 'onboard-{}-{}'.format(overworld_agent.id, time.time())
                     agent = self.manager._create_agent(onboard_id, overworld_agent.id)
+                    agent.data = overworld_agent.data
                     agent_state.set_active_agent(agent)
                     agent_state.assign_agent_to_task(agent, onboard_id)
                     _, onboard_data = self._run_world(task, onboard_type, [agent])

--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -71,9 +71,16 @@ class MessengerManager(ChatServiceManager):
         """
         if 'models' in self.opt and self.should_load_model:
             model_params = {}
+            model_info = {}
             for model in self.opt['models']:
                 model_opt = self.opt['models'][model]
+                overrides = model_opt.get('overrides', {})
+                if type(overrides) is list:
+                    print("Got list overrides!")
+                    model_opt['overrides'] = overrides[0]
                 model_params[model] = create_agent(model_opt).share()
+                model_info[model] = {'overrides': overrides}
+            self.runner_opt['model_info'] = model_info
             self.runner_opt['shared_bot_params'] = model_params
 
     def _init_logs(self):

--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -76,7 +76,6 @@ class MessengerManager(ChatServiceManager):
                 model_opt = self.opt['models'][model]
                 overrides = model_opt.get('overrides', {})
                 if type(overrides) is list:
-                    print("Got list overrides!")
                     model_opt['overrides'] = overrides[0]
                 model_params[model] = create_agent(model_opt).share()
                 model_info[model] = {'overrides': overrides}

--- a/parlai/chat_service/services/terminal_chat/client.py
+++ b/parlai/chat_service/services/terminal_chat/client.py
@@ -79,7 +79,7 @@ def _run(ws, id):
         data['text'] = x
         json_data = json.dumps(data)
         ws.send(json_data)
-        time.sleep(1)
+        time.sleep(0.1)
         if x == "[DONE]":
             break
     ws.close()

--- a/parlai/chat_service/services/terminal_chat/client.py
+++ b/parlai/chat_service/services/terminal_chat/client.py
@@ -79,7 +79,7 @@ def _run(ws, id):
         data['text'] = x
         json_data = json.dumps(data)
         ws.send(json_data)
-        time.sleep(0.1)
+        time.sleep(1)
         if x == "[DONE]":
             break
     ws.close()

--- a/parlai/chat_service/services/websocket/sockets.py
+++ b/parlai/chat_service/services/websocket/sockets.py
@@ -36,6 +36,7 @@ class MessageSocketHandler(WebSocketHandler):
         """
         if self.sid not in self.subs.values():
             self.subs[self.sid] = self
+            self.set_nodelay(True)
             logging.info(f"Opened new socket from ip: {self.request.remote_ip}")
             logging.info(f"Current subscribers: {self.subs}")
 


### PR DESCRIPTION
**Patch description**
In an effort to get more parity between internal and external uses of chat service, this PR includes the following changes:

- Overworlds are able to access and modify an `Agent`'s `data` attribute, and this `data` is then sent to onboarding and task worlds.
- Model options passed in `opt['models']` are allowed to have a `list` of overrides, and but the models loaded from this state should select the first override setting. The remaining overrides are exposed in a new `opt['model_info']` dict, which mirrors how we expose this internally.
- *Minor* Ensured we're waiting on some asyncio calls that were never awaited (which caused some log spam)
- *Minor* Set the tornado socket to have no sending delay, which slightly reduces the outgoing message write time. Turns out this is not the source of the longer delay that seems to only effect overworlds and onboarding worlds, though I haven't tracked that down yet.

**Testing steps**
Running some of the LIGHT project under the new architecture works fine. 