### PR TITLE
[Squad2] Add option to change label for impossible answers

### DIFF
--- a/parlai/tasks/squad2/agents.py
+++ b/parlai/tasks/squad2/agents.py
@@ -90,6 +90,7 @@ class DefaultTeacher(DialogTeacher):
 
     For SQuAD, this does not efficiently store the paragraphs in memory.
     """
+
     @classmethod
     def add_cmdline_args(cls, argparser):
         agent = argparser.add_argument_group('Squad2 teacher arguments')

--- a/parlai/tasks/squad2/agents.py
+++ b/parlai/tasks/squad2/agents.py
@@ -12,6 +12,16 @@ import json
 import os
 
 
+def add_common_cmdline_args(argparser):
+    agent = argparser.add_argument_group('Squad2 teacher arguments')
+    agent.add_argument(
+        '--impossible-answer-string',
+        type=str,
+        default='',
+        help='Set the label for impossible answers; defaults to an empty string, but one might try something like "I do not know"',
+    )
+
+
 class IndexTeacher(FixedDialogTeacher):
     """
     Hand-written SQuAD teacher, which loads the json squad data and implements its own
@@ -22,6 +32,10 @@ class IndexTeacher(FixedDialogTeacher):
     This teacher also provides access to the "answer_start" indices that specify the
     location of the answer in the context.
     """
+
+    @classmethod
+    def add_cmdline_args(cls, argparser):
+        add_common_cmdline_args(argparser)
 
     def __init__(self, opt, shared=None):
         build(opt)
@@ -55,6 +69,8 @@ class IndexTeacher(FixedDialogTeacher):
             for a in qa['answers']:
                 answers.append(a['text'])
                 answer_starts.append(a['answer_start'])
+        else:
+            answers = [self.opt['impossible_answer_string']]
         context = paragraph['context']
         plausible = qa.get("plausible_answers", [])
 
@@ -93,13 +109,7 @@ class DefaultTeacher(DialogTeacher):
 
     @classmethod
     def add_cmdline_args(cls, argparser):
-        agent = argparser.add_argument_group('Squad2 teacher arguments')
-        agent.add_argument(
-            '--impossible-answer-string',
-            type=str,
-            default='',
-            help='Set the label for impossible answers; defaults to an empty string, but one might try something like "I do not know"',
-        )
+        add_common_cmdline_args(argparser)
 
     def __init__(self, opt, shared=None):
         self.datatype = opt['datatype']
@@ -139,6 +149,10 @@ class OpenSquadTeacher(DialogTeacher):
     Note: This teacher omits the context paragraph
     """
 
+    @classmethod
+    def add_cmdline_args(cls, argparser):
+        add_common_cmdline_args(argparser)
+
     def __init__(self, opt, shared=None):
         self.datatype = opt['datatype']
         build(opt)
@@ -160,10 +174,10 @@ class OpenSquadTeacher(DialogTeacher):
                 # each question is an example
                 for qa in paragraph['qas']:
                     question = qa['question']
-                    ans_iter = [{"text": ''}]
+                    ans_iter = [{"text": self.opt['impossible_answer_string']}]
                     if not qa['is_impossible']:
                         ans_iter = qa['answers']
-                    answers = (a['text'] for a in ans_iter)
+                    answers = [a['text'] for a in ans_iter]
                     yield (question, answers), True
 
 
@@ -197,10 +211,10 @@ class TitleTeacher(DefaultTeacher):
                 # each question is an example
                 for qa in paragraph['qas']:
                     question = qa['question']
-                    ans_iter = [{"text": ""}]
+                    ans_iter = [{'text': self.opt['impossible_answer_string']}]
                     if not qa['is_impossible']:
                         ans_iter = qa['answers']
-                    answers = (a['text'] for a in ans_iter)
+                    answers = [a['text'] for a in ans_iter]
                     context = paragraph['context']
                     yield ('\n'.join([title, context, question]), answers), True
 
@@ -270,6 +284,8 @@ class SentenceIndexTeacher(IndexTeacher):
         plausible = []
         if qa['is_impossible']:
             plausible = qa['plausible_answers']
+            labels = [self.opt['impossible_answer_string']]
+
         action = {
             'id': 'squad',
             'text': context + '\n' + question,
@@ -326,6 +342,8 @@ class SentenceIndexEditTeacher(SentenceIndexTeacher):
         plausible = []
         if qa['is_impossible']:
             plausible = qa['plausible_answers']
+            labels = [self.opt['impossible_answer_string']]
+
         action = {
             'id': 'squad',
             'text': context + '\n' + question,
@@ -392,6 +410,7 @@ class SentenceLabelsTeacher(IndexTeacher):
         plausible = []
         if qa['is_impossible']:
             plausible = qa['plausible_answers']
+            labels = [self.opt['impossible_answer_string']]
         action = {
             'id': 'SquadSentenceLabels',
             'text': question,

--- a/parlai/tasks/squad2/agents.py
+++ b/parlai/tasks/squad2/agents.py
@@ -90,6 +90,15 @@ class DefaultTeacher(DialogTeacher):
 
     For SQuAD, this does not efficiently store the paragraphs in memory.
     """
+    @classmethod
+    def add_cmdline_args(cls, argparser):
+        agent = argparser.add_argument_group('Squad2 teacher arguments')
+        agent.add_argument(
+            '--impossible-answer-string',
+            type=str,
+            default='',
+            help='Set the label for impossible answers; defaults to an empty string, but one might try something like "I do not know"',
+        )
 
     def __init__(self, opt, shared=None):
         self.datatype = opt['datatype']
@@ -112,7 +121,7 @@ class DefaultTeacher(DialogTeacher):
                 # each question is an example
                 for qa in paragraph['qas']:
                     question = qa['question']
-                    ans_list = [{"text": ""}]
+                    ans_list = [{"text": self.opt['impossible_answer_string']}]
                     if not qa['is_impossible']:
                         ans_list = qa['answers']
                     answers = tuple(a['text'] for a in ans_list)


### PR DESCRIPTION
**Patch description**
Squad2 features questions with impossible answers. Currently, the label for these answers is an empty string. One might one to change this, say, for example, to train a model that responds "I don't know" to impossible answers. 

Data can be viewed by:
```
parlai dd -t squad2 --impossible-answer-string "I don't know" -ne 1000
```