### PR TITLE
[Chunk Teacher] Add sleep before enqueuing next load

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2223,6 +2223,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
             if self.is_train or self.tot_samples_loaded % self.dws == self.rank:
                 self.samples.put(sample)
             self.tot_samples_loaded += 1
+        time.sleep(0.01)  # release thread
         # and start loading the next chunk
         self._enqueue_request()
 


### PR DESCRIPTION
**Patch description**
Add a sleep before enqueueing the next load when the buffer is filled. This allows the thread to be released. I've been seeing issues where the thread is not released and this seems to help.
