### PR TITLE
Renaming save function in tokenizer

### DIFF
--- a/parlai/utils/bpe.py
+++ b/parlai/utils/bpe.py
@@ -826,7 +826,7 @@ class HuggingFaceBpeHelper(BPEHelper):
         :param file_name:
             file to save.
         """
-        self.tokenizer.save(dir_name, file_name)
+        self.tokenizer.save_model(dir_name, file_name)
 
 
 class SlowBytelevelBPE(Gpt2BpeHelper):


### PR DESCRIPTION
**Patch description**
Save function in tokenizers was renamed from `save()` to `save_model()` in recent version of Tokenizers. 
