### PR TITLE
Add printing of opts into scripts.

### DIFF
--- a/parlai/agents/bart/convert_fairseq_to_parlai.py
+++ b/parlai/agents/bart/convert_fairseq_to_parlai.py
@@ -203,7 +203,7 @@ class ConversionScript(ParlaiScript):
             transformer_common_config['bpe_add_prefix_space'] = True
         parser = ParlaiParser()
         parser.set_params(**transformer_common_config)
-        opt = parser.parse_args([], print_args=False)
+        opt = parser.parse_args([])
 
         # 6. Augment opt with additional ParlAI options
         opt['fp16'] = self.opt['fp16']

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -357,7 +357,7 @@ def add_datapath_and_model_args(opt: Opt):
     model = get_model_name(opt)
     if model is not None:
         parser.add_model_subargs(model)
-    opt_parser = parser.parse_args("", print_args=False)
+    opt_parser = parser.parse_args("")
     for k, v in opt_parser.items():
         if k not in opt:
             opt[k] = v

--- a/parlai/core/opt.py
+++ b/parlai/core/opt.py
@@ -12,6 +12,7 @@ import copy
 import json
 import pickle
 import traceback
+import parlai.utils.logging as logging
 
 from typing import List
 
@@ -131,3 +132,15 @@ class Opt(dict):
             if key in dct:
                 del dct[key]
         return cls(dct)
+
+    def log(self, header="Opt"):
+        from parlai.core.params import print_git_commit
+
+        logging.info(header + ":")
+        for key in sorted(self.keys()):
+            valstr = str(self[key])
+            if valstr.replace(" ", "").replace("\n", "") != valstr:
+                # show newlines as escaped keys, whitespace with quotes, etc
+                valstr = repr(valstr)
+            logging.info(f"    {key}: {valstr}")
+        print_git_commit()

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -1043,13 +1043,19 @@ class ParlaiParser(argparse.ArgumentParser):
         self._process_args_to_opts(args)
         return self.opt, unknowns
 
-    def parse_args(self, args=None, namespace=None):
+    def parse_args(self, args=None, namespace=None, **kwargs):
         """
         Parse the provided arguments and returns a dictionary of the ``args``.
 
         We specifically remove items with ``None`` as values in order to support the
         style ``opt.get(key, default)``, which would otherwise return ``None``.
         """
+        if 'print_args' in kwargs:
+            logging.error(
+                "You gave the print_args flag to parser.parse_args, but this is "
+                "no longer supported. Use opt.log() to print the arguments"
+            )
+            del kwargs['print_args']
         self.add_extra_args(args)
         self.args = super().parse_args(args=args)
 
@@ -1168,28 +1174,6 @@ class ParlaiParser(argparse.ArgumentParser):
             return self.parse_args(args=string_args)
         finally:
             self.error = old_error
-
-    def print_args(self):
-        """
-        Print out all the arguments in this parser.
-        """
-        if not self.opt:
-            self.parse_args(print_args=False)
-        values = {}
-        for key, value in self.opt.items():
-            values[str(key)] = str(value)
-        for group in self._action_groups:
-            group_dict = {
-                a.dest: getattr(self.args, a.dest, None) for a in group._group_actions
-            }
-            namespace = argparse.Namespace(**group_dict)
-            count = 0
-            for key in sorted(namespace.__dict__):
-                if key in values:
-                    if count == 0:
-                        print('[ ' + group.title + ': ] ')
-                    count += 1
-                    print('[  ' + key + ': ' + values[key] + ' ]')
 
     def set_params(self, **kwargs):
         """

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -1043,7 +1043,7 @@ class ParlaiParser(argparse.ArgumentParser):
         self._process_args_to_opts(args)
         return self.opt, unknowns
 
-    def parse_args(self, args=None, namespace=None, print_args=True):
+    def parse_args(self, args=None, namespace=None):
         """
         Parse the provided arguments and returns a dictionary of the ``args``.
 
@@ -1054,13 +1054,7 @@ class ParlaiParser(argparse.ArgumentParser):
         self.args = super().parse_args(args=args)
 
         self._process_args_to_opts(args)
-
-        if print_args:
-            self.print_args()
-            if GIT_AVAILABLE:
-                print_git_commit()
-            print_announcements(self.opt)
-
+        print_announcements(self.opt)
         logging.set_log_level(self.opt.get('loglevel', 'info').upper())
 
         assert '_subparser' not in self.opt
@@ -1171,7 +1165,7 @@ class ParlaiParser(argparse.ArgumentParser):
         self.error = _captured_error
         try:
             string_args = self._kwargs_to_str_args(**kwargs)
-            return self.parse_args(args=string_args, print_args=False)
+            return self.parse_args(args=string_args)
         finally:
             self.error = old_error
 

