### PR TITLE
Add "fb" option to autoformat script for `parlai_fb`

### DIFF
--- a/autoformat.sh
+++ b/autoformat.sh
@@ -28,6 +28,7 @@ Optional Arguments
   -f, --flake8       only run flake8.
   -h, --help         print this help message and exit
   -i, --internal     run within parlai_internal
+  -z, --fb     run within parlai_fb
 EOF
 }
 
@@ -53,6 +54,7 @@ onlyexists() {
 RUN_ALL_FILES=0
 RUNALL=1
 INTERNAL=0
+FB=0
 CHECK=0
 CMD=""
 while true; do
@@ -80,6 +82,9 @@ while true; do
     -i | --internal)
       INTERNAL=1
       ;;
+    -z | --fb)
+      FB=1
+      ;;
     -b | --black)
       [[ "$CMD" != "" ]] && (echo "Don't mix args." && false);
       CMD="black"
@@ -103,6 +108,9 @@ done
 if [[ $INTERNAL -eq 1 ]]; then
     ROOT="$(git -C ./parlai_internal/ rev-parse --show-toplevel)"
     REPO="-C ./parlai_internal"
+elif [[ $FB -eq 1 ]]; then
+    ROOT="$(git -C ./parlai_fb/ rev-parse --show-toplevel)"
+    REPO="-C ./parlai_fb"
 else
     ROOT=""
     REPO=""
@@ -112,7 +120,7 @@ fi
 if [[ $RUN_ALL_FILES -eq 1 ]]; then
     CHECK_FILES="$(git $REPO ls-files | grep '\.py$' | reroot $ROOT | onlyexists $ROOT | tr '\n' ' ')"
 else
-    CHECK_FILES="$(git $REPO diff --name-only master... | grep '\.py$' | reroot $ROOT | onlyexists | tr '\n' ' ')"
+    CHECK_FILES="$(git $REPO diff --name-only master | grep '\.py$' | reroot $ROOT | onlyexists | tr '\n' ' ')"
 fi
 
 # if we're doing all the tests, we should run them in serial
@@ -120,6 +128,7 @@ if [[ $RUNALL -eq 1 ]]
 then
     if [[ $CHECK -eq 1 ]]; then A="$A --check"; fi
     if [[ $INTERNAL -eq 1 ]]; then A="$A --internal"; fi
+    if [[ $FB -eq 1 ]]; then A="$A --fb"; fi
     if [[ $RUN_ALL_FILES -eq 1 ]]; then A="$A --all"; fi
     bash $0 --black $A
     bash $0 --doc $A


### PR DESCRIPTION
'f' was already taken by flake, so I just made the single letter code `z`

NOTE: I also fixed a bug where running the autoformatter didn't seem to do anything locally by removing the ellipses after "master" in
```
    CHECK_FILES="$(git $REPO diff --name-only master... | grep '\.py$' | reroot $ROOT | onlyexists | tr '\n' ' ')"
```

I have no idea if there are side effects on CircleCI or whatnot from doing this.

**Testing steps**
Add a bunch of empty new lines to the start of files in `parlai`, `parlai_internal`, and `parlai_fb`. Verify that autoformat appropriately removes these lines while running autoformat with no flag, `-i`, and `-z`, respectively. 