### PR TITLE
Preserve underscores in option values which differ from init_model

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -251,7 +251,7 @@ def compare_init_model_opts(opt: Opt, curr_opt: Opt):
         )
 
     different_strs = [
-        '--{} {}'.format(k, v).replace('_', '-') for k, v in different_opts.items()
+        '--{} {}'.format(k.replace('_', '-'), v) for k, v in different_opts.items()
     ]
     if different_strs:
         logging.warn(


### PR DESCRIPTION
**Patch description**
ParlAI sometimes prints a message like:
`your model is being loaded with opts that do not exist in the model you are initializing the weights with: ...`

But option values which have an underscore are mangled, e.g. `--polyencoder-type n_first` is printed as `n-first`. This patch fixes that.

**Testing steps**
Train any model with underscores in an `init_model` option but not in the command-line option, e.g.:
`parlai train_model --init-model zoo:blended_skill_talk/multi_task_bst_tuned/model -t convai2 --model transformer/polyencoder --polyencoder-type codes --model-file /tmp/foo`
(this will probably fail but if not, just kill it after the message is printed)