--- a/parlai/core/script.py
+++ b/parlai/core/script.py
@@ -78,7 +78,7 @@ class ParlaiScript(object):
         Construct and run the script using args, defaulting to getting from CLI.
         """
         parser = cls.setup_args()
-        opt = parser.parse_args(args=args, print_args=False)
+        opt = parser.parse_args(args=args)
         return cls._run_from_parser_and_opt(opt, parser)
 
     @classmethod
@@ -262,7 +262,7 @@ def superscript_main(args=None):
     except ModuleNotFoundError:
         pass
 
-    opt = parser.parse_args(args, print_args=False)
+    opt = parser.parse_args(args)
     cmd = opt.pop('super_command')
     if cmd == 'helpall':
         parser.print_helpall()

--- a/parlai/mturk/core/dev/test/test_full_system.py
+++ b/parlai/mturk/core/dev/test/test_full_system.py
@@ -388,7 +388,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['frontend_version'] = 1
         self.opt['assignment_duration_in_seconds'] = 1

--- a/parlai/mturk/core/dev/test/test_mturk_agent.py
+++ b/parlai/mturk/core/dev/test/test_mturk_agent.py
@@ -76,7 +76,7 @@ class TestAssignState(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         mturk_agent_ids = ['mturk_agent_1']
@@ -148,7 +148,7 @@ class TestMTurkAgent(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         mturk_agent_ids = ['mturk_agent_1']

--- a/parlai/mturk/core/dev/test/test_mturk_manager.py
+++ b/parlai/mturk/core/dev/test/test_mturk_manager.py
@@ -140,7 +140,7 @@ class InitTestMTurkManager(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
@@ -211,7 +211,7 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
@@ -691,7 +691,7 @@ class TestMTurkManagerPoolHandling(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
@@ -803,7 +803,7 @@ class TestMTurkManagerTimeHandling(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
@@ -904,7 +904,7 @@ class TestMTurkManagerLifecycleFunctions(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['task_description'] = 'Test task description'
         self.opt['assignment_duration_in_seconds'] = 6
@@ -1045,7 +1045,7 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']

--- a/parlai/mturk/core/dev/test/test_worker_manager.py
+++ b/parlai/mturk/core/dev/test/test_worker_manager.py
@@ -43,7 +43,7 @@ class TestWorkerState(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         mturk_agent_ids = ['mturk_agent_1']
@@ -143,7 +143,7 @@ class TestWorkerManager(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         mturk_agent_ids = ['mturk_agent_1']

--- a/parlai/mturk/core/legacy_2018/test/test_full_system.py
+++ b/parlai/mturk/core/legacy_2018/test/test_full_system.py
@@ -380,7 +380,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 1
         self.opt['hit_title'] = 'test_hit_title'

--- a/parlai/mturk/core/legacy_2018/test/test_mturk_agent.py
+++ b/parlai/mturk/core/legacy_2018/test/test_mturk_agent.py
@@ -72,7 +72,7 @@ class TestAssignState(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         mturk_agent_ids = ['mturk_agent_1']
@@ -158,7 +158,7 @@ class TestMTurkAgent(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         mturk_agent_ids = ['mturk_agent_1']

--- a/parlai/mturk/core/legacy_2018/test/test_mturk_manager.py
+++ b/parlai/mturk/core/legacy_2018/test/test_mturk_manager.py
@@ -138,7 +138,7 @@ class InitTestMTurkManager(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
@@ -209,7 +209,7 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
@@ -934,7 +934,7 @@ class TestMTurkManagerPoolHandling(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
@@ -1046,7 +1046,7 @@ class TestMTurkManagerTimeHandling(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
@@ -1147,7 +1147,7 @@ class TestMTurkManagerLifecycleFunctions(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['task_description'] = 'Test task description'
         self.opt['assignment_duration_in_seconds'] = 6
@@ -1290,7 +1290,7 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']

--- a/parlai/mturk/core/legacy_2018/test/test_worker_manager.py
+++ b/parlai/mturk/core/legacy_2018/test/test_worker_manager.py
@@ -44,7 +44,7 @@ class TestWorkerState(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         mturk_agent_ids = ['mturk_agent_1']
@@ -141,7 +141,7 @@ class TestWorkerManager(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args(print_args=False)
+        self.opt = argparser.parse_args()
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         mturk_agent_ids = ['mturk_agent_1']

--- a/parlai/mturk/core/test/test_full_system.py
+++ b/parlai/mturk/core/test/test_full_system.py
@@ -381,7 +381,7 @@ class TestMTurkManagerWorkflows(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args([], print_args=False)
+        self.opt = argparser.parse_args([])
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 1
         self.opt['hit_title'] = 'test_hit_title'

--- a/parlai/mturk/core/test/test_mturk_agent.py
+++ b/parlai/mturk/core/test/test_mturk_agent.py
@@ -72,7 +72,7 @@ class TestAssignState(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args([], print_args=False)
+        self.opt = argparser.parse_args([])
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         mturk_agent_ids = ['mturk_agent_1']
@@ -158,7 +158,7 @@ class TestMTurkAgent(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args([], print_args=False)
+        self.opt = argparser.parse_args([])
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         mturk_agent_ids = ['mturk_agent_1']

--- a/parlai/mturk/core/test/test_mturk_manager.py
+++ b/parlai/mturk/core/test/test_mturk_manager.py
@@ -139,7 +139,7 @@ class InitTestMTurkManager(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args([], print_args=False)
+        self.opt = argparser.parse_args([])
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
@@ -210,7 +210,7 @@ class TestMTurkManagerUnitFunctions(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args([], print_args=False)
+        self.opt = argparser.parse_args([])
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
@@ -937,7 +937,7 @@ class TestMTurkManagerPoolHandling(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args([], print_args=False)
+        self.opt = argparser.parse_args([])
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
@@ -1049,7 +1049,7 @@ class TestMTurkManagerTimeHandling(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args([], print_args=False)
+        self.opt = argparser.parse_args([])
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']
@@ -1150,7 +1150,7 @@ class TestMTurkManagerLifecycleFunctions(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args([], print_args=False)
+        self.opt = argparser.parse_args([])
         self.opt['task'] = 'unittest'
         self.opt['task_description'] = 'Test task description'
         self.opt['assignment_duration_in_seconds'] = 6
@@ -1294,7 +1294,7 @@ class TestMTurkManagerConnectedFunctions(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args([], print_args=False)
+        self.opt = argparser.parse_args([])
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         self.mturk_agent_ids = ['mturk_agent_1', 'mturk_agent_2']

--- a/parlai/mturk/core/test/test_worker_manager.py
+++ b/parlai/mturk/core/test/test_worker_manager.py
@@ -44,7 +44,7 @@ class TestWorkerState(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args([], print_args=False)
+        self.opt = argparser.parse_args([])
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         mturk_agent_ids = ['mturk_agent_1']
@@ -141,7 +141,7 @@ class TestWorkerManager(unittest.TestCase):
         argparser = ParlaiParser(False, False)
         argparser.add_parlai_data_path()
         argparser.add_mturk_args()
-        self.opt = argparser.parse_args([], print_args=False)
+        self.opt = argparser.parse_args([])
         self.opt['task'] = 'unittest'
         self.opt['assignment_duration_in_seconds'] = 6
         mturk_agent_ids = ['mturk_agent_1']

--- a/parlai/mturk/tasks/acute_eval/fast_eval.py
+++ b/parlai/mturk/tasks/acute_eval/fast_eval.py
@@ -516,7 +516,7 @@ class ParlAIQuickAcute(object):
         with capture_output():
             parser = self_chat_setup_args()
             parser.set_params(**config)
-            opt = parser.parse_args(args=[], print_args=False)
+            opt = parser.parse_args(args=[])
         self_chat(opt)
 
     def _convert_task_to_conversations(self, config_id: str):
@@ -534,7 +534,7 @@ class ParlAIQuickAcute(object):
         with capture_output():
             parser = convert_task_setup_args()
             parser.set_params(**config)
-            opt = parser.parse_args(args=[], print_args=False)
+            opt = parser.parse_args(args=[])
         convert_task_data(opt)
 
     ##################
@@ -610,7 +610,7 @@ class ParlAIQuickAcute(object):
         """
         self._print_progress(f'Analyzing Results for run id {self.run_id}')
         parser = analysis_setup_args()
-        opt = parser.parse_args([], print_args=False)
+        opt = parser.parse_args([])
         today = datetime.date.today().isoformat()
         self.results_path = f"{self._get_vs_path(f'acute_results/{today}/')}"
         opt.update(

--- a/parlai/mturk/tasks/acute_eval/fast_eval.py
+++ b/parlai/mturk/tasks/acute_eval/fast_eval.py
@@ -579,7 +579,7 @@ class ParlAIQuickAcute(object):
         """
         self._load_pairings_file()
 
-        self.acute_args = acute_add_args(print_args=False)
+        self.acute_args = acute_add_args()
         self.acute_args.update(ACUTE_DEFAULT_ARGS)
         total_convos = self.opt['matchups_per_pair'] * len(self.combos)
         self.acute_args.update(
@@ -632,7 +632,7 @@ class ParlAIQuickAcute(object):
 
 if __name__ == '__main__':
     parser = setup_args()
-    runner = ParlAIQuickAcute(parser.parse_args(print_args=False))
+    runner = ParlAIQuickAcute(parser.parse_args())
 
     # Compile Chat Logs
     runner.compile_chat_logs()

--- a/parlai/mturk/tasks/acute_eval/run.py
+++ b/parlai/mturk/tasks/acute_eval/run.py
@@ -25,7 +25,7 @@ DEFAULT_TASK_CONFIG = {
 AGENT_DISPLAY_NAME = 'RatingWorker'
 
 
-def add_args(from_argv=False, print_args=True):
+def add_args(from_argv=False):
     """
     Add arguments to parser and either parse from commandline or initialize to defaults
     (for overriding in scripts)

--- a/parlai/mturk/tasks/acute_eval/run.py
+++ b/parlai/mturk/tasks/acute_eval/run.py
@@ -97,9 +97,9 @@ def add_args(from_argv=False):
     )
     argparser.set_defaults(allowed_conversation=1)
     if from_argv:
-        return argparser.parse_args(print_args=print_args)
+        return argparser.parse_args()
     else:
-        return argparser.parse_args(args=[], print_args=print_args)
+        return argparser.parse_args(args=[])
 
 
 class AcuteEvaluator(object):

--- a/parlai/scripts/build_candidates.py
+++ b/parlai/scripts/build_candidates.py
@@ -50,6 +50,7 @@ def setup_args(parser=None) -> ParlaiParser:
 
 
 def build_cands(opt):
+    opt.log()
     # create repeat label agent and assign it to the specified task
     if opt['numthreads'] > 1:
         # Broken in hogwild mode. Just fall back to single processing mode

--- a/parlai/scripts/build_dict.py
+++ b/parlai/scripts/build_dict.py
@@ -102,6 +102,8 @@ def build_dict(opt, skip_if_built=False):
     # instantiated while building the dict
     ordered_opt['image_mode'] = 'no_image_model'
 
+    ordered_opt.log()
+
     datatypes = ['train:ordered:stream']
     if opt.get('dict_include_valid'):
         datatypes.append('valid:stream')

--- a/parlai/scripts/convert_data_to_fasttext_format.py
+++ b/parlai/scripts/convert_data_to_fasttext_format.py
@@ -28,6 +28,7 @@ def dump_data(opt):
     # create repeat label agent and assign it to the specified task
     agent = RepeatLabelAgent(opt)
     world = create_task(opt, agent)
