### PR TITLE
[Opt] Handle `argparser.set_params` with ParlAI Command

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -974,6 +974,7 @@ class ParlaiParser(argparse.ArgumentParser):
         if '_subparser' in self.opt:
             # if using the super command, we need to be aware of the subcommand's
             # arguments when identifying things manually set by the user
+            self.overridable.update(self.opt['_subparser'].overridable)
             extra_ag = self.opt.pop('_subparser')._action_groups
 
         # custom post-parsing


### PR DESCRIPTION
**FINAL EDIT: merging without automatic test, will add next time a change is necessary for `argparser`**
**Patch description**
ParlaiParser with the `parlai` command was ignoring any `argparser.set_params()` calls. Need to update `self.overridable` with the subparser's override dict to incorporate these.


**Testing steps**
Manual testing 👀 . 

Can add a real test prior to merge however; marking as WIP for now to reflect this.

See commands in **Logs**

**Logs**
The `transresnet` model sets `n_positions` to 1000 in it's [`add_cmdline_args` method](https://github.com/facebookresearch/ParlAI/blob/master/projects/personality_captions/transresnet/modules.py#L97).

The model in the zoo _does not_ have the n_positions arg set in it's opt (or, rather, it is None). Thus, the model fails to load (you can't have `None` as a dimension for a tensor):
```
$ parlai eval_model -bs 128 -t personality_captions -mf models:personality_captions/transresnet/model --num-test-labels 5 -dt test
12:22:12 | Overriding opt["batchsize"] to 128 (previously: 500)
12:22:12 | Overriding opt["datatype"] to test (previously: train)
.
.
.
File "/private/home/kshuster/ParlAI/parlai/agents/transformer/modules.py", line 432, in __init__
    self.position_embeddings = nn.Embedding(n_positions, embedding_size)
  File "/private/home/kshuster/miniconda3/lib/python3.6/site-packages/torch/nn/modules/sparse.py", line 97, in __init__
    self.weight = Parameter(torch.Tensor(num_embeddings, embedding_dim))
TypeError: new() received an invalid combination of arguments - got (NoneType, int), but expected one of:
 * (torch.device device)
 * (torch.Storage storage)
 * (Tensor other)
 * (tuple of ints size, torch.device device)
      didn't match because some of the arguments have invalid types: (NoneType, int)
 * (object data, torch.device device)
      didn't match because some of the arguments have invalid types: (NoneType, int)
```

However, after this change, we see the param is set successfully:

```
$ parlai eval_model -bs 128 -t personality_captions -mf models:personality_captions/transresnet/model --num-test-labels 5 -dt test
18:00:24 | Overriding opt["n_positions"] to 1000 (previously: None)
18:00:24 | Overriding opt["batchsize"] to 128 (previously: 500)
18:00:24 | Overriding opt["datatype"] to test (previously: train)
.
.
.
18:01:20 | 1.3% complete (128 / 10,000), 0:00:50 elapsed, 1:04:21 eta
           100  accuracy    bleu-4  exs    f1  hits@1  hits@10  hits@100  hits@5     loss  med_rank
   all           .007812 9.881e-06  128 .1452 .007812    .1016     .5703  .03906 -.007812      80.5
   hits@1    1
.
.
.
```

And the model loads!

**Other information**
As mentioned, I will add a test prior to merge.
