### PR TITLE
[DOC DAY] Updating installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Though pip install command is easier, it would not give you access to the ready 
 ## Examples
 
 A large set of scripts can be found in [`parlai/scripts`](https://github.com/facebookresearch/ParlAI/tree/master/parlai/scripts). Here are a few of them.
-Note: If any of these examples fail, check the [requirements section](#requirements) to see if you have missed something.
+Note: If any of these examples fail, check the [installation section](#installing-parlai) to see if you have missed something.
 
 Display 10 random examples from the SQuAD task
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ subword-nmt==0.3.7
 tensorboard==2.3.0
 tensorboardX==2.1
 tokenizers>=0.8.0
-torchtext==0.7.0
+torchtext>=0.5.0
 tqdm==4.36.1
 typing-extensions==3.7.4.1
 Unidecode==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ torch>=1.4.0
 joblib==0.14.1
 nltk==3.4.5
 numpy==1.17.5
+pandas==1.1.1
 pytest==5.3.2
 pexpect==4.7.0
 Pillow==7.2.0
@@ -32,7 +33,10 @@ sphinx_rtd_theme==0.4.3
 sphinx-autodoc-typehints==1.10.3
 Sphinx==2.2.0
 subword-nmt==0.3.7
+tensorboard==2.3.0
+tensorboardX==2.1
 tokenizers>=0.8.0
+torchtext==0.7.0
 tqdm==4.36.1
 typing-extensions==3.7.4.1
 Unidecode==1.1.1


### PR DESCRIPTION
**Patch description**
- Add some missing requirements
- Fix requirements section link in README

**Testing steps**
```
parlai display_data -t squad 
-> Ran fine

python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_90M/model
-> Ran fine

$ python -m parlai.scripts.train_model -t personachat -m transformer/ranker -mf /tmp/model_tr6 --n-layers 1 --embedding-size 300 --ffn-size 600 --n-heads 4 --num-epochs 2 -veps 0.25 -bs 64 -lr 0.001 --dropout 0.1 --embedding-type fasttext_cc --candidates batch  
->  ModuleNotFoundError: No module named 'torchtext'

Added --tensorboard-log true 
->  ImportError: Please run `pip install tensorboard tensorboardX`.

$ parlai display_data -t dialogue_safety
->  ImportError: Please install pandas by running `pip install pandas`
```

`pip freeze` gave me these versions:
```
pandas==1.1.1
tensorboard==2.3.0
tensorboardX==2.1
torchtext==0.7.0
```

I then created a new environment, ran `python setup.py develop`, and verified that all of the above commands now work "out fo the box".