+    opt.log()
     if opt['outfile'] is None:
         outfile = tempfile.mkstemp(
             prefix='{}_{}_'.format(opt['task'], opt['datatype']), suffix='.txt'

--- a/parlai/scripts/convert_data_to_parlai_format.py
+++ b/parlai/scripts/convert_data_to_parlai_format.py
@@ -28,6 +28,7 @@ def dump_data(opt):
     # create repeat label agent and assign it to the specified task
     agent = RepeatLabelAgent(opt)
     world = create_task(opt, agent)
+    opt.log()
     ignorefields = opt.get('ignore_fields', '')
     if opt['outfile'] is None:
         outfile = tempfile.mkstemp(

--- a/parlai/scripts/convo_render.py
+++ b/parlai/scripts/convo_render.py
@@ -297,6 +297,7 @@ def validate_args(opt):
 
 def render_convo(opt):
     # Run
+    opt.log()
     extension = validate_args(opt)
     input_file, output_file = opt['intput'], opt['output']
     height, width = opt['height'], opt['width']

--- a/parlai/scripts/data_stats.py
+++ b/parlai/scripts/data_stats.py
@@ -73,7 +73,7 @@ def report(world, counts, log_time):
     return text, log
 
 
-def verify(opt, printargs=None, print_parser=None):
+def verify(opt):
     if opt['datatype'] == 'train':
         logging.warn('changing datatype from train to train:ordered')
         opt['datatype'] = 'train:ordered'
@@ -81,6 +81,7 @@ def verify(opt, printargs=None, print_parser=None):
     # create repeat label agent and assign it to the specified task
     agent = RepeatLabelAgent(opt)
     world = create_task(opt, agent)
+    opt.log()
 
     log_every_n_secs = opt.get('log_every_n_secs', -1)
     if log_every_n_secs <= 0:
@@ -161,8 +162,7 @@ def verify(opt, printargs=None, print_parser=None):
 
         if log_time.time() > log_every_n_secs:
             text, log = report(world, counts, log_time)
-            if print_parser:
-                logging.info(text)
+            logging.info(text)
 
     try:
         # print dataset size if available
@@ -176,7 +176,7 @@ def verify(opt, printargs=None, print_parser=None):
 
 
 def obtain_stats(opt, parser):
-    report_text, report_log = verify(opt, print_parser=parser)
+    report_text, report_log = verify(opt)
     print(report_text.replace('\\n', '\n'))
 
 

--- a/parlai/scripts/detect_offensive_language.py
+++ b/parlai/scripts/detect_offensive_language.py
@@ -43,29 +43,19 @@ def setup_args(parser=None):
     return parser
 
 
-def detect(opt, printargs=None, print_parser=None):
+def detect(opt):
     """
     Checks a task for offensive language.
     """
-    if print_parser is not None:
-        if print_parser is True and isinstance(opt, ParlaiParser):
-            print_parser = opt
-        elif print_parser is False:
-            print_parser = None
-    random.seed(42)
-
     # Create model and assign it to the specified task
     agent = create_agent(opt, requireModelExists=True)
     world = create_task(opt, agent)
+    agent.opt.log()
     if opt['safety'] == 'string_matcher' or opt['safety'] == 'all':
         offensive_string_matcher = OffensiveStringMatcher()
     if opt['safety'] == 'classifier' or opt['safety'] == 'all':
         offensive_classifier = OffensiveLanguageClassifier()
 
-    if print_parser:
-        # Show arguments after loading model
-        print_parser.opt = agent.opt
-        print_parser.print_args()
     log_every_n_secs = opt.get('log_every_n_secs', -1)
     if log_every_n_secs <= 0:
         log_every_n_secs = float('inf')
@@ -139,7 +129,7 @@ class DetectOffensive(ParlaiScript):
         return setup_args()
 
     def run(self):
-        return detect(self.opt, print_parser=self.parser)
+        return detect(self.opt)
 
 
 if __name__ == '__main__':

--- a/parlai/scripts/detect_offensive_language.py
+++ b/parlai/scripts/detect_offensive_language.py
@@ -22,8 +22,6 @@ from parlai.utils.misc import TimeLogger
 import parlai.utils.logging as logging
 from parlai.core.script import ParlaiScript, register_script
 
-import random
-
 
 def setup_args(parser=None):
     if parser is None:

--- a/parlai/scripts/display_data.py
+++ b/parlai/scripts/display_data.py
@@ -67,6 +67,7 @@ def display_data(opt):
         opt['datatype'] = f"{opt['datatype']}:ordered"
 
     # create repeat label agent and assign it to the specified task
+    opt.log()
     agent = RepeatLabelAgent(opt)
     world = create_task(opt, agent)
 

--- a/parlai/scripts/display_model.py
+++ b/parlai/scripts/display_model.py
@@ -64,6 +64,7 @@ def display_model(opt):
     # Create model and assign it to the specified task
     agent = create_agent(opt)
     world = create_task(opt, agent)
+    agent.opt.log()
 
     # Show some example dialogs.
     turn = 0

--- a/parlai/scripts/distributed_eval.py
+++ b/parlai/scripts/distributed_eval.py
@@ -31,8 +31,6 @@ An example sbatch script is below, for a 2-host, 8-GPU setup (16 total gpus):
     -m seq2seq -t convai2 --dict-file /path/to/dict-file
 """
 
-import os
-
 import parlai.scripts.eval_model as eval_model
 import parlai.utils.distributed as distributed_utils
 

--- a/parlai/scripts/distributed_eval.py
+++ b/parlai/scripts/distributed_eval.py
@@ -41,7 +41,7 @@ def main():
     parser = eval_model.setup_args()
     parser.add_distributed_training_args()
     parser.add_argument('--port', type=int, default=61337, help='TCP port number')
-    opt = parser.parse_args(print_args=(os.environ['SLURM_PROCID'] == '0'))
+    opt = parser.parse_args()
 
     with distributed_utils.slurm_distributed_context(opt) as opt:
         return eval_model.eval_model(opt)

--- a/parlai/scripts/distributed_train.py
+++ b/parlai/scripts/distributed_train.py
@@ -51,9 +51,6 @@ class DistributedTrain(ParlaiScript):
     def run(self):
         with distributed_utils.slurm_distributed_context(self.opt) as opt:
             self.train_loop = single_train.TrainLoop(opt)
-            self.parser = self.parser
-            self.parser.opt = self.train_loop.agent.opt
-            self.parser.print_args()
             return self.train_loop.train()
 
 

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -172,13 +172,11 @@ def _eval_single_world(opt, agent, task):
     return report
 
 
-def eval_model(opt, print_parser=None):
+def eval_model(opt):
     """
     Evaluates a model.
 
     :param opt: tells the evaluation function how to run
-    :param bool print_parser: if provided, prints the options that are set within the
-        model after loading the model
     :return: the final result of calling report()
     """
     random.seed(42)
@@ -196,10 +194,7 @@ def eval_model(opt, print_parser=None):
 
     # load model and possibly print opt
     agent = create_agent(opt, requireModelExists=True)
-    if print_parser:
-        # show args after loading model
-        print_parser.opt = agent.opt
-        print_parser.print_args()
+    agent.opt.log()
 
     tasks = opt['task'].split(',')
     reports = []
@@ -229,7 +224,7 @@ class EvalModel(ParlaiScript):
         return setup_args()
 
     def run(self):
-        return eval_model(self.opt, print_parser=self.parser)
+        return eval_model(self.opt)
 
 
 if __name__ == '__main__':

--- a/parlai/scripts/eval_wordstat.py
+++ b/parlai/scripts/eval_wordstat.py
@@ -105,19 +105,18 @@ def get_word_stats(text, agent_dict, bins=(0, 100, 1000, 100000)):
     return freqs, len(pred_freq), wlength, clength
 
 
-def eval_wordstat(opt, print_parser=None):
+def eval_wordstat(opt):
     """
     Evaluates a model.
 
     :param opt: tells the evaluation function how to run
-    :param print_parser: if provided, prints the options that are set within the
-        model after loading the model
     """
     random.seed(42)
 
     # Create model and assign it to the specified task
     agent = create_agent(opt, requireModelExists=True)
     world = create_task(opt, agent)
+    agent.opt.log()
 
     if opt.get('external_dict'):
         print('[ Using external dictionary from: {} ]'.format(opt['external_dict']))
@@ -130,10 +129,6 @@ def eval_wordstat(opt, print_parser=None):
 
     batch_size = opt['batchsize']
 
-    if print_parser:
-        # Show arguments after loading model
-        print_parser.opt = agent.opt
-        print_parser.print_args()
     log_every_n_secs = opt.get('log_every_n_secs', -1)
     if log_every_n_secs <= 0:
         log_every_n_secs = float('inf')
@@ -286,7 +281,7 @@ class EvalWordStat(ParlaiScript):
         return setup_args()
 
     def run(self):
-        return eval_wordstat(self.opt, print_parser=self.parser)
+        return eval_wordstat(self.opt)
 
 
 if __name__ == '__main__':

--- a/parlai/scripts/extract_image_feature.py
+++ b/parlai/scripts/extract_image_feature.py
@@ -47,6 +47,7 @@ def extract_feats(opt):
     opt['gpu'] = 0
     opt['num_epochs'] = 1
     opt['num_load_threads'] = 20
+    opt.log()
     logging.info("Loading Images")
     # create repeat label agent and assign it to the specified task
     agent = RepeatLabelAgent(opt)

--- a/parlai/scripts/interactive.py
+++ b/parlai/scripts/interactive.py
@@ -75,22 +75,14 @@ def setup_args(parser=None):
     return parser
 
 
-def interactive(opt, print_parser=None):
-    if print_parser is not None:
-        if print_parser is True and isinstance(opt, ParlaiParser):
-            print_parser = opt
-        elif print_parser is False:
-            print_parser = None
+def interactive(opt):
     if isinstance(opt, ParlaiParser):
         logging.error('interactive should be passed opt not Parser')
         opt = opt.parse_args()
 
     # Create model and assign it to the specified task
     agent = create_agent(opt, requireModelExists=True)
-    if print_parser:
-        # Show arguments after loading model
-        print_parser.opt = agent.opt
-        print_parser.print_args()
+    agent.opt.log()
     human_agent = LocalHumanAgent(opt)
     # set up world logger
     world_logger = WorldLogger(opt) if opt.get('outfile') else None
@@ -123,7 +115,7 @@ class Interactive(ParlaiScript):
         return setup_args()
 
     def run(self):
-        return interactive(self.opt, print_parser=self.parser)
+        return interactive(self.opt)
 
 
 if __name__ == '__main__':

--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -252,13 +252,13 @@ def setup_interweb_args(shared):
 
 
 def interactive_web(opt):
-    SHARED['opt'] = parser.opt
 
     SHARED['opt']['task'] = 'parlai.agents.local_human.local_human:LocalHumanAgent'
 
     # Create model and assign it to the specified task
     agent = create_agent(SHARED.get('opt'), requireModelExists=True)
     agent.opt.log()
+    SHARED['opt'] = agent.opt
     SHARED['agent'] = agent
     SHARED['world'] = create_task(SHARED.get('opt'), SHARED['agent'])
 

--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -251,19 +251,17 @@ def setup_interweb_args(shared):
     return parser
 
 
-def interactive_web(opt, parser):
+def interactive_web(opt):
     SHARED['opt'] = parser.opt
 
     SHARED['opt']['task'] = 'parlai.agents.local_human.local_human:LocalHumanAgent'
 
     # Create model and assign it to the specified task
     agent = create_agent(SHARED.get('opt'), requireModelExists=True)
+    agent.opt.log()
     SHARED['agent'] = agent
     SHARED['world'] = create_task(SHARED.get('opt'), SHARED['agent'])
 
-    # show args after loading model
-    parser.opt = agent.opt
-    parser.print_args()
     MyHandler.protocol_version = 'HTTP/1.0'
     httpd = HTTPServer((opt['host'], opt['port']), MyHandler)
     logging.info('http://{}:{}/'.format(opt['host'], opt['port']))
@@ -282,7 +280,7 @@ class InteractiveWeb(ParlaiScript):
         return setup_interweb_args(SHARED)
 
     def run(self):
-        return interactive_web(self.opt, self.parser)
+        return interactive_web(self.opt)
 
 
 if __name__ == '__main__':

--- a/parlai/scripts/profile_interactive.py
+++ b/parlai/scripts/profile_interactive.py
@@ -49,25 +49,12 @@ def setup_args(parser=None):
     return parser
 
 
-def profile_interactive(opt, print_parser=None):
-    if print_parser is not None:
-        if print_parser is True and isinstance(opt, ParlaiParser):
-            print_parser = opt
-        elif print_parser is False:
-            print_parser = None
-    if isinstance(opt, ParlaiParser):
-        logging.error('interactive should be passed opt not Parser')
-        opt = opt.parse_args()
-
+def profile_interactive(opt):
     # Create model and assign it to the specified task
     agent = create_agent(opt, requireModelExists=True)
     human_agent = RepeatQueryAgent(opt)
     world = create_task(opt, [human_agent, agent])
-
-    if print_parser:
-        # Show arguments after loading model
-        print_parser.opt = agent.opt
-        print_parser.print_args()
+    agent.opt.log()
 
     pr = cProfile.Profile()
     pr.enable()
@@ -101,7 +88,7 @@ class ProfileInteractive(ParlaiScript):
         return setup_args()
 
     def run(self):
-        return profile_interactive(self.opt, print_parser=self.parser)
+        return profile_interactive(self.opt)
 
 
 if __name__ == '__main__':

--- a/parlai/scripts/profile_train.py
+++ b/parlai/scripts/profile_train.py
@@ -60,9 +60,6 @@ def setup_args(parser=None):
 
 
 def profile(opt):
-    if isinstance(opt, ParlaiParser):
-        logging.error('profile should be passed opt not Parser')
-        opt = opt.parse_args()
     if opt['torch'] or opt['torch_cuda']:
         with torch.autograd.profiler.profile(use_cuda=opt['torch_cuda']) as prof:
             TrainLoop(opt).train()

--- a/parlai/scripts/safe_interactive.py
+++ b/parlai/scripts/safe_interactive.py
@@ -46,22 +46,14 @@ def setup_args(parser=None):
     return parser
 
 
-def safe_interactive(opt, print_parser=None):
-    if print_parser is not None:
-        if print_parser is True and isinstance(opt, ParlaiParser):
-            print_parser = opt
-        elif print_parser is False:
-            print_parser = None
+def safe_interactive(opt):
     if isinstance(opt, ParlaiParser):
         logging.error('interactive should be passed opt not Parser')
         opt = opt.parse_args()
 
     # Create model and assign it to the specified task
     agent = create_agent(opt, requireModelExists=True)
-    if print_parser:
-        # Show arguments after loading model
-        print_parser.opt = agent.opt
-        print_parser.print_args()
+    agent.opt.log()
     human_agent = SafeLocalHumanAgent(opt)
     world = create_task(opt, [human_agent, agent])
 
@@ -87,7 +79,7 @@ class SafeInteractive(ParlaiScript):
         return setup_args()
 
     def run(self):
-        return safe_interactive(self.opt, print_parser=self.parser)
+        return safe_interactive(self.opt)
 
 
 if __name__ == '__main__':

--- a/parlai/scripts/self_chat.py
+++ b/parlai/scripts/self_chat.py
@@ -103,6 +103,7 @@ def self_chat(opt):
 
     # Create agents
     agent1 = create_agent(opt, requireModelExists=True)
+    agent1.opt.log("Agent 1 Opt")
     if partner is None:
         # Self chat with same model
         agent2 = agent1.clone()
@@ -119,6 +120,7 @@ def self_chat(opt):
             f"WARNING: Setting partner interactive mode to: {partner_opt['interactive_mode']}"
         )
         agent2 = create_agent_from_model_file(partner, partner_opt)
+        agent2.opt.log("Agent 2 Opt")
 
     # Set IDs
     agent1.id = agent1.id + "_1"

--- a/parlai/scripts/token_stats.py
+++ b/parlai/scripts/token_stats.py
@@ -51,6 +51,7 @@ class TokenStats(ParlaiScript):
         if 'ordered' not in self.opt['datatype'] and 'train' in self.opt['datatype']:
             self.opt['datatype'] = self.opt['datatype'] + ':ordered'
         agent = create_agent(self.opt)
+        agent.opt.log()
         num_examples = self.opt['num_examples']
         field = self.opt['field'] + '_vec'
         if num_examples < 0:

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -276,6 +276,7 @@ class TrainLoop:
 
         # Create model and assign it to the specified task
         self.agent = create_agent(opt)
+        self.agent.opt.log()
         self.world = create_task(opt, self.agent)
         # set up timers
         self.train_time = Timer()
@@ -766,8 +767,6 @@ class TrainModel(ParlaiScript):
 
     def run(self):
         self.train_loop = TrainLoop(self.opt)
-        self.parser.opt = self.train_loop.agent.opt
-        self.parser.print_args()
         return self.train_loop.train()
 
 

--- a/parlai/scripts/verify_data.py
+++ b/parlai/scripts/verify_data.py
@@ -56,10 +56,11 @@ def warn(txt, act, opt):
         warn_once(txt)
 
 
-def verify(opt, printargs=None, print_parser=None):
+def verify(opt):
     if opt['datatype'] == 'train':
         logging.warn("changing datatype from train to train:ordered")
         opt['datatype'] = 'train:ordered'
+    opt.log()
     # create repeat label agent and assign it to the specified task
     agent = RepeatLabelAgent(opt)
     world = create_task(opt, agent)
@@ -120,8 +121,7 @@ def verify(opt, printargs=None, print_parser=None):
 
         if log_time.time() > log_every_n_secs:
             text, log = report(world, counts, log_time)
-            if print_parser:
-                print(text)
+            print(text)
 
     try:
         # print dataset size if available
@@ -136,9 +136,7 @@ def verify(opt, printargs=None, print_parser=None):
 
 
 def verify_data(opt, parser):
-    report_text, report_log = verify(
-        parser.parse_args(print_args=False), print_parser=parser
-    )
+    report_text, report_log = verify(parser.parse_args())
     print(report_text)
 
 

--- a/parlai/tasks/talkthewalk/run.py
+++ b/parlai/tasks/talkthewalk/run.py
@@ -89,4 +89,4 @@ def run(opt):
 
 if __name__ == '__main__':
     parser = setup_args()
-    run(parser.parse_args(print_args=False))
+    run(parser.parse_args())

--- a/parlai/tasks/wizard_of_wikipedia/worlds.py
+++ b/parlai/tasks/wizard_of_wikipedia/worlds.py
@@ -69,7 +69,7 @@ class InteractiveWorld(DialogPartnerWorld):
             model='projects:wizard_of_wikipedia:knowledge_retriever',
             add_token_knowledge=add_token_knowledge,
         )
-        knowledge_opt = parser.parse_args([], print_args=False)
+        knowledge_opt = parser.parse_args([])
         self.knowledge_agent = create_agent(knowledge_opt)
 
     def _load_topics(self, opt):

--- a/parlai/utils/safety.py
+++ b/parlai/utils/safety.py
@@ -45,7 +45,7 @@ class OffensiveLanguageClassifier:
             model_file='zoo:dialogue_safety/single_turn/model',
             print_scores=True,
         )
-        safety_opt = parser.parse_args([], print_args=False)
+        safety_opt = parser.parse_args([])
         return create_agent(safety_opt)
 
     def contains_offensive_language(self, text):

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -327,7 +327,7 @@ def display_data(opt):
 
     parser = dd.setup_args()
     parser.set_params(**opt)
-    popt = parser.parse_args([], print_args=False)
+    popt = parser.parse_args([])
 
     with capture_output() as train_output:
         popt['datatype'] = 'train:stream'
@@ -352,7 +352,7 @@ def display_model(opt) -> Tuple[str, str, str]:
 
     parser = dm.setup_args()
     parser.set_params(**opt)
-    popt = parser.parse_args([], print_args=False)
+    popt = parser.parse_args([])
     with capture_output() as train_output:
         # evalmode so that we don't hit train_step
         popt['datatype'] = 'train:evalmode:stream'

--- a/projects/controllable_dialogue/Analysis_n_Graphs.ipynb
+++ b/projects/controllable_dialogue/Analysis_n_Graphs.ipynb
@@ -104,7 +104,7 @@
    "source": [
     "# Get where the logs are stored\n",
     "from parlai.core.params import ParlaiParser\n",
-    "basic_opt = ParlaiParser().parse_args([], print_args=False)\n",
+    "basic_opt = ParlaiParser().parse_args([])\n",
     "\n",
     "# make sure we download everything\n",
     "from projects.controllable_dialogue.tasks.build import build\n",

--- a/projects/controllable_dialogue/eval_wordstat.py
+++ b/projects/controllable_dialogue/eval_wordstat.py
@@ -117,13 +117,11 @@ def update_sent_attr_stats(sent_attrs, history, prediction):
     return sent_attrs
 
 
-def eval_wordstat(opt, print_parser=None):
+def eval_wordstat(opt):
     """
     Evaluates a model.
 
     :param opt: tells the evaluation function how to run
-    :param print_parser: if provided, prints the options that are set within the
-        model after loading the model
     """
     random.seed(42)
 
@@ -145,10 +143,6 @@ def eval_wordstat(opt, print_parser=None):
 
     batch_size = opt['batchsize']
 
-    if print_parser:
-        # Show arguments after loading model
-        print_parser.opt = agent.opt
-        print_parser.print_args()
     log_every_n_secs = opt.get('log_every_n_secs', -1)
     if log_every_n_secs <= 0:
         log_every_n_secs = float('inf')
@@ -298,4 +292,4 @@ def eval_wordstat(opt, print_parser=None):
 
 if __name__ == '__main__':
     parser = setup_args()
-    eval_wordstat(parser.parse_args(print_args=False), print_parser=parser)
+    eval_wordstat(parser.parse_args())

--- a/projects/controllable_dialogue/interactive.py
+++ b/projects/controllable_dialogue/interactive.py
@@ -21,4 +21,4 @@ if __name__ == '__main__':
     )
     print('*' * 80 + '\n')
 
-    interactive(parser.parse_args(print_args=False), print_parser=parser)
+    interactive(parser.parse_args())

--- a/projects/controllable_dialogue/tasks/build.py
+++ b/projects/controllable_dialogue/tasks/build.py
@@ -57,5 +57,5 @@ def make_path(opt, fname):
 
 
 if __name__ == '__main__':
-    opt = params.ParlaiParser().parse_args(print_args=False)
+    opt = params.ParlaiParser().parse_args()
     build(opt)

--- a/projects/drqa/eval_opensquad.py
+++ b/projects/drqa/eval_opensquad.py
@@ -16,5 +16,5 @@ if __name__ == '__main__':
         retriever_model_file='models:wikipedia_full/tfidf_retriever/model',
         reader_model_file='models:drqa/squad/model',
     )
-    opt = parser.parse_args(print_args=False)
+    opt = parser.parse_args()
     eval_model(opt)

--- a/projects/drqa/eval_opensquad.py
+++ b/projects/drqa/eval_opensquad.py
@@ -17,4 +17,4 @@ if __name__ == '__main__':
         reader_model_file='models:drqa/squad/model',
     )
     opt = parser.parse_args(print_args=False)
-    eval_model(opt, print_parser=parser)
+    eval_model(opt)

--- a/projects/drqa/eval_pretrained.py
+++ b/projects/drqa/eval_pretrained.py
@@ -15,4 +15,4 @@ if __name__ == '__main__':
         task='squad:fulldoc', model='drqa', model_file='models:drqa/squad/model'
     )
     opt = parser.parse_args(print_args=False)
-    eval_model(opt, print_parser=parser)
+    eval_model(opt)

--- a/projects/drqa/eval_pretrained.py
+++ b/projects/drqa/eval_pretrained.py
@@ -14,5 +14,5 @@ if __name__ == '__main__':
     parser.set_params(
         task='squad:fulldoc', model='drqa', model_file='models:drqa/squad/model'
     )
-    opt = parser.parse_args(print_args=False)
+    opt = parser.parse_args()
     eval_model(opt)

--- a/projects/image_chat/interactive.py
+++ b/projects/image_chat/interactive.py
@@ -308,7 +308,7 @@ def setup_interactive():
     Set up the interactive script.
     """
     parser = setup_args()
-    opt = parser.parse_args(print_args=True)
+    opt = parser.parse_args()
     if not opt.get("model_file"):
         raise RuntimeError("Please specify a model file")
     if opt.get("fixed_cands_path") is None:

--- a/projects/personality_captions/interactive.py
+++ b/projects/personality_captions/interactive.py
@@ -266,7 +266,7 @@ def setup_interactive():
     Set up the interactive script.
     """
     parser = setup_args()
-    opt = parser.parse_args(print_args=True)
+    opt = parser.parse_args()
     if not opt.get('model_file'):
         raise RuntimeError('Please specify a model file')
     if opt.get('fixed_cands_path') is None:

--- a/projects/self_feeding/download_data.py
+++ b/projects/self_feeding/download_data.py
@@ -9,5 +9,5 @@ from parlai.tasks.self_feeding.build import build
 
 
 if __name__ == '__main__':
-    opt = params.ParlaiParser().parse_args(print_args=False)
+    opt = params.ParlaiParser().parse_args()
     build(opt)

--- a/projects/self_feeding/interactive.py
+++ b/projects/self_feeding/interactive.py
@@ -31,16 +31,7 @@ def setup_args(parser=None):
     return parser
 
 
-def interactive(opt, print_parser=None):
-    if print_parser is not None:
-        if print_parser is True and isinstance(opt, ParlaiParser):
-            print_parser = opt
-        elif print_parser is False:
-            print_parser = None
-    if isinstance(opt, ParlaiParser):
-        print('[ Deprecated Warning: interactive should be passed opt not Parser ]')
-        opt = opt.parse_args()
-
+def interactive(opt):
     opt['task'] = 'self_feeding'
     build(opt)
     opt['task'] = 'parlai.agents.local_human.local_human:LocalHumanAgent'
@@ -71,11 +62,6 @@ def interactive(opt, print_parser=None):
     agent = create_agent(opt, requireModelExists=True)
     world = create_task(opt, agent)
 
-    if print_parser:
-        # Show arguments after loading model
-        print_parser.opt = agent.opt
-        print_parser.print_args()
-
     # Show some example dialogs:
     while True:
         world.parley()
@@ -87,4 +73,4 @@ def interactive(opt, print_parser=None):
 if __name__ == '__main__':
     random.seed(42)
     parser = setup_args()
-    interactive(parser.parse_args(print_args=False), print_parser=parser)
+    interactive(parser.parse_args())

--- a/projects/self_feeding/scripts/create_synth_supp.py
+++ b/projects/self_feeding/scripts/create_synth_supp.py
@@ -78,8 +78,6 @@ def create_supp(opt):
     Evaluates a model.
 
     :param opt: tells the evaluation function how to run
-    :param bool print_parser: if provided, prints the options that are set within the
-        model after loading the model
     :return: the final result of calling report()
     """
     # Create model and assign it to the specified task

--- a/projects/wizard_of_wikipedia/scripts/interactive_retrieval_model.py
+++ b/projects/wizard_of_wikipedia/scripts/interactive_retrieval_model.py
@@ -29,5 +29,5 @@ if __name__ == '__main__':
         eval_candidates='fixed',
         interactive_mode=True,
     )
-    opt = parser.parse_args(print_args=False)
+    opt = parser.parse_args()
     interactive(opt)

--- a/projects/wizard_of_wikipedia/scripts/interactive_retrieval_model.py
+++ b/projects/wizard_of_wikipedia/scripts/interactive_retrieval_model.py
@@ -30,4 +30,4 @@ if __name__ == '__main__':
         interactive_mode=True,
     )
     opt = parser.parse_args(print_args=False)
