### PR TITLE
Compare opts

### DIFF
--- a/parlai/scripts/compare_opts.py
+++ b/parlai/scripts/compare_opts.py
@@ -22,21 +22,36 @@ def compare_opts(opt_path_1: str, opt_path_2: str):
     print('\nArgs only found in opt 1:')
     opt1_only_keys = sorted([k for k in opt1.keys() if k not in opt2.keys()])
     for key in opt1_only_keys:
-        print(f'\t{key}: {opt1[key]}')
+        print(f'{key}: {opt1[key]}')
 
     print('\nArgs only found in opt 2:')
     opt2_only_keys = sorted([k for k in opt2.keys() if k not in opt1.keys()])
     for key in opt2_only_keys:
-        print(f'\t{key}: {opt2[key]}')
+        print(f'{key}: {opt2[key]}')
 
     print('\nArgs that are different in both opts:')
     keys_with_conflicting_values = sorted(
         [k for k, v in opt1.items() if k in opt2.keys() and v != opt2[k]]
     )
     for key in keys_with_conflicting_values:
-        print(f'\t{key}:')
-        print(f'\t\tIn opt 1: {opt1[key]}')
-        print(f'\t\tIn opt 2: {opt2[key]}')
+        if isinstance(opt1[key], dict) and isinstance(opt2[key], dict):
+            print(f'{key} (printing only non-matching values in each dict):')
+            all_inner_keys = sorted(
+                list(set(opt1[key].keys()).union(set(opt2[key].keys())))
+            )
+            for inner_key in all_inner_keys:
+                if (
+                    inner_key not in opt1[key]
+                    or inner_key not in opt2[key]
+                    or opt1[key][inner_key] != opt2[key][inner_key]
+                ):
+                    print(f'\t{key}:')
+                    print(f'\t\tIn opt 1: {opt1[key].get(inner_key, "<MISSING>")}')
+                    print(f'\t\tIn opt 2: {opt2[key].get(inner_key, "<MISSING>")}')
+        else:
+            print(f'{key}:')
+            print(f'\tIn opt 1: {opt1[key]}')
+            print(f'\tIn opt 2: {opt2[key]}')
 
 
 if __name__ == '__main__':

--- a/parlai/scripts/compare_opts.py
+++ b/parlai/scripts/compare_opts.py
@@ -7,8 +7,10 @@
 import argparse
 import json
 
+from parlai.core.opt import Opt
 
-def compare_opts(opt_path_1: str, opt_path_2: str) -> str:
+
+def compare_opts(opt_path_1: str, opt_path_2: str, load_raw: bool = False) -> str:
     """
     Super simple script to compare the contents of two .opt files.
 
@@ -16,10 +18,14 @@ def compare_opts(opt_path_1: str, opt_path_2: str) -> str:
     """
 
     # Loading opt files
-    with open(opt_path_1) as f1:
-        opt1 = json.load(f1)
-    with open(opt_path_2) as f2:
-        opt2 = json.load(f2)
+    if load_raw:
+        with open(opt_path_1) as f1:
+            opt1 = json.load(f1)
+        with open(opt_path_2) as f2:
+            opt2 = json.load(f2)
+    else:
+        opt1 = Opt.load(opt_path_1)
+        opt2 = Opt.load(opt_path_2)
 
     outputs = list()
 
@@ -69,7 +75,15 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('opt_path_1', type=str, help="Path to the first .opt file")
     parser.add_argument('opt_path_2', type=str, help="Path to the second .opt file")
+    parser.add_argument(
+        '-r',
+        '--load-raw',
+        action='store_true',
+        help='Load using JSON instead of with Opt.load()',
+    )
     args = parser.parse_args()
 
-    output = compare_opts(opt_path_1=args.opt_path_1, opt_path_2=args.opt_path_2)
+    output = compare_opts(
+        opt_path_1=args.opt_path_1, opt_path_2=args.opt_path_2, load_raw=args.load_raw
+    )
     print(output)

