### PR TITLE
[Image] Add ResNeXt101 WSL Spatial Features

### DIFF
--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -18,6 +18,28 @@ from zipfile import ZipFile
 _greyscale = '  .,:;crsA23hHG#98&@'
 _cache_size = 84000
 
+# Mapping from image mode to (torch_instantiation_str, layer_cutoff_idx)
+IMAGE_MODE_SWITCHER = {
+    'resnet152': ['resnet152', -1],
+    'resnet101': ['resnet101', -1],
+    'resnet50': ['resnet50', -1],
+    'resnet34': ['resnet34', -1],
+    'resnet18': ['resnet18', -1],
+    'resnet152_spatial': ['resnet152', -2],
+    'resnet101_spatial': ['resnet101', -2],
+    'resnet50_spatial': ['resnet50', -2],
+    'resnet34_spatial': ['resnet34', -2],
+    'resnet18_spatial': ['resnet18', -2],
+    'resnext101_32x8d_wsl': ['resnext101_32x8d_wsl', -1],
+    'resnext101_32x16d_wsl': ['resnext101_32x16d_wsl', -1],
+    'resnext101_32x32d_wsl': ['resnext101_32x32d_wsl', -1],
+    'resnext101_32x48d_wsl': ['resnext101_32x48d_wsl', -1],
+    'resnext101_32x8d_wsl_spatial': ['resnext101_32x8d_wsl', -2],
+    'resnext101_32x16d_wsl_spatial': ['resnext101_32x16d_wsl', -2],
+    'resnext101_32x32d_wsl_spatial': ['resnext101_32x32d_wsl', -2],
+    'resnext101_32x48d_wsl_spatial': ['resnext101_32x48d_wsl', -2],
+}
+
 
 class ImageLoader:
     """
@@ -112,13 +134,11 @@ class ImageLoader:
             self.netCNN = self.nn.Sequential(*list(model.children())[:layer_num])
         except RuntimeError as e:
             # Perhaps specified one of the wrong model names
+            model_names = [m for m in IMAGE_MODE_SWITCHER if 'resnext101' in m]
             logging.error(
                 'If you have specified one of the resnext101 wsl models, '
                 'please make sure it is one of the following: \n'
-                'resnext101_32x8d_wsl, resnext101_32x16d_wsl, '
-                'resnext101_32x32d_wsl, resnext101_32x48d_wsl '
-                'resnext101_32x8d_wsl_spatial, resnext101_32x16d_wsl_spatial, '
-                'resnext101_32x32d_wsl_spatial, resnext101_32x48d_wsl_spatial'
+                f"{', '.join(model_names)}"
             )
             raise e
         except AttributeError:
@@ -132,60 +152,20 @@ class ImageLoader:
             self.netCNN.cuda()
 
     def _image_mode_switcher(self):
-        switcher = {
-            'resnet152': ['resnet152', -1],
-            'resnet101': ['resnet101', -1],
-            'resnet50': ['resnet50', -1],
-            'resnet34': ['resnet34', -1],
-            'resnet18': ['resnet18', -1],
-            'resnet152_spatial': ['resnet152', -2],
-            'resnet101_spatial': ['resnet101', -2],
-            'resnet50_spatial': ['resnet50', -2],
-            'resnet34_spatial': ['resnet34', -2],
-            'resnet18_spatial': ['resnet18', -2],
-            'resnext101_32x8d_wsl': ['resnext101_32x8d_wsl', -1],
-            'resnext101_32x16d_wsl': ['resnext101_32x16d_wsl', -1],
-            'resnext101_32x32d_wsl': ['resnext101_32x32d_wsl', -1],
-            'resnext101_32x48d_wsl': ['resnext101_32x48d_wsl', -1],
-            'resnext101_32x8d_wsl_spatial': ['resnext101_32x8d_wsl', -2],
-            'resnext101_32x16d_wsl_spatial': ['resnext101_32x16d_wsl', -2],
-            'resnext101_32x32d_wsl_spatial': ['resnext101_32x32d_wsl', -2],
-            'resnext101_32x48d_wsl_spatial': ['resnext101_32x48d_wsl', -2],
-        }
-
-        if self.image_mode not in switcher:
+        if self.image_mode not in IMAGE_MODE_SWITCHER:
             raise NotImplementedError(
                 'image preprocessing mode'
                 + '{} not supported yet'.format(self.image_mode)
             )
 
-        return switcher.get(self.image_mode)
+        return IMAGE_MODE_SWITCHER.get(self.image_mode)
 
     @classmethod
     def get_available_model_names(cls):
         """
         Get a list of the available model variants in this ImageLoader.
         """
-        return [
-            'resnet152',
-            'resnet101',
-            'resnet50',
-            'resnet34',
-            'resnet18',
-            'resnet152_spatial',
-            'resnet101_spatial',
-            'resnet50_spatial',
-            'resnet34_spatial',
-            'resnet18_spatial',
-            'resnext101_32x8d_wsl',
-            'resnext101_32x16d_wsl',
-            'resnext101_32x32d_wsl',
-            'resnext101_32x48d_wsl',
-            'resnext101_32x8d_wsl_spatial',
-            'resnext101_32x16d_wsl_spatial',
-            'resnext101_32x32d_wsl_spatial',
-            'resnext101_32x48d_wsl_spatial',
-        ]
+        return list(IMAGE_MODE_SWITCHER.keys())
 
     def extract(self, image, path=None):
         # check whether initialize CNN network.

--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -105,16 +105,20 @@ class ImageLoader:
         When image_mode is one of the ``resnext101_..._wsl`` varieties
         """
         try:
