### PR TITLE
Self-chat batch size assertion error

### DIFF
--- a/parlai/scripts/self_chat.py
+++ b/parlai/scripts/self_chat.py
@@ -81,7 +81,7 @@ def setup_args(parser=None):
 def _run_self_chat_episode(opt, world, world_logger):
     bsz = opt.get('batchsize', 1)
     num_turns = opt['selfchat_max_turns']
-    assert bsz == 1, "Batch size cannot be greater than 1 for self-chat"
+    assert bsz == 1, "Batch size cannot be different than 1 for self-chat"
     num_parleys = math.ceil(num_turns / bsz)
     for _ in range(num_parleys):
         world.parley()

--- a/parlai/scripts/self_chat.py
+++ b/parlai/scripts/self_chat.py
@@ -81,7 +81,7 @@ def setup_args(parser=None):
 def _run_self_chat_episode(opt, world, world_logger):
     bsz = opt.get('batchsize', 1)
     num_turns = opt['selfchat_max_turns']
-
+    assert bsz == 1, "Batch size cannot be greater than 1 for self-chat"
     num_parleys = math.ceil(num_turns / bsz)
     for _ in range(num_parleys):
         world.parley()


### PR DESCRIPTION
**Patch description**
(Bug found during docday) Self-chat breaks whenever `-bsz` is greater than 1, adding `AssertionError` for now to prevent from breaking.