### PR TITLE
Seed messages from task flag in self chat

### DIFF
--- a/parlai/scripts/self_chat.py
+++ b/parlai/scripts/self_chat.py
@@ -49,7 +49,8 @@ def setup_args(parser=None):
     )
     parser.add_argument(
         '--seed-messages-from-task',
-        action='store_true',
+        type='bool',
+        default=False,
         help='Automatically seed conversation with messages from task dataset.',
     )
     parser.add_argument(


### PR DESCRIPTION
**Patch description**
`--seed-messages-from-task` it's been changed to a boolean flag since before it was `action_store` which made it impossible to override once set. I tried to look for anything else that could be affected by this change but couldn't find anything, so I think this should be okay but please let me know if you think I missed something. I also considered this should be `False` by default (I might be wrong though).

Once this PR is approved, [this](https://github.com/facebookresearch/ParlAI/pull/3082) will pass.