### PR TITLE
[WoW] Add options for certain delimiters

### DIFF
--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -202,6 +202,7 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
         self.include_knowledge = opt.get('include_knowledge', True)
         self.include_checked_sentence = opt.get('include_checked_sentence', False)
         self.knowledge_separator = opt.get('include_knowledge_separator', False)
+        self.chosen_topic_delimiter = opt.get('chosen_topic_delimiter', '\n')
         self.num_exs = sum(self.len_episode(i) for i in range(len(self.data)))
 
     @staticmethod
@@ -232,6 +233,12 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
             type='bool',
             default=False,
             help='include special __knowledge__ token between ' 'title and passage',
+        )
+        agent.add_argument(
+            '--chosen-topic-delimiter',
+            type=str,
+            default='\n',
+            help='delimiter used when including chosen topic'
         )
         agent.add_argument(
             '--num-topics',
@@ -285,7 +292,7 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
             text = chosen_topic
         elif idx == 1:
             # first response - only have the first message
-            text = '{}\n{}'.format(chosen_topic, apprentice_entry['text'])
+            text = f"{chosen_topic}{self.chosen_topic_delimiter}{apprentice_entry['text']}"
         else:
             text = ''
             if self.label_type == 'chosen_sent':
@@ -453,6 +460,7 @@ class GeneratorTeacher(WizardDialogKnowledgeTeacher):
         self.knowledge_separator = opt.get('include_knowledge_separator', True)
         self.only_checked_knowledge = opt.get('only_checked_knowledge', False)
         self.prepend_gold_knowledge = opt.get('prepend_gold_knowledge')
+        self.gold_knowledge_delimiter = opt.get('gold_knowledge_delimiter', '\n')
         self.dropout = opt.get('ignorant_dropout', 0.0)
 
     @staticmethod
@@ -478,6 +486,12 @@ class GeneratorTeacher(WizardDialogKnowledgeTeacher):
             type='bool',
             default=False,
             help='If true, prepend text with checked sentence',
+        )
+        agent.add_argument(
+            '--gold-knowledge-delimiter',
+            type=str,
+            default='\n',
+            help='delimiter for prepending gold knowledge'
         )
 
     def getID(self):
@@ -517,9 +531,7 @@ class GeneratorTeacher(WizardDialogKnowledgeTeacher):
                 TOKEN_NOCHOSEN + ' ' + TOKEN_KNOWLEDGE + ' ' + TOKEN_NOCHOSEN
             )
         elif self.prepend_gold_knowledge:
-            a['text'] = '{} {} {}\n{}'.format(
-                TOKEN_KNOWLEDGE, a['checked_sentence'], TOKEN_END_KNOWLEDGE, a['text']
-            )
+            a['text'] = f"{TOKEN_KNOWLEDGE} {a['checked_sentence']} {TOKEN_END_KNOWLEDGE}{self.gold_knowledge_delimiter}{a['text']}"
         return a
 
 

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -238,7 +238,7 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
             '--chosen-topic-delimiter',
             type=str,
             default='\n',
-            help='delimiter used when including chosen topic'
+            help='delimiter used when including chosen topic',
         )
         agent.add_argument(
             '--num-topics',
@@ -292,7 +292,9 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
             text = chosen_topic
         elif idx == 1:
             # first response - only have the first message
-            text = f"{chosen_topic}{self.chosen_topic_delimiter}{apprentice_entry['text']}"
+            text = (
+                f"{chosen_topic}{self.chosen_topic_delimiter}{apprentice_entry['text']}"
+            )
         else:
             text = ''
             if self.label_type == 'chosen_sent':
@@ -491,7 +493,7 @@ class GeneratorTeacher(WizardDialogKnowledgeTeacher):
             '--gold-knowledge-delimiter',
             type=str,
             default='\n',
-            help='delimiter for prepending gold knowledge'
+            help='delimiter for prepending gold knowledge',
         )
 
     def getID(self):
@@ -531,7 +533,9 @@ class GeneratorTeacher(WizardDialogKnowledgeTeacher):
                 TOKEN_NOCHOSEN + ' ' + TOKEN_KNOWLEDGE + ' ' + TOKEN_NOCHOSEN
             )
         elif self.prepend_gold_knowledge:
-            a['text'] = f"{TOKEN_KNOWLEDGE} {a['checked_sentence']} {TOKEN_END_KNOWLEDGE}{self.gold_knowledge_delimiter}{a['text']}"
+            a[
+                'text'
+            ] = f"{TOKEN_KNOWLEDGE} {a['checked_sentence']} {TOKEN_END_KNOWLEDGE}{self.gold_knowledge_delimiter}{a['text']}"
         return a
 
 


### PR DESCRIPTION
**Patch description**
Add two cmd line args for specifying delimiters in wiz of wiki task. This allows control over how 

1. Chosen topic is delimited in the first utterance
2. Gold knowledge is delimited when prepended in generator teacher

**Testing steps**
Tested using display data

**Logs**
```
$ parlai dd -t wizard_of_wikipedia --chosen-topic-delimiter '\\n'
.
.
.
- - - NEW EPISODE: wizard_of_wikipedia - - -
Internet access\\nCan you imagine the world without internet access?
   No I could not! I couldn't imagine living when internet access was rare and very few people had it!
Oh me either! It seems like such a long time ago. I wonder when Internet was first created?
   It used to be restricted, but around 1995, the restricted were lifted and commercial use of it began
That is awesome. I wonder why it was restricted? Probably because they only wanted government and big companies to use it at first.
   Yes, it was developed from a government funded projects to help with universities research and laboratories in the United States...I am so glad they expanded it!
I am too, it makes life so much easier!
   What is your favorite thing to do with internet access? I like being able to use my computer and smartphone to use my email and browse the world wide web
.
.
.
```


```
$ parlai dd -t wizard_of_wikipedia:Generator --prepend-gold-knowledge True --gold-knowledge-delimiter '\\n'
.
.
.
- - - NEW EPISODE: WizTeacher - - -
__knowledge__ Internet access was once rare, but has grown rapidly. __endknowledge__\\nInternet access
Can you imagine the world without internet access?
   No I could not! I couldn't imagine living when internet access was rare and very few people had it!
__knowledge__ Use by a wider audience only came in 1995 when restrictions on the use of the Internet to carry commercial traffic were lifted. __endknowledge__\\nOh me either! It seems like such a long time ago. I wonder when Internet was first created?
.
.
.
```
