### PR TITLE
Delay long tests for regular tests. Make unit tests more reliable.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -511,8 +511,14 @@ workflows:
       - unittests_36
       - mturk_tests
       - unittests_osx
-      - long_gpu_tests
       - teacher_tests
+      - long_gpu_tests
+          requires:
+            - cleaninstall_36
+            - unittests_gpu14
+            - unittests_38
+            - unittests_37
+            - unittests_36
       - build_website:
           filters:
             branches:


### PR DESCRIPTION
**Patch description**
Since many of our unittests are flaky and need to be retried, I find it quite annoying that I have to wait until "long" finishes before I can hit "retry."

This patch makes it so that we only run long gpu tests AFTER we run the others. This means if there's a flaky error, we can hit "retry" earlier. Downside is that the full pipeline will take longer.

**Testing steps**
CI.