### PR TITLE
Add return in report function of wrapper agent

### DIFF
--- a/parlai/tasks/wrapper/agents.py
+++ b/parlai/tasks/wrapper/agents.py
@@ -93,7 +93,7 @@ class AbstractWrapperTeacher(Teacher, ABC):
         """
         Report metrics for the subtask.
         """
-        self.task.report()
+        return self.task.report()
 
     def reset(self):
         """


### PR DESCRIPTION
**Patch description**
Agent was breaking because of missing `return` when calling `report()`.

**Testing steps**
Unit test:

```
$ python -m unittest tests.test_wrapper
16:06:36 INFO | creating task(s): wrapper:labelToTextTeacher
.
----------------------------------------------------------------------
Ran 1 test in 0.092s

OK
```

As stated [here](https://github.com/facebookresearch/ParlAI/pull/2642) this teacher doesn't (and is not expected to) pass `python tests/datatests/test_new_tasks.py` because of the nature of this task (read link's PR description for a more detailed explanation).