### PR TITLE
Open-sourcing BST context generator

### DIFF
--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -440,6 +440,11 @@ class AllTeacher(MultiTaskTeacher):
         super().__init__(opt, shared)
 
 
+################################################################
+##  Generator of context for crowdsourcing BST conversations  ##
+################################################################
+
+
 class ContextGenerator:
     """
     Generates contexts shown to crowdsourced workers when collecting BST conversations.

--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -482,8 +482,21 @@ class ContextGenerator:
         Get context information to be shown at the beginning of one conversation.
 
         Values in return dict:
-        - context_dataset: the dataset (ConvAI2, EmpatheticDialogues, or Wizard of Wikipedia) used to generate the context.
-        :return:
+        - context_dataset: the dataset (ConvAI2, EmpatheticDialogues, or Wizard of
+            Wikipedia) used to generate the context information.
+        - persona_1_strings, persona_2_strings: 2 persona strings each for the two
+            speakers, chosen randomly from the ConvAI2 dataset. If context_dataset ==
+            "wizard_of_wikipedia", these persona strings will be matched to the WoW
+            topic returned in the "additional_context" field.
+        - additional_context: provides additional bits of information to give context
+            for the speakers. If context_dataset == "empathetic_dialogues", this is a
+            situation from the start of an ED conversation. If context_dataset ==
+            "wizard_of_wikipedia", this is a topic from the WoW dataset that matches the
+            persona strings. If context_dataset == "convai2", this is None.
+        - person1_seed_utterance, person2_seed_utterance: two lines of a conversation
+            from the dataset specified by "context_dataset". They will be shown to the
+            speakers to "seed" the conversation, and the speakers continue from where
+            the lines left off.
         """
 
         # Determine which dataset we will show context for
@@ -652,6 +665,9 @@ class ContextGenerator:
             }
 
     def _setup_personas_to_topics(self) -> Dict[str, List[str]]:
+        """
+        Create a map from ConvAI2 personas to WoW topics that they correspond to.
+        """
 
         print('Starting to map personas to topics.')
 
@@ -672,6 +688,9 @@ class ContextGenerator:
         return persona_strings_to_topics
 
     def _setup_topics_to_episodes(self) -> Dict[str, List[int]]:
+        """
+        Create a map from WoW topics to the indices of the WoW episodes that use them.
+        """
 
         print('Starting to map topics to episodes.')
 
@@ -685,6 +704,9 @@ class ContextGenerator:
         return topics_to_episodes
 
     def _extract_personas(self, episode_idx: str) -> Tuple[List[str], List[str]]:
+        """
+        For the given ConvAI2 conversation, return strings of both speakers' personas.
+        """
         first_entry = self.convai2_teacher.get(episode_idx, entry_idx=0)
         first_text_strings = first_entry['text'].split('\n')
         persona_1_strings = []

--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -136,7 +136,7 @@ class ConvAI2PersonaTopicifierTeacher(Convai2DefaultTeacher):
         gotten = super().get(episode_idx, entry_idx=entry_idx)
         if entry_idx == 0:
             modified_text = self.persona_topicifier.get_modified_text(gotten['text'])
-            gotten['text'] = modified_text
+            gotten.force_set('text', modified_text)
         return gotten
 
 

--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -7,9 +7,10 @@
 import copy
 import json
 import os
+import random
 import re
 from collections import defaultdict
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Tuple
 from tqdm import tqdm
 
 from parlai.core.opt import Opt
@@ -18,7 +19,10 @@ from parlai.core.teachers import (
     create_task_agent_from_taskname,
     MultiTaskTeacher,
 )
-from parlai.tasks.convai2.agents import DefaultTeacher as Convai2DefaultTeacher
+from parlai.tasks.convai2.agents import (
+    DefaultTeacher as Convai2DefaultTeacher,
+    BothTeacher,
+)
 from parlai.tasks.empathetic_dialogues.agents import EmpatheticDialoguesTeacher
 from parlai.tasks.wizard_of_wikipedia.agents import WizardDialogKnowledgeTeacher
 from parlai.utils.misc import warn_once
