### PR TITLE
changed use_reply default from 'label' to 'none'

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -618,7 +618,7 @@ class TorchAgent(ABC, Agent):
         )
         agent.add_argument(
             '--use-reply',
-            default='none',
+            default='label',
             hidden=True,
             choices=['label', 'model', 'none'],
             help='Which previous replies to use as history. If label, use '
@@ -669,7 +669,6 @@ class TorchAgent(ABC, Agent):
             help='disable GPUs even if available. otherwise, will use GPUs if '
             'available on the device.',
         )
-
         cls.dictionary_class().add_cmdline_args(argparser)
         ParlAILRScheduler.add_cmdline_args(argparser)
 

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -618,7 +618,7 @@ class TorchAgent(ABC, Agent):
         )
         agent.add_argument(
             '--use-reply',
-            default='label',
+            default='none',
             hidden=True,
             choices=['label', 'model', 'none'],
             help='Which previous replies to use as history. If label, use '

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -290,6 +290,7 @@ class TorchClassifierAgent(TorchAgent):
             default=None,
             help='Ignore labels provided to model',
         )
+        parser.set_defaults(use_reply='none')
 
     def __init__(self, opt: Opt, shared=None):
         init_model, self.is_finetune = self._get_init_model(opt, shared)


### PR DESCRIPTION
This is a small change in the command line args for TorchAgent. This changes default value for the argument _use_reply_ from "label" to "none". This ensures the ground-truth labels won't, by default, be included in the history for multi-turn agents.