### PR TITLE
Split BST GPU test

### DIFF
--- a/tests/nightly/gpu/test_blended_skill_talk_gpu.py
+++ b/tests/nightly/gpu/test_blended_skill_talk_gpu.py
@@ -9,30 +9,95 @@ import unittest
 from parlai.utils import testing as testing_utils
 
 
+SHARED_OPTS = {
+    'batchsize': 16,
+    'task': 'blended_skill_talk',
+    'num_examples': 64,
+}
+
+
 class TestBlendedSkillTalkModels(unittest.TestCase):
-    def test_accuracies(self):
+    """
+    Test accuracies of BST models in the zoo.
+    """
+
+    def test_bst_single_task(self):
         """
-        Test accuracies of BST models in the zoo.
+        Test model trained single-task on BlendedSkillTalk.
         """
-        model_names_to_desired_accuracies = {
-            'bst_single_task': 0.8906,
-            'convai2_single_task': 0.8438,
-            'ed_single_task': 0.7656,
-            'wizard_single_task': 0.7500,
-            'multi_task': 0.9062,
-            'multi_task_bst_tuned': 0.9219,
-        }
-        for model_name, desired_accuracy in model_names_to_desired_accuracies.items():
-            valid, _ = testing_utils.eval_model(
-                opt={
-                    'batchsize': 16,
-                    'model_file': f'zoo:blended_skill_talk/{model_name}/model',
-                    'task': 'blended_skill_talk',
-                    'num_examples': 64,
-                },
-                skip_test=True,
-            )
-            self.assertAlmostEqual(valid['accuracy'], desired_accuracy, delta=0.005)
+        valid, _ = testing_utils.eval_model(
+            opt={
+                **SHARED_OPTS,
+                'model_file': f'zoo:blended_skill_talk/bst_single_task/model',
+            },
+            skip_test=True,
+        )
+        self.assertAlmostEqual(valid['accuracy'], 0.8906, delta=0.005)
+
+    def test_convai2_single_task(self):
+        """
+        Test model trained single-task on ConvAI2.
+        """
+        valid, _ = testing_utils.eval_model(
+            opt={
+                **SHARED_OPTS,
+                'model_file': f'zoo:blended_skill_talk/convai2_single_task/model',
+            },
+            skip_test=True,
+        )
+        self.assertAlmostEqual(valid['accuracy'], 0.8438, delta=0.005)
+
+    def test_ed_single_task(self):
+        """
+        Test model trained single-task on EmpatheticDialogues.
+        """
+        valid, _ = testing_utils.eval_model(
+            opt={
+                **SHARED_OPTS,
+                'model_file': f'zoo:blended_skill_talk/ed_single_task/model',
+            },
+            skip_test=True,
+        )
+        self.assertAlmostEqual(valid['accuracy'], 0.7656, delta=0.005)
+
+    def test_wizard_single_task(self):
+        """
+        Test model trained single-task on Wizard of Wikipedia.
+        """
+        valid, _ = testing_utils.eval_model(
+            opt={
+                **SHARED_OPTS,
+                'model_file': f'zoo:blended_skill_talk/wizard_single_task/model',
+            },
+            skip_test=True,
+        )
+        self.assertAlmostEqual(valid['accuracy'], 0.7500, delta=0.005)
+
+    def test_multi_task(self):
+        """
+        Test model trained multi-task on dialogue datasets.
+        """
+        valid, _ = testing_utils.eval_model(
+            opt={
+                **SHARED_OPTS,
+                'model_file': f'zoo:blended_skill_talk/multi_task/model',
+            },
+            skip_test=True,
+        )
+        self.assertAlmostEqual(valid['accuracy'], 0.9062, delta=0.005)
+
+    def test_multi_task_bst_tuned(self):
+        """
+        Test model trained multi-task and then tuned on BlendedSkillTalk.
+        """
+        valid, _ = testing_utils.eval_model(
+            opt={
+                **SHARED_OPTS,
+                'model_file': f'zoo:blended_skill_talk/multi_task_bst_tuned/model',
+            },
+            skip_test=True,
+        )
+        self.assertAlmostEqual(valid['accuracy'], 0.9219, delta=0.005)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Patch description**
Test all open-sourced BST models in their own test method, which is what the Dodeca model unit test does.

**Testing steps**
`python -m unittest tests.nightly.gpu.test_blended_skill_talk_gpu`

Output:

```
----------------------------------------------------------------------
Ran 6 tests in 94.215s

OK
```