### PR TITLE
Fixed ParlAI entry point

### DIFF
--- a/bin/parlai
+++ b/bin/parlai
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-
-import parlai.scripts.parlai_exe as parlai
-
-if __name__ == '__main__':
-    parlai.Parlai()

--- a/parlai/__init__.py
+++ b/parlai/__init__.py
@@ -3,7 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import sys
 
-if sys.version_info < (3, 0):
-    raise RuntimeError('ParlAI requires Python 3.')
+from parlai.scripts.parlai_exe import Parlai as main
+
+if __name__ == '__main__':
+    main()

--- a/parlai/__main__.py
+++ b/parlai/__main__.py
@@ -3,3 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+
+from parlai.scripts.parlai_exe import Parlai as main
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
         package_data={'': ['*.txt', '*.md']},
         entry_points={
             "flake8.extension": ["PAI = parlai.utils.flake8:ParlAIChecker"],
-            "console_scripts": ["parlai = parlai:main"],
+            "console_scripts": ["parlai=parlai.__main__:main"],
         },
         classifiers=[
             "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,15 @@ with open('README.md', encoding="utf8") as f:
     readme = f.read().split('--------------------')[-1]
 
 with open('requirements.txt') as f:
-    reqs = f.read()
+    reqs = []
+    for line in f:
+        line = line.strip()
+        if '>' in line:
+            reqs.append(line.split('>')[0])
+        elif '=' in line:
+            reqs.append(line.split('=')[0])
+        else:
+            reqs.append(line)
 
 
 if __name__ == '__main__':
@@ -36,7 +44,7 @@ if __name__ == '__main__':
         packages=find_packages(
             exclude=('data', 'docs', 'examples', 'tests', 'parlai_internal',)
         ),
-        install_requires=reqs.strip().split('\n'),
+        install_requires=reqs,
         include_package_data=True,
         package_data={'': ['*.txt', '*.md']},
         entry_points={

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,7 @@ with open('requirements.txt') as f:
     reqs = []
     for line in f:
         line = line.strip()
-        if '>' in line:
-            reqs.append(line.split('>')[0])
-        elif '=' in line:
-            reqs.append(line.split('=')[0])
-        else:
-            reqs.append(line)
+        reqs.append(line.split('=')[0].rstrip('=><~'))
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -33,14 +33,16 @@ if __name__ == '__main__':
         long_description_content_type='text/markdown',
         url='http://parl.ai/',
         python_requires='>=3.6',
-        scripts=['bin/parlai'],
         packages=find_packages(
             exclude=('data', 'docs', 'examples', 'tests', 'parlai_internal',)
         ),
         install_requires=reqs.strip().split('\n'),
         include_package_data=True,
         package_data={'': ['*.txt', '*.md']},
-        entry_points={"flake8.extension": ["PAI = parlai.utils.flake8:ParlAIChecker"]},
+        entry_points={
+            "flake8.extension": ["PAI = parlai.utils.flake8:ParlAIChecker"],
+            "console_scripts": ["parlai = parlai:main"],
+        },
         classifiers=[
             "Programming Language :: Python :: 3",
             "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
**Patch description**
Fixed the entry point into parlai so that:
- Things don't catastrophically fail when you upgrade one of parlai's dependencies
- You can also run with `python -m parlai` as an equivalent to running the command. This is good because it enables @emilydinan to do `python -m pdb -m parlai` and get her debug functionality.

**_This requires everyone rerun `python setup.py develop`_**. Furthermore, we should probably release a new pypi release with this.

**Testing steps**
Manual testing.