--- a/parlai/scripts/compare_opts.py
+++ b/parlai/scripts/compare_opts.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import json
+
+
+def compare_opts(opt_path_1: str, opt_path_2: str):
+    """
+    Super simple script to compare the contents of two .opt files.
+    """
+
+    # Loading opt files
+    with open(opt_path_1) as f1:
+        opt1 = json.load(f1)
+    with open(opt_path_2) as f2:
+        opt2 = json.load(f2)
+
+    print('\nArgs only found in opt 1:')
+    opt1_only_keys = sorted([k for k in opt1.keys() if k not in opt2.keys()])
+    for key in opt1_only_keys:
+        print(f'\t{key}: {opt1[key]}')
+
+    print('\nArgs only found in opt 2:')
+    opt2_only_keys = sorted([k for k in opt2.keys() if k not in opt1.keys()])
+    for key in opt2_only_keys:
+        print(f'\t{key}: {opt2[key]}')
+
+    print('\nArgs that are different in both opts:')
+    keys_with_conflicting_values = sorted(
+        [k for k, v in opt1.items() if k in opt2.keys() and v != opt2[k]]
+    )
+    for key in keys_with_conflicting_values:
+        print(f'\t{key}:')
+        print(f'\t\tIn opt 1: {opt1[key]}')
+        print(f'\t\tIn opt 2: {opt2[key]}')
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('opt_path_1', type=str, help="Path to the first .opt file")
+    parser.add_argument('opt_path_2', type=str, help="Path to the second .opt file")
+    args = parser.parse_args()
+
+    compare_opts(opt_path_1=args.opt_path_1, opt_path_2=args.opt_path_2)

--- a/parlai/scripts/compare_opts.py
+++ b/parlai/scripts/compare_opts.py
@@ -8,9 +8,11 @@ import argparse
 import json
 
 
-def compare_opts(opt_path_1: str, opt_path_2: str):
+def compare_opts(opt_path_1: str, opt_path_2: str) -> str:
     """
     Super simple script to compare the contents of two .opt files.
+
+    Return the formatted text comparing the two .opts, for printing.
     """
 
     # Loading opt files
@@ -19,23 +21,25 @@ def compare_opts(opt_path_1: str, opt_path_2: str):
     with open(opt_path_2) as f2:
         opt2 = json.load(f2)
 
-    print('\nArgs only found in opt 1:')
+    outputs = list()
+
+    outputs.append('\nArgs only found in opt 1:')
     opt1_only_keys = sorted([k for k in opt1.keys() if k not in opt2.keys()])
     for key in opt1_only_keys:
-        print(f'{key}: {opt1[key]}')
+        outputs.append(f'{key}: {opt1[key]}')
 
-    print('\nArgs only found in opt 2:')
+    outputs.append('\nArgs only found in opt 2:')
     opt2_only_keys = sorted([k for k in opt2.keys() if k not in opt1.keys()])
     for key in opt2_only_keys:
-        print(f'{key}: {opt2[key]}')
+        outputs.append(f'{key}: {opt2[key]}')
 
-    print('\nArgs that are different in both opts:')
+    outputs.append('\nArgs that are different in both opts:')
     keys_with_conflicting_values = sorted(
         [k for k, v in opt1.items() if k in opt2.keys() and v != opt2[k]]
     )
     for key in keys_with_conflicting_values:
         if isinstance(opt1[key], dict) and isinstance(opt2[key], dict):
-            print(f'{key} (printing only non-matching values in each dict):')
+            outputs.append(f'{key} (printing only non-matching values in each dict):')
             all_inner_keys = sorted(
                 list(set(opt1[key].keys()).union(set(opt2[key].keys())))
             )
@@ -45,13 +49,19 @@ def compare_opts(opt_path_1: str, opt_path_2: str):
                     or inner_key not in opt2[key]
                     or opt1[key][inner_key] != opt2[key][inner_key]
                 ):
-                    print(f'\t{inner_key}:')
-                    print(f'\t\tIn opt 1: {opt1[key].get(inner_key, "<MISSING>")}')
-                    print(f'\t\tIn opt 2: {opt2[key].get(inner_key, "<MISSING>")}')
+                    outputs.append(f'\t{inner_key}:')
+                    outputs.append(
+                        f'\t\tIn opt 1: {opt1[key].get(inner_key, "<MISSING>")}'
+                    )
+                    outputs.append(
+                        f'\t\tIn opt 2: {opt2[key].get(inner_key, "<MISSING>")}'
+                    )
         else:
