### PR TITLE
[BART] allow overriding BART args

### DIFF
--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -91,7 +91,13 @@ class BartAgent(TransformerGeneratorAgent):
             )
         if opt.get('init_fairseq_model'):
             opt = self._convert_model(opt)
-        opt.update(BART_ARGS)
+
+        overrides = opt.get('override', {})
+        for k, v in BART_ARGS.items():
+            # do not override anything in `override`
+            if k not in overrides:
+                opt[k] = v
+
         compare_init_model_opts(opt, opt)
         return opt
 

--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -63,6 +63,7 @@ class BartAgent(TransformerGeneratorAgent):
             help='where to save fairseq conversion',
         )
         argparser.set_defaults(dict_tokenizer='gpt2')
+        argparser.set_defaults(**BART_ARGS)
 
     def __init__(self, opt: Opt, shared: TShared = None):
         if not shared:
@@ -91,12 +92,6 @@ class BartAgent(TransformerGeneratorAgent):
             )
         if opt.get('init_fairseq_model'):
             opt = self._convert_model(opt)
-
-        overrides = opt.get('override', {})
-        for k, v in BART_ARGS.items():
-            # do not override anything in `override`
-            if k not in overrides:
-                opt[k] = v
 
         compare_init_model_opts(opt, opt)
         return opt


### PR DESCRIPTION
**Patch description**
Allow override of BART args. For example, @wyshi  is hacking on some extra positional embeddings so we can deal with longer contexts, so we need to be able to override `--n-positions 2048`. This allows us to do so.
