### PR TITLE
[TGA] Option to block full context

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1363,6 +1363,7 @@ class TorchAgent(ABC, Agent):
             obs['full_text'] = history_string
             if history_string:
                 obs['text_vec'] = history.get_history_vec()
+                obs['full_text_vec'] = history.get_history_vec()
 
         # check truncation
         if obs.get('text_vec') is not None:

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -394,7 +394,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
             type='bool',
             default=False,
             help='Block n-grams from the *full* history context. Default False blocks '
-            'up to m tokens in the past, where m is truncation parameter for agent'
+            'up to m tokens in the past, where m is truncation parameter for agent',
         )
         agent.add_argument(
             '--beam-length-penalty',

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -978,7 +978,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         ctxt = batch.text_vec[batch_idx]
         if self.beam_block_full_context:
             full_ctxt = batch.observations[batch_idx].get('full_text_vec', ctxt)
-            if not isinstance(full_ctxt, torch.Tensor):
+            if not isinstance(full_ctxt, torch.LongTensor):
                 full_ctxt = torch.LongTensor(full_ctxt).to(ctxt)
             ctxt = full_ctxt
         return ctxt

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -359,6 +359,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         # from generating ngrams from model's context, which is limited
         # by truncation parameters. Now, we block on full dialogue history.
         if 'beam_block_full_context' not in opt_from_disk:
+            warn_once('Loading model with `--beam-block-full-context false`')
             opt_from_disk['beam_block_full_context'] = False
 
         return opt_from_disk

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -354,6 +354,13 @@ class TorchGeneratorAgent(TorchAgent, ABC):
                 ]
             del opt_from_disk['beam_blacklist_filename']
 
+        # 2020-08-04: Introduce full context beam blocking
+        # Previous, specifying --beam-context-block-ngram > 1 would block
+        # from generating ngrams from model's context, which is limited
+        # by truncation parameters. Now, we block on full dialogue history.
+        if 'beam_block_full_context' not in opt_from_disk:
+            opt_from_disk['beam_block_full_context'] = False
+
         return opt_from_disk
 
     @classmethod
@@ -392,8 +399,8 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         agent.add_argument(
             '--beam-block-full-context',
             type='bool',
-            default=False,
-            help='Block n-grams from the *full* history context. Default False blocks '
+            default=True,
+            help='Block n-grams from the *full* history context. Specify False to block '
             'up to m tokens in the past, where m is truncation parameter for agent',
         )
         agent.add_argument(

--- a/tests/test_tga.py
+++ b/tests/test_tga.py
@@ -13,7 +13,6 @@ from parlai.core.params import ParlaiParser
 from parlai.core.torch_generator_agent import TorchGeneratorAgent
 
 
-@unittest.skip
 class TestUpgradeOpt(unittest.TestCase):
     """
     Test upgrade_opt behavior.

--- a/tests/test_tga.py
+++ b/tests/test_tga.py
@@ -6,12 +6,12 @@
 """
 Test TorchGeneratorAgent.
 """
-import torch
 import unittest
 from parlai.core.agents import create_agent
 import parlai.utils.testing as testing_utils
 from parlai.core.params import ParlaiParser
 from parlai.core.torch_generator_agent import TorchGeneratorAgent
+
 
 @unittest.skip
 class TestUpgradeOpt(unittest.TestCase):
@@ -90,9 +90,12 @@ class TestTreeSearch(unittest.TestCase):
         pp = ParlaiParser(True, True)
         opt = pp.parse_args(
             [
-                '--model-file', 'zoo:unittest/transformer_generator2/model',
-                '--inference', 'beam',
-                '--truncate', '1024'
+                '--model-file',
+                'zoo:unittest/transformer_generator2/model',
+                '--inference',
+                'beam',
+                '--truncate',
+                '1024',
             ]
         )
         agent = create_agent(opt, True)
@@ -116,7 +119,10 @@ class TestTreeSearch(unittest.TestCase):
         # observe 1 more obs, context is larger now
         agent2.observe(obs)
         batch = agent2.batchify([agent2.observation])
-        self.assertEqual(agent2._get_context(batch, 0).tolist(), [5, 4, 6, 7] * 256 + [3] + [5, 4, 6, 7] * 256)  # 3 is end token.
+        self.assertEqual(
+            agent2._get_context(batch, 0).tolist(),
+            [5, 4, 6, 7] * 256 + [3] + [5, 4, 6, 7] * 256,
+        )  # 3 is end token.
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Patch description**
Beam search context ngram blocking is currently limited by the text truncation for a given model (e.g. for Blender this is only 128 tokens). I've added a flag to allow context blocking throughout the whole dialogue history.

**Testing steps**
Added a test

**Logs**
```
$ pytest -k TestTreeSearch
============================================================================== test session starts ==============================================================================
platform linux -- Python 3.6.9, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini, testpaths: tests
plugins: requests-mock-1.7.0
collected 359 items / 358 deselected / 1 selected

tests/test_tga.py .                                                                                                                                                       [100%]

=========================================================================== slowest 10 test durations ===========================================================================
4.27s call     tests/test_tga.py::TestTreeSearch::test_full_context_block

(0.00 durations hidden.  Use -vv to show these durations.)
================================================================= 1 passed, 358 deselected, 5 warnings in 9.27s =================================================================
```