### PR TITLE
Ensure lengths for pack_padded_sequence in RNNEncoder are set to CPU

### DIFF
--- a/parlai/agents/seq2seq/modules.py
+++ b/parlai/agents/seq2seq/modules.py
@@ -303,7 +303,7 @@ class RNNEncoder(nn.Module):
         xes = self.dropout(self.lt(xs))
         attn_mask = xs.ne(0)
         try:
-            x_lens = torch.sum(attn_mask.int(), dim=1)
+            x_lens = torch.sum(attn_mask.int(), dim=1).cpu()
             xes = pack_padded_sequence(xes, x_lens, batch_first=True)
             packed = True
         except ValueError:


### PR DESCRIPTION
**Patch description**
A small change that ensures that the lengths' device is correctly set to CPU. Necessary due to a recent PyTorch update that ensures that lengths vector always assume the device from the input vector.

pack_padded_sequence expects lengths to be of type CPU
https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/PackedSequence.cpp#L6-L9

PyTorch now consistently infers lengths device from input tensor
https://github.com/pytorch/pytorch/pull/41984

Before, the device of lengths was being set to CPU automatically due to .int() conversion, even on CUDA, but with the PyTorch update is now being set to CUDA as well and pack_padded_sequence throws RuntimeError: 'lengths' argument should be a 1D CPU int64 tensor. This change ensures that lengths' device is always set to CPU.  

**Testing steps**
I am a FB intern working on a project using this module and was able to confirm that this change fixed the Runtime Error I described above. I further confirmed that this update in particular (https://github.com/pytorch/pytorch/pull/41984) was the problematic one by checking out the diff immediately before it and training seq2seq successfully, then checking out that diff and hitting the error. My manager was also able to reproduce this issue after running hg update. 

**Logs**
If PyTorch contains the problematic update, running seq2seq on any dataset on GPU should be enough to hit this issue. 

**Other information**
Even if seq2seq isn't being run with the latest version of PyTorch, this change shouldn't hit performance as the vector is already being calculated as a CPU vector inside of pack_padded_sequence.