-            print(f'{key}:')
-            print(f'\tIn opt 1: {opt1[key]}')
-            print(f'\tIn opt 2: {opt2[key]}')
+            outputs.append(f'{key}:')
+            outputs.append(f'\tIn opt 1: {opt1[key]}')
+            outputs.append(f'\tIn opt 2: {opt2[key]}')
+
+    return '\n'.join(outputs)
 
 
 if __name__ == '__main__':
@@ -61,4 +71,5 @@ if __name__ == '__main__':
     parser.add_argument('opt_path_2', type=str, help="Path to the second .opt file")
     args = parser.parse_args()
 
-    compare_opts(opt_path_1=args.opt_path_1, opt_path_2=args.opt_path_2)
+    output = compare_opts(opt_path_1=args.opt_path_1, opt_path_2=args.opt_path_2)
+    print(output)

--- a/parlai/scripts/compare_opts.py
+++ b/parlai/scripts/compare_opts.py
@@ -45,7 +45,7 @@ def compare_opts(opt_path_1: str, opt_path_2: str):
                     or inner_key not in opt2[key]
                     or opt1[key][inner_key] != opt2[key][inner_key]
                 ):
-                    print(f'\t{key}:')
+                    print(f'\t{inner_key}:')
                     print(f'\t\tIn opt 1: {opt1[key].get(inner_key, "<MISSING>")}')
                     print(f'\t\tIn opt 2: {opt2[key].get(inner_key, "<MISSING>")}')
         else:

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -4,10 +4,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import json
 import os
 import unittest
+
 import parlai.utils.testing as testing_utils
 from parlai.core.opt import Opt
