### PR TITLE
[Chunk teacher] Bug with distributed evaluation

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2164,6 +2164,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
                 self.rng = random.Random(42)
             self._enqueue_chunks()
             # launch queue loader on the main thread
+            self.tot_samples_loaded = 0
             self._enqueue_request()
 
         self._episode_done = True
@@ -2252,15 +2253,14 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
         data = future.result()
         if data is None:
             return
-        i = 0
         while data:
             # self.samples is a queue with maxsize
             # self.buffersize, so will block if the
             # buffer gets full
             sample = data.pop(0)
-            if self.is_train or i % self.dws == self.rank:
+            if self.is_train or self.tot_samples_loaded % self.dws == self.rank:
                 self.samples.put(sample)
-            i += 1
+            tot_samples_loaded += 1
         # and start loading the next chunk
         self._enqueue_request()
 
@@ -2344,6 +2344,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
             self._drain(self.samples)
             self._drain(self.chunks)
             self._enqueue_chunks()
+            self.tot_samples_loaded = 0  # reset the count of samples loaded
             self._enqueue_request()
 
 

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2260,7 +2260,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
             sample = data.pop(0)
             if self.is_train or self.tot_samples_loaded % self.dws == self.rank:
                 self.samples.put(sample)
-            tot_samples_loaded += 1
+            self.tot_samples_loaded += 1
         # and start loading the next chunk
         self._enqueue_request()
 


### PR DESCRIPTION
**Patch description**
Very subtle bug using chunk teacher with distributed evaluation. The count to place samples for different gpus was being reset every time a chunk was being loaded, which led to the wrong number of samples being placed on certain gpus IF the valid set had more than one chunk assigned to it. This led to the system hanging forever at the `self.samples.get()`, because `num_episodes` exceeded the actual number of samples on the queue.

💀  RIP a day of my life 💀 