### PR TITLE
add a --version flag to the parlai command #3163

### DIFF
--- a/parlai/core/script.py
+++ b/parlai/core/script.py
@@ -169,7 +169,6 @@ class _SupercommandParser(ParlaiParser):
         self.print_help()
 
 
-
 class _SubcommandParser(ParlaiParser):
     """
     ParlaiParser which always sets add_parlai_args and add_model_args to False.

--- a/parlai/core/script.py
+++ b/parlai/core/script.py
@@ -210,7 +210,7 @@ def superscript_main(args=None):
         action='helpall',
         help=helpall_help_str,
     )
-    versioninfo_help_str = 'Prints version info and exit.srlai '
+    versioninfo_help_str = 'Prints version info and exit.'
     parser.add_argument(
         '--version',
         action='version',

--- a/parlai/core/script.py
+++ b/parlai/core/script.py
@@ -204,18 +204,16 @@ def superscript_main(args=None):
     parser = _SupercommandParser(
         False, False, formatter_class=_SuperscriptHelpFormatter
     )
-    helpall_help_str = 'List all commands, including advanced ones.'
     parser.add_argument(
         '--helpall',
         action='helpall',
-        help=helpall_help_str,
+        help='List all commands, including advanced ones.',
     )
-    versioninfo_help_str = 'Prints version info and exit.'
     parser.add_argument(
         '--version',
         action='version',
         version=get_version_string(),
-        help=versioninfo_help_str,
+        help='Prints version info and exit.',
     )
     parser.set_defaults(super_command=None)
     subparsers = parser.add_subparsers(
@@ -225,13 +223,13 @@ def superscript_main(args=None):
         'help',
         aliases=['h'],
         help=argparse.SUPPRESS,
-        description="List the main commands",
+        description='Prints version info and exit.',
     )
     hparser.set_defaults(super_command='help')
     hparser = subparsers.add_parser(
         'helpall',
         help=argparse.SUPPRESS,
-        description=helpall_help_str,
+        description='List all commands, including advanced ones.',
     )
     hparser.set_defaults(super_command='helpall')
 

--- a/parlai/core/script.py
+++ b/parlai/core/script.py
@@ -223,7 +223,7 @@ def superscript_main(args=None):
         'help',
         aliases=['h'],
         help=argparse.SUPPRESS,
-        description='Prints version info and exit.',
+        description='List the main commands.',
     )
     hparser.set_defaults(super_command='help')
     hparser = subparsers.add_parser(

--- a/parlai/core/script.py
+++ b/parlai/core/script.py
@@ -17,6 +17,7 @@ Also contains helper classes for loading scripts, etc.
 import io
 import argparse
 from typing import List, Optional, Dict, Any
+import parlai
 from parlai.core.opt import Opt
 from parlai.core.params import ParlaiParser, CustomHelpFormatter
 from abc import abstractmethod
@@ -168,6 +169,7 @@ class _SupercommandParser(ParlaiParser):
         self.print_help()
 
 
+
 class _SubcommandParser(ParlaiParser):
     """
     ParlaiParser which always sets add_parlai_args and add_model_args to False.
@@ -203,10 +205,18 @@ def superscript_main(args=None):
     parser = _SupercommandParser(
         False, False, formatter_class=_SuperscriptHelpFormatter
     )
+    helpall_help_str = 'List all commands, including advanced ones.'
     parser.add_argument(
         '--helpall',
         action='helpall',
-        help='show all commands, including advanced ones.',
+        help=helpall_help_str,
+    )
+    versioninfo_help_str = 'Prints version info and exit.srlai '
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=get_version_string(),
+        help=versioninfo_help_str,
     )
     parser.set_defaults(super_command=None)
     subparsers = parser.add_subparsers(
@@ -222,7 +232,7 @@ def superscript_main(args=None):
     hparser = subparsers.add_parser(
         'helpall',
         help=argparse.SUPPRESS,
-        description="List all commands, including advanced ones.",
+        description=helpall_help_str,
     )
     hparser.set_defaults(super_command='helpall')
 
@@ -265,7 +275,13 @@ def superscript_main(args=None):
     cmd = opt.pop('super_command')
     if cmd == 'helpall':
         parser.print_helpall()
+    elif cmd == 'versioninfo':
+        exit(0)
     elif cmd == 'help' or cmd is None:
         parser.print_help()
     elif cmd is not None:
         return SCRIPT_REGISTRY[cmd].klass._run_from_parser_and_opt(opt, parser)
+
+
+def get_version_string() -> str:
+    return f"ParlAI version {parlai.__version__}"


### PR DESCRIPTION
**Patch description**
Fixes #3163 

Some utilities (like GNU core utilities) also print copyright/license info. Other utilities (like git or firefox) only print program name and the version.

I wasn't sure which the maintainers would prefer, so just left it at program name and version info, but this could be updated.

**Testing steps**
manual test of:
```
$ parlai --version
ParlAI version 0.9.3
```
meets expected behavior.

It's a small change and I didn't bother running the test suit locally. Hopefully the CI will do that...