### PR TITLE
Update Link and Commands Display format

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -62,7 +62,7 @@
             </p>
         </div>
         <ul class="primary-nav">
-          <li><a class="home" href="/">Get Started</a></li>
+          <li><a class="home" href="#getstarted">Get Started</a></li>
           <!-- <li><a class="leaderboard" href="/leaderboard/">Leaderboard</a></li> -->
           <li><a class="about" href="/about/">About</a></li>
           <li><a class="projects" href="/projects/">Projects</a></li>

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -36,7 +36,7 @@
       </div>
       <a class="btn" href="/docs/index.html">Docs</a>
       <ul class="primary-nav">
-        <li><a class="home" href="/">Get Started</a></li>
+        <li><a class="home" href="#getstarted">Get Started</a></li>
         <li><a class="about" href="/about/">About</a></li>
         <li><a class="projects" href="/projects/">Projects</a></li>
         <li><a class="github" href="https://github.com/facebookresearch/ParlAI">GitHub</a></li>

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -59,7 +59,7 @@ letter-spacing: 0em;">Seamless integration of Amazon Mechanical Turk for data co
         </div>
         <div class="command">
             <div class="label">Run this command:</div>
-            <div class="text">git clone https://github.com/facebookresearch/ParlAI.git<br>cd ParlAI; python setup.py develop</div>
+            <div class="text"><code>git clone https://github.com/facebookresearch/ParlAI.git<br>cd ParlAI; python setup.py develop</code></div>
         </div>
     </div>
 </section>
@@ -93,7 +93,7 @@ letter-spacing: 0em;">Seamless integration of Amazon Mechanical Turk for data co
         </div>
         <div class="command" style="margin-bottom: 20px">
             <div class="label">Run this command:</div>  
-            <div class="text" style="background-color: #fff">parlai display_data -t babi:task1k:1</div>
+            <div class="text" style="background-color: #fff"><code>parlai display_data -t babi:task1k:1</code></div>
         </div>
 
         <div class="row">
@@ -103,7 +103,7 @@ letter-spacing: 0em;">Seamless integration of Amazon Mechanical Turk for data co
         </div>
         <div class="command" style="margin-bottom: 20px">
             <div class="label">Run this command:</div>  
-            <div class="text" style="background-color: #fff">parlai display_data -t babi:task1k:1,squad -n 100</div>
+            <div class="text" style="background-color: #fff"><code>parlai display_data -t babi:task1k:1,squad -n 100</code></div>
         </div>
 
         <div class="row">
@@ -113,7 +113,7 @@ letter-spacing: 0em;">Seamless integration of Amazon Mechanical Turk for data co
         </div>
         <div class="command" style="margin-bottom: 20px">
             <div class="label">Run this command:</div>  
-            <div class="text" style="background-color: #fff">parlai eval_model -m ir_baseline -t "#moviedd-reddit" -dt valid</div>
+            <div class="text" style="background-color: #fff"><code>parlai eval_model -m ir_baseline -t "#moviedd-reddit" -dt valid</code></div>
         </div>
 
         <div class="row">
@@ -123,7 +123,7 @@ letter-spacing: 0em;">Seamless integration of Amazon Mechanical Turk for data co
         </div>
         <div class="command" style="margin-bottom: 20px">
             <div class="label">Run this command:</div>  
-            <div class="text" style="background-color: #fff">parlai display_model -m ir_baseline -t "#moviedd-reddit" -dt valid</div>
+            <div class="text" style="background-color: #fff"><code>parlai display_model -m ir_baseline -t "#moviedd-reddit" -dt valid</code></div>
         </div>
 
         <div class="row">
@@ -133,7 +133,7 @@ letter-spacing: 0em;">Seamless integration of Amazon Mechanical Turk for data co
         </div>
         <div class="command" style="margin-bottom: 20px">
             <div class="label">Run this command:</div>  
-            <div class="text" style="background-color: #fff">parlai train_model -m drqa -t squad -bs 32 -mf /tmp/model_drqa</div>
+            <div class="text" style="background-color: #fff"><code>parlai train_model -m drqa -t squad -bs 32 -mf /tmp/model_drqa</code></div>
         </div>
 
         <div class="row">


### PR DESCRIPTION
**Patch description**
Updated the Get Started link on navigations(head and footer nav) to the `#getstarted` div! It's professionally acceptable if the nav-item(Get Started) is directing to what it references instead of the homepage route. The nav-item(Get Started) can be removed or replaced too as an alternative solution since there's already a Get Started button on the page!

Run Commands samples are preferred to be displayed as code format which is more informative to the guest what those are!
So the commands are now displayed in `<code>Command</code>`

**Testing steps**
Same test mode as usual

**Logs**
<!-- If applicable, please paste the command line from your testing: -->
```
```

