### PR TITLE
[Torch] Model Parallel Customization

### DIFF
--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -370,6 +370,8 @@ class PipelineHelper(object):
         if not isinstance(submodule, torch.nn.ModuleList):
             # not a ModuleList, leave it untouched
             return
+        if getattr(submodule, 'model_parallel_exempt', False):
+            return
 
         assert isinstance(submodule, torch.nn.ModuleList)  # for typechecker
         layers = submodule
@@ -396,7 +398,7 @@ class PipelineHelper(object):
             # mark a layer as going to the given element
             layer_assignments[mostfree] += 1
 
-        devices = self.devices[:]
+        devices = [d for i, d in enumerate(self.devices[:]) if layer_assignments[d] > 0]
         for layer_no, layer in enumerate(layers):
             layer_gpu = devices[0]
             assert layer_assignments[layer_gpu] > 0

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -504,7 +504,9 @@ class PipelineHelper(object):
             # base case
             return torch.cat(items, dim=dim)  # type: ignore
         elif isinstance(item0, tuple):
-            return tuple(PipelineHelper.join(x, dim=dim) for x in zip(*items))  # type: ignore
+            return tuple(
+                PipelineHelper.join(x, dim=dim) for x in zip(*items)
+            )  # type: ignore
         elif isinstance(item0, dict):
             keys = item0.keys()
             return {  # type: ignore
@@ -524,9 +526,13 @@ class PipelineHelper(object):
         if isinstance(chunk, torch.Tensor):
             return chunk.to(device)  # type: ignore
         elif isinstance(chunk, tuple):
-            return tuple(PipelineHelper.chunk_to(c, device) for c in chunk)  # type: ignore
+            return tuple(
+                PipelineHelper.chunk_to(c, device) for c in chunk
+            )  # type: ignore
         elif isinstance(chunk, dict):
-            return {k: PipelineHelper.chunk_to(v, device) for k, v in chunk.items()}  # type: ignore
+            return {
+                k: PipelineHelper.chunk_to(v, device) for k, v in chunk.items()
+            }  # type: ignore
         else:
             raise TypeError('chunk_to only compatible with tensors, tuples or dicts.')
 


### PR DESCRIPTION
**Patch description**
2 very small changes to the model parallel Pipeline helper

1. Provide a way to exempt module lists from model parallel
2. Change devices considered (so as not to violate later assertion)

Note that my change is 2 lines. The additional 3 are `black`

**Testing steps**
Added a test to the `test_utils_torch` to check model parallel exemption. I am honestly not 100% sure how to test my second change.

**Logs**
```
 python -m pytest tests/test_utils_torch.py
============================================================================== test session starts ===============================================================================
platform linux -- Python 3.6.9, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini
plugins: requests-mock-1.7.0
collected 18 items

tests/test_utils_torch.py ..................                                                                                                                               [100%]

=========================================================================== slowest 10 test durations ============================================================================
0.01s call     tests/test_utils_torch.py::TestPipelineHelper::test_model_parallel_exempt

(0.00 durations hidden.  Use -vv to show these durations.)
========================================================================= 18 passed, 1 warning in 1.50s ==========================================================================
```
