### PR TITLE
[Dodeca] Split Dodeca tar file

### DIFF
--- a/parlai/zoo/dodecadialogue/all_tasks_mt.py
+++ b/parlai/zoo/dodecadialogue/all_tasks_mt.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'all_tasks_mt')

--- a/parlai/zoo/dodecadialogue/build.py
+++ b/parlai/zoo/dodecadialogue/build.py
@@ -21,9 +21,13 @@ def download(datapath, model_name):
     if not built(mdir, dodeca_version):
         opt = {'datapath': datapath}
         fnames = ['dodecadialogue_v2.tgz']
-        download_models(opt, fnames, 'dodecadialogue', version=dodeca_version, use_model_type=False)
+        download_models(
+            opt, fnames, 'dodecadialogue', version=dodeca_version, use_model_type=False
+        )
     model_version = 'v1.0'
     if not built(mdir, model_version):
         opt = {'datapath': datapath, 'model_type': model_name}
         fnames = [f'{model_name}.tgz']
-        download_models(opt, fnames, 'dodecadialogue', version=model_version, use_model_type=True)
+        download_models(
+            opt, fnames, 'dodecadialogue', version=model_version, use_model_type=True
+        )

--- a/parlai/zoo/dodecadialogue/build.py
+++ b/parlai/zoo/dodecadialogue/build.py
@@ -6,6 +6,8 @@
 """
 Pretrained models from The Dialogue Dodecathlon.
 
+The dodecadialogue_v2.tgz file contains a README.md and the dict for all models.
+
 https://arxiv.org/abs/1911.03768
 """
 from parlai.core.build_data import built, download_models, get_model_dir
@@ -13,11 +15,15 @@ import os
 import os.path
 
 
-def download(datapath):
-    model_name = 'dodecadialogue'
-    mdir = os.path.join(get_model_dir(datapath), model_name)
-    version = 'v1.0'
-    if not built(mdir, version):
+def download(datapath, model_name):
+    mdir = os.path.join(get_model_dir(datapath), 'dodecadialogue')
+    dodeca_version = 'v2.0'
+    if not built(mdir, dodeca_version):
         opt = {'datapath': datapath}
-        fnames = ['dodecadialogue.tgz']
-        download_models(opt, fnames, model_name, version=version, use_model_type=False)
+        fnames = ['dodecadialogue_v2.tgz']
+        download_models(opt, fnames, 'dodecadialogue', version=dodeca_version, use_model_type=False)
+    model_version = 'v1.0'
+    if not built(mdir, model_version):
+        opt = {'datapath': datapath, 'model_type': model_name}
+        fnames = [f'{model_name}.tgz']
+        download_models(opt, fnames, 'dodecadialogue', version=model_version, use_model_type=True)

--- a/parlai/zoo/dodecadialogue/build.py
+++ b/parlai/zoo/dodecadialogue/build.py
@@ -6,7 +6,8 @@
 """
 Pretrained models from The Dialogue Dodecathlon.
 
-The dodecadialogue_v2.tgz file contains a README.md and the dict for all models.
+The dodecadialogue_v2.tgz file is always downloaded,
+and contains 1) a README.md and 2) the dict for all models.
 
 https://arxiv.org/abs/1911.03768
 """
@@ -16,15 +17,16 @@ import os.path
 
 
 def download(datapath, model_name):
-    mdir = os.path.join(get_model_dir(datapath), 'dodecadialogue')
+    ddir = os.path.join(get_model_dir(datapath), 'dodecadialogue')
     dodeca_version = 'v2.0'
-    if not built(mdir, dodeca_version):
+    if not built(ddir, dodeca_version):
         opt = {'datapath': datapath}
         fnames = ['dodecadialogue_v2.tgz']
         download_models(
             opt, fnames, 'dodecadialogue', version=dodeca_version, use_model_type=False
         )
     model_version = 'v1.0'
+    mdir = os.path.join(ddir, model_name)
     if not built(mdir, model_version):
         opt = {'datapath': datapath, 'model_type': model_name}
         fnames = [f'{model_name}.tgz']

