### PR TITLE
Test and details in convo render

### DIFF
--- a/parlai/scripts/convo_render.py
+++ b/parlai/scripts/convo_render.py
@@ -174,7 +174,7 @@ def pre_process(fname, num_ex, alt_speaker):
             dialogue = data["dialog"]
             for item in dialogue:
                 speaker = item[0]['id']
-                text = item[0]["text"]
+                text = item[0]['text']
                 conversation += [(speaker, text)]
             conversation += [(END_OF_CONVO, END_OF_CONVO)]
 

--- a/parlai/scripts/convo_render.py
+++ b/parlai/scripts/convo_render.py
@@ -173,11 +173,9 @@ def pre_process(fname, num_ex, alt_speaker):
             data = json.loads(line)
             dialogue = data["dialog"]
             for item in dialogue:
-                if item["speaker"] == "human_evaluator":
-                    speaker = "human"
-                else:
-                    speaker = alt_speaker
-                conversation += [(speaker, item["text"])]
+                speaker = item[0]['id']
+                text = item[0]["text"]
+                conversation += [(speaker, text)]
             conversation += [(END_OF_CONVO, END_OF_CONVO)]
 
     return conversation
@@ -300,7 +298,7 @@ def render_convo(opt):
     # Run
     opt.log()
     extension = validate_args(opt)
-    input_file, output_file = opt['intput'], opt['output']
+    input_file, output_file = opt['input'], opt['output']
     height, width = opt['height'], opt['width']
     alt_speaker = input_file.split('/')[-1][:-6]
 

--- a/tests/test_convo_render.py
+++ b/tests/test_convo_render.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+import parlai.scripts.self_chat as self_chat
+import parlai.scripts.convo_render as convo_render
+
+
+class TestConvoRender(unittest.TestCase):
+    def test_convo_render(self):
+        """
+        Test convo render by creating a self-chat, saving it to file and render it to html.
+        """
+        self_chat_pp = self_chat.setup_args()
+        self_chat_opt = self_chat_pp.parse_args(
+            [
+                '-m',
+                'fixed_response',
+                '--fixed-response',
+                'Hey there',
+                '--save-format',
+                'conversations',
+                '--outfile',
+                'self_chat_output',
+            ]
+        )
+        self_chat.self_chat(self_chat_opt)
+
+        convo_render_pp = convo_render.setup_args()
+        convo_render_opt = convo_render_pp.parse_args(
+            ['-i', 'self_chat_output.jsonl', '-o', 'self_chat_output.html']
+        )
+        convo_render.render_convo(convo_render_opt)

--- a/tests/test_convo_render.py
+++ b/tests/test_convo_render.py
@@ -12,7 +12,8 @@ import parlai.scripts.convo_render as convo_render
 class TestConvoRender(unittest.TestCase):
     def test_convo_render(self):
         """
-        Test convo render by creating a self-chat, saving it to file and render it to html.
+        Test convo render by creating a self-chat, saving it to file and render it to
+        html.
         """
         self_chat_pp = self_chat.setup_args()
         self_chat_opt = self_chat_pp.parse_args(


### PR DESCRIPTION
**Patch description**
Test was added for `convo_render.py` that will create a self-chat, save it to file to then render it to HTML. Also fixed a typo and updated field names.



**Logs**
<!-- If applicable, please paste the command line from your testing: -->
Tested with:
```
pytest -s tests/test_convo_render.py
```
