### PR TITLE
Allow TimeLogger.log to be called with default arguments.

### DIFF
--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -247,7 +247,8 @@ class TimeLogger:
             done = done.value()
         self.tot_time += self.timer.time()
         self.timer.reset()
-        report['exs'] = done
+        if report:
+            report['exs'] = done
         if total > 0 and done > 0:
             progress = done / total
             seconds_left = max(0, self.tot_time / progress - self.tot_time)


### PR DESCRIPTION
Without this fix, the build_candidates script crashes on line 86
(if it takes long enough for this line to be reached).

**Patch description**
Prevents assigning items to `report` if it is `None` (or empty, just trying to be consistent with the `if` statement on line 264/265).

**Testing steps**
`python -c 'from parlai.utils.misc import TimeLogger; print(TimeLogger().log(1, 2)[0])'`

*Expected output*
`50.0% complete (1 / 2), 0:00:00 elapsed, 0:00:00 eta`

*Output before patch*
`TypeError: 'NoneType' object does not support item assignment`