### PR TITLE
Store website builds as an artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -444,6 +444,13 @@ jobs:
             - "~/venv/lib"
       - <<: *buildwebsite
       - run:
+          name: zip up the website
+          working_directory: ~/ParlAI/website/build/
+          command: |
+            zip -r ~/ParlAI/website.zip *
+      - store_artifacts:
+          path: website.zip
+      - run:
           name: check for bad links
           working_directory: ~/ParlAI/
           command: |


### PR DESCRIPTION
**Patch description**
In order to speed things up on doc day, I'm making it so that website builds are stored as build artifacts in CircleCI. This means that you can always download the generated website without having to compile it locally.

To use it, click on the "build_website" item in the github checks, then click the "Artifacts" tab.

**Testing steps**
Manual testing.

![image](https://user-images.githubusercontent.com/31896/91322099-545ce300-e78d-11ea-993f-117b30b9b4d3.png)

![image](https://user-images.githubusercontent.com/31896/91322067-4b6c1180-e78d-11ea-8069-60dba1965f14.png)