-            model = self.torch.hub.load('facebookresearch/WSL-Images', self.image_mode)
+            cnn_type, layer_num = self._image_mode_switcher()
+            model = self.torch.hub.load('facebookresearch/WSL-Images', cnn_type)
             # cut off layer for ImageNet classification
-            self.netCNN = self.nn.Sequential(*list(model.children())[:-1])
+            # if spatial, cut off another layer for spatial features
+            self.netCNN = self.nn.Sequential(*list(model.children())[:layer_num])
         except RuntimeError as e:
             # Perhaps specified one of the wrong model names
             logging.error(
                 'If you have specified one of the resnext101 wsl models, '
                 'please make sure it is one of the following: \n'
                 'resnext101_32x8d_wsl, resnext101_32x16d_wsl, '
-                'resnext101_32x32d_wsl, resnext101_32x48d_wsl'
+                'resnext101_32x32d_wsl, resnext101_32x48d_wsl '
+                'resnext101_32x8d_wsl_spatial, resnext101_32x16d_wsl_spatial, '
+                'resnext101_32x32d_wsl_spatial, resnext101_32x48d_wsl_spatial'
             )
             raise e
         except AttributeError:
@@ -139,6 +143,14 @@ class ImageLoader:
             'resnet50_spatial': ['resnet50', -2],
             'resnet34_spatial': ['resnet34', -2],
             'resnet18_spatial': ['resnet18', -2],
+            'resnext101_32x8d_wsl': ['resnext101_32x8d_wsl', -1],
+            'resnext101_32x16d_wsl': ['resnext101_32x16d_wsl', -1],
+            'resnext101_32x32d_wsl': ['resnext101_32x32d_wsl', -1],
+            'resnext101_32x48d_wsl': ['resnext101_32x48d_wsl', -1],
+            'resnext101_32x8d_wsl_spatial': ['resnext101_32x8d_wsl', -2],
+            'resnext101_32x16d_wsl_spatial': ['resnext101_32x16d_wsl', -2],
+            'resnext101_32x32d_wsl_spatial': ['resnext101_32x32d_wsl', -2],
+            'resnext101_32x48d_wsl_spatial': ['resnext101_32x48d_wsl', -2],
         }
 
         if self.image_mode not in switcher:
@@ -169,6 +181,10 @@ class ImageLoader:
             'resnext101_32x16d_wsl',
             'resnext101_32x32d_wsl',
             'resnext101_32x48d_wsl',
+            'resnext101_32x8d_wsl_spatial',
+            'resnext101_32x16d_wsl_spatial',
+            'resnext101_32x32d_wsl_spatial',
+            'resnext101_32x48d_wsl_spatial',
         ]
 
     def extract(self, image, path=None):

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -1881,6 +1881,8 @@ class AbstractImageTeacher(FixedDialogTeacher):
             img_id = ex[self.image_id_key]
             img_path = self.image_id_to_image_path(img_id)
             image = self.image_loader.load(img_path).detach()
+            # spatial features are [1, image_dim, spatial_dim, spatial_dim] tensors.
+            # reduce non-spatial features to one-dimensional feature prior to saving.
             if 'spatial' not in self.image_mode:
                 image = image[0, :, 0, 0]
             image_features_dict[img_id] = image

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -1881,7 +1881,8 @@ class AbstractImageTeacher(FixedDialogTeacher):
             img_id = ex[self.image_id_key]
             img_path = self.image_id_to_image_path(img_id)
             image = self.image_loader.load(img_path).detach()
