### PR TITLE
Fix ChunkTeacher bug

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -1993,8 +1993,8 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
 
         self.set_datasettings(opt['datatype'])
 
-        self.dws = int(self.opt['distributed_world_size'])
-        self.rank = int(self.opt['rank'])
+        self.dws = int(self.opt.get('distributed_world_size', 1))
+        self.rank = int(self.opt.get('rank', 0))
         if (
             shared is None
             and self.is_train


### PR DESCRIPTION
**Patch description**
Fix bug introduced in #2759. 

`distributed_world_size` and `rank` are not set when not in distributed mode.

**Testing steps**
local testing for now
