### PR TITLE
[History] Temp History Fixes

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -298,14 +298,11 @@ class History(object):
         """
         Return the string version of the history.
         """
-        if self.temp_history and self.history_strings:
-            logging.warn('temporary history strings now include the delimiter.')
-
         if len(self.history_strings) > 0:
             history = self.history_strings[:]
-            if self.temp_history is not None:
-                history.append(self.temp_history)
             history = self.delimiter.join(history)
+            if self.temp_history is not None:
+                history += self.temp_history
             return history
 
         return None
@@ -324,7 +321,7 @@ class History(object):
             history += [self.delimiter_tok]
         history += [self.history_vecs[-1]]
         if self.temp_history is not None:
-            history.extend(self.parse(self.temp_history))
+            history.extend([self.parse(self.temp_history)])
         if self._global_end_token is not None:
             history += [[self._global_end_token]]
 

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -591,10 +591,7 @@ class TorchAgent(ABC, Agent):
             'to `truncate`',
         )
         agent.add_argument(
-            '--history-reversed',
-            default=False,
-            type='bool',
-            help='Reverse the history',
+            '--history-reversed', default=False, type='bool', help='Reverse the history'
         )
         agent.add_argument(
             '-histsz',

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -748,7 +748,9 @@ class TestTorchAgent(unittest.TestCase):
         self.assertEqual(vec, [1, 2, 3, MockDict.END_IDX])
 
         # test temp history
-        agent = get_agent(history_size=-1, include_temp_history=True, delimiter='__delim__')
+        agent = get_agent(
+            history_size=-1, include_temp_history=True, delimiter='__delim__'
+        )
         agent.history.reset()
         agent.history.update_history(obs, temp_history=' temp history')
         text = agent.history.get_history_str()

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -747,6 +747,23 @@ class TestTorchAgent(unittest.TestCase):
         vec = agent.history.get_history_vec()
         self.assertEqual(vec, [1, 2, 3, MockDict.END_IDX])
 
+        # test temp history
+        agent = get_agent(history_size=-1, include_temp_history=True, delimiter='__delim__')
+        agent.history.reset()
+        agent.history.update_history(obs, temp_history=' temp history')
+        text = agent.history.get_history_str()
+        self.assertEqual(text, 'I am Groot. temp history')
+        vec = agent.history.get_history_vec()
+        self.assertEqual(vec, [1, 2, 3, 1, 2])
+
+        agent.history.update_history(obs, temp_history=' temp history')
+        text = agent.history.get_history_str()
+        self.assertEqual(text, 'I am Groot.__delim__I am Groot. temp history')
+        vecs = agent.history.get_history_vec_list()
+        self.assertEqual(vecs, [[1, 2, 3], [1, 2, 3]])
+        vec = agent.history.get_history_vec()
+        self.assertEqual(vec, [1, 2, 3, 1, 1, 2, 3, 1, 2])
+
     def test_reversed_history(self):
         agent = get_agent(history_reversed=True)
         agent.history.reset()


### PR DESCRIPTION
**Patch description**
1. Return semantics of `temp_history` to **not** be delimited
2. History now appropriately adds the vector of `temp_history`

This second issue is super subtle. Before, we were doing the following:

```
(suppose dict is mapping from str(int) to int)
>>> obs1 = {'text': '1 2 3'}; obs2 = {'text': '4, 5, 6'}; temp_history = '7, 8, 9'
>>> agent.history.update_history(obs1)
>>> agent.history.update_history(obs2)
>>> history
[[1, 2, 3], [4, 5, 6]]     # two vector history
>>> history.extend(self.parse(self.temp_history)
>>> history
[[1, 2, 3], [4, 5, 6], 7, 8, 9]
```

We need to actually extend a *list* of toks, not just the toks themselves.

**Testing steps**
Added a test to `test_torch_agent` testing the temp history

**Logs**
<!-- If applicable, please paste the command line from your testing: -->
```
$ python -m pytest tests/test_torch_agent.py
============================================================================== test session starts ===============================================================================
platform linux -- Python 3.6.9, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini
plugins: requests-mock-1.7.0
collected 16 items

tests/test_torch_agent.py ................                                                                                                                                 [100%]

=========================================================================== slowest 10 test durations ============================================================================
6.60s call     tests/test_torch_agent.py::TestTorchAgent::test_resume_checkpoint
0.08s call     tests/test_torch_agent.py::TestTorchAgent::test__add_person_tokens
0.05s call     tests/test_torch_agent.py::TestTorchAgent::test_history
0.02s call     tests/test_torch_agent.py::TestTorchAgent::test_interactive_mode
0.02s call     tests/test_torch_agent.py::TestTorchAgent::test_use_reply
0.01s call     tests/test_torch_agent.py::TestTorchAgent::test_vectorize
0.01s call     tests/test_torch_agent.py::TestTorchAgent::test_observe
0.01s call     tests/test_torch_agent.py::TestTorchAgent::test_mturk_racehistory
0.01s call     tests/test_torch_agent.py::TestTorchAgent::test_batchify
0.01s call     tests/test_torch_agent.py::TestTorchAgent::test_batch_act
======================================================================== 16 passed, 821 warnings in 9.88s ========================================================================
```
