### PR TITLE
Use special designator instead of NamedTemporaryFile.

### DIFF
--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -9,7 +9,6 @@ Utility methods for dealing with torch code.
 
 import os
 from typing import Union, Optional, Tuple, Any, List, Sized, TypeVar
-import tempfile
 import itertools
 from collections import namedtuple
 import parlai.utils.logging as logging
@@ -53,7 +52,7 @@ def atomic_save(state_dict: Any, path: str) -> None:
     final name.
     """
     torch.save(state_dict, path + ".tmp")
-    os.rename(tf.name, path)
+    os.rename(path + ".tmp", path)
 
 
 def padded_tensor(

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -52,9 +52,7 @@ def atomic_save(state_dict: Any, path: str) -> None:
     to disk. Works by writing to a temporary file, and then renaming the file to the
     final name.
     """
-    tf = tempfile.NamedTemporaryFile('wb', delete=False, dir=os.path.dirname(path))
-    torch.save(state_dict, tf)
-    tf.close()
+    torch.save(state_dict, path + ".tmp")
     os.rename(tf.name, path)
 
 


### PR DESCRIPTION
**Patch description**
After noticing our model files have user-only permissions, and are a pain to share within the team. Fix discussed in internal chat.

**Testing steps**
CI.