### PR TITLE
[Chunk Teacher] Allow multi-turn

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -286,7 +286,7 @@ class FixedDialogTeacher(Teacher):
         self.metrics.clear()
         self.lastY = None
         self.last_act = None
-        self.episode_done = True
+        self._episode_done = True
         self.epochDone = False
         self.data_queue = queue.Queue()
 
@@ -368,7 +368,7 @@ class FixedDialogTeacher(Teacher):
         episode. If that episode is over, gets a new episode index and returns the first
         example of that episode.
         """
-        if self.episode_done:
+        if self._episode_done:
             self.episode_idx = self.next_episode_idx()
             self.entry_idx = 0
         else:
@@ -378,11 +378,11 @@ class FixedDialogTeacher(Teacher):
             return {'episode_done': True}, True
 
         ex = self.get(self.episode_idx, self.entry_idx)
-        self.episode_done = ex.get('episode_done', False)
+        self._episode_done = ex.get('episode_done', False)
 
         if (
             not self.cycle
-            and self.episode_done
+            and self._episode_done
             and self.episode_idx + self.opt.get("batchsize", 1) >= self.num_episodes()
         ):
             epoch_done = True
@@ -2023,7 +2023,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
             # launch queue loader on the main thread
             self._enqueue_request()
 
-        self.episode_done = True
+        self._episode_done = True
         self.last_queue_output = None
 
     def _get_data_folder(self):
@@ -2170,7 +2170,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
         return output
 
     def get(self, episode_idx, entry_idx=0):
-        if self.episode_done:
+        if self._episode_done:
             # Get the next episode or example
             queue_output = self.samples.get()
             if queue_output is None:
@@ -2182,7 +2182,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
 
         # create a Message object from the queue output
         msg = self.create_message(self.last_queue_output, entry_idx)
-        self.episode_done = msg['episode_done']
+        self._episode_done = msg['episode_done']
 
         return msg
 

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2141,7 +2141,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
         pass
 
     @abstractmethod
-    def create_message(self, queue_output: List[ChunkOutput], entry_idx=0) -> 'Message':
+    def create_message(self, queue_output: ChunkOutput, entry_idx=0) -> 'Message':
         """
         [Abstract] Given the tuple output of the queue, return an act.
 

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -551,7 +551,8 @@ class ChunkyTeacher(ChunkTeacher):
     def _get_data_folder(self):
         return None
 
-    def get_num_samples(self, datatype: str) -> Tuple[int, int]:
+    def get_num_samples(self, opt) -> Tuple[int, int]:
+        datatype = opt['datatype']
         if 'train' in datatype:
             return NUM_TRAIN, NUM_TRAIN
         elif 'valid' in datatype:
@@ -559,7 +560,8 @@ class ChunkyTeacher(ChunkTeacher):
         elif 'test' in datatype:
             return NUM_TEST, NUM_TEST
 
-    def get_fold_chunks(self, datatype: str) -> List[int]:
+    def get_fold_chunks(self, opt) -> List[int]:
+        datatype = opt['datatype']
         if 'train' in datatype:
             return list(range(50))
         elif 'valid' in datatype:
@@ -575,7 +577,7 @@ class ChunkyTeacher(ChunkTeacher):
             output.append((text, resp))
         return output
 
-    def create_message(self, sample_item):
+    def create_message(self, sample_item, entry_idx=0):
         text, label = sample_item
         return {'text': text, 'labels': [label], 'episode_done': True}
 
@@ -585,7 +587,8 @@ class InfiniteTrainTeacher(ChunkyTeacher):
     Chunk teacher with an effectively infinite number of training examples.
     """
 
-    def get_num_samples(self, datatype: str) -> Tuple[int, int]:
+    def get_num_samples(self, opt) -> Tuple[int, int]:
+        datatype = opt['datatype']
         if 'train' in datatype:
             return INFINITE, INFINITE
         elif 'valid' in datatype:

--- a/parlai/tasks/wikipedia/agents.py
+++ b/parlai/tasks/wikipedia/agents.py
@@ -99,10 +99,11 @@ class FullSplitTeacher(ChunkTeacher):
     def _get_data_folder(self):
         return os.path.join(self.opt['datapath'], 'wikipedia/full/wiki_full_extracted')
 
-    def get_num_samples(self, datatype) -> Tuple[int, int]:
+    def get_num_samples(self, opt) -> Tuple[int, int]:
         """
         Return the number of samples given the datatype.
         """
+        datatype = opt['datatype']
         if 'train' in datatype:
             return self.TRAINSIZE, self.TRAINSIZE
         elif 'valid' in datatype:
@@ -116,13 +117,14 @@ class FullSplitTeacher(ChunkTeacher):
         all_subdirs = sorted([x for x in os.listdir(folder) if 'README' not in x])
         self.chunk_idx_to_file = {i: x for i, x in enumerate(all_subdirs)}
 
-    def get_fold_chunks(self, datatype) -> List[int]:  # type: ignore
+    def get_fold_chunks(self, opt) -> List[int]:  # type: ignore
         """
         Return a list of chunk IDs (integer).
 
         Given the datatype (train/test/valid), return the list of chunk IDs that
         correspond to that split.
         """
+        datatype = opt['datatype']
         all_chunk_idxs = list(self.chunk_idx_to_file.keys())
         if 'train' in datatype:
             return all_chunk_idxs[:-2]
@@ -131,7 +133,7 @@ class FullSplitTeacher(ChunkTeacher):
         else:
             return [all_chunk_idxs[-1]]
 
-    def load_from_chunk(self, chunk_idx: int) -> List[Tuple[str, str]]:
+    def load_from_chunk(self, chunk_idx: int):
         """
         Given the chunk index, load examples from that chunk.
 
@@ -151,7 +153,7 @@ class FullSplitTeacher(ChunkTeacher):
 
         return output
 
-    def create_message(self, queue_output: Tuple[str, ...]) -> 'Message':
+    def create_message(self, queue_output, entry_idx=0) -> 'Message':
         """
         Given the tuple output of the queue, return an act.
         """

--- a/parlai/tasks/wikipedia/agents.py
+++ b/parlai/tasks/wikipedia/agents.py
@@ -13,7 +13,7 @@ using 'wikipedia:summary'
 To put the article in the labels and the title in the text, specify
 ':key-value' at the end (for a title/content key-value association)
 """
-from parlai.core.teachers import DialogTeacher, ChunkTeacher
+from parlai.core.teachers import DialogTeacher, ChunkTeacher, ChunkOutput
 from parlai.core.message import Message
 from .build import build
 
@@ -153,7 +153,7 @@ class FullSplitTeacher(ChunkTeacher):
 
         return output
 
-    def create_message(self, queue_output, entry_idx=0) -> 'Message':
+    def create_message(self, queue_output: ChunkOutput, entry_idx=0) -> 'Message':
         """
         Given the tuple output of the queue, return an act.
         """


### PR DESCRIPTION
**Patch description**
Some changes to Chunk Teacher:
-  allow for multi-turn conversation
-  allow for ambiguous output from load_chunk
-  allow the data split to depend on other arguments in opt instead of just datatype