### PR TITLE
Version 0.9.1.

### DIFF
--- a/parlai/__init__.py
+++ b/parlai/__init__.py
@@ -4,4 +4,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
         url='http://parl.ai/',
         python_requires='>=3.6',
         packages=find_packages(
-            exclude=('data', 'docs', 'examples', 'tests', 'parlai_internal*',)
+            exclude=('data', 'docs', 'examples', 'tests', 'parlai_internal*')
         ),
         install_requires=reqs,
         include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 
 from setuptools import setup, find_packages
 
-VERSION = '0.9.0'  # if you update, update parlai/__init__.py too!
+VERSION = '0.9.1'  # if you update, update parlai/__init__.py too!
 
 if sys.version_info < (3, 6):
     sys.exit('Sorry, Python >=3.6 is required for ParlAI.')


### PR DESCRIPTION

# Version 0.9.1 Changelog:

ParlAI now supports pytorch 1.6.

Breaking changes:
- Change the arguments for JsonFile teacher, and fix some bugs (#3054)
- ParlAI now expects HuggingFace tokenizers >=0.8.0 (#2967)


New features/Improvements:
- Release of LIGHT-WILD project (#2992)
- HRED has now been added as a standard model (#2989)
- DialoGPT has been added as a standard model (#3007)
- Allow colored logging in jupyter notebooks. (#3024)
- [Squad2] Add option to change label for impossible answers (#3020)
- ChunkTeacher has support to prevent auto enqueuing (#2993)
- Add support for PathManager. (#3011)
- DistilGPT2 has been added as an option of GPT2 model (#2997)
- tfidf_retriever now reports doc ids (#3008)


**Lots of new/updated documentation**
- Custom metrics tutorial (#2975)
- Chat Services tutorial clarification (#3048)
- Release of Mephisto ACUTE-Evals (#3002)
- Writing custom scripts and integration with `parlai` command (#3046)
- Writing tests for ParlAI (#3044)
- Contributor guide (#3047)
- Mark deprecation of ParlAI MTurk for Mephisto (#2988)
- Small modifications (#3036, #2994, #3031, #2916)
- Updates to docs on how to build docs (#3041)
- Update Link and Commands Display format (#2952)



Bugfixes:
- Upgrade to pytorch 1.6 (#3022)
- Linear/Cosine LR schedulers don't crash in distributed (#3000)
- Fix unexpected crashes in convo_render (#3052)
- Context block segfault fix (#3019)
- Fix crash in loading from checkpoint in Cosine/Linear LR schedulers (#3025)
- Upgrade schedulers to be Pytorch 1.6 friendly (#3025)
- Fix bug where "restart conversation" didn't work in chat_services browser (#3050)
- Faster amazon QA teacher (#2851)
- Fix crashes to Reward Unlikelihood agent (#3034)
- Fix a misalignment in BART agent between generation and training (#3021)
- Prevent mixing model parallel and multiprocessing. (#2964)
- [ACUTE][Mephisto] Fix extend that should append (#3029)
- Adding option to load pretrained model from directory for gpt2 (#3027)
- Fix an obscure crash with dict_file and GPT2 (#3038)


Developer:
- Improve coverage of some base agents (#3026)
- CircleCI now produces a build of website as an artifact (#3035)
- Rework sphinx docs and upgrade docs to MarkDown (#2972, #2999, #3003)
- Minor refactor of transformer decoder forward (#3009)