### PR TITLE
Check directory depending on size param for gpt2 files

### DIFF
--- a/parlai/agents/hugging_face/dict.py
+++ b/parlai/agents/hugging_face/dict.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 from parlai.core.dict import DictionaryAgent
+from parlai.utils.io import PathManager
 
 
 try:
@@ -74,22 +75,23 @@ class Gpt2DictionaryAgent(HuggingFaceDictionaryAgent):
         """
         Instantiate tokenizer.
         """
+        model_sz = opt["gpt2_size"]
+        if model_sz == "small":
+            model_key = "gpt2"
+        elif model_sz == "distilgpt2":
+            model_key = "distilgpt2"
+        else:
+            model_key = f"gpt2-{model_sz}"
         # check if datapath has the files that hugging face code looks for
+        hf_dir = os.path.join(opt["datapath"], "hf", model_key)
         if all(
-            os.path.isfile(
-                os.path.join(opt["datapath"], "models", "gpt2_hf", file_name)
-            )
+            PathManager.exists(os.path.join(hf_dir, file_name))
             for file_name in ["merges.txt", "vocab.json"]
         ):
-            fle_key = os.path.join(opt["datapath"], "models", "gpt2_hf")
+            fle_key = PathManager.get_local_path(hf_dir, recursive=True)
+
         else:
-            model_sz = opt["gpt2_size"]
-            if model_sz == "small":
-                fle_key = "gpt2"
-            elif model_sz == "distilgpt2":
-                fle_key = "distilgpt2"
-            else:
-                fle_key = f"gpt2-{model_sz}"
+            fle_key = model_key
         return GPT2Tokenizer.from_pretrained(fle_key)
 
     def _define_special_tokens(self, opt):


### PR DESCRIPTION
**Patch description**
Earlier distilgpt2 model was trying to load the gpt2 weights and hence failing during runtime. Now we load the files according to the type of the model being loaded

**Testing steps**
with-proxy python3 parlai/scripts/train_model.py -t integration_tests -m hugging_face/gpt2 -mf /tmp/model --max-train-time 100 -vmt ppl