-    interactive(opt, print_parser=parser)
+    interactive(opt)

--- a/tests/datatests/test_new_tasks.py
+++ b/tests/datatests/test_new_tasks.py
@@ -25,7 +25,7 @@ class TestNewTasks(unittest.TestCase):
 
     def test_verify_data(self):
         parser = setup_args()
-        opt = parser.parse_args([], print_args=False)
+        opt = parser.parse_args([])
         changed_task_files = [
             fn
             for fn in testing_utils.git_changed_files()
@@ -57,11 +57,11 @@ class TestNewTasks(unittest.TestCase):
 
             for subt in subtasks:
                 parser = setup_args()
-                opt = parser.parse_args(args=['--task', subt], print_args=False)
+                opt = parser.parse_args(args=['--task', subt])
                 opt['task'] = subt
                 try:
                     with testing_utils.capture_output():
-                        text, log = verify(opt, print_parser=False)
+                        text, log = verify(opt)
                 except Exception:
                     found_errors = True
                     traceback.print_exc()

--- a/tests/nightly/gpu/test_transresnet.py
+++ b/tests/nightly/gpu/test_transresnet.py
@@ -34,7 +34,7 @@ class TestTransresnet(unittest.TestCase):
         """
         parser = display_data.setup_args()
         parser.set_defaults(**MODEL_OPTIONS)
-        opt = parser.parse_args([], print_args=False)
+        opt = parser.parse_args([])
         opt['num_examples'] = 1
         display_data.display_data(opt)
 

--- a/tests/nightly/gpu/test_transresnet_multimodal.py
+++ b/tests/nightly/gpu/test_transresnet_multimodal.py
@@ -33,7 +33,7 @@ class TestTransresnet(unittest.TestCase):
         """
         parser = display_data.setup_args()
         parser.set_defaults(**MODEL_OPTIONS)
-        opt = parser.parse_args([], print_args=False)
+        opt = parser.parse_args([])
         opt['num_examples'] = 1
         display_data.display_data(opt)
 

--- a/tests/nightly/gpu/test_wizard.py
+++ b/tests/nightly/gpu/test_wizard.py
@@ -49,7 +49,7 @@ class TestWizardModel(unittest.TestCase):
         # go ahead and download things here
         parser = display_data.setup_args()
         parser.set_defaults(**END2END_OPTIONS)
-        opt = parser.parse_args([], print_args=False)
+        opt = parser.parse_args([])
         opt['num_examples'] = 1
         opt['display_verbose'] = True
         display_data.display_data(opt)
@@ -81,7 +81,7 @@ class TestKnowledgeRetriever(unittest.TestCase):
             model='projects:wizard_of_wikipedia:knowledge_retriever',
             add_token_knowledge=True,
         )
