### PR TITLE
[BART] Don't override init if it exists

### DIFF
--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -28,6 +28,7 @@ from parlai.core.torch_agent import History
 from parlai.core.torch_generator_agent import PPLMetric
 from parlai.core.metrics import AverageMetric
 from parlai.utils.typing import TShared
+from parlai.utils.io import PathManager
 from parlai.zoo.bart.build import download, CONVERSION_ARGS, BART_ARGS
 
 
@@ -80,7 +81,7 @@ class BartAgent(TransformerGeneratorAgent):
         :return opt:
             return opt with BART-specific args.
         """
-        if not opt.get('converting') and not os.path.exists(opt.get('init_model'), ''):
+        if not opt.get('converting') and not PathManager.exists(opt.get('init_model'), ''):
             download(opt['datapath'])
             opt['init_model'] = os.path.join(
                 opt['datapath'], 'models/bart/bart_large/model'

--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -82,7 +82,7 @@ class BartAgent(TransformerGeneratorAgent):
             return opt with BART-specific args.
         """
         if not opt.get('converting') and not PathManager.exists(
-            opt.get('init_model'), ''
+            opt.get('init_model', '')
         ):
             download(opt['datapath'])
             opt['init_model'] = os.path.join(

--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -80,7 +80,7 @@ class BartAgent(TransformerGeneratorAgent):
         :return opt:
             return opt with BART-specific args.
         """
-        if not opt.get('converting'):
+        if not opt.get('converting') and not os.path.exists(opt.get('init_model'), ''):
             download(opt['datapath'])
             opt['init_model'] = os.path.join(
                 opt['datapath'], 'models/bart/bart_large/model'

--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -81,8 +81,9 @@ class BartAgent(TransformerGeneratorAgent):
         :return opt:
             return opt with BART-specific args.
         """
-        if not opt.get('converting') and not PathManager.exists(
-            opt.get('init_model', '')
+        if not opt.get('converting') and (
+            opt.get('init_model') is None
+            or not PathManager.exists(opt.get('init_model', ''))
         ):
             download(opt['datapath'])
             opt['init_model'] = os.path.join(

--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -81,7 +81,9 @@ class BartAgent(TransformerGeneratorAgent):
         :return opt:
             return opt with BART-specific args.
         """
-        if not opt.get('converting') and not PathManager.exists(opt.get('init_model'), ''):
+        if not opt.get('converting') and not PathManager.exists(
+            opt.get('init_model'), ''
+        ):
             download(opt['datapath'])
             opt['init_model'] = os.path.join(
                 opt['datapath'], 'models/bart/bart_large/model'


### PR DESCRIPTION
**Patch description**
We should not override the init model if it exists. This causes
- issues with load from checkpoint when you are pre-empted
- the BART model to download, even when you're fine-tuning an already trained model