### PR TITLE
Keep dynamic batches about the same shape

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -951,7 +951,8 @@ class StreamDialogData(DialogData):
         idx = 0
         while True:
             for episode in self._read_episode(data_loader(datafile)):
-                yield episode
+                if idx % self.dws == self.rank:
+                    yield episode
                 idx += 1
             while not self.cycle:
                 yield self._END_OF_EPOCH

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -731,7 +731,7 @@ class DialogData(object):
         # about the stratifications we're doing.
         self._num_examples_cache = 0
         self._num_episodes_cache = 0
-        for i, episode in enumerate(self._read_episode(data_loader(datafile))):
+        for episode in self._read_episode(data_loader(datafile)):
             self._num_episodes_cache += 1
             self._num_examples_cache += len(episode)
             self.data.append(episode)

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -967,7 +967,7 @@ class StreamDialogData(DialogData):
             for episode in self._read_episode(data_loader(datafile)):
                 # We only shard the data set at evaluation time, as training is
                 # done using sampling-with-replacement.
-                if idx % self.num_workers == self.rank
+                if idx % self.num_workers == self.rank:
                     yield episode
                 idx += 1
             while not self.cycle:

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1110,7 +1110,8 @@ class DynamicBatchWorld(World):
         self.number_parleys = 0
         self.total_exs = 0
         self.world.reset()
-        self.rng = random.Random(4)
+        self.rng = random.Random(4 + self.opt.get('rank', 0))
+        self.rng2 = random.Random(3)
         for w in self.worlds:
             w.reset()
 
@@ -1198,7 +1199,7 @@ class DynamicBatchWorld(World):
         # start with a random item. indices_idx is the lookup into indices, but
         # index is the actual world.
         width = 0
-        indices_idx = random.randint(0, len(indices) - 1)
+        indices_idx = self.rng2.randint(0, len(indices) - 1)
 
         # we picked a random spot, but we can get better packing if we start at
         # the last example with the same score, since we always move down to


### PR DESCRIPTION
**Patch description**
This patch aims to improve distributed training with dynamic batches. In distributed training, we are always bottlenecked by our slowest worker, as we need to `sync()` on every parley and every SGD step.

*On main branch*:
Dynamic batching introduces variability into the training procedure. When building a dynamic batch, we start with a random example, and then fill the batch with similar length examples until we run out of space. One issue here is that the workers may choose differently sized batches. For example, worker A might build a batch with 100 short examples, while worker B might build a batch with only a 5 very long examples. Both workers will forward/backward on these batches and both use roughly the same amount of memory, so there is actually _less_ variability in their performance. Sounds great, right?

However, tokenization is one of the most expensive parts of training (and one major reason we pay a performance cost relative to fairseq). Once both workers finish the current batch they are working on, it will be necessary for them to tokenize the _next_ sentences of the conversations. Here lies the straggler issue: worker A will now need to tokenize 100 sentences, but worker B only needs to tokenize 5. We can reduce this variability by ensuring _all_ workers attempt to build similarly-shaped batches (making the same many-short or few-long decision at the same time), so they all have roughly the same number of items to tokenize.

*With this patch*:
This patch adds this heuristic to training. While we can't guarantee that all workers make the same choice of batch size, we can ensure that they begin building from the same position when starting with the sorted list:

https://github.com/facebookresearch/ParlAI/blob/6728a9ad3d3a36e7d8f9315d027f51500c14cf47/parlai/core/worlds.py#L1197-L1207

Note that we need a separate RNG for this, because not all workers will pick the exact same sized batch, just similarly sized ones. This means the rng usage above could cause them to get out of sync.

However there is an issue: this introduces a significant amount of determinism into the conversation selection process, and separate workers may then begin to select the exact same conversation over. This reduces our stochasticity, and hinders learning. To remedy this, we expand upon our recent changes (#2433, #2445), which stratifies evaluation across many workers by having each of the N workers take only every Nth episode. We expand this to also include training, so the data loaded into memory by each worker is separate, and therefore they can never pick different examples.


**Testing steps**
Correctness tests:
- Added a print statement to all workers (using 8 workers) to print their examples on each step. Before the stratification change, I confirmed that many workers were picking the same conversation. I introduced the stratification change in order to fix this, and verified this was the case.
- Added a print statement to all workers to print their batch sizes. Verified that workers were creating roughly equal batch lengths.
- Trained small models and verified the PPL looked right. Before the stratification change, there was a performance hit (though it was somewhat moderate)

Timing tests:
- Trained on `large_secret_internal_teacher` (a ChunkTeacher) for 300 seconds. Measured the number of updates.
- Trained on `-t convai2 -dt train` for 300 seconds. Measured number of updates
- Trained on `-t convai2 -dt train:valid` for 300 seconds. Measured the number of updates.

**Logs**
Command run (via srun)
```
python -u -m parlai.scripts.distributed_train  -m transformer/generator -esz 128 --ffn-size 512 --n-heads 4 --dict-tokenizer bytelevelbpe --dict-file zoo:blender/blender_3B/model.dict -tr 512 -bs 32 --skip-generation true -opt adam -lr 1e-4 -vmt ppl --warmup-updates 1000 -bs 32 -dynb full -nl 8 -ttim 300 --distributed-world-size GPUS  -dt DATATYPE -t TEACHER
```

Legend: upd (m) = updates on main branch; upd (b) = updates on this branch.

 GPUs | Teacher |     Datatype |     Upd (m) | Upd (b) 
----- | ------- | ------------ | ----------- | --------
8     |  secret | train:stream |       601   | **679** 
16    |  secret | train:stream |       581   | **667** 
32    |  secret | train:stream |       543   | **617** 
64    |  secret | train:stream |       500   | **584** 
8     | ConvAI2 | train:stream |       799   | **817** 
16    | ConvAI2 | train:stream |     **762** |   748   
8     | ConvAI2 | train        |       801   | **867** 
16    | ConvAI2 | train        |       738   | **829** 
       
The one where we regressed slightly is explained to I/O thrashing: because ConvAI2 is so small, using 16 GPUs caused it to be loaded about 12 times in the experiment. Solution is to not use streaming with small data.

