### PR TITLE
Add jga metric to taskmaster2

### DIFF
--- a/parlai/tasks/taskmaster2/agents.py
+++ b/parlai/tasks/taskmaster2/agents.py
@@ -171,6 +171,9 @@ class _Abstract(DialogTeacher):
                     f'{domain}_slot_r',
                     AverageMetric(correct, len(teacher_action['slots'])),
                 )
+                self.metrics.add(
+                    'jga', AverageMetric(correct == len(teacher_action['slots']))
+                )
 
         elif teacher_action['type'] == 'apiresp':
             # keep track of statistics by domain


### PR DESCRIPTION
Fairly straightforward.

Test Plan:

Ran an eval model with the model that I had trained previously on taskmaster2 w/ PPL as a metric locally.