### PR TITLE
[Image S2S] Standardize Image Seq2Seq Image Processing

### DIFF
--- a/parlai/agents/image_seq2seq/image_seq2seq.py
+++ b/parlai/agents/image_seq2seq/image_seq2seq.py
@@ -128,7 +128,7 @@ class ImageSeq2seqAgent(TransformerGeneratorAgent, TorchImageAgent):
                 images.append(img)
             batch.image = images
         else:
-            images = [None for _ in range(len(batch.valid_indices))]
+            images = [None] * len(batch.valid_indices)
             batch.image = images
         return batch
 

--- a/parlai/agents/image_seq2seq/image_seq2seq.py
+++ b/parlai/agents/image_seq2seq/image_seq2seq.py
@@ -120,12 +120,15 @@ class ImageSeq2seqAgent(TransformerGeneratorAgent, TorchImageAgent):
 
         Image features represented by tensors will set to the right type.
         """
-        if type(batch.image) == list and any(b is not None for b in batch):
+        if type(batch.image) == list and any(b is not None for b in batch.image):
             images = []
             for img in batch.image:
                 if isinstance(img, torch.Tensor):
                     img = self._process_image_features(img)
                 images.append(img)
+            batch.image = images
+        else:
+            images = [None for _ in range(len(batch.valid_indices))]
             batch.image = images
         return batch
 

--- a/parlai/agents/image_seq2seq/modules.py
+++ b/parlai/agents/image_seq2seq/modules.py
@@ -303,9 +303,6 @@ class ContextWithImageEncoder(TransformerEncoder):
 
         Essentially overrides normal TransformerEncoder forward.
         """
-        import ipdb
-
-        ipdb.set_trace()
         context_tensor = context_mask = None
         image_tensor = image_mask = None
         if src_tokens is not None and image_features is not None:

--- a/parlai/agents/image_seq2seq/modules.py
+++ b/parlai/agents/image_seq2seq/modules.py
@@ -249,18 +249,15 @@ class ContextWithImageEncoder(TransformerEncoder):
                     self.embedding_size,
                 )
             )
-            assert image_masks.shape == image_encoded.shape[:2]
         else:
