### PR TITLE
[LIGHT] Flag for % of LIGHT Train Set

### DIFF
--- a/parlai/tasks/light_dialog/agents.py
+++ b/parlai/tasks/light_dialog/agents.py
@@ -9,6 +9,7 @@ from .build import build
 
 import copy
 import os
+import random
 
 
 def _path(opt):
@@ -107,13 +108,30 @@ class DefaultTeacher(ParlAIDialogTeacher):
         agent.add_argument('--light_use_cands', type=int, default=20)
         agent.add_argument('--light_use_clip_cands', type=int, default=10000)
         agent.add_argument('--light_speech_prefix', type='bool', default=True)
+        agent.add_argument(
+            '--light_percent_train_exs',
+            type=float,
+            default=1.0,
+            help='Float in range [0, 1] indicating proportion of train set to use')
 
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
+        self.pct_train_exs = opt['light_percent_train_exs']
+        assert 0.0 <= self.pct_train_exs <= 1.0
         opt['parlaidialogteacher_datafile'] = _path(opt)
         if 'light_use_speech_prefix' not in opt:
             opt['light_use_speech_prefix'] = True
         super().__init__(opt, shared)
+
+    def _setup_data(self, path):
+        """
+        Overriding to limit num train exs.
+        """
+        super()._setup_data(path)
+        if self.training and self.pct_train_exs <= 1.0:
+            random.seed(42)
+            self.episodes = random.sample(self.episodes, int(self.num_episodes() * self.pct_train_exs))
+            self.num_exs = sum(len(e) for e in self.episodes)
 
 
 class SimpleTeacher(DefaultTeacher):
@@ -171,6 +189,7 @@ class SimpleTeacher(DefaultTeacher):
         agent.add_argument('--light_use_cands', type=int, default=20)
         agent.add_argument('--light_use_clip_cands', type=int, default=10000)
         agent.add_argument('--light_use_speech_prefix', type='bool', default=False)
+        agent.add_argument('--light_percent_train_exs', type=float, default=1.0)
 
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
@@ -232,6 +251,7 @@ class SimpleMultiTeacher(DefaultTeacher):
         agent.add_argument('--light_use_cands', type=int, default=20)
         agent.add_argument('--light_use_clip_cands', type=int, default=10000)
         agent.add_argument('--light_use_speech_prefix', type='bool', default=False)
+        agent.add_argument('--light_percent_train_exs', type=float, default=1.0)
 
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)

--- a/parlai/tasks/light_dialog/agents.py
+++ b/parlai/tasks/light_dialog/agents.py
@@ -112,7 +112,8 @@ class DefaultTeacher(ParlAIDialogTeacher):
             '--light_percent_train_exs',
             type=float,
             default=1.0,
-            help='Float in range [0, 1] indicating proportion of train set to use')
+            help='Float in range [0, 1] indicating proportion of train set to use',
+        )
 
     def __init__(self, opt, shared=None):
         opt = copy.deepcopy(opt)
@@ -130,7 +131,9 @@ class DefaultTeacher(ParlAIDialogTeacher):
         super()._setup_data(path)
         if self.training and self.pct_train_exs <= 1.0:
             random.seed(42)
-            self.episodes = random.sample(self.episodes, int(self.num_episodes() * self.pct_train_exs))
+            self.episodes = random.sample(
+                self.episodes, int(self.num_episodes() * self.pct_train_exs)
+            )
             self.num_exs = sum(len(e) for e in self.episodes)
 
 

--- a/tests/tasks/test_light.py
+++ b/tests/tasks/test_light.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import parlai.utils.testing as testing_utils
+from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
+from parlai.core.worlds import create_task
+from parlai.scripts.display_data import setup_args
+
+NUM_EPS = 17075
+NUM_EXS = 110877
+
+
+class TestLightTeacher(unittest.TestCase):
+    """
+    Tests for the LIGHT Dialogue Teacher
+    """
+
+    def test_counts(self):
+
+        with testing_utils.tempdir() as tmpdir:
+            proportions = [0.1, 0.5, 1.0]
+            for proportion in proportions:
+                all_kwargs = {
+                    'datatype': 'train',
+                    'task': 'light_dialog',
+                    'datapath': tmpdir,
+                    'light_percent_train_exs': proportion
+                }
+                parser = setup_args()
+                parser.set_defaults(**all_kwargs)
+                opt = parser.parse_args([])
+                agent = RepeatLabelAgent(opt)
+                teacher = create_task(opt, agent).get_task_agent()
+                self.assertEqual(teacher.num_episodes(), int(NUM_EPS * proportion))
+                self.assertEqual(teacher.num_examples(), int(NUM_EXS * proportion))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/tasks/test_light.py
+++ b/tests/tasks/test_light.py
@@ -17,7 +17,7 @@ NUM_EXS = 110877
 
 class TestLightTeacher(unittest.TestCase):
     """
-    Tests for the LIGHT Dialogue Teacher
+    Tests for the LIGHT Dialogue Teacher.
     """
 
     def test_counts(self):
@@ -29,7 +29,7 @@ class TestLightTeacher(unittest.TestCase):
                     'datatype': 'train',
                     'task': 'light_dialog',
                     'datapath': tmpdir,
-                    'light_percent_train_exs': proportion
+                    'light_percent_train_exs': proportion,
                 }
                 parser = setup_args()
                 parser.set_defaults(**all_kwargs)
@@ -38,6 +38,7 @@ class TestLightTeacher(unittest.TestCase):
                 teacher = create_task(opt, agent).get_task_agent()
                 self.assertEqual(teacher.num_episodes(), int(NUM_EPS * proportion))
                 self.assertEqual(teacher.num_examples(), int(NUM_EXS * proportion))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Patch description**
Adds a flag to the LIGHT Dialogue teacher to control percentage of train examples given.

**Testing steps**
Added a test.

**Logs**
```
$ pytest tests/tasks/test_light.py
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.6.9, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini
plugins: requests-mock-1.7.0
collected 1 item

tests/tasks/test_light.py .                                                                                                                                                  [100%]

============================================================================ slowest 10 test durations =============================================================================
52.04s call     tests/tasks/test_light.py::TestLightTeacher::test_counts

(0.00 durations hidden.  Use -vv to show these durations.)
========================================================================== 1 passed, 1 warning in 54.54s ===========================================================================
```
