### PR TITLE
R3f mixin

### DIFF
--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -20,6 +20,7 @@ from typing import Optional, Dict, Any
 from parlai.agents.bart.convert_fairseq_to_parlai import ConversionScript
 from parlai.agents.bart.modules import BartModel
 from parlai.agents.transformer.transformer import TransformerGeneratorAgent
+from parlai.agents.transformer.module_extensions import R3FMixin
 from parlai.core.agents import compare_init_model_opts
 from parlai.core.message import Message
 from parlai.core.opt import Opt
@@ -49,6 +50,7 @@ class BartAgent(TransformerGeneratorAgent):
         Override to add init-fairseq-model arg.
         """
         TransformerGeneratorAgent.add_cmdline_args(argparser)
+        R3FMixin.add_cmdline_args(argparser)
         group = argparser.add_argument_group('Bart Args')
         group.add_argument(
             '--init-fairseq-model',
@@ -173,9 +175,7 @@ class BartAgent(TransformerGeneratorAgent):
         Override to seed decoder with EOS BOS token.
         """
         return (
-            torch.LongTensor(  # type: ignore
-                [self.END_IDX, self.START_IDX]
-            )
+            torch.LongTensor([self.END_IDX, self.START_IDX])  # type: ignore
             .expand(bsz * beam_size, 2)
             .to(dev)
         )
@@ -237,3 +237,12 @@ class BartAgent(TransformerGeneratorAgent):
                 )
             )
         return token_losses
+
+
+class BartAgent_R3F(R3FMixin, BartAgent):
+    @staticmethod
+    def add_cmdline_args(argparser: ParlaiParser):
+        R3FMixin.add_cmdline_args(argparser)
+        BartAgent.add_cmdline_args(argparser)
+
+    pass

--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -20,7 +20,6 @@ from typing import Optional, Dict, Any
 from parlai.agents.bart.convert_fairseq_to_parlai import ConversionScript
 from parlai.agents.bart.modules import BartModel
 from parlai.agents.transformer.transformer import TransformerGeneratorAgent
-from parlai.agents.transformer.module_extensions import R3FMixin
 from parlai.core.agents import compare_init_model_opts
 from parlai.core.message import Message
 from parlai.core.opt import Opt
@@ -28,6 +27,7 @@ from parlai.core.params import ParlaiParser
 from parlai.core.torch_agent import History
 from parlai.core.torch_generator_agent import PPLMetric
 from parlai.core.metrics import AverageMetric
+from parlai.nn.r3f import R3FMixin
 from parlai.utils.typing import TShared
 from parlai.utils.io import PathManager
 from parlai.zoo.bart.build import download, CONVERSION_ARGS, BART_ARGS

--- a/parlai/agents/hugging_face/gpt2.py
+++ b/parlai/agents/hugging_face/gpt2.py
@@ -11,7 +11,7 @@ from parlai.agents.hugging_face.dict import Gpt2DictionaryAgent
 from parlai.core.torch_generator_agent import TorchGeneratorAgent, TorchGeneratorModel
 from parlai.utils.misc import warn_once
 from parlai.utils.torch import IdentityLayer, concat_without_padding, padded_tensor
-from parlai.agents.transformer.module_extensions import R3FMixin
+from parlai.nn.r3f import R3FMixin
 
 try:
     from transformers import GPT2Model

--- a/parlai/agents/hugging_face/gpt2.py
+++ b/parlai/agents/hugging_face/gpt2.py
@@ -11,7 +11,7 @@ from parlai.agents.hugging_face.dict import Gpt2DictionaryAgent
 from parlai.core.torch_generator_agent import TorchGeneratorAgent, TorchGeneratorModel
 from parlai.utils.misc import warn_once
 from parlai.utils.torch import IdentityLayer, concat_without_padding, padded_tensor
-
+from parlai.agents.transformer.module_extensions import R3FMixin
 
 try:
     from transformers import GPT2Model
@@ -290,3 +290,10 @@ class Gpt2Agent(TorchGeneratorAgent):
         return padded_tensor(
             items, pad_idx=self.NULL_IDX, use_cuda=self.use_cuda, fp16friendly=False
         )
+
+
+class Gpt2Agent_R3F(R3FMixin, Gpt2Agent):
+    @staticmethod
+    def add_cmdline_args(argparser):
+        R3FMixin.add_cmdline_args(argparser)
+        Gpt2Agent.add_cmdline_args(argparser)

