### PR TITLE
[Chat Services] Browser Chat Bug Fix

### DIFF
--- a/parlai/chat_service/services/browser_chat/client.py
+++ b/parlai/chat_service/services/browser_chat/client.py
@@ -64,10 +64,13 @@ class BrowserHandler(BaseHTTPRequestHandler):
             json_str = json.dumps(model_response)
             self.wfile.write(bytes(json_str, 'utf-8'))
         elif self.path == '/reset':
+            self._interactive_running(b"[RESET]")
             self.send_response(200)
             self.send_header('Content-type', 'application/json')
             self.end_headers()
             self.wfile.write(bytes("{}", 'utf-8'))
+            message_available.wait()
+            message_available.clear()
         else:
             return self._respond({'status': 500})
 

--- a/parlai/chat_service/tasks/chatbot/worlds.py
+++ b/parlai/chat_service/tasks/chatbot/worlds.py
@@ -62,7 +62,7 @@ class MessengerBotChatTaskWorld(World):
                     'id': 'World',
                     'text': 'Welcome to the ParlAI Chatbot demo. '
                     'You are now paired with a bot - feel free to send a message.'
-                    'Type [DONE] to finish the chat.',
+                    'Type [DONE] to finish the chat, or [RESET] to reset the dialogue history.',
                 }
             )
             self.first_time = False
@@ -70,6 +70,9 @@ class MessengerBotChatTaskWorld(World):
         if a is not None:
             if '[DONE]' in a['text']:
                 self.episodeDone = True
+            elif '[RESET]' in a['text']:
+                self.model.reset()
+                self.agent.observe({"text": "[History Cleared]", "episode_done": False})
             else:
                 print("===act====")
                 print(a)


### PR DESCRIPTION
**Patch description**
Fix for issue #3033. "Restart Conversation" in the browser chat was not resetting convo history, and instead just clearing the window text.

This patch also adds the `[RESET]` option to the `chatbot` demo, allowing one to reset the dialogue history.

**Testing steps**
Local testing; see screenshots in logs.

**Logs**
Here's the conversation without resetting dialogue history:

<img width="1523" alt="Screen Shot 2020-09-02 at 5 24 44 PM" src="https://user-images.githubusercontent.com/8562788/92038716-cf9c3700-ed41-11ea-86b6-7d3231879ae7.png">


Here's the conversation using the `[RESET]`  message:

<img width="1523" alt="Screen Shot 2020-09-02 at 5 25 12 PM" src="https://user-images.githubusercontent.com/8562788/92038727-d2972780-ed41-11ea-973f-c612e0f8aff1.png">

Finally, here's two screenshots of the conversation before and after hitting "Restart Conversation"
<img width="1531" alt="Screen Shot 2020-09-02 at 5 25 30 PM" src="https://user-images.githubusercontent.com/8562788/92038733-d6c34500-ed41-11ea-996e-963b62648bd2.png">
<img width="1518" alt="Screen Shot 2020-09-02 at 5 25 41 PM" src="https://user-images.githubusercontent.com/8562788/92038745-d88d0880-ed41-11ea-9c8c-36f6b595c978.png">