-            image_encoded = torch.stack(
-                [self.dummy_image_enc for _ in range(len(images))]
-            ).reshape(
+            image_encoded = torch.stack([self.dummy_image_enc] * len(images)).reshape(
                 len(images),
                 self.n_image_tokens * self.n_image_channels,
                 self.embedding_size,
             )
-            image_masks = torch.stack([~self.ones_mask for _ in range(len(images))])
-            assert image_masks.shape == image_encoded.shape[:2]
+            image_masks = torch.stack([~self.ones_mask] * len(images))
 
+        assert image_masks.shape == image_encoded.shape[:2]
         return image_encoded, image_masks
 
     def forward(  # type: ignore

--- a/parlai/agents/image_seq2seq/modules.py
+++ b/parlai/agents/image_seq2seq/modules.py
@@ -179,7 +179,7 @@ class ContextWithImageEncoder(TransformerEncoder):
         images: Union[List[object], torch.Tensor],
         positions: Optional[torch.LongTensor] = None,
         segments: Optional[torch.LongTensor] = None,
-    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Encode Images.
 
@@ -214,7 +214,6 @@ class ContextWithImageEncoder(TransformerEncoder):
         assert positions is not None
         assert segments is not None
 
-        image_masks = image_encoded = None
         valid_inds = [
             i
             for i, img in enumerate(images)
@@ -250,6 +249,12 @@ class ContextWithImageEncoder(TransformerEncoder):
                     self.embedding_size,
                 )
             )
+            assert image_masks.shape == image_encoded.shape[:2]
+        else:
+            image_encoded = torch.stack(
+                [self.dummy_image_enc for _ in range(len(images))]
+            ).reshape(len(images), self.n_image_tokens * self.n_image_channels, self.embedding_size)
+            image_masks = torch.stack([~self.ones_mask for _ in range(len(images))])
             assert image_masks.shape == image_encoded.shape[:2]
 
         return image_encoded, image_masks
@@ -294,6 +299,7 @@ class ContextWithImageEncoder(TransformerEncoder):
 
         Essentially overrides normal TransformerEncoder forward.
         """
+        import ipdb; ipdb.set_trace()
         context_tensor = context_mask = None
         image_tensor = image_mask = None
         if src_tokens is not None and image_features is not None:
@@ -305,18 +311,14 @@ class ContextWithImageEncoder(TransformerEncoder):
         if image_features is not None:
             # sometimes can just be a list of None
             valid_imgs = [v for v in image_features if isinstance(v, torch.Tensor)]
+            segments: Optional[torch.LongTensor] = None
             if valid_imgs:
-                image_tensor, image_mask = self.encode_images(
-                    image_features,
-                    segments=torch.ones(  # type: ignore
-                        (
-                            len(image_features),
-                            self.n_image_channels * self.n_image_tokens,
-                        ),
-                        dtype=torch.long,
-                        device=valid_imgs[0].device,
-                    ),
-                )
+                segments = torch.ones(  # type: ignore
+                    (len(image_features), self.n_image_channels * self.n_image_tokens),
+                    dtype=torch.long,
+                    device=valid_imgs[0].device,
+                ),
+            image_tensor, image_mask = self.encode_images(image_features, segments=segments)
 
         # perform early fusion
         tensor = self._cat([context_tensor, image_tensor])

--- a/parlai/agents/image_seq2seq/modules.py
+++ b/parlai/agents/image_seq2seq/modules.py
@@ -253,7 +253,11 @@ class ContextWithImageEncoder(TransformerEncoder):
         else:
             image_encoded = torch.stack(
                 [self.dummy_image_enc for _ in range(len(images))]
-            ).reshape(len(images), self.n_image_tokens * self.n_image_channels, self.embedding_size)
+            ).reshape(
+                len(images),
+                self.n_image_tokens * self.n_image_channels,
+                self.embedding_size,
+            )
             image_masks = torch.stack([~self.ones_mask for _ in range(len(images))])
             assert image_masks.shape == image_encoded.shape[:2]
 
@@ -299,7 +303,9 @@ class ContextWithImageEncoder(TransformerEncoder):
 
         Essentially overrides normal TransformerEncoder forward.
         """
-        import ipdb; ipdb.set_trace()
+        import ipdb
+
+        ipdb.set_trace()
         context_tensor = context_mask = None
         image_tensor = image_mask = None
         if src_tokens is not None and image_features is not None:
@@ -313,12 +319,19 @@ class ContextWithImageEncoder(TransformerEncoder):
             valid_imgs = [v for v in image_features if isinstance(v, torch.Tensor)]
             segments: Optional[torch.LongTensor] = None
             if valid_imgs:
-                segments = torch.ones(  # type: ignore
-                    (len(image_features), self.n_image_channels * self.n_image_tokens),
-                    dtype=torch.long,
-                    device=valid_imgs[0].device,
-                ),
-            image_tensor, image_mask = self.encode_images(image_features, segments=segments)
+                segments = (
+                    torch.ones(  # type: ignore
+                        (
+                            len(image_features),
+                            self.n_image_channels * self.n_image_tokens,
+                        ),
+                        dtype=torch.long,
+                        device=valid_imgs[0].device,
+                    ),
+                )
+            image_tensor, image_mask = self.encode_images(
+                image_features, segments=segments
+            )
 
         # perform early fusion
         tensor = self._cat([context_tensor, image_tensor])

--- a/parlai/agents/image_seq2seq/modules.py
+++ b/parlai/agents/image_seq2seq/modules.py
@@ -313,15 +313,10 @@ class ContextWithImageEncoder(TransformerEncoder):
             valid_imgs = [v for v in image_features if isinstance(v, torch.Tensor)]
             segments: Optional[torch.LongTensor] = None
             if valid_imgs:
-                segments = (
-                    torch.ones(  # type: ignore
-                        (
-                            len(image_features),
-                            self.n_image_channels * self.n_image_tokens,
-                        ),
-                        dtype=torch.long,
-                        device=valid_imgs[0].device,
-                    ),
+                segments = torch.ones(  # type: ignore
+                    (len(image_features), self.n_image_channels * self.n_image_tokens),
+                    dtype=torch.long,
+                    device=valid_imgs[0].device,
                 )
             image_tensor, image_mask = self.encode_images(
                 image_features, segments=segments


### PR DESCRIPTION
**Patch description**
In the current Image Seq2Seq implementation, dummy image features are only concatenated to token embeddings if there is at least one valid image in a batch. However, this means that during interactive, the model would never see dummy image features. This fix updates to *always* concatenate dummy image features.  

**Testing steps**
Relying on existing CI tests for Image Seq2seq. I additionally tried locally in interactive mode.