### PR TITLE
Add style-controlled generation agent

### DIFF
--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1453,4 +1453,17 @@ model_list = [
             "[TransformerSequenceVocabUnlikelihood]: hi there !"
         ),
     },
+    {
+        "title": "Style-controlled generation: C75-D+ generator",
+        "id": "style_gen",
+        "path": "zoo:style_gen/c75_labeled_dialogue_generator/model",
+        "agent": "projects.style_gen",
+        "task": "style_gen:BlendedSkillTalk",
+        "project": 'https://github.com/facebookresearch/ParlAI/tree/master/projects/style_gen',
+        "description": "Generator trained on dialogue datasets, with 75% of train examples appended with Image-Chat personality labels",
+        "example": "python examples/eval_model.py --datatype test --model projects.style_gen --model-file zoo:style_gen/c75_labeled_dialogue_generator/model --skip-generation True --task style_gen:LabeledBlendedSkillTalk --use-style-frac 1.00",
+        "result": """11:32:59 | Finished evaluating tasks ['style_gen:LabeledBlendedSkillTalk'] using datatype test
+    exs  gpu_mem  loss   ppl  token_acc   tpb
+   5482    .4899 2.245 9.442      .4879 19.94""",
+    },
 ]

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1462,8 +1462,8 @@ model_list = [
         "project": 'https://github.com/facebookresearch/ParlAI/tree/master/projects/style_gen',
         "description": "Generator trained on dialogue datasets, with 75% of train examples appended with Image-Chat personality labels",
         "example": "parlai eval_model --datatype test --model projects.style_gen.style_gen:StyleGenAgent --model-file zoo:style_gen/c75_labeled_dialogue_generator/model --skip-generation True --task style_gen:LabeledBlendedSkillTalk --use-style-frac 1.00",
-        "result": """11:32:59 | Finished evaluating tasks ['style_gen:LabeledBlendedSkillTalk'] using datatype test
-    exs  gpu_mem  loss   ppl  token_acc   tpb
-   5482    .4899 2.245 9.442      .4879 19.94""",
+        "result": """18:09:58 | Finished evaluating tasks ['style_gen:LabeledBlendedSkillTalk'] using datatype test
+    ctpb  ctps  exps  exs  gpu_mem  loss  ltpb  ltps   ppl  token_acc   tpb  tps
+     120  1849 15.41 5482    .1635 2.245 19.94 307.4 9.442      .4879 139.9 2157""",
     },
 ]

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1462,8 +1462,8 @@ model_list = [
         "project": 'https://github.com/facebookresearch/ParlAI/tree/master/projects/style_gen',
         "description": "Generator trained on dialogue datasets, with 75% of train examples appended with Image-Chat personality labels",
         "example": "parlai eval_model --datatype test --model projects.style_gen.style_gen:StyleGenAgent --model-file zoo:style_gen/c75_labeled_dialogue_generator/model --skip-generation True --task style_gen:LabeledBlendedSkillTalk --use-style-frac 1.00",
-        "result": """18:09:58 | Finished evaluating tasks ['style_gen:LabeledBlendedSkillTalk'] using datatype test
+        "result": """16:56:52 | Finished evaluating tasks ['style_gen:LabeledBlendedSkillTalk'] using datatype test
     ctpb  ctps  exps  exs  gpu_mem  loss  ltpb  ltps   ppl  token_acc   tpb  tps
-     120  1849 15.41 5482    .1635 2.245 19.94 307.4 9.442      .4879 139.9 2157""",
+     120  1855 15.46 5482    .1635 2.248 19.94 308.2 9.468      .4872 139.9 2163""",
     },
 ]

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1461,7 +1461,7 @@ model_list = [
         "task": "style_gen:BlendedSkillTalk",
         "project": 'https://github.com/facebookresearch/ParlAI/tree/master/projects/style_gen',
         "description": "Generator trained on dialogue datasets, with 75% of train examples appended with Image-Chat personality labels",
-        "example": "python examples/eval_model.py --datatype test --model projects.style_gen.style_gen:StyleGenAgent --model-file zoo:style_gen/c75_labeled_dialogue_generator/model --skip-generation True --task style_gen:LabeledBlendedSkillTalk --use-style-frac 1.00",
+        "example": "parlai eval_model --datatype test --model projects.style_gen.style_gen:StyleGenAgent --model-file zoo:style_gen/c75_labeled_dialogue_generator/model --skip-generation True --task style_gen:LabeledBlendedSkillTalk --use-style-frac 1.00",
         "result": """11:32:59 | Finished evaluating tasks ['style_gen:LabeledBlendedSkillTalk'] using datatype test
     exs  gpu_mem  loss   ppl  token_acc   tpb
    5482    .4899 2.245 9.442      .4879 19.94""",

--- a/parlai/zoo/style_gen/__init__.py
+++ b/parlai/zoo/style_gen/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/parlai/zoo/style_gen/c75_labeled_dialogue_generator.py
+++ b/parlai/zoo/style_gen/c75_labeled_dialogue_generator.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Generator trained on dialogue datasets (BST, ConvAI2, ED, and WoW), with style labels
+(Image-Chat personalities) attached to train examples 75% of the time.
+"""
+
+from parlai.core.build_data import download_models
+
+
+def download(datapath):
+    model_type = 'c75_labeled_dialogue_generator'
+    version = 'v1.0'
+    opt = {'datapath': datapath, 'model_type': model_type}
+    fnames = [f'{version}.tar.gz']
+    download_models(
+        opt=opt,
+        fnames=fnames,
+        model_folder='style_gen',
+        version=version,
+        use_model_type=True,
+    )

--- a/projects/style_gen/README.md
+++ b/projects/style_gen/README.md
@@ -1,0 +1,5 @@
+# Style-controlled generation
+
+Agent for training and evaluating generative models conditioned on a style token, for instance, the "personality" string attached to each example of the Image-Chat dataset.
+
+- `--model style_gen`: Subclass of `TransformerGeneratorAgent` for which style tokens can be appended to the history for every training/evaluation example. Found in `style_gen.py`.

--- a/projects/style_gen/README.md
+++ b/projects/style_gen/README.md
@@ -8,9 +8,9 @@ Agent for training and evaluating generative models conditioned on a style token
 
 Evaluating a style-controlled generation model on the BlendedSkillTalk dataset, labeled with personalities from Image-Chat:
 ```
-python examples/eval_model.py \
+parlai eval_model \
 --model-file zoo:style_gen/c75_labeled_dialogue_generator/model \
---model projects.style_gen \
+--model projects.style_gen.style_gen:StyleGenAgent \
 --skip-generation True \
 --task style_gen:LabeledBlendedSkillTalk \
 --datatype test \

--- a/projects/style_gen/README.md
+++ b/projects/style_gen/README.md
@@ -2,7 +2,7 @@
 
 Agent for training and evaluating generative models conditioned on a style token, for instance, the "personality" string attached to each example of the Image-Chat dataset.
 
-- `--model style_gen`: Subclass of `TransformerGeneratorAgent` for which style tokens can be appended to the history for every training/evaluation example. Found in `style_gen.py`.
+- `--model projects.style_gen.style_gen:StyleGenAgent`: Subclass of `TransformerGeneratorAgent` for which style tokens can be appended to the history for every training/evaluation example. Found in `style_gen.py`.
 
 ## Basic examples
 

--- a/projects/style_gen/README.md
+++ b/projects/style_gen/README.md
@@ -3,3 +3,16 @@
 Agent for training and evaluating generative models conditioned on a style token, for instance, the "personality" string attached to each example of the Image-Chat dataset.
 
 - `--model style_gen`: Subclass of `TransformerGeneratorAgent` for which style tokens can be appended to the history for every training/evaluation example. Found in `style_gen.py`.
+
+## Basic examples
+
+Evaluating a style-controlled generation model on the BlendedSkillTalk dataset, labeled with personalities from Image-Chat:
+```
+python examples/eval_model.py \
+--model-file zoo:style_gen/c75_labeled_dialogue_generator/model \
+--model projects.style_gen \
+--skip-generation True \
+--task style_gen:LabeledBlendedSkillTalk \
+--datatype test \
+--use-style-frac 1.00
+```

--- a/projects/style_gen/__init__.py
+++ b/projects/style_gen/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/projects/style_gen/modules.py
+++ b/projects/style_gen/modules.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Models and helper classes for style-controlled generation.
+"""
+
+import random
+
+from parlai.core.torch_agent import History
+
+
+STYLE_SEP_TOKEN = ' STYLE '
+
+
+class StyleHistoryMixin(History):
+    """
+    Methods for adding style to history.
+    """
+
+    def __init__(self, opt, **kwargs):
+        super().__init__(opt, **kwargs)
+        self.use_style_frac = opt['use_style_frac']
+        self.style = None
+
+    def reset(self):
+        super().reset()
+        self.style = None
+
+    def update_history(self, obs, *args, **kwargs):
+        super().update_history(obs, *args, **kwargs)
+        use_style_rand = random.random()
+        if use_style_rand < self.use_style_frac:
+            # Use the style
+            self.style = obs.get('personality')
+            # This key name is dependent on Image-Chat and will change for other tasks.
+            # If obs does not contain 'personality' (i.e. at the end of an epoch during
+            # validation), there will be no style
+            if self.style == '':
+                self.style = None
+        else:
+            self.style = None
+
+    def get_history_str(self):
+        history_str = super().get_history_str()
+        if history_str is not None and self.style is not None:
+            history_str += STYLE_SEP_TOKEN + self.style
+
+        return history_str
+
+    def get_history_vec(self):
+        history = super().get_history_vec()
+
+        if history is not None and self.style is not None:
+            style = STYLE_SEP_TOKEN + self.style
+            style_tok = self.parse(style)
+            history += style_tok
+
+        return history
+
+
+class StyleAgentMixin:
+    """
+    Methods for agents that return style from their histories.
+    """
+
+    @classmethod
+    def add_cmdline_args(cls, argparser):
+        """
+        Add command-line arguments specifically for this agent.
+
+        Does not add arguments from its superclass because it's a mixin.
+        """
+        agent = argparser.add_argument_group('StyleAgentMixin arguments')
+        agent.add_argument(
+            '--use-style-frac',
+            type=float,
+            default=1.0,
+            help='What fraction of the time to use the style label',
+        )
+        return agent
+
+
+class StyleHistory(StyleHistoryMixin, History):
+    """
+    Modify history to save the style.
+    """

--- a/projects/style_gen/modules.py
+++ b/projects/style_gen/modules.py
@@ -11,6 +11,7 @@ import random
 from typing import Optional
 
 from parlai.core.message import Message
+from parlai.core.opt import Opt
 
 
 STYLE_SEP_TOKEN = ' STYLE '
@@ -37,8 +38,8 @@ class StyleAgentMixin:
         )
         return agent
 
