### PR TITLE
fix underscore opt

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -997,6 +997,8 @@ class ParlaiParser(argparse.ArgumentParser):
         if args_that_override is None:
             args_that_override = _sys.argv[1:]
 
+        args_that_override = fix_underscores(args_that_override)
+
         for i in range(len(args_that_override)):
             if args_that_override[i] in option_strings_dict:
                 if args_that_override[i] in store_true:


### PR DESCRIPTION
**Patch description**
Observation: parse args  from cmd won't override the param (see from From the prints of https://github.com/facebookresearch/ParlAI/pull/2933#pullrequestreview-461183770
) as intended, plus NO  ``` Parse Error: unrecognized arguments: ```.  

Command to reproduce:  ``` parlai interactive -mf {model_file_path} --beam-context_block_ngram 10  ```
```
14:40:17 INFO | Using CUDA
14:40:17 INFO | loading dictionary from /checkpoint/jingxu23/projects/wiz2/inverse_persona/sweeps/utt2p/swp9_utt2p/3d8_jobid=12/model.dict
14:40:17 INFO | num words = 8008
14:40:17 INFO | TransformerGenerator: full interactive mode on.
```
No overrides WARNING.

Instead, if one runs  ```parlai interactive -mf  {model_file_path}  --beam-context-block-ngram 10 ```,
the params were overriden as expected.
```
13:20:41 WARN | Overriding opt["beam_context_block_ngram"] to 10 (previously: -1)
13:20:41 INFO | Using CUDA
13:20:41 INFO | loading dictionary from /checkpoint/jingxu23/projects/wiz2/inverse_persona/sweeps/utt2p/swp9_utt2p/3d8_jobid=12/model.dict
13:20:41 INFO | num words = 8008
13:20:41 INFO | TransformerGenerator: full interactive mode on.
13:21:37 INFO | Total parameters: 2,696,268,800 (2,695,613,440 trainable)
13:21:37 INFO | Loading existing model params from /checkpoint/jingxu23/projects/wiz2/inverse_persona/sweeps/utt2p/swp9_utt2p/3d8_jobid=12/model
13:21:56 INFO | Opt:
13:21:56 INFO |     activation: gelu
13:21:56 INFO |     adafactor_eps: '[1e-30, 0.001]'
13:21:56 INFO |     adam_eps: 1e-08
13:21:56 INFO |     add_p1_after_newln: False
13:21:56 INFO |     aggregate_micro: False
13:21:56 INFO |     attention_dropout: 0.0
13:21:56 INFO |     batchsize: 64
13:21:56 INFO |     beam_block_list_filename: None
13:21:56 INFO |     beam_block_ngram: 3
13:21:56 INFO |     beam_context_block_ngram: 10
13:21:56 INFO |     beam_delay: 30
13:21:56 INFO |     beam_length_penalty: 0.65
13:21:56 INFO |     beam_min_length: 1
13:21:56 INFO |     beam_size: 10
13:21:56 INFO |     betas: '[0.9, 0.999]'```
```

**Testing steps**
CI

**Logs**
```
> /private/home/jingxu23/ParlAI/parlai/core/params.py(1005)_process_args_to_opts()
   1004 
-> 1005         for i in range(len(args_that_override)):
   1006             if args_that_override[i] in option_strings_dict:

ipdb> args_that_override                                                             
['interactive', '-mf', '/checkpoint/jingxu23/projects/wiz2/inverse_persona/sweeps/utt2p/swp9_utt2p/3d8_jobid=12/model', '--beam-context_block_ngram', '10']
ipdb> '--beam-context_block_ngram' in option_strings_dict                            
False
``` 