-        knowledge_opt = parser.parse_args([], print_args=False)
+        knowledge_opt = parser.parse_args([])
         knowledge_agent = create_agent(knowledge_opt)
 
         knowledge_agent.observe(

--- a/tests/tasks/self_chat/test_worlds.py
+++ b/tests/tasks/self_chat/test_worlds.py
@@ -21,7 +21,7 @@ class TestSelfChat(unittest.TestCase):
             selfchat_task=True,
             selfchat_max_turns=1,
         )
-        self.opt = parser.parse_args([], print_args=False)
+        self.opt = parser.parse_args([])
 
         agent1 = RepeatLabelAgent(self.opt)
         agent2 = agent1.clone()

--- a/tests/test_apex.py
+++ b/tests/test_apex.py
@@ -53,7 +53,6 @@ class TestNoApex(unittest.TestCase):
                 '--optimizer',
                 'adam',
             ],
-            print_args=False,
         )
         create_agent(opt, requireModelExists=True)
 

--- a/tests/test_build_data.py
+++ b/tests/test_build_data.py
@@ -22,7 +22,7 @@ class TestBuildData(unittest.TestCase):
     dest_filenames = ('mnist0.tar.gz', 'mnist1.tar.gz', 'mnist2.tar.gz')
 
     def setUp(self):
