### PR TITLE
Make sure folder is always created when unzipping COCO

### DIFF
--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -348,10 +348,19 @@ def _unzip(path, fname, delete=True):
     with zipfile.ZipFile(PathManager.open(fullpath, 'rb'), 'r') as zf:
         for member in zf.namelist():
             outpath = os.path.join(path, member)
+            dirname = os.path.dirname(member)
             if zf.getinfo(member).is_dir():
+                # Member is a subfolder, so make it if it does not exist
                 logging.debug(f"Making directory {outpath}")
                 PathManager.mkdirs(outpath)
                 continue
+            elif dirname != '':
+                # Member is a file *in* a subfolder, so make the subfolder if it does
+                # not exist
+                outfolder = os.path.join(path, dirname)
+                if not PathManager.isdir(outfolder):
+                    logging.debug(f"Making directory {outfolder}")
+                    PathManager.mkdirs(outfolder)
             logging.debug(f"Extracting to {outpath}")
             with zf.open(member, 'r') as inf, PathManager.open(outpath, 'wb') as outf:
                 shutil.copyfileobj(inf, outf)

--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -348,19 +348,10 @@ def _unzip(path, fname, delete=True):
     with zipfile.ZipFile(PathManager.open(fullpath, 'rb'), 'r') as zf:
         for member in zf.namelist():
             outpath = os.path.join(path, member)
-            dirname = os.path.dirname(member)
             if zf.getinfo(member).is_dir():
-                # Member is a subfolder, so make it if it does not exist
                 logging.debug(f"Making directory {outpath}")
                 PathManager.mkdirs(outpath)
                 continue
-            elif dirname != '':
-                # Member is a file *in* a subfolder, so make the subfolder if it does
-                # not exist
-                outfolder = os.path.join(path, dirname)
-                if not PathManager.isdir(outfolder):
-                    logging.debug(f"Making directory {outfolder}")
-                    PathManager.mkdirs(outfolder)
             logging.debug(f"Extracting to {outpath}")
             with zf.open(member, 'r') as inf, PathManager.open(outpath, 'wb') as outf:
                 shutil.copyfileobj(inf, outf)

--- a/parlai/tasks/coco_caption/build_2017.py
+++ b/parlai/tasks/coco_caption/build_2017.py
@@ -69,7 +69,8 @@ def build(opt):
         if build_data.built(dpath):
             # an older version exists, so remove these outdated files.
             build_data.remove_dir(dpath)
-        build_data.make_dir(dpath)
+        build_data.make_dir(os.path.join(dpath, 'annotations'))
+        # Make the subfolder into which files will be unzipped
 
         # download the data.
         for downloadable_file in RESOURCES[3:]:


### PR DESCRIPTION
**Patch description**
The members of the COCO Captions ZIP file, as listed by `ZipFile.namelist()`, include several files in an `annotations` subfolder but not the `annotations` subfolder itself, leading to a `FileNotFoundError` when `.built_data._unzip()` tries to copy these nested files to a subfolder that does not exist. This fix will create the subfolder if it does not exist.  

**Testing steps**
`parlai dd -t coco_caption`
