### PR TITLE
Show all stdout on GPU tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ jobs:
       - run:
           name: Nightly GPU tests
           no_output_timeout: 60m
-          command: coverage run -m pytest --junitxml=test-results/junit.xml -m nightly_gpu -v
+          command: coverage run -m pytest --junitxml=test-results/junit.xml -m nightly_gpu -v -s
       - run:
           name: Quickstart unit tests (GPU; pytorch 1.4)
           command: sh tests/test_quickstart.sh


### PR DESCRIPTION
**Patch description**
Show stdout on all long GPU tests, which will help prevent tests from timing out with no output

**Testing steps**
CI check
