### PR TITLE
Small fixes to allow inheritance and compatibility issues with message force_set

### DIFF
--- a/parlai/mturk/tasks/turn_annotations/bot_agent.py
+++ b/parlai/mturk/tasks/turn_annotations/bot_agent.py
@@ -60,7 +60,7 @@ class TurkLikeAgent:
         else:
             act_out = self.model_agent.act()
 
-        annotations_html = TurkLikeAgent.construct_annotations_html(self.turn_idx)
+        annotations_html = self.construct_annotations_html(self.turn_idx)
 
         if 'dict_lower' in self.opt and not self.opt['dict_lower']:
             # model is cased so we don't want to normalize the reply like below

--- a/parlai/mturk/tasks/turn_annotations/utils.py
+++ b/parlai/mturk/tasks/turn_annotations/utils.py
@@ -36,8 +36,8 @@ class Compatibility(object):
     def serialize_bot_message(bot_message):
         if 'metrics' in bot_message:
             metric_report = bot_message['metrics']
-            bot_message['metrics'] = {
+            bot_message = Compatibility.backward_compatible_force_set(bot_message, 'metrics', {
                 k: v.value() if isinstance(v, Metric) else v
                 for k, v in metric_report.items()
-            }
+            })
         return bot_message

--- a/parlai/mturk/tasks/turn_annotations/utils.py
+++ b/parlai/mturk/tasks/turn_annotations/utils.py
@@ -36,8 +36,12 @@ class Compatibility(object):
     def serialize_bot_message(bot_message):
         if 'metrics' in bot_message:
             metric_report = bot_message['metrics']
-            bot_message = Compatibility.backward_compatible_force_set(bot_message, 'metrics', {
-                k: v.value() if isinstance(v, Metric) else v
-                for k, v in metric_report.items()
-            })
+            bot_message = Compatibility.backward_compatible_force_set(
+                bot_message,
+                'metrics',
+                {
+                    k: v.value() if isinstance(v, Metric) else v
+                    for k, v in metric_report.items()
+                },
+            )
         return bot_message


### PR DESCRIPTION
**Patch description**
Small fix for
- call TurkLikeAgent's.construct_annotations_html inside act(self, timeout) would bypass any override of the static method on a subclass.
- Support Message-compatible force_set in serialize_bot_message in utils

**Testing steps**
CI

