### PR TITLE
[History] Global end token bug

### DIFF
--- a/parlai/agents/hugging_face/gpt2.py
+++ b/parlai/agents/hugging_face/gpt2.py
@@ -246,6 +246,7 @@ class Gpt2Agent(TorchGeneratorAgent):
         argparser.set_defaults(
             text_truncate=768,
             label_truncate=256,
+            history_add_global_end_token='\n',
             dict_maxexs=0,  # skip building dictionary
         )
         super(Gpt2Agent, cls).add_cmdline_args(argparser)

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -203,7 +203,7 @@ class History(object):
         self.reversed = opt.get('history_reversed', False)
         self._global_end_token = opt.get('history_add_global_end_token', None)
         if self._global_end_token is not None:
-            self._global_end_token = self.dict[self.dict.end_token]
+            self._global_end_token = self.parse(opt['history_add_global_end_token'])
 
         # set up history objects
         self.max_len = maxlen
@@ -322,7 +322,7 @@ class History(object):
         if self.temp_history is not None:
             history.extend([self.parse(self.temp_history)])
         if self._global_end_token is not None:
-            history += [[self._global_end_token]]
+            history += [self._global_end_token]
 
         history = sum(history, [])
         if self.reversed:


### PR DESCRIPTION
**Patch description**
The global end token in history was not respecting the argument set by the flag `--history-add-global-end-token` and instead was adding `self.end_idx` always.