+from parlai.scripts.compare_opts import compare_opts
 
 """
 Test Opt and related mechanisms.
@@ -31,3 +34,55 @@ class TestOpt(unittest.TestCase):
             o2 = Opt.load(fn)
             assert o != o2
             assert 'override' not in o2
+
+    def test_compare_opts(self):
+        with testing_utils.tempdir() as tmpdir:
+
+            # Define test opts
+            opt1 = {
+                'key0': (1, 2),
+                'key1': 0,
+                'key2': 'a',
+                'key4': {'inner_key0': [1], 'inner_key1': True, 'inner_key2': 'yes'},
+            }
+            opt2 = {
+                'key0': (1, 2),
+                'key1': 1,
+                'key3': 'b',
+                'key4': {'inner_key0': [1], 'inner_key1': False, 'inner_key3': 'no'},
+            }
+
+            # Write test opts
+            opt_dir = tmpdir
+            opt_path_1 = os.path.join(opt_dir, '1.opt')
+            opt_path_2 = os.path.join(opt_dir, '2.opt')
+            with open(opt_path_1, 'w') as f1:
+                json.dump(opt1, f1)
+            with open(opt_path_2, 'w') as f2:
+                json.dump(opt2, f2)
+
+            # Compare opts
+            output = compare_opts(opt_path_1=opt_path_1, opt_path_2=opt_path_2)
+            desired_output = """
+Args only found in opt 1:
+key2: a
+
+Args only found in opt 2:
+key3: b
+
+Args that are different in both opts:
+key1:
+    In opt 1: 0
+    In opt 2: 1
+key4 (printing only non-matching values in each dict):
+    inner_key1:
+        In opt 1: True
+        In opt 2: False
+    inner_key2:
+        In opt 1: yes
+        In opt 2: <MISSING>
+    inner_key3:
+        In opt 1: <MISSING>
+        In opt 2: no
+"""
+            self.assertEqual(output, desired_output)

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -72,17 +72,16 @@ key3: b
 
 Args that are different in both opts:
 key1:
-    In opt 1: 0
-    In opt 2: 1
+\tIn opt 1: 0
+\tIn opt 2: 1
 key4 (printing only non-matching values in each dict):
-    inner_key1:
-        In opt 1: True
-        In opt 2: False
-    inner_key2:
-        In opt 1: yes
-        In opt 2: <MISSING>
-    inner_key3:
-        In opt 1: <MISSING>
-        In opt 2: no
-"""
+\tinner_key1:
+\t\tIn opt 1: True
+\t\tIn opt 2: False
+\tinner_key2:
+\t\tIn opt 1: yes
+\t\tIn opt 2: <MISSING>
+\tinner_key3:
+\t\tIn opt 1: <MISSING>
+\t\tIn opt 2: no"""
             self.assertEqual(output, desired_output)

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -18,6 +18,21 @@ Test Opt and related mechanisms.
 
 
 class TestOpt(unittest.TestCase):
+
+    # Define test opts for opt comparison script
+    compare_opt_1 = {
+        'key0': (1, 2),
+        'key1': 0,
+        'key2': 'a',
+        'override': {'inner_key0': [1], 'inner_key1': True, 'inner_key2': 'yes'},
+    }
+    compare_opt_2 = {
+        'key0': (1, 2),
+        'key1': 1,
+        'key3': 'b',
+        'override': {'inner_key0': [1], 'inner_key1': False, 'inner_key3': 'no'},
+    }
+
     def test_save_load(self):
         o = Opt({'a': 3, 'b': 'foo'})
         with testing_utils.tempdir() as tmpdir:
@@ -36,30 +51,21 @@ class TestOpt(unittest.TestCase):
             assert 'override' not in o2
 
     def test_compare_opts(self):
+        """
+        Compare opts by loading them with Opt.load().
+
+        Will not compare the override field.
+        """
+
         with testing_utils.tempdir() as tmpdir:
-
-            # Define test opts
-            opt1 = {
-                'key0': (1, 2),
-                'key1': 0,
-                'key2': 'a',
-                'key4': {'inner_key0': [1], 'inner_key1': True, 'inner_key2': 'yes'},
-            }
-            opt2 = {
-                'key0': (1, 2),
-                'key1': 1,
-                'key3': 'b',
-                'key4': {'inner_key0': [1], 'inner_key1': False, 'inner_key3': 'no'},
-            }
-
             # Write test opts
             opt_dir = tmpdir
             opt_path_1 = os.path.join(opt_dir, '1.opt')
             opt_path_2 = os.path.join(opt_dir, '2.opt')
             with open(opt_path_1, 'w') as f1:
-                json.dump(opt1, f1)
+                json.dump(self.compare_opt_1, f1)
             with open(opt_path_2, 'w') as f2:
-                json.dump(opt2, f2)
+                json.dump(self.compare_opt_2, f2)
 
             # Compare opts
             output = compare_opts(opt_path_1=opt_path_1, opt_path_2=opt_path_2)
@@ -73,8 +79,43 @@ key3: b
 Args that are different in both opts:
 key1:
 \tIn opt 1: 0
+\tIn opt 2: 1"""
+            self.assertEqual(output, desired_output)
+
+    def test_compare_opts_load_raw(self):
+        """
+        Compare opts by loading them from JSON instead of with Opt.load().
+
+        Will compare the override field.
+        """
+
+        with testing_utils.tempdir() as tmpdir:
+
+            # Write test opts
+            opt_dir = tmpdir
+            opt_path_1 = os.path.join(opt_dir, '1.opt')
+            opt_path_2 = os.path.join(opt_dir, '2.opt')
+            with open(opt_path_1, 'w') as f1:
+                json.dump(self.compare_opt_1, f1)
+            with open(opt_path_2, 'w') as f2:
+                json.dump(self.compare_opt_2, f2)
+
+            # Compare opts
+            output = compare_opts(
+                opt_path_1=opt_path_1, opt_path_2=opt_path_2, load_raw=True
+            )
+            desired_output = """
+Args only found in opt 1:
+key2: a
+
+Args only found in opt 2:
+key3: b
+
+Args that are different in both opts:
+key1:
+\tIn opt 1: 0
 \tIn opt 2: 1
-key4 (printing only non-matching values in each dict):
+override (printing only non-matching values in each dict):
 \tinner_key1:
 \t\tIn opt 1: True
 \t\tIn opt 2: False


### PR DESCRIPTION
**Patch description**
Simple script to compare two `.opt` files. Checks keys present in one but not the other and keys whose values are different in both. If values of keys are dicts in both opts, prints the keys within those dicts that differ between the two opts (useful for comparing `'override'` in the two opts).

**Testing steps**
```pytest tests/test_opt.py```