@@ -42,6 +46,20 @@ def _processed_data_path(opt: Opt) -> str:
     build(opt)
     dt = opt['datatype'].split(':')[0]
     return os.path.join(opt['datapath'], 'blended_skill_talk', dt + '.txt')
+
+
+def _persona_list_path(opt: Opt) -> str:
+    # Build the data if it doesn't exist.
+    build(opt)
+    return os.path.join(opt['datapath'], 'blended_skill_talk', 'persona_list.txt')
+
+
+def _topic_to_persona_path(opt: Opt) -> str:
+    # Build the data if it doesn't exist.
+    build(opt)
+    return os.path.join(
+        opt['datapath'], 'blended_skill_talk', 'topic_to_persona_list.txt'
+    )
 
 
 def _cached_data_path(opt: Opt, experiencer_side_only: bool) -> str:
@@ -248,36 +266,30 @@ class PersonaTopicifier:
         should_have_topics: bool = False,
         no_persona_is_error: bool = False,
     ):
-        self.datapath = opt['datapath']
         self.utterance_to_persona_map = {}
         self.should_have_personas = should_have_personas
         self.should_have_topics = should_have_topics
         self.no_persona_is_error = no_persona_is_error
         # Throw an exception if a persona is not found for the input WoW topic
 
-        # Get persona files
-        build(opt)
-
         # this returns map of persona line str to WoW topic
         (
             self.wow_topics_to_persona_strings_map,
             self.persona_strings_to_wow_topics_map,
         ) = self._setup_personas_to_wow_topics()
-        self.personas_file_path = os.path.join(
-            self.datapath, 'blended_skill_talk', 'persona_list.txt'
-        )
+        self.personas_file_path = _persona_list_path(opt)
+        self.topic_to_persona_path = _topic_to_persona_path(opt)
         with open(self.personas_file_path, 'r') as f:
             self.personas = f.read().strip().split('||')
             # There's an extra line at the end of the file which is ''
             self.personas = [p for p in self.personas if p]
 
-    def _setup_personas_to_wow_topics(self) -> Dict[str, List[str]]:
-        topic_to_persona_path = os.path.join(
-            self.datapath, 'blended_skill_talk', 'topic_to_persona_list.txt'
-        )
+    def _setup_personas_to_wow_topics(
+        self
+    ) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
         persona_strings_to_topics = defaultdict(list)
         topics_to_persona_strings = defaultdict(list)
-        with open(topic_to_persona_path, 'r') as f:
+        with open(self.topic_to_persona_path, 'r') as f:
             for line in f:
                 match = re.fullmatch(r'([^[]+): (\[.+\])\n', line)
                 topic = match.group(1)
@@ -426,3 +438,262 @@ class AllTeacher(MultiTaskTeacher):
         opt = copy.deepcopy(opt)
         opt['task'] = ','.join(topicifier_tasks)
         super().__init__(opt, shared)
