### PR TITLE
Wrapper teacher test fix

### DIFF
--- a/parlai/scripts/self_chat.py
+++ b/parlai/scripts/self_chat.py
@@ -103,7 +103,7 @@ def self_chat(opt):
 
     # Create agents
     agent1 = create_agent(opt, requireModelExists=True)
-    if partner is not None:
+    if partner is None:
         # Self chat with same model
         agent2 = agent1.clone()
     else:

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -25,7 +25,7 @@ class TestWrapper(unittest.TestCase):
         # Set up label-to-text teacher
         kwargs = {
             'task': 'wrapper:labelToTextTeacher',
-            'label_to_text_task': 'integration_tests:multiturn',
+            'wrapper_task': 'integration_tests:multiturn',
         }
         parser = setup_args()
         parser.set_defaults(**kwargs)


### PR DESCRIPTION
**Patch description**
Incorrect arg name was breaking the test.

**Logs**
```
$  py tests/test_wrapper.py

[ AbstractWrapper args: ]
[  wrapper_task: integration_tests:multiturn ]
13:50:38 INFO | creating task(s): wrapper:labelToTextTeacher
.
----------------------------------------------------------------------
Ran 1 test in 0.095s

OK
```
