### PR TITLE
Pending deprecation for MTurk

### DIFF
--- a/docs/source/tutorial_mturk.rst
+++ b/docs/source/tutorial_mturk.rst
@@ -1,6 +1,17 @@
 Using Mechanical Turk
 =====================
+
+ParlAI's MTurk functionality has expanded out of this project to become `Mephisto <https://github.com/facebookresearch/Mephisto>`__. The instructions for hosting a ParlAI-Chat style task can be found `here <https://github.com/facebookresearch/Mephisto/tree/master/examples/parlai_chat_task_demo>`__, and regular collection tasks can be found `here <https://github.com/facebookresearch/Mephisto/tree/master/examples/static_react_task>`__.
+
+We will be moving some of our common tasks out of the Mephisto repo into the ParlAI repo soon, alongside better documentation and tooling for those common tasks.
+
+The original guide for using the ``parlai.mturk.core`` module to collect data on MTurk is preserved below for those who are still running tasks on the old framework. 
+
+Using Mechanical Turk <deprecated>
+==================================
 **Authors**: Jack Urbanek, Emily Dinan, Will Feng
+
+**NOTE**: ParlAI's internal MTurk implementation (in the ``parlai.mturk.core``) module is pending deprecation, and we will no longer be supporting new tasks or functionality.
 
 In ParlAI, you can use Amazon Mechanical Turk for **data collection**, **training**, or **evaluation** of your dialog model.
 

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -14,14 +14,25 @@ import uuid
 import errno
 import requests
 
-# TODO uncomment once stable is created.
-# logging.warn(
-#     'Directly importing parlai.mturk.core.<module> is pending deprecation, '
-#     'please update your callsites to use either '
-#     'parlai.mturk.core.stable.<module>  '
-#     'or parlai.mturk.core.legacy_2018.<module>. \n'
-#     'updating to stable may require some migration, as detailed in <link>.'
-# )
+print(
+    '\n\33[5m\33[101m'
+    "WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING"
+    '\33[0m\n'
+    'At this point, parlai.mturk.core is pending deprecation as we '
+    'prepare for a migration to Mephisto: '
+    'https://github.com/facebookresearch/Mephisto. \n'
+    'We will no longer be developing anything in parlai.mturk.core and '
+    'will eventually archive the whole module. \n'
+    "If you're creating a new task, we strongly suggest building on "
+    "Mephisto, starting from the example task here: "
+    "https://github.com/facebookresearch/Mephisto/tree/master/examples/parlai_chat_task_demo"
+    "\n"
+    "Our existing tasks will either be archived along with parlai.mturk.core "
+    "or migrated to work with Mephisto, depending on usage.\n"
+    '\33[5m\33[101m'
+    "WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING"
+    '\33[0m\n\n'
+)
 
 from parlai.mturk.core.shared_utils import AssignState
 from parlai.mturk.core.socket_manager import Packet, SocketManager, StaticSocketManager

--- a/parlai/mturk/core/mturk_manager.py
+++ b/parlai/mturk/core/mturk_manager.py
@@ -14,6 +14,16 @@ import uuid
 import errno
 import requests
 
+from parlai.mturk.core.shared_utils import AssignState
+from parlai.mturk.core.socket_manager import Packet, SocketManager, StaticSocketManager
+from parlai.mturk.core.worker_manager import WorkerManager
+from parlai.mturk.core.mturk_data_handler import MTurkDataHandler
+from parlai.core.params import print_announcements
+import parlai.mturk.core.data_model as data_model
+import parlai.mturk.core.mturk_utils as mturk_utils
+import parlai.mturk.core.server_utils as server_utils
+import parlai.mturk.core.shared_utils as shared_utils
+
 print(
     '\n\33[5m\33[101m'
     "WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING"
@@ -33,16 +43,6 @@ print(
     "WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING"
     '\33[0m\n\n'
 )
-
-from parlai.mturk.core.shared_utils import AssignState
-from parlai.mturk.core.socket_manager import Packet, SocketManager, StaticSocketManager
-from parlai.mturk.core.worker_manager import WorkerManager
-from parlai.mturk.core.mturk_data_handler import MTurkDataHandler
-from parlai.core.params import print_announcements
-import parlai.mturk.core.data_model as data_model
-import parlai.mturk.core.mturk_utils as mturk_utils
-import parlai.mturk.core.server_utils as server_utils
-import parlai.mturk.core.shared_utils as shared_utils
 
 # Timeout before cancelling a world start
 WORLD_START_TIMEOUT = 11


### PR DESCRIPTION
**Patch description**
Updating documentation to reflect the pending deprecation of ParlAI-MTurk in favor of using Mephisto for MTurk runs. I've also added a message to the import of `parlai.mturk.core.mturk_manager` to this effect.

**Testing steps**
![Screen Shot 2020-08-18 at 3 14 15 PM](https://user-images.githubusercontent.com/1276867/90555640-b00fe680-e165-11ea-94c3-b2c2cf9b3bc2.png)