### PR TITLE
Update torch_generator_agent.py for compatibility with pytorch 1.5

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -1533,7 +1533,7 @@ class BeamSearch(TreeSearch):
         voc_size = logprobs.size(-1)
 
         # get the backtracking hypothesis id as a multiple of full voc_sizes
-        hyp_ids = best_idxs / voc_size
+        hyp_ids = best_idxs // voc_size
         # get the actual word id from residual of the same division
         tok_ids = best_idxs % voc_size
 


### PR DESCRIPTION
Avoid recent Python3 RuntimeError: Integer division of tensors using div or / is no longer supported, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.

