### PR TITLE
[ImageS2S] Spatial Features Support in ImageSeq2Seq Model

### DIFF
--- a/parlai/agents/image_seq2seq/image_seq2seq.py
+++ b/parlai/agents/image_seq2seq/image_seq2seq.py
@@ -102,6 +102,8 @@ class ImageSeq2seqAgent(TransformerGeneratorAgent, TorchImageAgent):
         """
         b = super()._dummy_batch(batchsize, maxlen)
         image = torch.ones(batchsize, self.image_features_dim).cuda()
+        if self.n_image_channels > 1:
+            image = image.unsqueeze(1).repeat(1, self.n_image_channels, 1)
         if self.fp16:
             image = image.half()
         return Batch(
@@ -125,6 +127,17 @@ class ImageSeq2seqAgent(TransformerGeneratorAgent, TorchImageAgent):
                 images.append(img)
             batch.image = images
         return batch
+
+    def _process_image_features(self, features: torch.Tensor) -> torch.Tensor:
+        """
+        Format shape and type of input image-feature tensor.
+
+        Override TorchImageAgent._process_image_features to handle multi-dimensional images.
+        """
+        features = features.view(-1, self.image_features_dim)
+        return torch.stack(
+            [TorchImageAgent._process_image_features(self, features[i]) for i in range(features.size(0))]
+        )
 
     def _model_input(self, batch: Batch) -> Tuple[torch.Tensor, List[object]]:
         return (batch.text_vec, batch.image)

--- a/parlai/agents/image_seq2seq/image_seq2seq.py
+++ b/parlai/agents/image_seq2seq/image_seq2seq.py
@@ -132,11 +132,15 @@ class ImageSeq2seqAgent(TransformerGeneratorAgent, TorchImageAgent):
         """
         Format shape and type of input image-feature tensor.
 
-        Override TorchImageAgent._process_image_features to handle multi-dimensional images.
+        Override TorchImageAgent._process_image_features to handle multi-dimensional
+        images.
         """
         features = features.view(-1, self.image_features_dim)
         return torch.stack(
-            [TorchImageAgent._process_image_features(self, features[i]) for i in range(features.size(0))]
+            [
+                TorchImageAgent._process_image_features(self, features[i])
+                for i in range(features.size(0))
+            ]
         )
 
     def _model_input(self, batch: Batch) -> Tuple[torch.Tensor, List[object]]:

--- a/parlai/agents/image_seq2seq/modules.py
+++ b/parlai/agents/image_seq2seq/modules.py
@@ -75,6 +75,8 @@ class ImageSeq2seqModel(TransformerGeneratorModel):
             image_encoder_num_layers=opt['image_encoder_num_layers'],
             image_features_dim=opt['image_features_dim'],
             fusion=opt['image_fusion_type'],
+            n_image_tokens=opt.get('n_image_tokens', 1),
+            n_image_channels=opt.get('n_image_channels', False)
         )
 
 
@@ -109,6 +111,7 @@ class ContextWithImageEncoder(TransformerEncoder):
         image_combination_mode='append',
         n_image_tokens=1,
         fusion='late',
+        n_image_channels=1
     ):
         """
         Override TransformerEncoder __init__.
@@ -123,6 +126,7 @@ class ContextWithImageEncoder(TransformerEncoder):
         self.image_combination_mode = image_combination_mode
         self.n_image_tokens = n_image_tokens
         self.fusion = FusionType(fusion)
+        self.n_image_channels = n_image_channels
         if self.image_combination_mode == 'add' and self.n_image_tokens > 1:
             raise ValueError(
                 'Image encoding cannot be added to context encoding if there is more than one image token!'
@@ -154,10 +158,13 @@ class ContextWithImageEncoder(TransformerEncoder):
         # Images will be embedded to this size, and then the embedding will be folded
         # into however many tokens are needed
         self._build_image_encoder()
+        dummy_image_size = (self.full_embedding_size,)
+        if n_image_channels > 1:
+            dummy_image_size = (n_image_channels, self.full_embedding_size,)
         self.register_buffer(
-            'dummy_image_enc', torch.zeros((self.full_embedding_size,))
+            'dummy_image_enc', torch.zeros(dummy_image_size)
         )
-        self.register_buffer('ones_mask', torch.ones(self.n_image_tokens).bool())
+        self.register_buffer('ones_mask', torch.ones(self.n_image_tokens * self.n_image_channels).bool())
 
     def _build_image_encoder(self):
         image_layers = [nn.Linear(self.img_dim, self.full_embedding_size)]
@@ -239,7 +246,7 @@ class ContextWithImageEncoder(TransformerEncoder):
 
             image_masks = torch.stack(image_mask_list)  # type: ignore
             image_encoded = torch.stack(image_encoded_list).reshape(
-                (len(images), self.n_image_tokens, self.embedding_size)
+                (len(images), self.n_image_tokens * self.n_image_channels, self.embedding_size)
             )
             assert image_masks.shape == image_encoded.shape[:2]
 
@@ -294,13 +301,17 @@ class ContextWithImageEncoder(TransformerEncoder):
                 src_tokens, segments=torch.zeros_like(src_tokens)  # type: ignore
             )
         if image_features is not None:
-            valid_img = [v for v in image_features if isinstance(v, torch.Tensor)][0]
-            image_tensor, image_mask = self.encode_images(
-                image_features,
-                segments=torch.ones(  # type: ignore
-                    len(image_features), dtype=torch.long, device=valid_img.device
-                ),
-            )
+            # sometimes can just be a list of None
+            valid_imgs = [v for v in image_features if isinstance(v, torch.Tensor)]
+            if valid_imgs:
+                image_tensor, image_mask = self.encode_images(
+                    image_features,
+                    segments=torch.ones(  # type: ignore
+                        (len(image_features), valid_imgs[0].size(0)),
+                        dtype=torch.long,
+                        device=valid_imgs[0].device
+                    ),
+                )
 
         # perform early fusion
         tensor = self._cat([context_tensor, image_tensor])

--- a/parlai/agents/image_seq2seq/modules.py
+++ b/parlai/agents/image_seq2seq/modules.py
@@ -76,7 +76,7 @@ class ImageSeq2seqModel(TransformerGeneratorModel):
             image_features_dim=opt['image_features_dim'],
             fusion=opt['image_fusion_type'],
             n_image_tokens=opt.get('n_image_tokens', 1),
-            n_image_channels=opt.get('n_image_channels', False),
+            n_image_channels=opt.get('n_image_channels', 1),
         )
 
 

--- a/parlai/agents/image_seq2seq/modules.py
+++ b/parlai/agents/image_seq2seq/modules.py
@@ -158,9 +158,7 @@ class ContextWithImageEncoder(TransformerEncoder):
         # Images will be embedded to this size, and then the embedding will be folded
         # into however many tokens are needed
         self._build_image_encoder()
