### PR TITLE
LR Scheduler fixes

### DIFF
--- a/parlai/agents/test_agents/unigram.py
+++ b/parlai/agents/test_agents/unigram.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+
+"""
+UnigramAgent always predictions the same vocabulary distribution.
+
+It is a full TorchGeneratorAgent model, so it can be used heavily in testing,
+while being very quick to optimize.
+"""
+
+import torch
+import torch.nn as nn
+from parlai.core.torch_generator_agent import TorchGeneratorAgent, TorchGeneratorModel
+
+
+class UnigramEncoder(nn.Module):
+    def forward(self, x):
+        return None
+
+
+class UnigramDecoder(nn.Module):
+    def forward(self, x, encoder_state, incr_state=None):
+        return x, None
+
+
+class UnigramModel(TorchGeneratorModel):
+    def __init__(self, dictionary):
+        super().__init__()
+        self.encoder = UnigramEncoder()
+        self.decoder = UnigramDecoder()
+        self.v = len(dictionary)
+        self.p = nn.Parameter(torch.randn(self.v))
+
+    def output(self, do):
+        desired = tuple(list(do.shape) + [self.v])
+        return self.p.unsqueeze(0).unsqueeze(0).expand(desired)
+
+    def reorder_encoder_states(self, *args):
+        return None
+
+    def reorder_decoder_incremental_state(self, *args):
+        return None
+
+
+class UnigramAgent(TorchGeneratorAgent):
+    def build_model(self):
+        return UnigramModel(self.dict)

--- a/parlai/agents/test_agents/unigram.py
+++ b/parlai/agents/test_agents/unigram.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 """
 UnigramAgent always predictions the same vocabulary distribution.
 
-It is a full TorchGeneratorAgent model, so it can be used heavily in testing,
-while being very quick to optimize.
+It is a full TorchGeneratorAgent model, so it can be used heavily in testing, while
+being very quick to optimize.
 """
 
 import torch

--- a/parlai/agents/test_agents/unigram.py
+++ b/parlai/agents/test_agents/unigram.py
@@ -20,7 +20,7 @@ class UnigramEncoder(nn.Module):
 
 class UnigramDecoder(nn.Module):
     def forward(self, x, encoder_state, incr_state=None):
-        return x, None
+        return x.unsqueeze(-1), None
 
 
 class UnigramModel(TorchGeneratorModel):
@@ -29,11 +29,12 @@ class UnigramModel(TorchGeneratorModel):
         self.encoder = UnigramEncoder()
         self.decoder = UnigramDecoder()
         self.v = len(dictionary)
-        self.p = nn.Parameter(torch.randn(self.v))
+        self.p = nn.Parameter(torch.zeros(self.v))
 
     def output(self, do):
-        desired = tuple(list(do.shape) + [self.v])
-        return self.p.unsqueeze(0).unsqueeze(0).expand(desired)
+        desired = list(do.shape)[:2] + [self.v]
+        x = self.p.unsqueeze(0).unsqueeze(0)
+        return x.expand(desired)
 
     def reorder_encoder_states(self, *args):
         return None

