### PR TITLE
[TriviaQA] elevate primary answer over aliases

### DIFF
--- a/parlai/tasks/triviaqa/agents.py
+++ b/parlai/tasks/triviaqa/agents.py
@@ -41,7 +41,9 @@ class WebTeacher(DialogTeacher):
             data = json.load(data_file)['Data']
         for datapoint in data:
             question = datapoint['Question']
-            answers = datapoint['Answer']['Aliases']
+            answers = [datapoint['Answer']['Value']] + sorted(
+                list(set(datapoint['Answer']['Aliases']))
+            )
             evidence_list = datapoint['SearchResults']
 
             if self.no_evidence:
@@ -100,7 +102,9 @@ class WikipediaTeacher(DialogTeacher):
             data = json.load(data_file)['Data']
         for datapoint in data:
             question = datapoint['Question']
-            answers = datapoint['Answer']['Aliases']
+            answers = [datapoint['Answer']['Value']] + sorted(
+                list(set(datapoint['Answer']['Aliases']))
+            )
             evidence_list = datapoint['EntityPages']
 
             if self.no_evidence:
@@ -165,7 +169,9 @@ class NoEvidenceUnionTeacher(DialogTeacher):
             data = json.load(data_file)['Data']
         for datapoint in data:
             question = datapoint['Question']
-            answers = datapoint['Answer']['Aliases']
+            answers = [datapoint['Answer']['Value']] + sorted(
+                list(set(datapoint['Answer']['Aliases']))
+            )
             yield (question, answers), True
 
 


### PR DESCRIPTION
TriviaQA gives many aliases of the correct answer, but sometimes there are a lot of those and some are wrong. So, to make it easier to differentiate the one "true" answer from the noisy alises we sort the evals such that the first is the gold and the others are the (alphabetically sorted, deduplicated and de-" (disambiguation)"-ed) aliases.