--- a/parlai/agents/transformer/module_extensions.py
+++ b/parlai/agents/transformer/module_extensions.py
@@ -134,21 +134,17 @@ class R3FMixin(object):
                 re.match(f"^encoder.*norm_embeddings$", name)
                 or re.match("^encoder.*wte$", name)
             ):
-                print("found encoder embedding")
                 self.r3f_embeddings["encoder"] = layer
                 encoder_embedding_found = True
             if self.noise_decoder and (
                 re.match(f"^decoder.*norm_embeddings$", name)
                 or re.match("^decoder.*wte$", name)
             ):
-                print("found decoder embedding")
                 self.r3f_embeddings["decoder"] = layer
                 decoder_embedding_found = True
         if (self.noise_encoder != encoder_embedding_found) or (
             self.noise_decoder != decoder_embedding_found
         ):
-            print(self.noise_encoder, encoder_embedding_found)
-            print(self.noise_decoder, decoder_embedding_found)
             raise RuntimeError("R3F: Embedding to noise not found.")
 
     def _deep_copy_encoder_embedding(self, parent, found_encoder=False):
@@ -161,14 +157,12 @@ class R3FMixin(object):
             if name == "encoder":
                 self._deep_copy_encoder_embedding(layer, True)
             elif found_encoder and name is "norm_embeddings":
-                print("deep copying encoder embedding")
                 setattr(
                     parent,
                     "norm_embeddings",
                     copy.deepcopy(getattr(parent, "norm_embeddings")),
                 )
             elif found_encoder and name is "wte":
-                print("deep copying encoder embedding")
                 setattr(parent, "wte", copy.deepcopy(getattr(parent, "wte")))
                 return
             else:
@@ -188,12 +182,10 @@ class R3FNoiseEmbeddingContextManager(AbstractContextManager):
         self.hooks = {}
 
         if self.context.noise_encoder:
-            print("encoder hook")
             self.hooks["encoder"] = self.context.r3f_embeddings[
                 "encoder"
             ].register_forward_hook(self._hook_implementation)
         if self.context.noise_decoder:
-            print("decoder hook")
             self.hooks["decoder"] = self.context.r3f_embeddings[
                 "decoder"
             ].register_forward_hook(self._hook_implementation)
@@ -208,7 +200,6 @@ class R3FNoiseEmbeddingContextManager(AbstractContextManager):
             self.hooks[key] = None
 
     def _hook_implementation(self, module, input, output):
-        print("call")
         noise = self.context.r3f_noise_sampler.sample(sample_shape=output.shape).to(
             output
         )

