### PR TITLE
Add tests for the ChunkTeacher

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2163,8 +2163,6 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
         if self.is_train:
             # randomize the samples
             random.Random().shuffle(output)
-        else:
-            random.Random(42).shuffle(output)
         return output
 
     def get(self, episode_idx, entry_idx=0):

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -16,6 +16,7 @@ from parlai.core.teachers import (
     DialogTeacher,
     AbstractImageTeacher,
     Teacher,
+    ChunkTeacher,
 )
 from parlai.core.opt import Opt
 from torch.utils.data import Dataset
@@ -27,6 +28,7 @@ from PIL import Image
 import string
 import json
 from abc import ABC
+from typing import Tuple, List
 
 # default parameters
 VOCAB_SIZE = 7
@@ -542,6 +544,39 @@ class RepeatTeacher(DialogTeacher):
 
     def num_episodes(self):
         return self.data_length
+
+
+class ChunkyTeacher(ChunkTeacher):
+    def _get_data_folder(self):
+        return None
+
+    def get_num_samples(self, datatype: str) -> Tuple[int, int]:
+        if 'train' in datatype:
+            return NUM_TRAIN, NUM_TRAIN
+        elif 'valid' in datatype:
+            return NUM_TEST, NUM_TEST
+        elif 'test' in datatype:
+            return NUM_TEST, NUM_TEST
+
+    def get_fold_chunks(self, datatype: str) -> List[int]:
+        if 'train' in datatype:
+            return list(range(50))
+        elif 'valid' in datatype:
+            return list(range(50, 60))
+        elif 'test' in datatype:
+            return list(range(60, 70))
+
+    def load_from_chunk(self, chunk_idx: int):
+        output = []
+        for i in range(10):
+            text = " ".join([str(i)] + [str(chunk_idx)] * 5)
+            resp = " ".join([str(i)])
+            output.append((text, resp))
+        return output
+
+    def create_message(self, sample_item):
+        text, label = sample_item
+        return {'text': text, 'labels': [label], 'episode_done': True}
 
 
 class DefaultTeacher(CandidateTeacher):

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -281,7 +281,9 @@ def train_model(opt: Opt) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     return valid, test
 
 
-def eval_model(opt, skip_valid=False, skip_test=False, valid_datatype=None):
+def eval_model(
+    opt, skip_valid=False, skip_test=False, valid_datatype='valid', test_datatype='test'
+):
     """
     Run through an evaluation loop.
 
@@ -308,7 +310,7 @@ def eval_model(opt, skip_valid=False, skip_test=False, valid_datatype=None):
 
     opt['datatype'] = 'valid' if valid_datatype is None else valid_datatype
     valid = None if skip_valid else ems.EvalModel.main(**opt)
-    opt['datatype'] = 'test'
+    opt['datatype'] = 'test' if test_datatype is None else test_datatype
     test = None if skip_test else ems.EvalModel.main(**opt)
 
     return valid, test

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -149,6 +149,26 @@ class TestDistributed(unittest.TestCase):
         self.assertEqual(valid['exs'].value(), 98)
         self.assertEqual(test['exs'].value(), 98)
 
+    def test_chunked_dynamic_teacher(self):
+        config = copy.deepcopy(self._base_config)
+        config['datatype'] = 'train:stream'
+        config['dynamic_batching'] = 'full'
+        config['truncate'] = 16
+
+        valid, test = self._distributed_train_model(config)
+        assert valid['exs'].value() == 100
+        assert test['exs'].value() == 100
+
+    def test_chunked_teacher(self):
+        config = copy.deepcopy(self._base_config)
+        config['datatype'] = 'train:stream'
+        config['num_epochs'] = 5
+        config['dynamic_batching'] = None
+
+        valid, test = self._distributed_train_model(config)
+        assert valid['exs'].value() == 100
+        assert test['exs'].value() == 100
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_teachers.py
+++ b/tests/test_teachers.py
@@ -135,6 +135,72 @@ class TestParlAIDialogTeacher(unittest.TestCase):
                     assert any('long episode' in l for l in cm.output)
 
 
+class TestChunkTeacher(unittest.TestCase):
+    """
+    Test chunked teacher.
+    """
+
+    def test_no_batched(self):
+        valid, test = testing_utils.eval_model(
+            dict(task='integration_tests:chunky', model='repeat_label',),
+            valid_datatype='valid:stream',
+            test_datatype='test:stream',
+        )
+        assert valid['exs'] == 100
+        assert test['exs'] == 100
+
+    def test_batched(self):
+        valid, test = testing_utils.eval_model(
+            dict(
+                task='integration_tests:chunky',
+                model='parlai.agents.test_agents.test_agents:MockTorchAgent',
+                batchsize=32,
+            ),
+            valid_datatype='valid:stream',
+            test_datatype='test:stream',
+        )
+        assert valid['exs'] == 100
+        assert test['exs'] == 100
+
+    def test_dynamic_batched(self):
+        valid, test = testing_utils.eval_model(
+            dict(
+                task='integration_tests:chunky',
+                model='parlai.agents.test_agents.test_agents:MockTorchAgent',
+                datatype='valid:stream',
+                batchsize=32,
+                truncate=16,
+                dynamic_batching='full',
+            ),
+            valid_datatype='valid:stream',
+            test_datatype='test:stream',
+        )
+        assert valid['exs'] == 100
+        assert test['exs'] == 100
+
+    def test_stream_only(self):
+        with self.assertRaises(ValueError):
+            valid, test = testing_utils.eval_model(
+                dict(
+                    task='integration_tests:chunky',
+                    model='parlai.agents.test_agents.test_agents:MockTorchAgent',
+                    batchsize=32,
+                ),
+                valid_datatype='valid',
+            )
+
+        with self.assertRaises(ValueError):
+            valid, test = testing_utils.eval_model(
+                dict(
+                    task='integration_tests:chunky',
+                    model='parlai.agents.test_agents.test_agents:MockTorchAgent',
+                    batchsize=32,
+                ),
+                valid_datatype='valid:stream',
+                test_datatype='test',
+            )
+
+
 class CustomEvaluationTeacher(DialogTeacher):
     def __init__(self, opt, shared=None):
         opt['datafile'] = 'mock'


### PR DESCRIPTION
**Patch description**
Adds some tests for the the ChunkTeacher, including inside and outside distributed mode. Follow up to #2759 and #2770.

**Testing steps**
New CI.