### PR TITLE
Tweak colors.

### DIFF
--- a/parlai/utils/logging.py
+++ b/parlai/utils/logging.py
@@ -39,7 +39,7 @@ COLORED_LEVEL_STYLES = {
     'debug': {'faint': True},
     'verbose': {'color': 'blue'},
     'error': {'color': 'red'},
-    'info': {'faint': True},
+    'info': {},
     'report': {'bold': True},
     'success': {'bold': True, 'color': 'green'},
     'warning': {'color': 'yellow'},


### PR DESCRIPTION
**Patch description**
Slightly tweak colors of logs. I hadn't realized it was like this because my console was ignoring 256 colors.

**Testing steps**
Before:

![image](https://user-images.githubusercontent.com/31896/89419853-ebd79480-d6ff-11ea-8728-36e3ae927776.png)

After:
![image](https://user-images.githubusercontent.com/31896/89419954-10337100-d700-11ea-9d78-14baf5dd277b.png)
