### PR TITLE
add  metrics_dict as argument for LinearLRScheduler

### DIFF
--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -488,5 +488,5 @@ class LinearLRScheduler(ParlAILRScheduler):
             raise StopTrainException('End of Linear LR Schedule')
         self.scheduler.step(epoch=scheduler_steps)
 
-    def valid_step(self):
+    def valid_step(self, metrics_dict):
         pass


### PR DESCRIPTION
I was using the `LinearLRScheduler` but encountered `TypeError: valid_step() takes 1 positional argument but 2 were given
`. 

It seems the `valid_step` in other Scheduler all have `metrics_dict` as an argument. Not sure if there is anything special about `LinearLRScheduler`? 