### PR TITLE
Note about metrics in AbstractWrapperTeacher.act()

### DIFF
--- a/parlai/tasks/wrapper/agents.py
+++ b/parlai/tasks/wrapper/agents.py
@@ -60,9 +60,8 @@ class AbstractWrapperTeacher(Teacher, ABC):
     def act(self):
         """
         Act on the previous observation.
-        
-        Note that self.task.act() must be called in this method for metrics to be
-        recorded correctly.
+
+        Typically, self.task.act() will be called in this method.
         """
         raise NotImplementedError('Abstract class: user must implement act() method')
 

--- a/parlai/tasks/wrapper/agents.py
+++ b/parlai/tasks/wrapper/agents.py
@@ -60,6 +60,9 @@ class AbstractWrapperTeacher(Teacher, ABC):
     def act(self):
         """
         Act on the previous observation.
+        
+        Note that self.task.act() must be called in this method for metrics to be
+        recorded correctly.
         """
         raise NotImplementedError('Abstract class: user must implement act() method')
 

--- a/parlai/tasks/wrapper/agents.py
+++ b/parlai/tasks/wrapper/agents.py
@@ -61,7 +61,7 @@ class AbstractWrapperTeacher(Teacher, ABC):
         """
         Act on the previous observation.
 
-        Typically, self.task.act() will be called in this method.
+        Typically, self.task.act() will need to be called in this method.
         """
         raise NotImplementedError('Abstract class: user must implement act() method')
 


### PR DESCRIPTION
Add to the docstring that `self.task.act()` must be called in the wrapper's `.act()` method for metrics to be recorded correctly