### PR TITLE
Shrink model file of style_gen/c75

### DIFF
--- a/parlai/scripts/vacuum.py
+++ b/parlai/scripts/vacuum.py
@@ -24,13 +24,26 @@ import parlai.utils.logging as logging
 class Vacuum(ParlaiScript):
     @classmethod
     def setup_args(cls):
-        parser = ParlaiParser(False, False)
-        parser.add_argument('path', help="Path to model file.")
+        parser = ParlaiParser(
+            False, False, description='Shrink a model file for release.'
+        )
+        parser.add_argument(
+            # dest is intentionally not model_file so the parlai parser doesn't
+            # add extra opts to it
+            '-mf',
+            '--model-file',
+            dest='path',
+            help="Path to model file.",
+        )
         return parser
 
     def run(self):
         self.opt.log()
         model_file = self.opt['path']
+        if not model_file:
+            raise RuntimeError('--model-file argument is required')
+        if not os.path.isfile(model_file):
+            raise RuntimeError(f"'{model_file}' does not exist")
         logging.info(f"Loading {model_file}")
         states = torch.load(
             model_file,

--- a/parlai/scripts/vacuum.py
+++ b/parlai/scripts/vacuum.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """
 Reduces the size of a model file by stripping the optimizer.
 

--- a/parlai/scripts/vacuum.py
+++ b/parlai/scripts/vacuum.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+"""
+Reduces the size of a model file by stripping the optimizer.
+
+Assumes we are working with a TorchAgent
+"""
+
+import os
+import torch
+
+from parlai.core.params import ParlaiParser
+from parlai.core.script import ParlaiScript, register_script
+from parlai.utils.torch import atomic_save
+import parlai.utils.pickle
+import parlai.utils.logging as logging
+
+
+@register_script("vacuum")
+class Vacuum(ParlaiScript):
+    @classmethod
+    def setup_args(cls):
+        parser = ParlaiParser(False, False)
+        parser.add_argument('path', help="Path to model file.")
+        return parser
+
+    def run(self):
+        self.opt.log()
+        model_file = self.opt['path']
+        logging.info(f"Loading {model_file}")
+        states = torch.load(
+            model_file,
+            map_location=lambda cpu, _: cpu,
+            pickle_module=parlai.utils.pickle,
+        )
+        logging.info(f"Backing up {model_file} to {model_file}.unvacuumed")
+        os.rename(model_file, model_file + ".unvacuumed")
+        for key in [
+            'optimizer',
+            'optimizer_type',
+            'lr_scheduler',
+            'lr_scheduler_type',
+            'warmup_scheduler',
+            'number_training_updates',
+        ]:
+            if key in states:
+                logging.info(f"Deleting key {key}")
+                del states[key]
+        keys = ", ".join(states.keys())
+        logging.info(f"Remaining keys: {keys}")
+        logging.info(f"Saving to {model_file}")
+        atomic_save(states, model_file)

--- a/parlai/zoo/style_gen/c75_labeled_dialogue_generator.py
+++ b/parlai/zoo/style_gen/c75_labeled_dialogue_generator.py
@@ -13,7 +13,8 @@ from parlai.core.build_data import download_models
 
 def download(datapath):
     model_type = 'c75_labeled_dialogue_generator'
-    version = 'v1.0'
+    # v1.1 vacuumed the model file to be smaller
+    version = 'v1.1'
     opt = {'datapath': datapath, 'model_type': model_type}
     fnames = [f'{version}.tar.gz']
     download_models(


### PR DESCRIPTION
**Patch description**
"Vacuumed" the stylegen distributed model file. Will talk about on Tuesday. Essentially removed the "optimizer" field to shrink the model file from 31gb to 5gb. Also uploaded a vacuum script. Should make CI a lot faster.

**Testing steps**
CI.