--- a/parlai/agents/test_agents/unigram.py
+++ b/parlai/agents/test_agents/unigram.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-UnigramAgent always predictions the same vocabulary distribution.
+UnigramAgent always predicts the unigram distribution.
 
 It is a full TorchGeneratorAgent model, so it can be used heavily in testing, while
 being very quick to optimize.

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -310,7 +310,7 @@ class ParlaiParser(argparse.ArgumentParser):
 
         super().__init__(
             description=description,
-            allow_abbrev=False,
+            allow_abbrev=True,
             conflict_handler='resolve',
             add_help=True,
             **kwargs,

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -310,7 +310,7 @@ class ParlaiParser(argparse.ArgumentParser):
 
         super().__init__(
             description=description,
-            allow_abbrev=True,
+            allow_abbrev=False,
             conflict_handler='resolve',
             add_help=True,
             **kwargs,

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1101,7 +1101,7 @@ class TorchAgent(ABC, Agent):
 
         # only report LR if we have a scheduler
         if hasattr(self, 'scheduler') and self.scheduler is not None:
-            report['lr'] = GlobalAverageMetric(self.optimizer.param_groups[0]['lr'])
+            report['lr'] = GlobalAverageMetric(self.scheduler.get_last_lr())
 
         if self.use_cuda:
             report['gpu_mem'] = GlobalAverageMetric(self._gpu_usage())

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -60,7 +60,7 @@ class ParlAILRScheduler(object):
             self.warmup_scheduler = optim.lr_scheduler.LambdaLR(
                 optimizer, self._warmup_lr
             )
-            if 'warmup_scheduler' in states:
+            if states.get('warmup_scheduler'):
                 self.warmup_scheduler.load_state_dict(states['warmup_scheduler'])
         else:
             self.warmup_scheduler = None
@@ -307,7 +307,7 @@ class ParlAILRScheduler(object):
 
         Override this method to override the behavior for training schedulers.
         """
-        self._number_training_updates += 1
+        self._number_training_updates = num_steps
         if self._is_lr_warming_up():
             self.warmup_scheduler.step()
         else:

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -63,12 +63,14 @@ class ParlAILRScheduler(object):
         else:
             self.warmup_scheduler = None
 
-    def get_lr(self):
-        if self._is_lr_warming_up():
-            s = self.warmup_scheduler.get_last_lr()[0]
-        else:
-            s = self.scheduler.get_last_lr()[0]
-        return s.get_last_lr()
+    def get_last_lr(self):
+        s = self.warmup_scheduler if self._is_lr_warming_up() else self.scheduler
+        try:
+            # pytorch 1.5 or newer
+            return s.get_last_lr()[0]
+        except AttributeError:
+            # pytorch 1.4 or older
+            return s.optimizer.param_groups[0]['lr']
 
     def _is_lr_warming_up(self):
         """

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -71,6 +71,7 @@ class ParlAILRScheduler(object):
             # pytorch 1.5 or newer
             return s.get_last_lr()[0]
         except AttributeError:
+            # TODO: upon getting rid of pytorch 1.4, kill this
             # pytorch 1.4 or older
             return s.optimizer.param_groups[0]['lr']
 

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -653,7 +653,8 @@ class TrainLoop:
                 # do one example / batch of examples
                 try:
                     world.parley()
-                except StopTrainException:
+                except StopTrainException as e:
+                    logging.info(f"Stopping from {e}")
                     break
 
                 self.parleys += 1

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -22,10 +22,10 @@ class TestLRSchedulers(unittest.TestCase):
         output = []
         for step in range(total_steps):
             scheduler.step(step)
-            output.append(optimizer.param_groups[0]['lr'])
+            output.append(scheduler.get_lr())
         for step, o in enumerate(output):  # noqa: B007
             assert o <= max_lr
-            assert o > 0
+            assert o > 0 or step == total_steps - 1
         warmup_updates = args.get('warmup_updates', 0)
         if warmup_updates > 0:
             assert output[warmup_updates] == max_lr

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -7,6 +7,7 @@
 import unittest
 import torch
 import parlai.nn.lr_scheduler as lr_scheduler
+import parlai.utils.testing as testing_utils
 
 
 class TestLRSchedulers(unittest.TestCase):
@@ -28,9 +29,9 @@ class TestLRSchedulers(unittest.TestCase):
             assert o > 0 or step == total_steps - 1
         warmup_updates = args.get('warmup_updates', 0)
         if warmup_updates > 0:
-            assert output[warmup_updates] == max_lr
+            assert output[warmup_updates - 1] == max_lr
             # no steep cliffs of > 50% of LR
-            assert (output[warmup_updates + 1] - max_lr) / max_lr < 0.5
+            assert (output[warmup_updates] - max_lr) / max_lr < 0.5
             # LR is always linear
             for step in range(warmup_updates - 1):
                 self.assertAlmostEqual(
@@ -38,17 +39,54 @@ class TestLRSchedulers(unittest.TestCase):
                 )
         return output
 
+    def _run_resume(self, max_lr=1.0, warmup_updates=0, total_steps=200, **args):
+        args['warmup_updates'] = warmup_updates
+        if 'max_lr_steps' not in args:
+            args['max_lr_steps'] = total_steps - warmup_updates
+        p = torch.nn.Parameter(torch.randn(4, 4))
+        optimizer = torch.optim.SGD([p], lr=max_lr)
+        scheduler = lr_scheduler.ParlAILRScheduler.lr_scheduler_factory(
+            args, optimizer, {}, True
+        )
+
+        for step in range(total_steps):
+            p = torch.nn.Parameter(torch.randn(4, 4))
+            optimizer2 = torch.optim.SGD([p], lr=max_lr)
+            sd = {
+                'number_training_updates': step + 1,
+                'lr_scheduler': scheduler.get_state_dict(),
+                'lr_scheduler_type': args['lr_scheduler'],
+                'warmup_scheduler': scheduler.get_warmup_state_dict(),
+            }
+            scheduler2 = lr_scheduler.ParlAILRScheduler.lr_scheduler_factory(
+                args, optimizer2, sd, False,
+            )
+            assert scheduler.get_last_lr() == scheduler2.get_last_lr(), step
+            scheduler.step(step)
+
+        sd = {
+            'number_training_updates': step,
+            'lr_scheduler': scheduler.get_state_dict(),
+            'lr_scheduler_type': args['lr_scheduler'],
+            'warmup_scheduler': scheduler.get_warmup_state_dict(),
+        }
+        optimizer2 = torch.optim.SGD([p], lr=max_lr)
+        scheduler2 = lr_scheduler.ParlAILRScheduler.lr_scheduler_factory(
+            args, optimizer2, sd, False
+        )
+        assert scheduler.get_last_lr() == scheduler2.get_last_lr()
+
     def test_cosine(self):
         self._run_pass(lr_scheduler='cosine', warmup_updates=0)
         self._run_pass(lr_scheduler='cosine', warmup_updates=50)
         with self.assertRaises(lr_scheduler.StopTrainException):
             self._run_pass(lr_scheduler='cosine', max_lr_steps=100, total_steps=1000)
 
-    def test_linear_warmup(self):
+    def test_linear(self):
         self._run_pass(lr_scheduler='linear', warmup_updates=0)
         self._run_pass(lr_scheduler='linear', warmup_updates=50)
         with self.assertRaises(lr_scheduler.StopTrainException):
-            self._run_pass(lr_scheduler='cosine', max_lr_steps=100, total_steps=1000)
+            self._run_pass(lr_scheduler='linear', max_lr_steps=100, total_steps=1000)
 
     def test_invsqrt(self):
         self._run_pass(lr_scheduler='invsqrt', warmup_updates=0)
@@ -58,10 +96,49 @@ class TestLRSchedulers(unittest.TestCase):
         steps = self._run_pass(
             lr_scheduler='invsqrt', warmup_updates=50, invsqrt_lr_decay_gamma=1
         )
-        self.assertAlmostEquals(steps[-1], 0.0324443)
+        self.assertAlmostEquals(steps[-1], 0.0324272)
 
         # decay very slowly
         steps = self._run_pass(
             lr_scheduler='invsqrt', warmup_updates=50, invsqrt_lr_decay_gamma=5000
         )
         assert all(x > 0.9 for x in steps[50:])
+
+    def test_cosine_resume(self):
+        self._run_resume(lr_scheduler='cosine', warmup_updates=0)
+        self._run_resume(lr_scheduler='cosine', warmup_updates=50)
+
+    def test_linear_resume(self):
+        self._run_resume(lr_scheduler='linear', warmup_updates=0)
+        self._run_resume(lr_scheduler='linear', warmup_updates=50)
+
+    def test_invsqrt_resume(self):
+        self._run_resume(lr_scheduler='invsqrt', warmup_updates=0)
+        self._run_resume(lr_scheduler='invsqrt', warmup_updates=50)
+
+    def _run_end2end(
+        self, lr_scheduler, max_lr=1.0, warmup_updates=0, total_steps=100, **args
+    ):
+        testing_utils.train_model(
+            {
+                'task': 'integration_tests:nocandidate',
+                'model': 'test_agents/unigram',
+                'skip_generation': True,
+                'lr_scheduler': lr_scheduler,
+                'max_lr_steps': total_steps,
+                'warmup_updates': warmup_updates,
+                'learningrate': max_lr,
+            }
+        )
+
+    def test_end2end_cosine(self):
+        self._run_end2end(lr_scheduler='cosine', warmup_updates=0)
+        self._run_end2end(lr_scheduler='cosine', warmup_updates=50)
+
+    def test_end2end_linear(self):
+        self._run_end2end(lr_scheduler='linear', warmup_updates=0)
+        self._run_end2end(lr_scheduler='linear', warmup_updates=50)
+
+    def test_end2end_invsqrt(self):
+        self._run_end2end(lr_scheduler='invsqrt', warmup_updates=0)
+        self._run_end2end(lr_scheduler='invsqrt', warmup_updates=50)

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -96,7 +96,7 @@ class TestLRSchedulers(unittest.TestCase):
         steps = self._run_pass(
             lr_scheduler='invsqrt', warmup_updates=50, invsqrt_lr_decay_gamma=1
         )
-        self.assertAlmostEquals(steps[-1], 0.0324272)
+        self.assertAlmostEquals(steps[-1], 0.0324443)
 
         # decay very slowly
         steps = self._run_pass(

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -22,7 +22,7 @@ class TestLRSchedulers(unittest.TestCase):
         output = []
         for step in range(total_steps):
             scheduler.step(step)
-            output.append(scheduler.get_lr())
+            output.append(scheduler.get_last_lr())
         for step, o in enumerate(output):  # noqa: B007
             assert o <= max_lr
             assert o > 0 or step == total_steps - 1

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -35,7 +35,7 @@ class TestLRSchedulers(unittest.TestCase):
             # LR is always linear
             for step in range(warmup_updates - 1):
                 self.assertAlmostEqual(
-                    output[step + 1] - output[step], max_lr / warmup_updates, places=3,
+                    output[step + 1] - output[step], max_lr / warmup_updates, places=3
                 )
         return output
 
@@ -59,7 +59,7 @@ class TestLRSchedulers(unittest.TestCase):
                 'warmup_scheduler': scheduler.get_warmup_state_dict(),
             }
             scheduler2 = lr_scheduler.ParlAILRScheduler.lr_scheduler_factory(
-                args, optimizer2, sd, False,
+                args, optimizer2, sd, False
             )
             assert scheduler.get_last_lr() == scheduler2.get_last_lr(), step
             scheduler.step(step)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -797,6 +797,7 @@ class TestLearningRateScheduler(unittest.TestCase):
                     init_model=os.path.join(tmpdir, 'model'),
                     model_file=os.path.join(tmpdir, 'newmodel2'),
                     lr_scheduler='reduceonplateau',
+                    log_every_n_secs=0.001,
                     **args,
                 )
             )

