### PR TITLE
git not defined fix at parlai/core/params.py

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -39,6 +39,8 @@ def print_git_commit():
     """
     Print the current git commit of ParlAI and parlai_internal.
     """
+    if not GIT_AVAILABLE:
+        return
     root = os.path.dirname(os.path.dirname(parlai.__file__))
     internal_root = os.path.join(root, 'parlai_internal')
     try:


### PR DESCRIPTION
**BUG**
```
Traceback (most recent call last):
  File "/content/ParlAI/parlai/core/params.py", line 46, in print_git_commit
    git_ = git.Git(root)
NameError: name 'git' is not defined
```
**Patch description**
    GIT_AVAILABLE variable at the top of the parlai/core/params.py denote if git import is available or not. 
    But unfortunately it was never used. System where there is no git import  will encounter above shown Error.
    I used GIT_AVAILABLE variable to fix this simple problem.
```
    if not GIT_AVAILABLE:
        return
```
By just adding above simple line at the top of print_git_commit() function inside parlai/core/params.py fix the problem. 
