### PR TITLE
[Chunk Teacher] hidden arg to prevent auto enqueueing

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2130,7 +2130,8 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
             self._enqueue_chunks()
             # launch queue loader on the main thread
             self.tot_samples_loaded = 0
-            self._enqueue_request()
+            if not opt.get("no_auto_enqueues", False):
+                self._enqueue_request()
 
         self._episode_done = True
         self.last_queue_output = None


### PR DESCRIPTION
**Patch description**
Add a hidden arg to prevent auto enqueuing for chunk teacher. This is useful for multi-threaded counting of the examples in Chunk TEacher.