### PR TITLE
[Scripts] Set Script Defaults Appropriately when invoking ParlAI-cmd

### DIFF
--- a/parlai/core/script.py
+++ b/parlai/core/script.py
@@ -244,6 +244,7 @@ def superscript_main(args=None):
             formatter_class=CustomHelpFormatter,
         )
         subparser.set_defaults(super_command=script_name)
+        subparser.set_defaults(**script_parser._defaults)
         for action in script_parser._actions:
             subparser._add_action(action)
         for action_group in script_parser._action_groups:


### PR DESCRIPTION
**Patch description**
Previously, when invoking the parlai command, the appropriate parser defaults for the scripts were not being set correctly.

A prime example is `interactive.py`, which sets `interactive_mode: True`, a crucial arg for generative models (most are trained with `--skip-generation true`, and this sets that to false).

**Testing steps**
Tested locally with `parlai interactive`