--- a/parlai/agents/transformer/module_extensions.py
+++ b/parlai/agents/transformer/module_extensions.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Implements extentions to NN code for transformers.
+These include custom fine-tuning losses and the like that are training detail extentions
+rather than new model architectures in themselves.
+"""
+
+from contextlib import AbstractContextManager
+import copy
+import re
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from parlai.core.params import ParlaiParser
+
+R3F_NOISE_NORMAL = "normal"
+R3F_NOISE_UNIFORM = "uniform"
+
+
+class R3FMixin(object):
+    """
+    Class that helps implement "Better Fine-Tuning by Reducing Representational
+    Collapse", Aghajanyan et al. (2020). https://arxiv.org/ans/2008.03156.
+    """
+
+    @staticmethod
+    def add_cmdline_args(argparser: ParlaiParser):
+        group = argparser.add_argument_group('R3F fine-tuning Args')
+        group.add_argument(
+            '--use-r3f',
+            type=bool,
+            default=False,
+            help='should we use the R3f loss at all?',
+        )
+        group.add_argument('--r3f-eps', type=float, default=1e-5, help='noise eps')
+        group.add_argument(
+            '--r3f-lambda',
+            type=float,
+            default=1.0,
+            help='lambda for combining logistic loss and noisy KL loss',
+        )
+        group.add_argument(
+            '--r3f-noise-type',
+            type=str,
+            default=R3F_NOISE_UNIFORM,
+            choices=[R3F_NOISE_NORMAL, R3F_NOISE_UNIFORM],
+            help='type of noises for RXF methods',
+        )
+        group.add_argument(
+            '--r3f-encoder-noise',
+            type=bool,
+            default=True,
+            help='Add noise to encoder. At least one of `r3f-encoder-noise` and `r3f-coder-noise` must be set to True',
+        )
+        group.add_argument(
+            '--r3f-decoder-noise',
+            type=bool,
+            default=False,
+            help='Add noise to decoder. At least one of `r3f-encoder-noise` and `r3f-coder-noise` must be set to True',
+        )
+
+    def set_r3f_settings_from_opts(self, opts):
+        self.use_r3f = opts.get('use_r3f')
+        self.r3f_eps = opts.get('r3f_eps')
+        self.r3f_noise_type = opts.get('r3f_noise_type')
+        if self.r3f_noise_type == R3F_NOISE_NORMAL:
+            self.r3f_noise_sampler = torch.distributions.normal.Normal(
+                loc=0.0, scale=self.r3f_eps
+            )
+        elif self.r3f_noise_type == R3F_NOISE_UNIFORM:
+            self.r3f_noise_sampler = torch.distributions.uniform.Uniform(
+                low=-self.r3f_eps, high=self.eps
+            )
+        self.r3f_lambda = opts.get("r3f_lambda")
+
+        # NOTE: Following is temporary until it is clear whether or not to noise both or just one of encoder/decoder
+        self.noise_encoder = opts.get("r3f_encoder_noise")
+        self.noise_decoder = opts.get("r3f_decoder_noise")
+
+        if self.use_r3f and not self.noise_encoder and not self.noise_decoder:
+            raise RuntimeError(
+                "R3FContext: Noise must be added to at least one of the encoder or decoder."
+            )
+        # Find embedding values and store locally so we don't have to find them each turn
+        self.r3f_embeddings = {}
+        self._deep_copy_encoder_embedding(self.model)  # temporary
+        self._find_embeddings(self.model)
+
+    def compute_loss(self, batch, return_output=False):
+        if not hasattr(self, 'use_r3f'):
+            self.set_r3f_settings_from_opts(self.opt)
+        loss, standard_output = super().compute_loss(batch, True)
+        if self.use_r3f:
+            with R3FNoiseEmbeddingContextManager(self, self.model) as r3f:
+                noised_scores, _, _ = self.model(
+                    *self._model_input(batch), ys=batch.label_vec
+                )
+                standard_scores, _, _ = standard_output
+                r3f_loss = r3f._calculate_symm_kl(noised_scores, standard_scores)
+                loss += self.r3f_lambda * r3f_loss
+        if return_output:
+            return loss, standard_output
+        else:
+            return loss
+
+    def _calculate_symm_kl(self, noised_logits, input_logits):
+        return (
+            F.kl_div(
+                F.log_softmax(noised_logits, dim=-1, dtype=torch.float32),
+                F.softmax(input_logits, dim=-1, dtype=torch.float32),
+                None,
+                None,
+                "sum",
+            )
+            + F.kl_div(
+                F.log_softmax(input_logits, dim=-1, dtype=torch.float32),
+                F.softmax(noised_logits, dim=-1, dtype=torch.float32),
+                None,
+                None,
+                "sum",
+            )
+        ) / noised_logits.size(0)
+
+    def _find_embeddings(self, module):
+        encoder_embedding_found = False
+        decoder_embedding_found = False
+        for name, layer in module.named_modules():
+            if self.noise_encoder and (
+                re.match(f"^encoder.*norm_embeddings$", name)
+                or re.match("^encoder.*wte$", name)
+            ):
+                print("found encoder embedding")
+                self.r3f_embeddings["encoder"] = layer
+                encoder_embedding_found = True
+            if self.noise_decoder and (
+                re.match(f"^decoder.*norm_embeddings$", name)
+                or re.match("^decoder.*wte$", name)
+            ):
+                print("found decoder embedding")
+                self.r3f_embeddings["decoder"] = layer
+                decoder_embedding_found = True
+        if (self.noise_encoder != encoder_embedding_found) or (
+            self.noise_decoder != decoder_embedding_found
+        ):
+            print(self.noise_encoder, encoder_embedding_found)
+            print(self.noise_decoder, decoder_embedding_found)
+            raise RuntimeError("R3F: Embedding to noise not found.")
+
+    def _deep_copy_encoder_embedding(self, parent, found_encoder=False):
+        """
+        TEMPORARY UNTIL BEST NOISING MODE (encoder only, decoder only, both) determined.
+
+        Needed cause BART has the same embedding in both the encoder/decoder; use this to separate them.
+        """
+        for name, layer in parent.named_children():
+            if name == "encoder":
+                self._deep_copy_encoder_embedding(layer, True)
+            elif found_encoder and name is "norm_embeddings":
+                print("deep copying encoder embedding")
+                setattr(
+                    parent,
+                    "norm_embeddings",
+                    copy.deepcopy(getattr(parent, "norm_embeddings")),
+                )
+            elif found_encoder and name is "wte":
+                print("deep copying encoder embedding")
+                setattr(parent, "wte", copy.deepcopy(getattr(parent, "wte")))
+                return
+            else:
+                self._deep_copy_encoder_embedding(layer, found_encoder)
+
+
+class R3FNoiseEmbeddingContextManager(AbstractContextManager):
+    """
+    This class finds the input embeddings map under the encoder/decoder, depending on what
+    is selected, and adds R3F noise to their output.
+    """
+
+    def __init__(self, context, module):
+        self.encoder_hook = None
+        self.decoder_hook = None
+        self.context = context
+        self.hooks = {}
+
+        if self.context.noise_encoder:
+            print("encoder hook")
+            self.hooks["encoder"] = self.context.r3f_embeddings[
+                "encoder"
+            ].register_forward_hook(self._hook_implementation)
+        if self.context.noise_decoder:
+            print("decoder hook")
+            self.hooks["decoder"] = self.context.r3f_embeddings[
+                "decoder"
+            ].register_forward_hook(self._hook_implementation)
+
+    def __enter__(self):
+        return self.context
+
+    def __exit__(self, type, value, traceback):
+        for key in self.hooks.keys():
+            if self.hooks[key]:
+                self.hooks[key].remove()
+            self.hooks[key] = None
+
+    def _hook_implementation(self, module, input, output):
+        print("call")
+        noise = self.context.r3f_noise_sampler.sample(sample_shape=output.shape).to(
+            output
+        )
+        return output + noise


### PR DESCRIPTION
Implementation of "Better Fine-Tuning by Reducing Representational Collapse", Aghajanyan et al. (2020). https://arxiv.org/ans/2008.03156."

Same as https://github.com/facebookresearch/ParlAI/pull/3177, but did in a new branch cause that seemed easier.

NOTE: Still need to run evaluations to see end performance; a few settings here (documented) are remnants of that but general structure should be fine. 

Test plan:

GPT2:
Ran

```
parlai train -t taskmaster2 -veps 0.1 --batchsize 2 --model parlai.agents.hugging_face.gpt2:Gpt2Agent_R3F --model-file ~/tmp/modlefile --use-r3f true --r3f-lambda 0.001 --r3f-noise-type normal --r3f-eps 0.001 --domains music --model-file ~/tmp/model --r3f-decoder -noise true --r3f-encoder-noise false
```

and verified output made sense relative to

    parlai train -t taskmaster2 -veps 0.1 --batchsize 2 --model parlai.agents.hugging_face.gpt2:Gpt2Agent --model-file ~/tmp/modlefile

BART:
Ran

    parlai train -t taskmaster2 -veps 0.1 --batchsize 2 --model parlai.agents.bart.bart:BartAgent_R3F --fp16 True --label-truncate 512 --log-every-n-secs 10 -lr 0.0001 --lr-scheduler invsqrt --optimizer adam --save-after-valid True --text-truncate 512 --warmup-updates 100 --fp16-impl apex --update-freq 2 --gradient-clip 1.0 --skip-generation False -vp 50 --max-train-time 171000 -vmt jga -vmm max -dynb full -tblog true --load-from-checkpoint true --use-r3f true --r3f-lambda 0.001 --r3f-noise-type normal --r3f-eps 0.001 --domains music --model-file ~/tmp/model

and made sure output made sense relative to

    parlai train -t taskmaster2 -veps 0.1 --batchsize 1 --model bart --fp16 True --label-truncate 512 --log-every-n-secs 10 -lr 0.0001 --lr-scheduler invsqrt --optimizer adam --save-after-valid True --text-truncate 512 --warmup-updates 100 --fp16-impl apex --update-freq 2 --gradient-clip 1.0 --skip-generation False -vp 50 --max-train-time 171000 -vmt jga -vmm max -dynb full -tblog true --load-from-checkpoint true --domains music --model-file ~/tmp/test


Debug logs still present in the first commit of this PR to show that usage of hooks made sense.