+
+
+class ContextGenerator:
+    """
+    Generates contexts shown to crowdsourced workers when collecting BST conversations.
+
+    This generator was used to generate the context information shown to workers at the
+    beginning of a conversation, when crowdsourcing the conversations that make up the
+    BST dataset.
+    """
+
+    def __init__(self, opt, datatype: str = 'train'):
+        """
+        Initalize the context generator.
+
+        opt: only a 'datapath' key is required, to specify the ParlAI data folder
+        """
+
+        convai2_opt = Opt({'datapath': opt['datapath'], 'datatype': datatype})
+        self.convai2_teacher = BothTeacher(convai2_opt)
+
+        ed_opt = Opt(
+            {
+                'datapath': opt['datapath'],
+                'datatype': datatype,
+                'train_experiencer_only': True,
+            }
+        )
+        # Specify train_experiencer_only = True because we want to ensure that the text
+        # will correspond to a Speaker utterance and the label to a Listener response
+        self.ed_teacher = EmpatheticDialoguesTeacher(ed_opt)
+
+        wow_opt = Opt({'datapath': opt['datapath'], 'datatype': datatype})
+        self.wow_teacher = WizardDialogKnowledgeTeacher(wow_opt)
+
+        self.topic_to_persona_path = _topic_to_persona_path(opt)
+        self.wow_topics_to_episode_idxes = self._setup_topics_to_episodes()
+        self.persona_strings_to_wow_topics = self._setup_personas_to_topics()
+
+    def get_context(self) -> dict:
+        """
+        Get context information to be shown at the beginning of one conversation.
+
+        Values in return dict:
+        - context_dataset: the dataset (ConvAI2, EmpatheticDialogues, or Wizard of Wikipedia) used to generate the context.
+        :return:
+        """
+
+        # Determine which dataset we will show context for
+        rand_value = random.random()
+        if rand_value < 1 / 3:
+            context_dataset = 'convai2'
+        elif rand_value < 2 / 3:
+            context_dataset = 'empathetic_dialogues'
+        else:
+            context_dataset = 'wizard_of_wikipedia'
+
+        if context_dataset == 'convai2':
+
+            # Select episode
+            episode_idx = random.randrange(self.convai2_teacher.num_episodes())
+
+            # Extract personas
+            persona_1_strings, persona_2_strings = self._extract_personas(episode_idx)
+
+            # Sample persona strings
+            selected_persona_1_strings = random.sample(persona_1_strings, 2)
+            selected_persona_2_strings = random.sample(persona_2_strings, 2)
+
+            # Select previous utterances
+            num_entries = len(self.convai2_teacher.data.data[episode_idx])
+            entry_idx = random.randrange(1, num_entries)
+            # Don't select the first entry, which often doesn't include an apprentice
+            # utterance
+            chosen_entry = self.convai2_teacher.get(episode_idx, entry_idx=entry_idx)
+            person1_seed_utterance = chosen_entry['text']
+            assert len(chosen_entry['labels']) == 1
+            person2_seed_utterance = chosen_entry['labels'][0]
+
+            return {
+                'context_dataset': context_dataset,
+                'persona_1_strings': selected_persona_1_strings,
+                'persona_2_strings': selected_persona_2_strings,
+                'additional_context': None,
+                'person1_seed_utterance': person1_seed_utterance,
+                'person2_seed_utterance': person2_seed_utterance,
+            }
+
+        elif context_dataset == 'empathetic_dialogues':
+
+            # Select episode
+            persona_episode_idx = random.randrange(self.convai2_teacher.num_episodes())
+
+            # Extract personas
+            persona_1_strings, persona_2_strings = self._extract_personas(
+                persona_episode_idx
+            )
+
+            # Sample persona strings
+            selected_persona_1_strings = random.sample(persona_1_strings, 2)
+            selected_persona_2_strings = random.sample(persona_2_strings, 2)
+
+            # Select previous utterances
+            episode_idx = random.randrange(self.ed_teacher.num_episodes())
+            entry_idx = 0  # We'll only use the first pair of utterances
+            entry = self.ed_teacher.get(episode_idx, entry_idx=entry_idx)
+            situation = entry['situation']
+            speaker_utterance = entry['text']
+            assert len(entry['labels']) == 1
+            listener_response = entry['labels'][0]
+
+            return {
+                'context_dataset': context_dataset,
+                'persona_1_strings': selected_persona_1_strings,
+                'persona_2_strings': selected_persona_2_strings,
+                'additional_context': situation,
+                'person1_seed_utterance': speaker_utterance,
+                'person2_seed_utterance': listener_response,
+            }
+
+        elif context_dataset == 'wizard_of_wikipedia':
+
+            # Pull different personas until you get a pair for which at least one
+            # sentence has a WoW topic bound to it
+            num_tries = 0
+            while True:
+
+                num_tries += 1
+
+                # Extract a random (matched) pair of personas
+                persona_episode_idx = random.randrange(
+                    self.convai2_teacher.num_episodes()
+                )
+                all_persona_strings = dict()
+                all_persona_strings[1], all_persona_strings[2] = self._extract_personas(
+                    persona_episode_idx
+                )
+
+                # See if any of the persona strings have a matching WoW topic
+                matching_persona_string_idxes = []
+                for persona_idx, persona_strings in all_persona_strings.items():
+                    for str_idx, str_ in enumerate(persona_strings):
+                        wow_topics = self.persona_strings_to_wow_topics[str_]
+                        if len(wow_topics) > 0:
+                            matching_persona_string_idxes.append((persona_idx, str_idx))
+                if len(matching_persona_string_idxes) > 0:
+                    break
+
+            print(
+                f'{num_tries:d} try/tries needed to find a pair of personas with an '
+                f'associated WoW topic.'
+            )
+
+            # Pick out the WoW topic and matching persona string
+            matching_persona_idx, matching_persona_string_idx = random.sample(
+                matching_persona_string_idxes, k=1
+            )[0]
+            matching_persona_string = all_persona_strings[matching_persona_idx][
+                matching_persona_string_idx
+            ]
+            wow_topic = random.sample(
+                self.persona_strings_to_wow_topics[matching_persona_string], k=1
+            )[0]
+
+            # Sample persona strings, making sure that we keep the one connected to the
+            # WoW topic
+            if matching_persona_idx == 1:
+                remaining_persona_1_strings = [
+                    str_
+                    for str_ in all_persona_strings[1]
+                    if str_ != matching_persona_string
+                ]
+                selected_persona_1_strings = [
+                    matching_persona_string,
+                    random.sample(remaining_persona_1_strings, k=1)[0],
+                ]
+                random.shuffle(selected_persona_1_strings)
+                selected_persona_2_strings = random.sample(all_persona_strings[2], 2)
+            else:
+                selected_persona_1_strings = random.sample(all_persona_strings[1], 2)
+                remaining_persona_2_strings = [
+                    str_
+                    for str_ in all_persona_strings[2]
+                    if str_ != matching_persona_string
+                ]
+                selected_persona_2_strings = [
+                    matching_persona_string,
+                    random.sample(remaining_persona_2_strings, k=1)[0],
+                ]
+                random.shuffle(selected_persona_2_strings)
+
+            # Sample WoW previous utterances, given the topic
+            episode_idx = random.sample(
+                self.wow_topics_to_episode_idxes[wow_topic], k=1
+            )[0]
+            entry_idx = 1
+            # Select the second entry, which (unlike the first entry) will always have
+            # two valid utterances and which will not usually be so far along in the
+            # conversation that the new Turkers will be confused
+            entry = self.wow_teacher.get(episode_idx, entry_idx=entry_idx)
+            apprentice_utterance = entry['text']
+            assert len(entry['labels']) == 1
+            wizard_utterance = entry['labels'][0]
+
+            return {
+                'context_dataset': context_dataset,
+                'persona_1_strings': selected_persona_1_strings,
+                'persona_2_strings': selected_persona_2_strings,
+                'additional_context': wow_topic,
+                'person1_seed_utterance': apprentice_utterance,
+                'person2_seed_utterance': wizard_utterance,
+            }
+
+    def _setup_personas_to_topics(self) -> Dict[str, List[str]]:
+
+        print('Starting to map personas to topics.')
+
+        persona_strings_to_topics = defaultdict(list)
+        with open(self.topic_to_persona_path, 'r') as f:
+            for line in f:
+                match = re.fullmatch(r'([^[]+): (\[.+\])\n', line)
+                topic = match.group(1)
+                if topic not in self.wow_topics_to_episode_idxes:
+                    continue
+                persona_strings = eval(match.group(2))
+                assert isinstance(persona_strings, list)
+                for str_ in persona_strings:
+                    persona_strings_to_topics[str_].append(topic)
+
+        print('Finished mapping personas to topics.')
+
+        return persona_strings_to_topics
+
+    def _setup_topics_to_episodes(self) -> Dict[str, List[int]]:
+
+        print('Starting to map topics to episodes.')
+
+        topics_to_episodes = defaultdict(list)
+        for episode_idx in range(self.wow_teacher.num_episodes()):
+            topic = self.wow_teacher.get(episode_idx, entry_idx=0)['chosen_topic']
+            topics_to_episodes[topic].append(episode_idx)
+
+        print('Finished mapping topics to episodes.')
+
+        return topics_to_episodes
+
+    def _extract_personas(self, episode_idx: str) -> Tuple[List[str], List[str]]:
+        first_entry = self.convai2_teacher.get(episode_idx, entry_idx=0)
+        first_text_strings = first_entry['text'].split('\n')
+        persona_1_strings = []
+        persona_2_strings = []
+        for str_ in first_text_strings[:-1]:  # The last string is the first utterance
+            if str_.startswith('your persona: '):  # Here, "you" are Person 2
+                persona_2_strings.append(str_[len('your persona: ') :])
+            elif str_.startswith("partner's persona: "):
+                persona_1_strings.append(str_[len("partner's persona: ") :])
+            else:
+                raise ValueError('Persona string cannot be parsed!')
+        return persona_1_strings, persona_2_strings