--- a/parlai/zoo/dodecadialogue/convai2_ft.py
+++ b/parlai/zoo/dodecadialogue/convai2_ft.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'convai2_ft')

--- a/parlai/zoo/dodecadialogue/cornell_movie_ft.py
+++ b/parlai/zoo/dodecadialogue/cornell_movie_ft.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'cornell_movie_ft')

--- a/parlai/zoo/dodecadialogue/daily_dialog_ft.py
+++ b/parlai/zoo/dodecadialogue/daily_dialog_ft.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'daily_dialog_ft')

--- a/parlai/zoo/dodecadialogue/eli5_ft.py
+++ b/parlai/zoo/dodecadialogue/eli5_ft.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'eli5_ft')

--- a/parlai/zoo/dodecadialogue/empathetic_dialogues_ft.py
+++ b/parlai/zoo/dodecadialogue/empathetic_dialogues_ft.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'empathetic_dialogues_ft')

--- a/parlai/zoo/dodecadialogue/igc_ft.py
+++ b/parlai/zoo/dodecadialogue/igc_ft.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'igc_ft')

--- a/parlai/zoo/dodecadialogue/image_chat_ft.py
+++ b/parlai/zoo/dodecadialogue/image_chat_ft.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'image_chat_ft')

--- a/parlai/zoo/dodecadialogue/light_dialog_ft.py
+++ b/parlai/zoo/dodecadialogue/light_dialog_ft.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'light_dialog_ft')

--- a/parlai/zoo/dodecadialogue/reddit_ft.py
+++ b/parlai/zoo/dodecadialogue/reddit_ft.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'reddit_ft')

--- a/parlai/zoo/dodecadialogue/twitter_ft.py
+++ b/parlai/zoo/dodecadialogue/twitter_ft.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'twitter_ft')

--- a/parlai/zoo/dodecadialogue/ubuntu_ft.py
+++ b/parlai/zoo/dodecadialogue/ubuntu_ft.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'ubuntu_ft')

--- a/parlai/zoo/dodecadialogue/wizard_of_wikipedia_ft.py
+++ b/parlai/zoo/dodecadialogue/wizard_of_wikipedia_ft.py
@@ -3,4 +3,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from .build import download  # noqa: F401
+from .build import download as download_dodeca
+
+
+def download(datapath):
+    download_dodeca(datapath, 'wizard_of_wikipedia_ft')

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -764,7 +764,10 @@ model_list = [
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/dodecadialogue/",
         "task": "TBD",
         "description": (
-            "Image Seq2Seq model trained on all DodecaDialogue tasks and fine-tuned on the ELI5 task"
+            "Image Seq2Seq model trained on all DodecaDialogue tasks and fine-tuned on the ELI5 task. "
+            "The ELI5 model in the zoo is the one that scored the highest ROUGE scores; "
+            "it may have slightly lower f1, bleu, and slightly higher ppl than the numbers "
+            "reported in the dodeca paper."
         ),
         "example": (
             "parlai interactive -mf zoo:dodecadialogue/eli5_ft/model "


### PR DESCRIPTION
**Patch description**
Address #2697 - break up the dodeca models into separate tar files. I.e., you do not have to download all 13 models to use one.

CC @EricMichaelSmith as this might reduce runtime for GPU tests (reduces download size significantly)

**Testing steps**
Dodeca GPU CI Test; I ran locally as well (see logs)

**Logs**
```
$ pytest tests/nightly/gpu/test_dodeca.py
============================================================================== test session starts ===============================================================================
platform linux -- Python 3.6.9, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini
plugins: requests-mock-1.7.0
collected 3 items

tests/nightly/gpu/test_dodeca.py ...                                                                                                                                       [100%]

=========================================================================== slowest 10 test durations ============================================================================
70.51s call     tests/nightly/gpu/test_dodeca.py::TestDodecaModel::test_wizard
52.40s call     tests/nightly/gpu/test_dodeca.py::TestDodecaModel::test_convai2
49.33s call     tests/nightly/gpu/test_dodeca.py::TestDodecaModel::test_ed

(0.00 durations hidden.  Use -vv to show these durations.)
=================================================================== 3 passed, 38 warnings in 173.66s (0:02:53) ===================================================================
```
