### PR TITLE
Start always with human when no topic is selected. Else it gives erro…

### DIFF
--- a/parlai/tasks/wizard_of_wikipedia/worlds.py
+++ b/parlai/tasks/wizard_of_wikipedia/worlds.py
@@ -135,7 +135,10 @@ class InteractiveWorld(DialogPartnerWorld):
         if self.cnt == 0:
             self.topic = self._get_new_topic()
             self.acts = [None, None]
-            self.human_first = random.choice([0, 1])
+            if self.topic != NO_TOPIC:
+                self.human_first = random.choice([0, 1])
+            else:
+                self.human_first = 1
 
         # possibly get human act first
         if self.cnt == 0 and not self.human_first:


### PR DESCRIPTION
Always start with the human when no topic (Option E) is selected in Interactive mode. Else it gives error since no text to process if the bot goes first (i.e. 50% time).

**Patch description**
WoW throws an error of "no text" 50% of the time, when option E is selected, i.e. No Topic

**Testing steps**
You can now run WoW scripts with WoW tasks in interactive mode and it will always run with option E selected. Which was happening earlier randomly 50% of the time.

**Logs**
parlai interactive -t wizard_of_wikipedia:generator -mf zoo:wizard_of_wikipedia/end2end_generator/model

Then select option E.
```
```
