### PR TITLE
Allow colored logging in jupyter notebooks.

### DIFF
--- a/parlai/utils/logging.py
+++ b/parlai/utils/logging.py
@@ -58,9 +58,7 @@ def _is_interactive():
 # Some functions in this class assume that ':' will be the separator used in
 # the logging formats setup for this class
 class ParlaiLogger(logging.Logger):
-    def __init__(
-        self, name, console_level=INFO,
-    ):
+    def __init__(self, name, console_level=INFO):
         """
         Initialize the logger object.
 
@@ -88,11 +86,11 @@ class ParlaiLogger(logging.Logger):
             )
         elif _is_interactive():
             return logging.Formatter(
-                prefix_format + CONSOLE_FORMAT, datefmt=CONSOLE_DATE_FORMAT,
+                prefix_format + CONSOLE_FORMAT, datefmt=CONSOLE_DATE_FORMAT
             )
         else:
             return logging.Formatter(
-                prefix_format + LOGFILE_FORMAT, datefmt=LOGFILE_DATE_FORMAT,
+                prefix_format + LOGFILE_FORMAT, datefmt=LOGFILE_DATE_FORMAT
             )
 
     def log(self, msg, level=INFO):

--- a/parlai/utils/logging.py
+++ b/parlai/utils/logging.py
@@ -47,6 +47,14 @@ COLORED_LEVEL_STYLES = {
 }
 
 
+def _is_color_friendly():
+    try:
+        __IPYTHON__
+        return True
+    except NameError:
+        return sys.stdout.isatty()
+
+
 # Some functions in this class assume that ':' will be the separator used in
 # the logging formats setup for this class
 class ParlaiLogger(logging.Logger):

--- a/parlai/utils/logging.py
+++ b/parlai/utils/logging.py
@@ -47,7 +47,7 @@ COLORED_LEVEL_STYLES = {
 }
 
 
-def _is_color_friendly():
+def _is_interactive():
     try:
         __IPYTHON__
         return True
@@ -79,14 +79,14 @@ class ParlaiLogger(logging.Logger):
 
     def _build_formatter(self):
         prefix_format = f'{self.prefix} ' if self.prefix else ''
-        if COLORED_LOGS and sys.stdout.isatty():
+        if COLORED_LOGS and _is_interactive():
             return coloredlogs.ColoredFormatter(
                 prefix_format + COLORED_FORMAT,
                 datefmt=CONSOLE_DATE_FORMAT,
                 level_styles=COLORED_LEVEL_STYLES,
                 field_styles={},
             )
-        elif sys.stdout.isatty():
+        elif _is_interactive():
             return logging.Formatter(
                 prefix_format + CONSOLE_FORMAT, datefmt=CONSOLE_DATE_FORMAT,
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 boto3==1.9.246
 botocore==1.12.246
+coloredlogs==14.0
 docutils<0.16
 emoji==0.5.4
 docformatter==1.3.0


### PR DESCRIPTION
**Patch description**
Right now, jupyter/colab users see these full verbose logs that look like we're logging to files. It's quite annoying. This improves their experience.

**Testing steps**
![image](https://user-images.githubusercontent.com/31896/91625441-67320c00-e975-11ea-8616-fa0f1ab77efe.png)
