### PR TITLE
[supercmd] Show subcommand help error messages on parse error.

### DIFF
--- a/parlai/core/script.py
+++ b/parlai/core/script.py
@@ -126,6 +126,9 @@ class _SupercommandParser(ParlaiParser):
     """
 
     def __init__(self, *args, **kwargs):
+        # used to target help messages more correctly, see GH #3182
+        self._help_subparser = None
+
         from parlai.utils.strings import colorize
 
         logo = ""
@@ -146,6 +149,22 @@ class _SupercommandParser(ParlaiParser):
         sa = sa[0]
         for _, v in sa.choices.items():
             v.add_extra_args(args)
+
+    def parse_known_args(self, args=None, namespace=None, nohelp=False):
+        known, unused = super().parse_known_args(args, namespace, nohelp)
+        if hasattr(known, '_subparser'):
+            # keep this around to keep the print message more in tune
+            self._help_subparser = known._subparser
+        return known, unused
+
+    def print_help(self):
+        """
+        Print help, possibly deferring to the appropriate subcommand.
+        """
+        if self._help_subparser:
+            self._help_subparser.print_help()
+        else:
+            return super().print_help()
 
     def add_subparsers(self, **kwargs):
         return super().add_subparsers(**kwargs)

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -92,8 +92,17 @@ class TestSuperCommand(unittest.TestCase):
             script.superscript_main(args=['help'])
             assert 'test_script' in output.getvalue()
             assert 'hidden_script' not in output.getvalue()
+            # showing help for the super command, not the subcommand
+            assert '--foo' not in output.getvalue()
 
         with testing_utils.capture_output() as output:
             script.superscript_main(args=['helpall'])
             assert 'test_script' in output.getvalue()
             assert 'hidden_script' in output.getvalue()
+
+    def test_subcommand_help(self):
+        with testing_utils.capture_output() as output:
+            with self.assertRaises(SystemExit):
+                script.superscript_main(args=['test_script', 'foo'])
+                assert 'parlai test_script' in output.getvalue()
+                assert '--foo' in output.getvalue()


### PR DESCRIPTION
**Patch description**
Fixes #3182.

**Testing steps**
New CI.

**Logs**
Manual test
```
$ parlai interactive foo
usage: parlai interactive [-h] [--helpall] [-o INIT_OPT] [-t TASK]
                          [-dt DATATYPE] [-bs BATCHSIZE]
                          [-dynb {None,full,batchsort}] [-dp DATAPATH]
                          [-m MODEL] [-mf MODEL_FILE] [-im INIT_MODEL]
                          [-d DISPLAY_EXAMPLES]
                          [--display-prettify DISPLAY_PRETTIFY]
                          [--display-ignore-fields DISPLAY_IGNORE_FIELDS]
                          [-it INTERACTIVE_TASK] [--outfile OUTFILE]
                          [--save-format {conversations,parlai}]
                          [-fixedCands LOCAL_HUMAN_CANDIDATES_FILE]
                          [--single-turn SINGLE_TURN]
                          [--log-keep-fields LOG_KEEP_FIELDS]

Interactive chat with a model on the command line

optional arguments:
  -h, --help
        show this help message and exit
  --helpall
        Show usage, including advanced arguments.
  -o, --init-opt INIT_OPT
        Path to json file of options. Note: Further Command-line arguments
        override file-based options. (default: None)
  -t, --task TASK
        ParlAI task(s), e.g. "babi:Task1" or "babi,cbt" (default: interactive)
  -dt, --datatype DATATYPE
        choose from: train, train:ordered, valid, test. to stream data add
        ":stream" to any option (e.g., train:stream). by default train is
        random with replacement, valid is ordered, test is ordered. (default:
        train)
  -bs, --batchsize BATCHSIZE
        batch size for minibatch training schemes (default: 1)
  -dynb, --dynamic-batching {None,full,batchsort}
        Use dynamic batching (default: None)
  -dp, --datapath DATAPATH
        path to datasets, defaults to {parlai_dir}/data (default: None)
  -m, --model MODEL
        the model class name. can match parlai/agents/<model> for agents in
        that directory, or can provide a fully specified module for `from X
        import Y` via `-m X:Y` (e.g. `-m
        parlai.agents.seq2seq.seq2seq:Seq2SeqAgent`) (default: None)
  -mf, --model-file MODEL_FILE
        model file name for loading and saving models (default: None)
  -im, --init-model INIT_MODEL
        Initialize model weights and dict from this file (default: None)
  -d, --display-examples DISPLAY_EXAMPLES
  --display-prettify DISPLAY_PRETTIFY
        Set to use a prettytable when displaying examples with text candidates
        (default: False)
  --display-ignore-fields DISPLAY_IGNORE_FIELDS
        Do not display these fields (default:
        label_candidates,text_candidates)
  -it, --interactive-task INTERACTIVE_TASK
        Create interactive version of task (default: True)
  --outfile OUTFILE
        Saves a jsonl file containing all of the task examples and model
        replies. Set to the empty string to not save at all (default: )
  --save-format {conversations,parlai}
        Format to save logs in. conversations is a jsonl format, parlai is a
        text format. (default: conversations)
  -fixedCands, --local-human-candidates-file LOCAL_HUMAN_CANDIDATES_FILE
        File of label_candidates to send to other agent (default: None)
  --single-turn SINGLE_TURN
        If on, assumes single turn episodes. (default: False)
  --log-keep-fields LOG_KEEP_FIELDS
        Fields to keep when logging. Should be a comma separated list
        (default: all)

optional arguments:
  -h, --help
        show this help message and exit
  --helpall
        Show usage, including advanced arguments.
  -d, --display-examples DISPLAY_EXAMPLES
  --display-prettify DISPLAY_PRETTIFY
        Set to use a prettytable when displaying examples with text candidates
        (default: False)
  --display-ignore-fields DISPLAY_IGNORE_FIELDS
        Do not display these fields (default:
        label_candidates,text_candidates)
  -it, --interactive-task INTERACTIVE_TASK
        Create interactive version of task (default: True)
  --outfile OUTFILE
        Saves a jsonl file containing all of the task examples and model
        replies. Set to the empty string to not save at all (default: )
  --save-format {conversations,parlai}
        Format to save logs in. conversations is a jsonl format, parlai is a
        text format. (default: conversations)

Main ParlAI Arguments:
  -o, --init-opt INIT_OPT
        Path to json file of options. Note: Further Command-line arguments
        override file-based options. (default: None)
  -t, --task TASK
        ParlAI task(s), e.g. "babi:Task1" or "babi,cbt" (default: interactive)
  -dt, --datatype DATATYPE
        choose from: train, train:ordered, valid, test. to stream data add
        ":stream" to any option (e.g., train:stream). by default train is
        random with replacement, valid is ordered, test is ordered. (default:
        train)
  -bs, --batchsize BATCHSIZE
        batch size for minibatch training schemes (default: 1)
  -dynb, --dynamic-batching {None,full,batchsort}
        Use dynamic batching (default: None)
  -dp, --datapath DATAPATH
        path to datasets, defaults to {parlai_dir}/data (default: None)

ParlAI Model Arguments:
  -m, --model MODEL
        the model class name. can match parlai/agents/<model> for agents in
        that directory, or can provide a fully specified module for `from X
        import Y` via `-m X:Y` (e.g. `-m
        parlai.agents.seq2seq.seq2seq:Seq2SeqAgent`) (default: None)
  -mf, --model-file MODEL_FILE
        model file name for loading and saving models (default: None)
  -im, --init-model INIT_MODEL
        Initialize model weights and dict from this file (default: None)

Local Human Arguments:
  -fixedCands, --local-human-candidates-file LOCAL_HUMAN_CANDIDATES_FILE
        File of label_candidates to send to other agent (default: None)
  --single-turn SINGLE_TURN
        If on, assumes single turn episodes. (default: False)

World Logging:
  --log-keep-fields LOG_KEEP_FIELDS
        Fields to keep when logging. Should be a comma separated list
        (default: all)

Parse Error: unrecognized arguments: foo
```
