### PR TITLE
[Bug] Fix `log.warn`

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -299,7 +299,7 @@ class History(object):
         Return the string version of the history.
         """
         if self.temp_history and self.history_strings:
-            logging.warning('temporary history strings now include the delimiter.')
+            logging.warn('temporary history strings now include the delimiter.')
 
         if len(self.history_strings) > 0:
             history = self.history_strings[:]

--- a/parlai/utils/logging.py
+++ b/parlai/utils/logging.py
@@ -170,6 +170,10 @@ def warn(*args, **kwargs):
     return logger.warn(*args, **kwargs)
 
 
+def warning(*args, **kwargs):
+    return logger.warn(*args, **kwargs)
+
+
 def get_all_levels():
     levels = set(logging._nameToLevel.keys())
     levels.remove('WARNING')


### PR DESCRIPTION
**Patch description**
The correct syntax (now) for `logging.warning` is `logging.warn`

**Testing steps**
Tested locally with agents that defined `self.temp_history`
