### PR TITLE
Load from checkpoint by default

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -161,7 +161,7 @@ def setup_args(parser=None) -> ParlaiParser:
         '-lfc',
         '--load-from-checkpoint',
         type='bool',
-        default=False,
+        default=True,
         hidden=True,
         help='load model from checkpoint if available',
     )


### PR DESCRIPTION
Change the default value of `--load-from-checkpoint` to `True` by default. This is likely what the user is expecting, and it will speed up training upon re-submission of a job.
