### PR TITLE
Make tests/datatests/test_new_tasks.py work

### DIFF
--- a/tests/datatests/test_new_tasks.py
+++ b/tests/datatests/test_new_tasks.py
@@ -59,13 +59,13 @@ class TestNewTasks(unittest.TestCase):
                 opt['task'] = subt
                 try:
                     with testing_utils.capture_output():
-                        text, log = verify(opt)
+                        verify_results = verify(opt)
                 except Exception:
                     found_errors = True
                     traceback.print_exc()
                     print("Got above exception in {}".format(subt))
                 for key in KEYS:
-                    if log[key] != 0:
+                    if verify_results[key] != 0:
                         print('There are {} {} in {}.'.format(log[key], key, subt))
                         found_errors = True
 

--- a/tests/datatests/test_new_tasks.py
+++ b/tests/datatests/test_new_tasks.py
@@ -66,7 +66,11 @@ class TestNewTasks(unittest.TestCase):
                     print("Got above exception in {}".format(subt))
                 for key in KEYS:
                     if verify_results[key] != 0:
-                        print('There are {} {} in {}.'.format(log[key], key, subt))
+                        print(
+                            'There are {} {} in {}.'.format(
+                                verify_results[key], key, subt
+                            )
+                        )
                         found_errors = True
 
         if found_errors:


### PR DESCRIPTION
Values were there, just the format changed slightly.

Tested/debugged by changing
  `parlai/tasks/jsonfile/agents.py`
to load in the example json file colocated in the same directly.

Printed the results of `verify(opt)` as well as the `KEYS` object; that made it clear-ish what ought to be happening.

**Patch description**
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. -->

**Logs**
<!-- If applicable, please paste the command line from your testing: -->
```
```

**Other information**
<!-- Any other information or context you would like to provide. -->

**Data tests (if applicable)**
If you added a new teacher, you will be asked to run
`python tests/datatests/test_new_tasks.py`. Please paste this log here.
