### PR TITLE
Another opt bug fix ('init_model' not being set correctly)

### DIFF
--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -324,9 +324,12 @@ def create_agent_from_opt_file(opt: Opt):
         if k not in opt_from_file:
             opt_from_file[k] = v
 
-    opt_from_file['model_file'] = model_file  # update model file path
+    # update model file path to the one set by opt
+    opt_from_file['model_file'] = model_file
+    # update init model path to the one set by opt
+    # NOTE: this step is necessary when for example the 'init_model' is
+    # set by the Train Loop (as is the case when loading from checkpoint)
     if opt.get('init_model') is not None:
-        # update the init model path
         opt_from_file['init_model'] = opt['init_model']
 
     # update dict file path

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -325,6 +325,9 @@ def create_agent_from_opt_file(opt: Opt):
             opt_from_file[k] = v
 
     opt_from_file['model_file'] = model_file  # update model file path
+    if opt.get('init_model') is not None:
+        # update the init model path
+        opt_from_file['init_model'] = opt['init_model']
 
     # update dict file path
     if not opt_from_file.get('dict_file'):

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -182,7 +182,7 @@ class TestInitOpt(unittest.TestCase):
 
 class TestCreateAgentFromOpt(unittest.TestCase):
     """
-    Test functionality related to create_agent_from_opt_file
+    Test functionality related to create_agent_from_opt_file.
     """
 
     def test_init_from_from_checkpoint(self):

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -9,6 +9,7 @@ import os
 import unittest
 
 import parlai.utils.testing as testing_utils
+from parlai.core.agents import create_agent_from_opt_file
 from parlai.core.opt import Opt
 from parlai.core.params import ParlaiParser
 from parlai.scripts.compare_opts import compare_opts
@@ -177,3 +178,35 @@ class TestInitOpt(unittest.TestCase):
                 init_opt=init_opt_path, allow_missing_init_opts=True
             )
             self.assertFalse(hasattr(opt, 'made_up_arg'))
+
+
+class TestCreateAgentFromOpt(unittest.TestCase):
+    """
+    Test functionality related to create_agent_from_opt_file
+    """
+
+    def test_init_from_from_checkpoint(self):
+        with testing_utils.tempdir() as temp_dir:
+            opt_from_file = {
+                'datapath': 'dummy_path',
+                'model': 'repeat_label',
+                'init_model': os.path.join(temp_dir, 'something'),
+                'model_file': os.path.join(temp_dir, 'something_else'),
+            }
+            opt = Opt(
+                {
+                    'datapath': 'dummy_path',
+                    'model': 'repeat_label',
+                    'init_model': os.path.join(temp_dir, 'something_else.checkpoint'),
+                    'model_file': os.path.join(temp_dir, 'something_else'),
+                    'load_from_checkpoint': True,
+                }
+            )
+
+            with open(os.path.join(temp_dir, 'something_else.opt'), 'w') as f:
+                f.write(json.dumps(opt_from_file))
+
+            agent = create_agent_from_opt_file(opt)
+            init_model = agent.opt['init_model']
+            # assert that the model was loaded with the correct checkpoitn
+            assert '.checkpoint' in init_model


### PR DESCRIPTION
**Patch description**
`create_agent_from_opt_file` was not properly copying over `'init_model'` as set by `opt`. This causes issues, when, for example, we have a model that has been (1) initialized with some model file (2) requeued and has (3) `load_from_checkpoint = True`. When requeued, the `'init_model'` will revert back to the model set in (1) inside `create_agent_from_opt_file`, instead of using the checkpoint file set by the train script (which is contained in `opt['init_model']`). This in turn leads to TorchAgent loading the model file from the best valid instead of the checkpoint.

Thanks to @wyshi for finding this bug!!

