### PR TITLE
Disable zipfile serialization option of torch.save

### DIFF
--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -55,10 +55,12 @@ def atomic_save(state_dict: Any, path: str) -> None:
 
     if io_util.USE_ATOMIC_TORCH_SAVE:
         with open(path + ".tmp", "wb") as f:
+            # TODO: Upgrade the manifold torch version. See T75615407
             torch.save(state_dict, f, _use_new_zipfile_serialization=False)
         os.rename(path + ".tmp", path)
     else:
         # PathManager deosn't support os.rename. See T71772714
+        # TODO: Upgrade the manifold torch version. See T75615407
         torch.save(state_dict, path, _use_new_zipfile_serialization=False)
 
 

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -55,11 +55,11 @@ def atomic_save(state_dict: Any, path: str) -> None:
 
     if io_util.USE_ATOMIC_TORCH_SAVE:
         with open(path + ".tmp", "wb") as f:
-            torch.save(state_dict, f)
+            torch.save(state_dict, f, _use_new_zipfile_serialization=False)
         os.rename(path + ".tmp", path)
     else:
         # PathManager deosn't support os.rename. See T71772714
-        torch.save(state_dict, path)
+        torch.save(state_dict, path, _use_new_zipfile_serialization=False)
 
 
 def padded_tensor(

--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -55,12 +55,12 @@ def atomic_save(state_dict: Any, path: str) -> None:
 
     if io_util.USE_ATOMIC_TORCH_SAVE:
         with open(path + ".tmp", "wb") as f:
-            # TODO: Upgrade the manifold torch version. See T75615407
+            # Manifold plugin doesn't support the new 1.6 serialization method. See T75615407
             torch.save(state_dict, f, _use_new_zipfile_serialization=False)
         os.rename(path + ".tmp", path)
     else:
         # PathManager deosn't support os.rename. See T71772714
-        # TODO: Upgrade the manifold torch version. See T75615407
+        # Manifold plugin doesn't support the new 1.6 serialization method. See T75615407
         torch.save(state_dict, path, _use_new_zipfile_serialization=False)
 
 


### PR DESCRIPTION
Due to torch versioning, the option is needed when loading the models from manifold
This will fix the error 
raise RuntimeError('New zip file serialization is currently not supported '
RuntimeError: New zip file serialization is currently not supported by Manifold serialization. Please set _use_new_zipfile_serialization=False when doing torch.save

**Testing steps**
With the patch, I was able to successfully load the model from manifold and use it for inference on the messaging_internal

the model was saved in manifold here:
manifold ls cair_models/tree/test_model/v8
  2041509510 model
  2041509510 model.checkpoint
       64601 model.checkpoint.dict
        3593 model.checkpoint.dict.opt
        3474 model.checkpoint.opt
       39400 model.checkpoint.trainstats
       64577 model.dict
        3567 model.dict.opt
        3474 model.opt
         245 model.test
       39401 model.trainstats
         248 model.valid

test:
python tests/datatests/test_new_tasks.py
.
----------------------------------------------------------------------
Ran 1 test in 0.031s

OK
