### PR TITLE
Context block segfault fix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run flake8
         run: |
           set -eux
-          pip install -q flake8 flake8-bugbear flake8-black docformatter==1.3.0
+          pip install -q flake8 flake8-bugbear flake8-black docformatter==1.3.0 black==19.3b0
           python setup.py develop --no-deps  # get our custom flake8 errors
           python -c 'import parlai'
           flake8 --version

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -998,8 +998,8 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         ctxt = batch.text_vec[batch_idx]
         if self.beam_block_full_context:
             full_ctxt = batch.observations[batch_idx].get('full_text_vec', ctxt)
-            if not isinstance(full_ctxt, torch.LongTensor):
-                full_ctxt = torch.LongTensor(full_ctxt).to(ctxt)
+            if not isinstance(full_ctxt, torch.Tensor):
+                full_ctxt = torch.LongTensor(full_ctxt).to(ctxt.device)
             ctxt = full_ctxt
         return ctxt
 


### PR DESCRIPTION
**Patch description**
In some environments, our beam blocking code causes a segfault. See #2989, for example. This turns out to be because our context blocking isn't semantically correct: torch.cuda.LongTensor is not a subclass of torch.LongTensor, so we're actually converting to cpu and then back to gpu (making it much slower than it should be). It also crashes on pytorch 1.6 somehow, because the LongTensor(cuda_tensor) now throws an exception

CC @jxmsML and @EricMichaelSmith, as this will speed up generation likely.

**Testing steps**
Manual testing on pytorch 1.4 and 1.6. CI.