### PR TITLE
Fix convai2:normalized task's candidate list

### DIFF
--- a/parlai/tasks/convai2/agents.py
+++ b/parlai/tasks/convai2/agents.py
@@ -108,7 +108,7 @@ class NormalizedTeacher(SelfOriginalTeacher):
         for (text, labels, reward, candidates), new_episode in super().setup_data(path):
             text = self.normalize_replies(text)
             labels = [self.normalize_replies(l) for l in labels]
-            candidates = [self.normalize_replies(l) for l in labels]
+            candidates = [self.normalize_replies(c) for c in candidates]
             yield (text, labels, reward, candidates), new_episode
 
 


### PR DESCRIPTION
**Patch description**
- Fix the list of candidates generated by `convai2:normalized` task.
  - AS-IS code returns normalized labels rather than candidates, which was ruining the evaluation of retrieval based models on this task. (hits@1 always hits 1.0)