### PR TITLE
Add beam_texts to defaults

### DIFF
--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -46,6 +46,7 @@ DISPLAY_MESSAGE_DEFAULT_FIELDS = {
     'text_vec',
     'label_candidates_vecs',
     'token_losses',
+    'beam_texts'
 }
 
 

--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -46,7 +46,7 @@ DISPLAY_MESSAGE_DEFAULT_FIELDS = {
     'text_vec',
     'label_candidates_vecs',
     'token_losses',
-    'beam_texts'
+    'beam_texts',
 }
 
 


### PR DESCRIPTION
Otherwise it prints out these when doing standard interactive.