-        dummy_image_size = (self.full_embedding_size,)
-        if n_image_channels > 1:
-            dummy_image_size = (n_image_channels, self.full_embedding_size)
+        dummy_image_size = (n_image_channels, self.full_embedding_size)
         self.register_buffer('dummy_image_enc', torch.zeros(dummy_image_size))
         self.register_buffer(
             'ones_mask', torch.ones(self.n_image_tokens * self.n_image_channels).bool()
@@ -311,7 +309,10 @@ class ContextWithImageEncoder(TransformerEncoder):
                 image_tensor, image_mask = self.encode_images(
                     image_features,
                     segments=torch.ones(  # type: ignore
-                        (len(image_features), valid_imgs[0].size(0)),
+                        (
+                            len(image_features),
+                            self.n_image_channels * self.n_image_tokens,
+                        ),
                         dtype=torch.long,
                         device=valid_imgs[0].device,
                     ),

--- a/parlai/agents/transformer/image_polyencoder.py
+++ b/parlai/agents/transformer/image_polyencoder.py
@@ -46,15 +46,6 @@ class ImagePolyencoderAgent(PolyencoderAgent, TorchImageAgent):
         # TODO: more thoroughly test out whether one of these choices is best and add a
         #  'recommended' arg here. 'add' and 'prepend' seem to be roughly similar in
         #  performance
-        agent.add_argument(
-            '--n-image-tokens',
-            type=int,
-            default=1,
-            help=(
-                'Number of tokens that the image encoding will consist of (when adding '
-                'or prepending)'
-            ),
-        )
         agent.set_defaults(reduction_type=None)
         # This agent doesn't support any encoder output reductions
         return agent

--- a/parlai/core/torch_image_agent.py
+++ b/parlai/core/torch_image_agent.py
@@ -43,12 +43,32 @@ class TorchImageAgent(TorchAgent):
             recommended=1,
             help='Number of linear layers to encode image features with',
         )
+        agent.add_argument(
+            '--n-image-tokens',
+            type=int,
+            default=1,
+            help=(
+                'Number of tokens that the image encoding will consist of. '
+                'Specify to spread image encoding over multiple tokens'
+            ),
+        )
+        agent.add_argument(
+            '--n-image-channels',
+            type=int,
+            default=1,
+            help=(
+                'Number of channels that the image encoding will consist of. '
+                'Specify if incoming image is multidimensional'
+            ),
+        )
         return agent
 
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
         self.image_features_dim = opt['image_features_dim']
         self.image_encoder_num_layers = opt['image_encoder_num_layers']
+        self.n_image_tokens = opt['n_image_tokens']
+        self.n_image_channels = opt['n_image_channels']
 
     def batchify(self, obs_batch: List[Message], sort: bool = False) -> Batch:
         """

--- a/tests/test_image_seq2seq.py
+++ b/tests/test_image_seq2seq.py
@@ -23,6 +23,7 @@ BASE_ARGS = {
     'gradient_clip': 0.1,
     'num_epochs': 10,
     'skip_generation': True,
+    'n_image_channels': 1,
     # Train args
     'learningrate': 7e-3,
     'batchsize': 16,
@@ -42,7 +43,7 @@ SPATIAL_IMAGE_ARGS = {
     'task': 'integration_tests:ImageTeacher',
     'num_epochs': 5,
     'image_mode': 'resnet152_spatial',
-    'n_image_channels': 49
+    'n_image_channels': 49,
 }
 
 EARLY_FUSION_ARGS = {'image_fusion_type': 'early', 'n_segments': 2}
@@ -163,7 +164,7 @@ class TestImageSeq2Seq(unittest.TestCase):
         self.assertLessEqual(
             valid['ppl'],
             7.5,
-            'failed to train image_seq2seq on image task with spatial features'
+            'failed to train image_seq2seq on image task with spatial features',
         )
 
     @testing_utils.retry(ntries=3)
@@ -182,7 +183,7 @@ class TestImageSeq2Seq(unittest.TestCase):
         self.assertLessEqual(
             valid['ppl'],
             7.5,
-            'failed to train image_seq2seq on image task with spatial features'
+            'failed to train image_seq2seq on image task with spatial features',
         )
 
 

--- a/tests/test_image_seq2seq.py
+++ b/tests/test_image_seq2seq.py
@@ -90,8 +90,6 @@ class TestImageSeq2Seq(unittest.TestCase):
     def test_image_task(self):
         """
         Test that model correctly handles image task.
-
-        No training, only eval
         """
         args = BASE_ARGS.copy()
         args.update(IMAGE_ARGS)
@@ -155,7 +153,7 @@ class TestImageSeq2Seq(unittest.TestCase):
         """
         Test that model correctly handles image task.
 
-        No training, only eval
+        With spatial features.
         """
         args = BASE_ARGS.copy()
         args.update(SPATIAL_IMAGE_ARGS)
@@ -172,6 +170,8 @@ class TestImageSeq2Seq(unittest.TestCase):
     def test_image_task_spatial_features_early_fusion(self):
         """
         Test that model correctly handles image task.
+
+        With spatial features.
 
         Early Fusion
         """


### PR DESCRIPTION
**Patch description**
- Add support for spatial, multidimensional features in the image-seq2seq model. 
- Add a flag, `--n-image-channels`, to specify the total spatial dimension of the image features (so that this may be combined with `--n-image-tokens`, if necessary.

I've also moved the `n_image_tokens` argument from the `ImagePolyencoderAgent` to the `TorchImageAgent`.

**Testing steps**
Added some tests to the existing `image_seq2seq` tests.

**Logs**
```
$ python -m pytest tests/test_image_seq2seq.py
================================================================================ test session starts ================================================================================
platform linux -- Python 3.6.9, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini
plugins: requests-mock-1.7.0
collected 7 items

tests/test_image_seq2seq.py .......                                                                                                                                           [100%]

============================================================================= slowest 10 test durations =============================================================================
24.71s call     tests/test_image_seq2seq.py::TestImageSeq2Seq::test_multitask
24.36s call     tests/test_image_seq2seq.py::TestImageSeq2Seq::test_multitask_early_fusion
8.38s call     tests/test_image_seq2seq.py::TestImageSeq2Seq::test_image_task
7.04s call     tests/test_image_seq2seq.py::TestImageSeq2Seq::test_text_task
4.53s call     tests/test_image_seq2seq.py::TestImageSeq2Seq::test_image_task_spatial_features
2.61s call     tests/test_image_seq2seq.py::TestImageSeq2Seq::test_image_task_early_fusion
2.22s call     tests/test_image_seq2seq.py::TestImageSeq2Seq::test_image_task_spatial_features_early_fusion

(0.00 durations hidden.  Use -vv to show these durations.)
==================================================================== 7 passed, 198 warnings in 75.22s (0:01:15) =====================================================================
```
