### PR TITLE
Tie off release 0.9.0.

### DIFF
--- a/parlai/__init__.py
+++ b/parlai/__init__.py
@@ -4,4 +4,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-__version__ = '0.8.0'
+__version__ = '0.9.0'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 
 from setuptools import setup, find_packages
 
-VERSION = '0.8.0'  # if you update, update parlai/__init__.py too!
+VERSION = '0.9.0'  # if you update, update parlai/__init__.py too!
 
 if sys.version_info < (3, 6):
     sys.exit('Sorry, Python >=3.6 is required for ParlAI.')


### PR DESCRIPTION
**Patch description**
Want to sync with fbcode. Tie off 0.9.0 release. This is 0.9.0 because we landed the deletion of hogwild.

**Testing steps**
python setup.py bdist.