### PR TITLE
Fix fp16 gradient clip when len(params) == 1

### DIFF
--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -63,10 +63,11 @@ def clip_grad_norm(params, max_norm):
     params = list(params)
     if len(params) == 1:
         p = params[0]
-        grad_norm = torch.norm(p)
+        grads = p.grad.detach()
+        grad_norm = torch.norm(grads)
         if grad_norm > max_norm > 0:
             clip_coef = max_norm / (grad_norm + 1e-6)
-            p.mul_(clip_coef)
+            grads.mul_(clip_coef)
         return grad_norm
     elif max_norm > 0:
         return torch.nn.utils.clip_grad_norm_(params, max_norm)


### PR DESCRIPTION
**Patch description**
The previous way of handling FP16 gradient clip would crash when  len(params) == 1.
Because p is a leaf node and p.mul_(clip_coef) is a in place operation, It causes ```RuntimeError: a leaf Variable that requires grad has been used in an in-place operation.``` 
Some reference implementations (see below Pytorch, Fairseq) all use detach and apply this operation on the gradient instead of the parameters as well. 

Please see:  
1. [leaf](https://pytorch.org/docs/stable/autograd.html#torch.Tensor.is_leaf)
2. [Pytorch](https://github.com/pytorch/pytorch/blob/2b70f827373fe5c90e15ce7ba0a1d331dcd57379/torch/nn/utils/clip_grad.py#L40)
3. [Fairseq](https://github.com/pytorch/fairseq/blob/226f0e45391ac1dcacb72ff68b523bf7b2ebceda/fairseq/utils.py#L291)

@emilydinan : You originally wrote this code; do you remember why you need this special logic (len() == 1)? I found commenting that out and let pytorch clip handles everything, the training was going fine. 
