### PR TITLE
rename rouge metrics to use underscores

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -788,7 +788,7 @@ class TeacherMetrics(Metrics):
                 if 'rouge-2' in self._metrics_list:
                     self.add('rouge-2', r2)
                 if 'rouge-L' in self._metrics_list:
-                    self.add('rouge-L', rL)
+                    self.add('rouge_L', rL)
 
         # Ranking metrics.
         self._update_ranking_metrics(observation, labels)

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -784,9 +784,9 @@ class TeacherMetrics(Metrics):
             if self._metrics_list & ROUGE_METRICS:
                 r1, r2, rL = RougeMetric.compute_many(prediction, labels)
                 if 'rouge-1' in self._metrics_list:
-                    self.add('rouge-1', r1)
+                    self.add('rouge_1', r1)
                 if 'rouge-2' in self._metrics_list:
-                    self.add('rouge-2', r2)
+                    self.add('rouge_2', r2)
                 if 'rouge-L' in self._metrics_list:
                     self.add('rouge_L', rL)
 

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -68,12 +68,12 @@ class TestEvalModel(unittest.TestCase):
 
         self.assertEqual(valid['accuracy'], 1)
         self.assertEqual(valid['rouge_L'], 1)
-        self.assertEqual(valid['rouge-1'], 1)
-        self.assertEqual(valid['rouge-2'], 1)
+        self.assertEqual(valid['rouge_1'], 1)
+        self.assertEqual(valid['rouge_2'], 1)
         self.assertEqual(test['accuracy'], 1)
         self.assertEqual(test['rouge_L'], 1)
-        self.assertEqual(test['rouge-1'], 1)
-        self.assertEqual(test['rouge-2'], 1)
+        self.assertEqual(test['rouge_1'], 1)
+        self.assertEqual(test['rouge_2'], 1)
 
     def test_metrics_select(self):
         """
@@ -92,12 +92,12 @@ class TestEvalModel(unittest.TestCase):
 
         self.assertEqual(valid['accuracy'], 1)
         self.assertEqual(valid['rouge_L'], 1)
-        self.assertEqual(valid['rouge-1'], 1)
-        self.assertEqual(valid['rouge-2'], 1)
+        self.assertEqual(valid['rouge_1'], 1)
+        self.assertEqual(valid['rouge_2'], 1)
         self.assertEqual(test['accuracy'], 1)
         self.assertEqual(test['rouge_L'], 1)
-        self.assertEqual(test['rouge-1'], 1)
-        self.assertEqual(test['rouge-2'], 1)
+        self.assertEqual(test['rouge_1'], 1)
+        self.assertEqual(test['rouge_2'], 1)
 
         self.assertNotIn('bleu-4', valid)
         self.assertNotIn('bleu-4', test)

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -48,8 +48,8 @@ class TestEvalModel(unittest.TestCase):
 
         self.assertEqual(valid['accuracy'], 1)
         self.assertEqual(test['accuracy'], 1)
-        self.assertNotIn('rouge-L', valid)
-        self.assertNotIn('rouge-L', test)
+        self.assertNotIn('rouge_L', valid)
+        self.assertNotIn('rouge_L', test)
 
     def test_metrics_all(self):
         """
@@ -67,11 +67,11 @@ class TestEvalModel(unittest.TestCase):
         valid, test = testing_utils.eval_model(opt)
 
         self.assertEqual(valid['accuracy'], 1)
-        self.assertEqual(valid['rouge-L'], 1)
+        self.assertEqual(valid['rouge_L'], 1)
         self.assertEqual(valid['rouge-1'], 1)
         self.assertEqual(valid['rouge-2'], 1)
         self.assertEqual(test['accuracy'], 1)
-        self.assertEqual(test['rouge-L'], 1)
+        self.assertEqual(test['rouge_L'], 1)
         self.assertEqual(test['rouge-1'], 1)
         self.assertEqual(test['rouge-2'], 1)
 
@@ -91,11 +91,11 @@ class TestEvalModel(unittest.TestCase):
         valid, test = testing_utils.eval_model(opt)
 
         self.assertEqual(valid['accuracy'], 1)
-        self.assertEqual(valid['rouge-L'], 1)
+        self.assertEqual(valid['rouge_L'], 1)
         self.assertEqual(valid['rouge-1'], 1)
         self.assertEqual(valid['rouge-2'], 1)
         self.assertEqual(test['accuracy'], 1)
-        self.assertEqual(test['rouge-L'], 1)
+        self.assertEqual(test['rouge_L'], 1)
         self.assertEqual(test['rouge-1'], 1)
         self.assertEqual(test['rouge-2'], 1)
 


### PR DESCRIPTION
**Patch description**
rename rouge-{x} to rouge_{x} in the train stats outputs, to play nicer with jq, as requested in #2142.

**Testing steps**
`pytest -v tests/test_eval_model.py` passes all tests