-    def __init__(self, opt, **kwargs):
-        super().__init__(opt, **kwargs)
+    def __init__(self, opt: Opt, shared=None):
+        super().__init__(opt, shared)
         self.use_style_frac = opt['use_style_frac']
 
     def get_temp_history(self, observation: Message) -> Optional[str]:

--- a/projects/style_gen/modules.py
+++ b/projects/style_gen/modules.py
@@ -8,57 +8,12 @@ Models and helper classes for style-controlled generation.
 """
 
 import random
+from typing import Optional
 
-from parlai.core.torch_agent import History
+from parlai.core.message import Message
 
 
 STYLE_SEP_TOKEN = ' STYLE '
-
-
-class StyleHistoryMixin(History):
-    """
-    Methods for adding style to history.
-    """
-
-    def __init__(self, opt, **kwargs):
-        super().__init__(opt, **kwargs)
-        self.use_style_frac = opt['use_style_frac']
-        self.style = None
-
-    def reset(self):
-        super().reset()
-        self.style = None
-
-    def update_history(self, obs, *args, **kwargs):
-        super().update_history(obs, *args, **kwargs)
-        use_style_rand = random.random()
-        if use_style_rand < self.use_style_frac:
-            # Use the style
-            self.style = obs.get('personality')
-            # This key name is dependent on Image-Chat and will change for other tasks.
-            # If obs does not contain 'personality' (i.e. at the end of an epoch during
-            # validation), there will be no style
-            if self.style == '':
-                self.style = None
-        else:
-            self.style = None
-
-    def get_history_str(self):
-        history_str = super().get_history_str()
-        if history_str is not None and self.style is not None:
-            history_str += STYLE_SEP_TOKEN + self.style
-
-        return history_str
-
-    def get_history_vec(self):
-        history = super().get_history_vec()
-
-        if history is not None and self.style is not None:
-            style = STYLE_SEP_TOKEN + self.style
-            style_tok = self.parse(style)
-            history += style_tok
-
-        return history
 
 
 class StyleAgentMixin:
@@ -82,8 +37,22 @@ class StyleAgentMixin:
         )
         return agent
 
+    def __init__(self, opt, **kwargs):
+        super().__init__(opt, **kwargs)
+        self.use_style_frac = opt['use_style_frac']
 
-class StyleHistory(StyleHistoryMixin, History):
-    """
-    Modify history to save the style.
-    """
+    def get_temp_history(self, observation: Message) -> Optional[str]:
+        """
+        Conditionally return a style-token string to temporarily insert into history.
+        """
+        use_style_rand = random.random()
+        if use_style_rand < self.use_style_frac:
+            # Use the style
+            style = observation.get('personality')
+            # This key name is dependent on Image-Chat and will change for other tasks.
+            # If obs does not contain 'personality' (i.e. at the end of an epoch during
+            # validation), there will be no style
+        else:
+            style = ''
+        if style is not None and style != '':
+            return STYLE_SEP_TOKEN + style

--- a/projects/style_gen/style_gen.py
+++ b/projects/style_gen/style_gen.py
@@ -8,20 +8,13 @@ Agent for style-controlled generation.
 """
 
 from parlai.agents.transformer.transformer import TransformerGeneratorAgent