-        self.datapath = ParlaiParser().parse_args([], print_args=False)['datapath']
+        self.datapath = ParlaiParser().parse_args([])['datapath']
         self.datapath = os.path.join(self.datapath, 'build_data_pyt_data')
         os.makedirs(self.datapath, exist_ok=True)
 

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -18,7 +18,7 @@ class TestConversations(unittest.TestCase):
     """
 
     def setUp(self):
-        self.datapath = ParlaiParser().parse_args([], print_args=False)['datapath']
+        self.datapath = ParlaiParser().parse_args([])['datapath']
         self.datapath = os.path.join(self.datapath, 'tmp_conversations')
         os.makedirs(self.datapath, exist_ok=True)
 

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -134,7 +134,7 @@ class TestDictionary(unittest.TestCase):
         """
         argparser = ParlaiParser()
         DictionaryAgent.add_cmdline_args(argparser)
-        opt = argparser.parse_args([], print_args=False)
+        opt = argparser.parse_args([])
         dictionary = DictionaryAgent(opt)
         num_builtin = len(dictionary)
 
@@ -162,7 +162,7 @@ class TestDictionary(unittest.TestCase):
         Check that moving a model without moving the dictfile raises an error.
         """
         # Download model, move to a new location
-        datapath = ParlaiParser().parse_args([], print_args=False)['datapath']
+        datapath = ParlaiParser().parse_args([])['datapath']
         try:
             # remove unittest models if there before
             shutil.rmtree(os.path.join(datapath, 'models/unittest'))
@@ -189,7 +189,7 @@ class TestDictionary(unittest.TestCase):
 
         parser = tms.setup_args()
         parser.set_params(task='babi:task1k:1', model='seq2seq')
-        popt = parser.parse_args([], print_args=False)
+        popt = parser.parse_args([])
         with self.assertRaises(RuntimeError):
             tms.TrainLoop(popt)
 
@@ -209,7 +209,7 @@ class TestByteLevelBPE(unittest.TestCase):
             bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,
             bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
         )
-        opt = parser.parse_args([], print_args=False)
+        opt = parser.parse_args([])
         agent = DictionaryAgent(opt)
         self.assertEqual(
             # grinning face emoji
@@ -237,7 +237,7 @@ class TestByteLevelBPE(unittest.TestCase):
             bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
             bpe_add_prefix_space=False,
         )
-        opt = parser.parse_args([], print_args=False)
+        opt = parser.parse_args([])
         agent = DictionaryAgent(opt)
         self.assertEqual(
             # grinning face emoji
@@ -392,7 +392,7 @@ class TestByteLevelBPE(unittest.TestCase):
             bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
             hf_skip_special_tokens=False,
         )
-        opt = parser.parse_args([], print_args=False)
+        opt = parser.parse_args([])
 
         agent = DictionaryAgent(opt)
         agent.add_additional_special_tokens(special_toks_lst)
@@ -412,7 +412,7 @@ class TestBuildDict(unittest.TestCase):
             pp = build_dict.setup_args()
             pp.set_defaults(**opt)
             pp.set_defaults(task='babi')
-            popt = pp.parse_args([], print_args=False)
+            popt = pp.parse_args([])
             popt['dict_file'] = dict_file
             for k, v in opt.items():
                 popt[k] = v
@@ -444,7 +444,7 @@ class TestGpt2HFInterop(unittest.TestCase):
             bpe_add_prefix_space=False,
             dict_loaded=True,
         )
-        opt = parser.parse_args([], print_args=False)
+        opt = parser.parse_args([])
         return opt
 
     def _run_test(self, slow_bytelevel_bpe, hf_bpe):
@@ -493,7 +493,7 @@ class TestGpt2HFInterop(unittest.TestCase):
             pp = build_dict.setup_args()
             pp.set_defaults(**hf_bpe_opt)
             pp.set_defaults(task='babi')
-            popt = pp.parse_args([], print_args=False)
+            popt = pp.parse_args([])
             popt['dict_file'] = dict_file
             build_dict.build_dict(popt)
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -16,7 +16,7 @@ import parlai.scripts.multiprocessing_train as mp_train
 def _forced_parse(parser, opt):
     parser.set_params(**opt)
     parser.set_params(log_every_n_sec=10)
-    popt = parser.parse_args([], print_args=False)
+    popt = parser.parse_args([])
     # in some rare cases, like for instance if the model class also
     # overrides its default params, the params override will not
     # be taken into account.

--- a/tests/test_image_featurizers.py
+++ b/tests/test_image_featurizers.py
@@ -37,7 +37,7 @@ class TestImageLoader(unittest.TestCase):
         """
         Test that model correctly handles text task.
         """
-        opt = ParlaiParser().parse_args([], print_args=False)
+        opt = ParlaiParser().parse_args([])
         opt.update(BASE_IMAGE_ARGS)
         for image_mode, dim in IMAGE_MODE_TO_DIM.items():
             opt["image_mode"] = image_mode

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -49,7 +49,7 @@ class TestInteractive(unittest.TestCase):
 
     def test_repeat(self):
         pp = interactive.setup_args()
-        opt = pp.parse_args(['-m', 'repeat_query'], print_args=False)
+        opt = pp.parse_args(['-m', 'repeat_query'])
         interactive.interactive(opt)
 
 
@@ -63,7 +63,7 @@ class TestInteractiveConvai2(unittest.TestCase):
     def test_repeat(self):
         pp = interactive.setup_args()
         opt = pp.parse_args(
-            ['-m', 'repeat_query', '-t', 'convai2', '-dt', 'valid'], print_args=False
+            ['-m', 'repeat_query', '-t', 'convai2', '-dt', 'valid']
         )
         interactive.interactive(opt)
 
@@ -80,7 +80,7 @@ class TestInteractiveLogging(unittest.TestCase):
         outfile = os.path.join(tmpdir, 'log.jsonl')
         pp = interactive.setup_args()
         opt = pp.parse_args(
-            ['-m', 'repeat_query', '--outfile', outfile], print_args=False
+            ['-m', 'repeat_query', '--outfile', outfile]
         )
         interactive.interactive(opt)
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -62,9 +62,7 @@ class TestInteractiveConvai2(unittest.TestCase):
 
     def test_repeat(self):
         pp = interactive.setup_args()
-        opt = pp.parse_args(
-            ['-m', 'repeat_query', '-t', 'convai2', '-dt', 'valid']
-        )
+        opt = pp.parse_args(['-m', 'repeat_query', '-t', 'convai2', '-dt', 'valid'])
         interactive.interactive(opt)
 
 
@@ -79,9 +77,7 @@ class TestInteractiveLogging(unittest.TestCase):
     def _run_test_repeat(self, tmpdir: str, fake_input: FakeInput):
         outfile = os.path.join(tmpdir, 'log.jsonl')
         pp = interactive.setup_args()
-        opt = pp.parse_args(
-            ['-m', 'repeat_query', '--outfile', outfile]
-        )
+        opt = pp.parse_args(['-m', 'repeat_query', '--outfile', outfile])
         interactive.interactive(opt)
 
         log = conversations.Conversations(outfile)

--- a/tests/test_ta_inheritence.py
+++ b/tests/test_ta_inheritence.py
@@ -45,7 +45,7 @@ class TestInheritence(unittest.TestCase):
         """
         parser = ParlaiParser(add_model_args=True)
         opt = parser.parse_args(
-            args=['--model', 'tests.test_ta_inheritence:SubClassA'], print_args=False
+            args=['--model', 'tests.test_ta_inheritence:SubClassA']
         )
         self.assertEqual('a', opt.get('withclassinheritence'))
         # make sure we have the dictionary arg
