### PR TITLE
Temp static-turn-annotations compatibility note

### DIFF
--- a/parlai/crowdsourcing/tasks/turn_annotations_static/README.md
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/README.md
@@ -1,3 +1,5 @@
+**NOTE: this code is incompatible with the latest version of Mephisto, beginning with the changes made in [PR #246](https://github.com/facebookresearch/Mephisto/pull/246). This task will be upgraded shortly to regain compatibility with the latest version; in the meantime, please use the last version release of Mephisto prior to that PR, [v0.1](https://github.com/facebookresearch/Mephisto/releases/tag/v0.1).**
+
 # Turn Annotations Static Task
 This task renders conversations from a file and asks for turn by turn annotations of them. 
 This is in contrast to the crowdsourcing task turn_annotations which collects turn by turn annotations from a live human-model conversation.


### PR DESCRIPTION
Add a temporary note to mention the compatibility issue with the static turn-annotations task until the refactor has been tested and merged in
