### PR TITLE
Undo codecov change.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 coverage:
   status:
     project: off
-    patch: on
+    patch: off
     changes: off


### PR DESCRIPTION
**Patch description**
Changed this when I enabled long tests on every PR. I forgot this means "Fail a commit if it doesn't have minimum coverage", not "comment on patches." Turn it back off so the red X's go away on our repo.

**Testing steps**
lol nope