### PR TITLE
[Poly] Allow Polyencoder to resize token embs

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -21,7 +21,7 @@ from parlai.core.params import ParlaiParser
 
 class TestTransformerBase(unittest.TestCase):
     """
-    Base Tester class for sharing functionality
+    Base Tester class for sharing functionality.
     """
 
     def _test_resize_embeddings(self, model):
@@ -327,7 +327,7 @@ class TestTransformerGenerator(TestTransformerBase):
     @pytest.mark.nofbcode
     def test_beamsearch_return_all_texts(self):
         """
-        Test beam_texts for beam_size > 1
+        Test beam_texts for beam_size > 1.
         """
         size = 3
 

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -19,6 +19,55 @@ from .test_dict import DEFAULT_BYTELEVEL_BPE_VOCAB, DEFAULT_BYTELEVEL_BPE_MERGE
 from parlai.core.params import ParlaiParser
 
 
+class TestTransformerBase(unittest.TestCase):
+    """
+    Base Tester class for sharing functionality
+    """
+
+    def _test_resize_embeddings(self, model):
+        with testing_utils.tempdir() as tmpdir:
+            model_file = os.path.join(tmpdir, 'model_file')
+            _, _ = testing_utils.train_model(
+                dict(
+                    model=model,
+                    task='integration_tests:short_fixed',
+                    n_layers=1,
+                    n_encoder_layers=2,
+                    n_decoder_layers=4,
+                    num_epochs=1,
+                    dict_tokenizer='bytelevelbpe',
+                    bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,
+                    bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
+                    bpe_add_prefix_space=False,
+                    model_file=model_file,
+                    save_after_valid=True,
+                )
+            )
+
+            # now create agent with special tokens
+            parser = ParlaiParser()
+            parser.set_params(
+                model=model,
+                task='integration_tests:short_fixed',
+                n_layers=1,
+                n_encoder_layers=2,
+                n_decoder_layers=4,
+                dict_tokenizer='bytelevelbpe',
+                bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,
+                bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
+                bpe_add_prefix_space=False,
+                model_file=model_file,
+                save_after_valid=True,
+                special_tok_lst='PARTY,PARROT',
+            )
+            opt = parser.parse_args([])
+            agent = create_agent(opt)
+            # assert that the embeddings were resized
+            assert agent.resized_embeddings
+            # assert model has special tokens
+            self.assertEqual(agent.special_toks, ['PARTY', 'PARROT'])
+
+
 class TestTransformerRanker(unittest.TestCase):
     """
     Checks that transformer_ranker can learn some very basic tasks.
@@ -199,7 +248,7 @@ class TestTransformerRanker(unittest.TestCase):
         self.assertGreaterEqual(test['hits@1'], 0.90)
 
 
-class TestTransformerGenerator(unittest.TestCase):
+class TestTransformerGenerator(TestTransformerBase):
     """
     Checks that the generative transformer can learn basic tasks.
     """
@@ -560,48 +609,7 @@ class TestTransformerGenerator(unittest.TestCase):
 
     @pytest.mark.nofbcode
     def test_resize_embeddings(self):
-        # train original model
-        with testing_utils.tempdir() as tmpdir:
-            model_file = os.path.join(tmpdir, 'model_file')
-            _, _ = testing_utils.train_model(
-                dict(
-                    model='transformer/generator',
-                    task='integration_tests:short_fixed',
-                    n_layers=1,
-                    n_encoder_layers=2,
-                    n_decoder_layers=4,
-                    num_epochs=1,
-                    dict_tokenizer='bytelevelbpe',
-                    bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,
-                    bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
-                    bpe_add_prefix_space=False,
-                    model_file=model_file,
-                    save_after_valid=True,
-                )
-            )
-
-            # now create agent with special tokens
-            parser = ParlaiParser()
-            parser.set_params(
-                model='transformer/generator',
-                task='integration_tests:short_fixed',
-                n_layers=1,
-                n_encoder_layers=2,
-                n_decoder_layers=4,
-                dict_tokenizer='bytelevelbpe',
-                bpe_vocab=DEFAULT_BYTELEVEL_BPE_VOCAB,
-                bpe_merge=DEFAULT_BYTELEVEL_BPE_MERGE,
-                bpe_add_prefix_space=False,
-                model_file=model_file,
-                save_after_valid=True,
-                special_tok_lst='PARTY,PARROT',
-            )
-            opt = parser.parse_args([])
-            agent = create_agent(opt)
-            # assert that the embeddings were resized
-            assert agent.resized_embeddings
-            # assert model has special tokens
-            self.assertEqual(agent.special_toks, ['PARTY', 'PARROT'])
+        self._test_resize_embeddings('transformer/generator')
 
 
 class TestClassifier(unittest.TestCase):
@@ -761,6 +769,16 @@ class TestLearningRateScheduler(unittest.TestCase):
             msg='Invsqrt LR {} was not 1/4 at step 16'.format(valid2['lr']),
             delta=0.001,
         )
+
+
+class TestPolyencoder(TestTransformerBase):
+    """
+    Unit tests for PolyencoderAgent.
+    """
+
+    @pytest.mark.nofbcode
+    def test_resize_embeddings(self):
+        self._test_resize_embeddings('transformer/polyencoder')
 
 
 @testing_utils.skipUnlessVision


### PR DESCRIPTION
**Patch description**
Similar to how we support this for the `transformer/generator`, I've enabled the ability to add special tokens to the poly-encoder dictionary via adding the function to resize token embeddings.

1) Mainly copied `TransformerGenerator._resize_embeddings` and fit to polyencoder setup.
2) Shamelessly used an existing test for CI

Note that it might look a bit like copy and paste, and there probably is a way to make this slightly more readable, however it's a bit model-dependent (i.e. which embeddings specifically are resized, the model attrs/state dict keys). If we find ourselves adding this to several more models it'll probably be better to standardize the function in `TorchAgent`

**Testing steps**
Local testing as well as CI.

**Logs**
<!-- If applicable, please paste the command line from your testing: -->
```
$  pytest -k TestPolyencoder
======= test session starts =======
platform linux -- Python 3.6.10, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, configfile: pytest.ini, testpaths: tests
plugins: requests-mock-1.8.0
collected 414 items / 413 deselected / 1 selected

tests/test_transformers.py .                                                                                                                                                   [100%]

======= slowest 10 durations =======
11.41s call     tests/test_transformers.py::TestPolyencoder::test_resize_embeddings

(2 durations < 0.005s hidden.  Use -vv to show these durations.)
======= 1 passed, 413 deselected, 15 warnings in 16.24s =======
```
