### PR TITLE
Fix broken master (set explicit requirement for myst's sake)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pyyaml==5.3.1
 pyzmq==18.1.0
 regex==2020.1.8
 myst-parser==0.11.1
+attrs~=19.3
 requests-mock==1.7.0
 requests==2.22.0
 scikit-learn==0.23.1


### PR DESCRIPTION
**Patch description**
Myst bumped some version requirement from between when I authored #2972 and when I landed it. The result was that the testing environment broke when I merged it.

This patch fixes that by explicitly setting a particular requirement. It might be nice to have different requirements for docs and stuff, but maybe not right now.

_Since I'm on PTO Monday, please merge this for me._

**Testing steps**
CI.