### PR TITLE
added MultiProcessEval to mimic multiprocessing_train.py

### DIFF
--- a/parlai/scripts/multiprocessing_eval.py
+++ b/parlai/scripts/multiprocessing_eval.py
@@ -29,6 +29,7 @@ import os
 import signal
 import parlai.utils.distributed as distributed_utils
 import parlai.scripts.eval_model as eval_model
+from parlai.core.script import ParlaiScript, register_script
 
 
 def multiprocess_eval(
@@ -78,11 +79,16 @@ def setup_args():
     return parser
 
 
-def main():
-    opt = setup_args().parse_args()
-    port = random.randint(32000, 48000)
-    return launch_and_eval(opt, port)
+@register_script("multiprocessing_eval", aliases=["mp_eval"], hidden=True)
+class MultiProcessEval(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        return setup_args()
+
+    def run(self):
+        port = random.randint(32000, 48000)
+        return launch_and_eval(self.opt, port)
 
 
 if __name__ == '__main__':
-    main()
+    MultiProcessEval.main()


### PR DESCRIPTION
needed to import ParlAI in other projects. 

`MultiProcessEval` is easier, so I just made the change. 

Might also be a good idea to add `DistributedEval` in distributed_eval.py, I tried to mimic distributed_train.py, but not sure if it's correct and finally decided not to do anything. 