--- a/tests/test_unigram.py
+++ b/tests/test_unigram.py
@@ -14,3 +14,17 @@ class TestUnigram(unittest.TestCase):
             {'model': 'unigram', 'task': 'integration_tests', 'num_epochs': 0.01}
         )
         assert valid['f1'] > 0
+
+
+class TestUnigramTorchAgent(unittest.TestCase):
+    def test_unigram(self):
+        valid, test = testing_utils.train_model(
+            {
+                'model': 'test_agents/unigram',
+                'task': 'integration_tests',
+                'num_epochs': 1.0,
+                'batchsize': 32,
+                'truncate': 4,
+            }
+        )
+        assert valid['f1'] > 0


### PR DESCRIPTION
**Patch description**
Loading a model trained with `cosine` or `linear` LR schedules was throwing an exception on PyTorch 1.6. This is because pytorch 1.6 broke our method for forwarding an LR schedule with `step(num_epochs)`.

List of changes:
- Migrates us to the new sanctioned LR loading
- Works on both pytorch 1.4 and 1.6 (didn't bother testing 1.5.1)
- Adds a new `test_agents/unigram` model, which is a torch generator agent that always outputs fixed distributions. This is useful to have a TA that has extremely few parameters (tens or hundreds) and can be trained extremely fast. (Also added its own CI for this)
- Add end2end tests for select LR schedulers
- Add resume LR checks for select LR schedulers.

**Testing steps**
- Ran select unit tests in both 1.4 and 1.6.
- New CI