### PR TITLE
We can handle distributed stoptrain just fine.

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -652,10 +652,6 @@ class TrainLoop:
                 try:
                     world.parley()
                 except StopTrainException:
-                    if is_distributed():
-                        raise RuntimeError(
-                            "StopTrainException not supported for " "distributed mode"
-                        )
                     break
 
                 self.parleys += 1
@@ -698,10 +694,6 @@ class TrainLoop:
                         world.reset_metrics()
                         stop_training = self.validate()
                     except StopTrainException:
-                        if is_distributed():
-                            raise RuntimeError(
-                                "StopTrainException not supported for distributed mode"
-                            )
                         break
                     # reset the log time because we logged right before validating
                     self.log_time.reset()


### PR DESCRIPTION
**Patch description**
Previously, the advisory around using StopTrain exceptions was that it didn't work in distributed mode. However, they work in distributed mode just fine, so long as _all_ workers raise the exception at the same time.

As it is, because metrics are synced, reduceonplataue can still raise a StopTrain just fine. and because the remaining StopTrains come from learning rate schedulers, which move in fixed amounts on all workers, those will also raise in synchronization.

So all in, it's fine.

**Testing steps**
Distributed training with a cosine scheduler