### PR TITLE
[Params] Weird opt override bug

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -959,10 +959,7 @@ class ParlaiParser(argparse.ArgumentParser):
                     self.overridable[option_strings_dict[args_that_override[i]]] = True
                 elif args_that_override[i] in store_false:
                     self.overridable[option_strings_dict[args_that_override[i]]] = False
-                elif (
-                    i < len(args_that_override) - 1
-                    and args_that_override[i + 1][:1] != '-'
-                ):
+                elif i < len(args_that_override) - 1:
                     key = option_strings_dict[args_that_override[i]]
                     self.overridable[key] = self.opt[key]
         self.opt['override'] = self.overridable

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -959,7 +959,10 @@ class ParlaiParser(argparse.ArgumentParser):
                     self.overridable[option_strings_dict[args_that_override[i]]] = True
                 elif args_that_override[i] in store_false:
                     self.overridable[option_strings_dict[args_that_override[i]]] = False
-                elif i < len(args_that_override) - 1:
+                elif (
+                    i < len(args_that_override) - 1
+                    and args_that_override[i + 1] not in option_strings_dict
+                ):
                     key = option_strings_dict[args_that_override[i]]
                     self.overridable[key] = self.opt[key]
         self.opt['override'] = self.overridable


### PR DESCRIPTION
**Patch description**
@jxmsML encountered a weird bug in which if you set an argument on the command line to a negative numerical value, it will not override the default values (or whatever value was loaded from opt). This is because we have a check in there for if the first character of a value is a `-` (which is the case for negative numbers). For now I'm just getting rid of this check, since it should be captured by the checks for store true and false above...and seeing what happens.