### PR TITLE
Fix a bug with nice_report.

### DIFF
--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -424,6 +424,9 @@ def nice_report(report) -> str:
     If pandas is not available, we will use a dict with like-metrics placed
     next to each other.
     """
+    if not report:
+        return ""
+
     from parlai.core.metrics import Metric
 
     try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from parlai.core.opt import Opt
-from parlai.utils.misc import Timer, round_sigfigs, set_namedtuple_defaults
+from parlai.utils.misc import Timer, round_sigfigs, set_namedtuple_defaults, nice_report
 import parlai.utils.strings as string_utils
 from copy import deepcopy
 import time
@@ -13,6 +13,15 @@ import unittest
 
 
 class TestUtils(unittest.TestCase):
+    def test_report_render(self):
+        """
+        Test rendering of nice reports.
+        """
+        report_s = nice_report({'foo': 3})
+        assert "foo" in report_s
+        assert "3" in report_s
+        assert nice_report({}) == ""
+
     def test_round_sigfigs(self):
         x = 0
         y = 0


### PR DESCRIPTION
**Patch description**
If we called `nice_report` with an empty report and had pandas installed, we would throw an exception. This is not caught in public unit tests, but it is caught in internal ones.

**Testing steps**
New unit test, run on local machine with pandas installed. I don't really want to add pandas as a public dependency.