### PR TITLE
MemNN test breaks too often.

### DIFF
--- a/tests/test_memnn.py
+++ b/tests/test_memnn.py
@@ -13,6 +13,7 @@ NUM_EPOCHS = 3
 LR = 1
 
 
+@unittest.skip
 class TestMemnn(unittest.TestCase):
     """
     Checks that seq2seq can learn some very basic tasks.


### PR DESCRIPTION
**Patch description**
With the release of pytorch 1.6, we have to retire hogwild. I don't have time for that now.

But this MemNN test is probably the most frequent breaker. Given that it's going to die, and no one uses it, I propose just removing the test for the time being.

**Testing steps**
CI.