-from projects.style_gen.modules import StyleAgentMixin, StyleHistory
+from projects.style_gen.modules import StyleAgentMixin
 
 
 class StyleGenAgent(StyleAgentMixin, TransformerGeneratorAgent):
     """
     General purpose generator with a style in the history.
     """
-
-    @classmethod
-    def history_class(cls):
-        """
-        Determine the history class in order to append the style.
-        """
-        return StyleHistory
 
     @classmethod
     def add_cmdline_args(cls, argparser):

--- a/projects/style_gen/style_gen.py
+++ b/projects/style_gen/style_gen.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Agent for style-controlled generation.
+"""
+
+from parlai.agents.transformer.transformer import TransformerGeneratorAgent
+from projects.style_gen.modules import StyleAgentMixin, StyleHistory
+
+
+class StyleGenAgent(StyleAgentMixin, TransformerGeneratorAgent):
+    """
+    General purpose generator with a style in the history.
+    """
+
+    @classmethod
+    def history_class(cls):
+        """
+        Determine the history class in order to append the style.
+        """
+        return StyleHistory
+
+    @classmethod
+    def add_cmdline_args(cls, argparser):
+        """
+        Add command-line arguments specifically for this agent.
+        """
+        StyleAgentMixin.add_cmdline_args(argparser)
+        TransformerGeneratorAgent.add_cmdline_args(argparser)
+        return argparser

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,29 @@
+# Running Tests Locally
+
+Tests are run in ParlAI with [pytest](https://docs.pytest.org/en/stable/).
+
+To run all tests in your current directory, simply run:
+```
+pytest
+```
+
+To run tests from a specific file, run:
+```
+pytest <filepath>
+```
+
+To use name-based filtering to run tests, use the flag `-k`. For example, to only run tests with `TransformerRanker` in the name, run:
+```
+pytest -k TransformerRanker
+```
+
+For verbose testing logs, use `-v`:
+```
+pytest -v -k TransformerRanker
+```
+
+
+To print the output from a test or set of tests, use `-s`:
+```
+pytest -s -k TransformerRanker
+```

--- a/tests/nightly/gpu/test_style_gen.py
+++ b/tests/nightly/gpu/test_style_gen.py
@@ -17,11 +17,11 @@ class TestStyleGen(unittest.TestCase):
         """
         Test perplexities of style-controlled generation models in the zoo.
         """
-        test_cases = [('c75_labeled_dialogue_generator', 1.0, 9.665)]
+        test_cases = [('c75_labeled_dialogue_generator', 1.0, 7.664)]
         for model_name, style_frac, desired_ppl in test_cases:
             _, test = testing_utils.eval_model(
                 opt={
-                    'batchsize': 16,
+                    'batchsize': 4,
                     'fp16': False,
                     'num_examples': 16,
                     'model_file': f'zoo:style_gen/{model_name}/model',

--- a/tests/nightly/gpu/test_style_gen.py
+++ b/tests/nightly/gpu/test_style_gen.py
@@ -17,7 +17,7 @@ class TestStyleGen(unittest.TestCase):
         """
         Test perplexities of style-controlled generation models in the zoo.
         """
-        test_cases = [('c75_labeled_dialogue_generator', 1.0, 8.689)]
+        test_cases = [('c75_labeled_dialogue_generator', 1.0, 8.715)]
         for model_name, style_frac, desired_ppl in test_cases:
             _, test = testing_utils.eval_model(
                 opt={

--- a/tests/nightly/gpu/test_style_gen.py
+++ b/tests/nightly/gpu/test_style_gen.py
@@ -17,13 +17,13 @@ class TestStyleGen(unittest.TestCase):
         """
         Test perplexities of style-controlled generation models in the zoo.
         """
-        test_cases = [('c75_labeled_dialogue_generator', 1.0, 8.715)]
+        test_cases = [('c75_labeled_dialogue_generator', 1.0, 9.665)]
         for model_name, style_frac, desired_ppl in test_cases:
             _, test = testing_utils.eval_model(
                 opt={
                     'batchsize': 16,
                     'fp16': False,
-                    'num_examples': 64,
+                    'num_examples': 16,
                     'model_file': f'zoo:style_gen/{model_name}/model',
                     'model': 'projects.style_gen.style_gen:StyleGenAgent',
                     'skip_generation': True,

--- a/tests/nightly/gpu/test_style_gen.py
+++ b/tests/nightly/gpu/test_style_gen.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Test agents used with style-controlled generation.
+"""
+
+import unittest
+
+import parlai.utils.testing as testing_utils
+from parlai.core.opt import Opt
+
+
+class TestStyleGen(unittest.TestCase):
+    def test_perplexities(self):
+        """
+        Test perplexities of style-controlled generation models in the zoo.
+        """
+        test_cases = [('c75_labeled_dialogue_generator', 1.0, 8.689)]
+        for model_name, style_frac, desired_ppl in test_cases:
+            _, test = testing_utils.eval_model(
+                opt={
+                    'batchsize': 16,
+                    'num_examples': 64,
+                    'model_file': f'zoo:style_gen/{model_name}/model',
+                    'model': 'projects.style_gen',
+                    'skip_generation': True,
+                    'task': 'style_gen:LabeledBlendedSkillTalk',
+                    'use_style_frac': style_frac,
+                },
+                skip_valid=True,
+            )
+            self.assertAlmostEqual(test['ppl'], desired_ppl, delta=0.005)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/nightly/gpu/test_style_gen.py
+++ b/tests/nightly/gpu/test_style_gen.py
@@ -22,6 +22,7 @@ class TestStyleGen(unittest.TestCase):
             _, test = testing_utils.eval_model(
                 opt={
                     'batchsize': 16,
+                    'fp16': False,
                     'num_examples': 64,
                     'model_file': f'zoo:style_gen/{model_name}/model',
                     'model': 'projects.style_gen.style_gen:StyleGenAgent',
@@ -31,6 +32,7 @@ class TestStyleGen(unittest.TestCase):
                 },
                 skip_valid=True,
             )
+            # We turn off FP16 because emulation of this is likely slow on the CI GPUs
             self.assertAlmostEqual(test['ppl'], desired_ppl, delta=0.005)
 
 

--- a/tests/nightly/gpu/test_style_gen.py
+++ b/tests/nightly/gpu/test_style_gen.py
@@ -10,7 +10,6 @@ Test agents used with style-controlled generation.
 import unittest
 
 import parlai.utils.testing as testing_utils
-from parlai.core.opt import Opt
 
 
 class TestStyleGen(unittest.TestCase):


### PR DESCRIPTION
**Patch description**
Add code to train/evaluate style-controlled generative models. Some of this code was also in https://github.com/facebookresearch/ParlAI/pull/2829, but the classifier code in that PR will be open-sourced at a later date. Also add a model trained with this agent.

**Testing steps**
```pytest tests/nightly/gpu/test_style_gen.py```