--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -285,7 +285,7 @@ class PersonaTopicifier:
             self.personas = [p for p in self.personas if p]
 
     def _setup_personas_to_wow_topics(
-        self
+        self,
     ) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
         persona_strings_to_topics = defaultdict(list)
         topics_to_persona_strings = defaultdict(list)
@@ -552,7 +552,9 @@ class ContextGenerator:
         elif context_dataset == 'empathetic_dialogues':
 
             # Select episode
-            persona_episode_idx = self.rng.randrange(self.convai2_teacher.num_episodes())
+            persona_episode_idx = self.rng.randrange(
+                self.convai2_teacher.num_episodes()
+            )
 
             # Extract personas
             persona_1_strings, persona_2_strings = self._extract_personas(

--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -273,12 +273,12 @@ class PersonaTopicifier:
         # Throw an exception if a persona is not found for the input WoW topic
 
         # this returns map of persona line str to WoW topic
+        self.personas_file_path = _persona_list_path(opt)
+        self.topic_to_persona_path = _topic_to_persona_path(opt)
         (
             self.wow_topics_to_persona_strings_map,
             self.persona_strings_to_wow_topics_map,
         ) = self._setup_personas_to_wow_topics()
-        self.personas_file_path = _persona_list_path(opt)
-        self.topic_to_persona_path = _topic_to_persona_path(opt)
         with open(self.personas_file_path, 'r') as f:
             self.personas = f.read().strip().split('||')
             # There's an extra line at the end of the file which is ''

--- a/tests/tasks/test_blended_skill_talk.py
+++ b/tests/tasks/test_blended_skill_talk.py
@@ -12,6 +12,7 @@ from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
 from parlai.core.opt import Opt
 from parlai.core.worlds import create_task
 from parlai.scripts.display_data import setup_args
+from parlai.tasks.blended_skill_talk.agents import ContextGenerator
 from parlai.tasks.blended_skill_talk.worlds import InteractiveWorld, _load_personas
 
 
@@ -292,6 +293,13 @@ class TestPersonaTopicifierTeachers(unittest.TestCase):
                 print(key)
                 self.assertEqual(desired_message[key], actual_message[key])
             print('')
+
+
+class TestContextGenerator(unittest.TestCase):
+    def test_generated_context(self):
+        seeds_to_desired_contexts = {0: None, 1: None, 2: None}  # TODO: add in
+        for seed, desired_context in seeds_to_desired_contexts.items():
+            # {{{TODO}}}
 
 
 class TestBlendedSkillTalkInteractiveWorld(unittest.TestCase):

--- a/tests/tasks/test_blended_skill_talk.py
+++ b/tests/tasks/test_blended_skill_talk.py
@@ -298,16 +298,69 @@ class TestPersonaTopicifierTeachers(unittest.TestCase):
 
 class TestContextGenerator(unittest.TestCase):
     def test_generated_context(self):
-        datatypes_to_desired_contexts = {
-            'train': None,
-            'valid': None,
-            'tests': None,
-        }  # TODO: add in
-        for datatype, desired_context in datatypes_to_desired_contexts.items():
+        datatypes_seeds_and_desired_contexts = [
+            (
+                'train',
+                0,
+                {
+                    'context_dataset': 'wizard_of_wikipedia',
+                    'persona_1_strings': [
+                        'i am a vegetarian.',
+                        'i live on a pig farm.',
+                    ],
+                    'persona_2_strings': [
+                        "my wife hates me , she thinks i'm lazy and poor.",
+                        'i won a lottery 6 years ago but nobody knows.',
+                    ],
+                    'additional_context': 'Vegetarianism',
+                    'person1_seed_utterance': 'What reasons would a person become a vegetarian?',
+                    'person2_seed_utterance': 'religion is one, it is strongly linked with a number of religions that originated in ancient India ',
+                },
+            ),
+            (
+                'valid',
+                1,
+                {
+                    'context_dataset': 'convai2',
+                    'persona_1_strings': [
+                        'my parents were also teachers.',
+                        'for vacation i enjoy time at the beach.',
+                    ],
+                    'persona_2_strings': [
+                        'i love to go to disney world every year.',
+                        'i am in the third grade.',
+                    ],
+                    'additional_context': None,
+                    'person1_seed_utterance': "you have your whole life in front of you i am sure you'll",
+                    'person2_seed_utterance': 'maybe i will meet him at disney world ! 3',
+                },
+            ),
+            (
+                'test',
+                2,
+                {
+                    'context_dataset': 'wizard_of_wikipedia',
+                    'persona_1_strings': [
+                        'i like to dance.',
+                        'my aunt helped me escape when i was of.',
+                    ],
+                    'persona_2_strings': [
+                        'my bedroom is purple and lime green.',
+                        'i am a vegan.',
+                    ],
+                    'additional_context': 'Dance',
+                    'person1_seed_utterance': 'I love to dance too!  What kind do you do?',
+                    'person2_seed_utterance': 'I love choreography dance, Dance can be categorized and described by its choreography, by its repertoire of movements',
+                },
+            ),
+        ]
+        for datatype, seed, desired_context in datatypes_seeds_and_desired_contexts:
             argparser = ParlaiParser(False, False)
             argparser.add_parlai_data_path()
-            context_opt = argparser.parse_args()
-            context_generator = ContextGenerator(context_opt, datatype=datatype, seed=0)
+            context_opt = argparser.parse_args([])
+            context_generator = ContextGenerator(
+                context_opt, datatype=datatype, seed=seed
+            )
             actual_context = context_generator.get_context()
             self.assertEqual(desired_context, actual_context)
 

--- a/tests/tasks/test_blended_skill_talk.py
+++ b/tests/tasks/test_blended_skill_talk.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import parlai.utils.testing as testing_utils
 from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
 from parlai.core.opt import Opt
+from parlai.core.params import ParlaiParser
 from parlai.core.worlds import create_task
 from parlai.scripts.display_data import setup_args
 from parlai.tasks.blended_skill_talk.agents import ContextGenerator
@@ -297,9 +298,18 @@ class TestPersonaTopicifierTeachers(unittest.TestCase):
 
 class TestContextGenerator(unittest.TestCase):
     def test_generated_context(self):
-        seeds_to_desired_contexts = {0: None, 1: None, 2: None}  # TODO: add in
-        for seed, desired_context in seeds_to_desired_contexts.items():
-            # {{{TODO}}}
+        datatypes_to_desired_contexts = {
+            'train': None,
+            'valid': None,
+            'tests': None,
+        }  # TODO: add in
+        for datatype, desired_context in datatypes_to_desired_contexts.items():
+            argparser = ParlaiParser(False, False)
+            argparser.add_parlai_data_path()
+            context_opt = argparser.parse_args()
+            context_generator = ContextGenerator(context_opt, datatype=datatype, seed=0)
+            actual_context = context_generator.get_context()
+            self.assertEqual(desired_context, actual_context)
 
 
 class TestBlendedSkillTalkInteractiveWorld(unittest.TestCase):


### PR DESCRIPTION
**Patch description**
- Open-sourcing `ContextGenerator`, used to generate the contexts used to start off BST conversations when crowdsourcing the dataset
- Cleaner specification of paths to two persona files from AWS
- Fix issue in ConvAI2PersonaTopicifierTeacher: base ConvAI2 teacher now returns an Opt, requiring a .force_set() when modifying the text

**Testing steps**
- Added `tests.tasks.test_blended_skill_talk.TestContextGenerator`
- Output of `test_new_tasks.py`:
```
Ran 1 test in 391.892s

OK
```