### PR TITLE
[ACUTE][Mephisto] Fix extend that should append

### DIFF
--- a/parlai/crowdsourcing/tasks/acute_eval/acute_eval_runner.py
+++ b/parlai/crowdsourcing/tasks/acute_eval/acute_eval_runner.py
@@ -277,7 +277,7 @@ class AcuteEvalRunner(TaskRunner):
             worker_data["conversations_seen"].extend(
                 self._get_dialogue_ids(self.desired_tasks[t])
             )
-            task_data.extend(self.desired_tasks[t])
+            task_data.append(self.desired_tasks[t])
 
         return task_data
 


### PR DESCRIPTION
**Patch description**
Small fix to the ACUTE-eval Mephisto task. Over time, as people returned tasks they would sometimes be added wrongly to the missing task queue (due to being wrongly added to an individual's queue with `extend` rather than `append`).

**Testing steps**
@hadasah has been running ACUTEs with this change successfully without running into this bug.
