### PR TITLE
Old dict file fix

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -327,7 +327,6 @@ def create_agent_from_opt_file(opt: Opt):
     opt_from_file['model_file'] = model_file  # update model file path
 
     # update dict file path
-    import pdb; pdb.set_trace()
     if not opt_from_file.get('dict_file'):
         old_dict_file = None
         opt_from_file['dict_file'] = model_file + '.dict'

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -327,7 +327,9 @@ def create_agent_from_opt_file(opt: Opt):
     opt_from_file['model_file'] = model_file  # update model file path
 
     # update dict file path
+    import pdb; pdb.set_trace()
     if not opt_from_file.get('dict_file'):
+        old_dict_file = None
         opt_from_file['dict_file'] = model_file + '.dict'
     elif opt_from_file.get('dict_file') and not PathManager.exists(
         opt_from_file['dict_file']


### PR DESCRIPTION
**Patch description**
This fixes the issue where, if you have no `opt['dict_file']` at all, the `warn_once()` on line 339 will break because `old_dict_file` hasn't been defined. This happens if you're loading a model that doesn't read a dictionary from disk (i.e. a HuggingFace model)

**Testing steps**
(Running the internal version of https://github.com/facebookresearch/ParlAI/tree/master/parlai/mturk/tasks/turn_annotations on the medium-sized DialoGPT model)