-            image = image[0, :, 0, 0]
+            if 'spatial' not in self.image_mode:
+                image = image[0, :, 0, 0]
             image_features_dict[img_id] = image
             num += 1
             pbar.update(1)

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -492,7 +492,9 @@ class ImageTeacher(AbstractImageTeacher):
         imagepath = os.path.join(datapath, 'images')
         os.makedirs(imagepath, exist_ok=True)
 
-        self.image_features_path = os.path.join(datapath, f'{opt["image_mode"]}_image_features')
+        self.image_features_path = os.path.join(
+            datapath, f'{opt["image_mode"]}_image_features'
+        )
 
         # Create fake images and features
         imgs = [f'img_{i}' for i in range(10)]

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -492,7 +492,7 @@ class ImageTeacher(AbstractImageTeacher):
         imagepath = os.path.join(datapath, 'images')
         os.makedirs(imagepath, exist_ok=True)
 
-        self.image_features_path = os.path.join(datapath, 'image_features')
+        self.image_features_path = os.path.join(datapath, f'{opt["image_mode"]}_image_features')
 
         # Create fake images and features
         imgs = [f'img_{i}' for i in range(10)]

--- a/tests/test_image_featurizers.py
+++ b/tests/test_image_featurizers.py
@@ -15,7 +15,7 @@ BASE_IMAGE_ARGS = {
     "task": "integration_tests:ImageTeacher",
     "image_size": 256,
     "image_cropsize": 224,
-    "image_features_dim": 2048
+    "image_features_dim": 2048,
 }
 
 IMAGE_MODE_TO_DIM = {
@@ -46,7 +46,8 @@ class TestImageLoader(unittest.TestCase):
             self.assertEquals(
                 teacher_act["image"].size(),
                 dim,
-                f"dim mismatch for image mode {image_mode}")
+                f"dim mismatch for image mode {image_mode}",
+            )
 
 
 if __name__ == '__main__':

--- a/tests/test_image_featurizers.py
+++ b/tests/test_image_featurizers.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import unittest
+import torch
+
+from parlai.core.params import ParlaiParser
+from parlai.core.teachers import create_task_agent_from_taskname
+import parlai.utils.testing as testing_utils
+
+BASE_IMAGE_ARGS = {
+    "no_cuda": False,
+    "task": "integration_tests:ImageTeacher",
+    "image_size": 256,
+    "image_cropsize": 224,
+    "image_features_dim": 2048
+}
+
+IMAGE_MODE_TO_DIM = {
+    "resnet152": torch.Size([2048]),
+    "resnet152_spatial": torch.Size([1, 2048, 7, 7]),
+    "resnext101_32x48d_wsl": torch.Size([2048]),
+    "resnext101_32x48d_wsl_spatial": torch.Size([1, 2048, 7, 7]),
+}
+
+
+@testing_utils.skipUnlessTorch
+@testing_utils.skipUnlessGPU
+class TestImageLoader(unittest.TestCase):
+    """
+    Unit Tests for the ImageLoader.
+    """
+
+    def test_image_loader(self):
+        """
+        Test that model correctly handles text task.
+        """
+        opt = ParlaiParser().parse_args([], print_args=False)
+        opt.update(BASE_IMAGE_ARGS)
+        for image_mode, dim in IMAGE_MODE_TO_DIM.items():
+            opt["image_mode"] = image_mode
+            teacher = create_task_agent_from_taskname(opt)[0]
+            teacher_act = teacher.get(0)
+            self.assertEquals(
+                teacher_act["image"].size(),
+                dim,
+                f"dim mismatch for image mode {image_mode}")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Patch description**
Provide support for spatial image features from the ResNeXt101 WSL PyTorch models.

Tagging @mwillwork since there's a slight modification to the `AbstractImageTeacher`

**Testing steps**
Included new test to ensure that we get appropriate image features given some standard image modes.

**Logs**
```
$ python -m pytest tests/test_image_featurizers.py
================================================================================ test session starts ================================================================================
platform linux -- Python 3.6.9, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini
plugins: requests-mock-1.7.0
collected 1 item

tests/test_image_featurizers.py .                                                                                                                                             [100%]

============================================================================= slowest 10 test durations =============================================================================
44.36s call     tests/test_image_featurizers.py::TestImageLoader::test_image_loader

(0.00 durations hidden.  Use -vv to show these durations.)
========================================================================== 1 passed, 11 warnings in 47.32s ==========================================================================

```