@@ -61,7 +61,7 @@ class TestInheritence(unittest.TestCase):
         """
         parser = ParlaiParser(add_model_args=True)
         opt = parser.parse_args(
-            args=['--model', 'tests.test_ta_inheritence:SubClassB'], print_args=False
+            args=['--model', 'tests.test_ta_inheritence:SubClassB']
         )
         self.assertEqual('b', opt.get('withoutclassinheritence'))
         # make sure we don't have the dictionary now

--- a/tests/test_ta_inheritence.py
+++ b/tests/test_ta_inheritence.py
@@ -44,9 +44,7 @@ class TestInheritence(unittest.TestCase):
         Verify that class A does contain the super args.
         """
         parser = ParlaiParser(add_model_args=True)
-        opt = parser.parse_args(
-            args=['--model', 'tests.test_ta_inheritence:SubClassA']
-        )
+        opt = parser.parse_args(args=['--model', 'tests.test_ta_inheritence:SubClassA'])
         self.assertEqual('a', opt.get('withclassinheritence'))
         # make sure we have the dictionary arg
         self.assertEqual('d', opt.get('dictarg'))
@@ -60,9 +58,7 @@ class TestInheritence(unittest.TestCase):
         Verify that class B does not contain the super args.
         """
         parser = ParlaiParser(add_model_args=True)
-        opt = parser.parse_args(
-            args=['--model', 'tests.test_ta_inheritence:SubClassB']
-        )
+        opt = parser.parse_args(args=['--model', 'tests.test_ta_inheritence:SubClassB'])
         self.assertEqual('b', opt.get('withoutclassinheritence'))
         # make sure we don't have the dictionary now
         self.assertNotIn('dictarg', opt)

--- a/tests/test_tfidf_retriever.py
+++ b/tests/test_tfidf_retriever.py
@@ -44,7 +44,7 @@ class TestTfidfRetriever(unittest.TestCase):
                 datatype='train:ordered',
                 num_epochs=1,
             )
-            opt = parser.parse_args([], print_args=False)
+            opt = parser.parse_args([])
             agent = create_agent(opt)
             train_world = create_task(opt, agent)
             # pass examples to dictionary

--- a/tests/test_tga.py
+++ b/tests/test_tga.py
@@ -72,8 +72,7 @@ class TestUpgradeOpt(unittest.TestCase):
                 'zoo:unittest/transformer_generator2/model',
                 '--beam-size',
                 '5',
-            ],
-            print_args=False,
+            ]
         )
         agent = create_agent(opt, True)
         self.assertEqual(agent.opt['inference'], 'beam')

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -36,7 +36,7 @@ def get_agent(**kwargs):
     parser = ParlaiParser()
     MockTorchAgent.add_cmdline_args(parser)
     parser.set_params(**kwargs)
-    opt = parser.parse_args([], print_args=False)
+    opt = parser.parse_args([])
     return MockTorchAgent(opt)
 
 
@@ -1015,7 +1015,7 @@ class TestTorchAgent(unittest.TestCase):
         def get_popt_and_tl(opt):
             parser = tms.setup_args()
             parser.set_params(**opt)
-            popt = parser.parse_args([], print_args=False)
+            popt = parser.parse_args([])
             for k, v in opt.items():
                 popt[k] = v
             return popt, tms.TrainLoop(popt)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -713,7 +713,7 @@ class TestTransformerGenerator(unittest.TestCase):
                 save_after_valid=True,
                 special_tok_lst='PARTY,PARROT',
             )
-            opt = parser.parse_args([], print_args=False)
+            opt = parser.parse_args([])
             agent = create_agent(opt)
             # assert that the embeddings were resized
             assert agent.resized_embeddings


### PR DESCRIPTION
**Patch description**
Fix a long standing issue where opts weren't printed.

Note that we made a sacrifice here, no longer printing opts grouped by argument group. But we do print correct args, and we print them everywhere.

**Testing steps**
Manual testing. I didn't cover everything. Let's review carefully. I'll include a review from myself, as this is some heavy usage

**Logs**:
```
$ parlai mp_eval --task convai2 -mf zoo:blender/blender_90M/model -bs 31 -dynb none --label-truncate 512 --text-truncate 128 --skip-generation true  -dt valid:stream
12:39:50 | Distributed group initialized
12:39:53 | Overriding opt["task"] to convai2 (previously: internal:blended_skill_talk,wizard_of_wikipedia,convai2,empathetic_dialogues)
12:39:53 | Overriding opt["model_file"] to /private/home/roller/working/parlai/data/models/blender/blender_90M/model (previously: /checkpoint/edinan/20200210/baseline_BST_retnref/lr=7.5e-06_attention-dropout=0.0_relu-dropout=0.0/model)
12:39:53 | Overriding opt["batchsize"] to 31 (previously: 16)
12:39:53 | Overriding opt["label_truncate"] to 512 (previously: 128)
12:39:53 | Overriding opt["text_truncate"] to 128 (previously: 512)
12:39:53 | Overriding opt["skip_generation"] to True (previously: False)
12:39:53 | Overriding opt["datatype"] to valid:stream (previously: train)
12:39:53 | Overriding opt["gpu"] to 0 (previously: -1)
12:39:53 | Using CUDA
12:39:53 | loading dictionary from /private/home/roller/working/parlai/data/models/blender/blender_90M/model.dict
12:39:54 | num words = 54944
12:39:54 | DEPRECATED: XLM should only be used for backwards compatibility, as it involves a less-stable layernorm operation.
12:39:55 | Total parameters: 87,508,992 (87,508,992 trainable)
12:39:55 | Loading existing model params from /private/home/roller/working/parlai/data/models/blender/blender_90M/model
12:39:55 | Opt:
12:39:55 |     activation: gelu
12:39:55 |     adafactor_eps: '[1e-30, 0.001]'
12:39:55 |     adam_eps: 1e-08
12:39:55 |     add_p1_after_newln: False
12:39:55 |     aggregate_micro: False
12:39:55 |     attention_dropout: 0.0
12:39:55 |     batchsize: 31
12:39:55 |     beam_block_list_filename: None
12:39:55 |     beam_block_ngram: 3
12:39:55 |     beam_context_block_ngram: 3
12:39:55 |     beam_delay: 30
12:39:55 |     beam_length_penalty: 0.65
12:39:55 |     beam_min_length: 20
12:39:55 |     beam_size: 10
12:39:55 |     betas: '[0.9, 0.999]'
12:39:55 |     bpe_add_prefix_space: None
12:39:55 |     bpe_debug: False
12:39:55 |     bpe_merge: None
12:39:55 |     bpe_vocab: None
12:39:55 |     compute_tokenized_bleu: False
12:39:55 |     datapath: /private/home/roller/working/parlai/data
12:39:55 |     datatype: valid:stream
12:39:55 |     delimiter: '\n'
12:39:55 |     dict_class: parlai.core.dict:DictionaryAgent
12:39:55 |     dict_endtoken: __end__
12:39:55 |     dict_file: /private/home/roller/working/parlai/data/models/blender/blender_90M/model.dict
12:39:55 |     dict_include_test: False
12:39:55 |     dict_include_valid: False
12:39:55 |     dict_initpath: None
12:39:55 |     dict_language: english
12:39:55 |     dict_loaded: True
12:39:55 |     dict_lower: True
12:39:55 |     dict_max_ngram_size: -1
12:39:55 |     dict_maxexs: -1
12:39:55 |     dict_maxtokens: -1
12:39:55 |     dict_minfreq: 0
12:39:55 |     dict_nulltoken: __null__
12:39:55 |     dict_starttoken: __start__
12:39:55 |     dict_textfields: text,labels
12:39:55 |     dict_tokenizer: bpe
12:39:55 |     dict_unktoken: __unk__
12:39:55 |     display_examples: False
12:39:55 |     distributed_world_size: 2
12:39:55 |     download_path: /private/home/roller/working/parlai/downloads
12:39:55 |     dropout: 0.1
12:39:55 |     dynamic_batching: None
12:39:55 |     embedding_projection: random
12:39:55 |     embedding_size: 512
12:39:55 |     embedding_type: random
12:39:55 |     embeddings_scale: True
12:39:55 |     eval_batchsize: None
12:39:55 |     evaltask: None
12:39:55 |     ffn_size: 2048
12:39:55 |     force_fp16_tokens: True
12:39:55 |     fp16: True
12:39:55 |     fp16_impl: apex
12:39:55 |     gpu: 0
12:39:55 |     gradient_clip: 0.1
12:39:55 |     hf_skip_special_tokens: True
12:39:55 |     hide_labels: False                                                                                                                                                                                                                                                                                                                                             [7/2644]
12:39:55 |     history_add_global_end_token: None
12:39:55 |     history_reversed: False
12:39:55 |     history_size: -1
12:39:55 |     image_cropsize: 224
12:39:55 |     image_mode: raw
12:39:55 |     image_size: 256
12:39:55 |     include_checked_sentence: True
12:39:55 |     include_knowledge: True
12:39:55 |     include_knowledge_separator: False
12:39:55 |     inference: beam
12:39:55 |     init_model: /checkpoint/parlai/zoo/new_reddit/newreddit_trained20190909_usedfordodeca/model
12:39:55 |     init_opt: None
12:39:55 |     interactive_mode: False
12:39:55 |     invsqrt_lr_decay_gamma: -1
12:39:55 |     label_truncate: 512
12:39:55 |     label_type: response
12:39:55 |     learn_positional_embeddings: True
12:39:55 |     learningrate: 7.5e-06
12:39:55 |     load_from_checkpoint: False
12:39:55 |     log_every_n_secs: 2
12:39:55 |     log_keep_fields: all
12:39:55 |     loglevel: info
12:39:55 |     lr_scheduler: reduceonplateau
12:39:55 |     lr_scheduler_decay: 0.5
12:39:55 |     lr_scheduler_patience: 3
12:39:55 |     max_lr_steps: -1
12:39:55 |     max_train_time: -1
12:39:55 |     metrics: default
12:39:55 |     model: transformer/generator
12:39:55 |     model_file: /private/home/roller/working/parlai/data/models/blender/blender_90M/model
12:39:55 |     model_parallel: False
12:39:55 |     momentum: 0
12:39:55 |     multitask_weights: '[1.0, 3.0, 3.0, 3.0]'
12:39:55 |     n_decoder_layers: -1
12:39:55 |     n_encoder_layers: -1
12:39:55 |     n_heads: 16
12:39:55 |     n_layers: 8
12:39:55 |     n_positions: 512
12:39:55 |     n_segments: 0
12:39:55 |     nesterov: True
12:39:55 |     no_cuda: False
12:39:55 |     num_epochs: -1
12:39:55 |     num_examples: -1
12:39:55 |     num_topics: 5
12:39:55 |     numthreads: 1
12:39:55 |     nus: [0.7]
12:39:55 |     optimizer: adamax
12:39:55 |     output_scaling: 1.0
12:39:55 |     override: "{'task': 'convai2', 'model_file': '/private/home/roller/working/parlai/data/models/blender/blender_90M/model', 'batchsize': 31, 'dynamic_batching': None, 'label_truncate': 512, 'text_truncate': 128, 'skip_generation': True, 'datatype': 'valid:stream', 'gpu': 0}"
12:39:55 |     parlai_home: /private/home/edinan/ParlAI
12:39:55 |     person_tokens: False
12:39:55 |     rank: 0
12:39:55 |     rank_candidates: False
12:39:55 |     relu_dropout: 0.0
12:39:55 |     report_filename:
12:39:55 |     save_after_valid: True
12:39:55 |     save_every_n_secs: 60.0
12:39:55 |     save_format: conversations
12:39:55 |     save_world_logs: False
12:39:55 |     share_word_embeddings: True
12:39:55 |     short_final_eval: False
12:39:55 |     show_advanced_args: False
12:39:55 |     skip_generation: True
12:39:55 |     special_tok_lst: None
12:39:55 |     split_lines: False
12:39:55 |     starttime: Feb10_07-25
12:39:55 |     task: convai2
12:39:55 |     temperature: 1.0
12:39:55 |     tensorboard_log: False
12:39:55 |     text_truncate: 128
12:39:55 |     topk: 10
12:39:55 |     topp: 0.9
12:39:55 |     train_experiencer_only: False
12:39:55 |     truncate: -1
12:39:55 |     update_freq: 1
12:39:55 |     use_reply: label
12:39:55 |     validation_cutoff: 1.0
12:39:55 |     validation_every_n_epochs: 0.25
12:39:55 |     validation_every_n_secs: -1
12:39:55 |     validation_max_exs: 20000
12:39:55 |     validation_metric: ppl
12:39:55 |     validation_metric_mode: min
12:39:55 |     validation_patience: 15
12:39:55 |     validation_share_agent: False
12:39:55 |     variant: xlm
12:39:55 |     verbose: False
12:39:55 |     warmup_rate: 0.0001
12:39:55 |     warmup_updates: -1
12:39:55 |     weight_decay: None
12:39:55 | Current ParlAI commit: 0638277ef107dda9591e1c0b19028087db5b68a5
12:39:55 | Evaluating task convai2 using datatype valid:stream.
12:39:55 | creating task(s): convai2
12:39:55 | Progress bar is approximate in distributed mode.
12:39:55 | loading fbdialog data: /private/home/roller/working/parlai/data/ConvAI2/valid_self_original.txt
12:39:56 | --skip-generation true produces limited metrics
```