### PR TITLE
Using the ParlAI color

### DIFF
--- a/docs/source/_static/css/parlai_theme.css
+++ b/docs/source/_static/css/parlai_theme.css
@@ -91,11 +91,11 @@ th p, td div.line-block {
 /* Change link colors (except for the menu) */
 
 a {
-    color: #CE3239;
+    color: #ec1454;
 }
 
 a:hover {
-    color: #CE3239;
+    color: #ec1454;
 }
 
 

--- a/website/static/css/home-theme.css
+++ b/website/static/css/home-theme.css
@@ -400,7 +400,7 @@ footer ul.primary-nav li:last-child a {
     background-repeat: no-repeat;
     background-size: cover;
     background-position: center;
-    background-color: #ce3239;
+    background-color: #ec1454;
     height: 500px;
     position: relative;
 }

--- a/website/static/css/parlai.css
+++ b/website/static/css/parlai.css
@@ -501,7 +501,7 @@ footer ul.primary-nav li:last-child a {
     background-repeat: no-repeat;
     background-size: cover;
     background-position: center;
-    background-color: #ce3239;
+    background-color: #ec1454;
     height: 500px;
     position: relative;
 }

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -1,4 +1,4 @@
-<div class="jumbotron" style="background-color: #ce3239; margin-bottom: 0px">
+<div class="jumbotron" style="background-color: #ec1454; margin-bottom: 0px">
     <div class="container" style="text-align: center; color: #fff">
         <h1 style="font-size: 40px; margin-bottom: 30px; margin-top: 32px; letter-spacing: -0.01em;
 line-height: 1.22em">A unified platform for sharing, training and evaluating dialogue models across many tasks.</h1>


### PR DESCRIPTION
**Patch description**
@moyapchen raised the concern that the parl.ai website was not using the same color throughout as the color of the icon, and now the discrepancy can't be unseen. 

This PR replaces all references to the wrong `#ce3239` with the correct `#ec1454`

**Testing steps**
Directly edited the HTML on the site, this now looks like it matches:
![Screen Shot 2020-09-30 at 1 53 44 PM](https://user-images.githubusercontent.com/1276867/94721890-803b2d80-0324-11eb-8173-941b1900ceff.png)
