### PR TITLE
adding task multiwoz_trade (multiwoz2.1 with TRADE preprocess), including both dialog state tracking and dialog response generation

### DIFF
--- a/parlai/tasks/multiwoz_trade/__init__.py
+++ b/parlai/tasks/multiwoz_trade/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/parlai/tasks/multiwoz_trade/agents.py
+++ b/parlai/tasks/multiwoz_trade/agents.py
@@ -10,85 +10,103 @@ from parlai.core.metrics import AverageMetric
 from parlai.utils.io import PathManager
 from .build import build
 from .utils.trade_proc import trade_process
-from .utils.reformat import reformat_dst
+from .utils.reformat import reformat_dst, reformat_dial
 import os
 import json, random
 
-
-def _path(opt):
-    # build the data if it does not exist
-    build(opt)
-
-    # set up path to data (specific to each dataset)
-    data_dir = os.path.join(opt['datapath'], 'multiwoz_trade', 'MULTIWOZ2.1')
-    conversations_path = os.path.join(data_dir, 'data.json')
-    return conversations_path, data_dir
-
-
 class MultiWozTeacher(FixedDialogTeacher):
     """
-    MultiWOZ 2.1 Teacher.
-
+    MultiWOZ 2.1 Teacher with TRADE preprocess
+    Two main differences from multiwoz_v2.1:
+    1. with TRADE preprocess, which would normalize and split data
+    into "_train.json" "_val.json" and "_test.json"
+    2. each turn is an individual episode, turn["context"] includes
+    all the dialog history in previous turns.
     """
-
     def __init__(self, opt, shared=None):
         super().__init__(opt, shared)
-        opt['datafile'], jsons_path = _path(opt)
-        self._setup_data(opt['datafile'], jsons_path)
         self.id = 'multiwoz_trade'
+
+        # # # reading args
+        self.just_test = opt.get('just_test', False)
+        self.seed = opt.get('rand_seed', 0)
+
+        # # # set random seeds
+        random.seed(self.seed)
+
+        opt['datafile'], data_dir = self._path(opt)
+        self._setup_data(opt['datafile'], data_dir)
         self.reset()
 
-    def _setup_data(self, data_path, jsons_path):
-        print('loading: ' + data_path)
-        with PathManager.open(data_path) as data_file:
-            self.messages = json.load(data_file)
+    def _load_json(self, file_path):
+        with open(file_path) as df:
+            data = json.loads(df.read().lower())
+        return data
 
-        test_path = os.path.join(jsons_path, 'testListFile.json')
-        valid_path = os.path.join(jsons_path, 'valListFile.json')
+    def _setup_data(self, data_path, jsons_path):
+        # # # loading directly from test file or val file or train file
         if self.datatype.startswith('test'):
-            with PathManager.open(test_path) as f:
-                test_data = {line.strip(): self.messages[line.strip()] for line in f}
-                self.messages = test_data
+            test_path = data_path.replace(".json", "_test.json")
+            test_data = self._load_json(test_path)
+            self.messages = list(test_data.values())
         elif self.datatype.startswith('valid'):
-            with PathManager.open(valid_path) as f:
-                valid_data = {line.strip(): self.messages[line.strip()] for line in f}
-                self.messages = valid_data
+            valid_path = data_path.replace(".json", "_valid.json")
+            valid_data = self._load_json(valid_path)
+            self.messages = list(valid_data.values())
         else:
-            with PathManager.open(test_path) as f:
-                for line in f:
-                    if line.strip() in self.messages:
-                        del self.messages[line.strip()]
-            with PathManager.open(valid_path) as f:
-                for line in f:
-                    if line.strip() in self.messages:
-                        del self.messages[line.strip()]
-        self.messages = list(self.messages.values())
+            train_path = data_path.replace(".json", "_train.json")
+            train_data = self._load_json(train_path)
+            self.messages = list(train_data.values())
+            random.shuffle(self.messages)
+        
+        if self.just_test:
+            self.messages = self.messages[:50]
+
+    def _path(self, opt):
+        # set up path to data (specific to each dataset)
+        data_dir = os.path.join(opt['datapath'], 'multiwoz_trade', 'MULTIWOZ2.1')
+        data_path = os.path.join(data_dir, 'data_reformat_trade_dial.json')
+
+        # build the data if it does not exist
+        build(opt)
+
+        # process the data with TRADE's code, if it does not exist
+        if not os.path.exists(os.path.join(data_dir, 'dials_trade.json')):
+            trade_process(data_dir)
+
+        # reformat data for DST
+        if not os.path.exists(data_path):
+            reformat_dial(data_dir)
+
+        return data_path, data_dir
 
     def num_examples(self):
-        examples = 0
-        for data in self.messages:
-            examples += len(data['log']) // 2
-        return examples
+        # each turn be seen as a individual dialog
+        return len(self.messages)
 
     def num_episodes(self):
         return len(self.messages)
 
     def get(self, episode_idx, entry_idx=0):
-        log_idx = entry_idx * 2
-        entry = self.messages[episode_idx]['log'][log_idx]['text']
-        episode_done = log_idx == len(self.messages[episode_idx]['log']) - 2
+        entry = self.messages[episode_idx]['context']
+        episode_done = True
         action = {
             'id': self.id,
             'text': entry,
             'episode_done': episode_done,
-            'labels': [self.messages[episode_idx]['log'][log_idx + 1]['text']],
+            'labels': [self.messages[episode_idx]['response']],
+            'dial_id': self.messages[episode_idx]['dial_id'],
+            'turn_num': self.messages[episode_idx]['turn_num'],
         }
         return action
 
 
 class MultiWozDSTTeacher(FixedDialogTeacher):
     """
-    MultiWOZ2.1 DST Teacher.
+    MultiWOZ2.1 Dialog State Tracking (DST) Teacher with TRADE preprocess, 
+    Each turn contains all the dialog history in the previous (turn["context"])
+    and is expected to generate all previous dialog slots. Therefore, each turn
+    is a individual episode.
     """
 
     def __init__(self, opt, shared=None):
@@ -106,22 +124,6 @@ class MultiWozDSTTeacher(FixedDialogTeacher):
         self._setup_data(opt['datafile'], data_dir)
 
         self.reset()
-
-    @classmethod
-    def add_cmdline_args(cls, argparser):
-        agent = argparser.add_argument_group('MultiWozDST Teacher Args')
-        agent.add_argument(
-            '--just_test',
-            type='bool',
-            default=False,
-            help="True if one would like to test agent's training with small amount of data (default: False).",
-        )
-        agent.add_argument(
-            '--rand_seed',
-            type=int,
-            default=0,
-            help="specify to set random seed (default: 0).",
-        )
 
     def _load_json(self, file_path):
         with open(file_path) as df:
@@ -164,7 +166,6 @@ class MultiWozDSTTeacher(FixedDialogTeacher):
         
         if self.just_test:
             self.messages = self.messages[:100]
-
 
     def _extract_slot_from_string(self, slots_string):
         """
@@ -223,9 +224,8 @@ class MultiWozDSTTeacher(FixedDialogTeacher):
         return len(self.messages)
 
     def get(self, episode_idx, entry_idx=0):
-        # log_idx = entry_idx
-        entry = self.messages[episode_idx]['context']
-        episode_done = True
+        entry = self.messages[episode_idx]['context'] # includes all previous dialog history
+        episode_done = True     # each turn is a individual episode
         action = {
             'id': self.id,
             'text': entry,
@@ -236,5 +236,20 @@ class MultiWozDSTTeacher(FixedDialogTeacher):
         }
         return action
 
-class DefaultTeacher(MultiWozDSTTeacher):
-    pass
+class DefaultTeacher(MultiWozTeacher):
+    @classmethod
+    def add_cmdline_args(cls, argparser):
+        agent = argparser.add_argument_group('MultiWozDST Teacher Args')
+        agent.add_argument(
+            '--just_test',
+            type='bool',
+            default=False,
+            help="True if one would like to test agent's training with small amount of data (default: False).",
+        )
+        agent.add_argument(
+            '--rand_seed',
+            type=int,
+            default=0,
+            help="specify to set random seed (default: 0).",
+        )
+

--- a/parlai/tasks/multiwoz_trade/agents.py
+++ b/parlai/tasks/multiwoz_trade/agents.py
@@ -236,7 +236,7 @@ class MultiWozDSTTeacher(FixedDialogTeacher):
         }
         return action
 
-class DefaultTeacher(MultiWozTeacher):
+class DefaultTeacher(MultiWozDSTTeacher):
     @classmethod
     def add_cmdline_args(cls, argparser):
         agent = argparser.add_argument_group('MultiWozDST Teacher Args')

--- a/parlai/tasks/multiwoz_trade/agents.py
+++ b/parlai/tasks/multiwoz_trade/agents.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from parlai.core.teachers import FixedDialogTeacher
+from parlai.core.message import Message
+from parlai.core.metrics import AverageMetric
+from parlai.utils.io import PathManager
+from .build import build
+from .utils.trade_proc import trade_process
+from .utils.reformat import reformat_dst
+import os
+import json, random
+
+
+def _path(opt):
+    # build the data if it does not exist
+    build(opt)
+
+    # set up path to data (specific to each dataset)
+    data_dir = os.path.join(opt['datapath'], 'multiwoz_trade', 'MULTIWOZ2.1')
+    conversations_path = os.path.join(data_dir, 'data.json')
+    return conversations_path, data_dir
+
+
+class MultiWozTeacher(FixedDialogTeacher):
+    """
+    MultiWOZ 2.1 Teacher.
+
+    """
+
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
+        opt['datafile'], jsons_path = _path(opt)
+        self._setup_data(opt['datafile'], jsons_path)
+        self.id = 'multiwoz_trade'
+        self.reset()
+
+    def _setup_data(self, data_path, jsons_path):
+        print('loading: ' + data_path)
+        with PathManager.open(data_path) as data_file:
+            self.messages = json.load(data_file)
+
+        test_path = os.path.join(jsons_path, 'testListFile.json')
+        valid_path = os.path.join(jsons_path, 'valListFile.json')
+        if self.datatype.startswith('test'):
+            with PathManager.open(test_path) as f:
+                test_data = {line.strip(): self.messages[line.strip()] for line in f}
+                self.messages = test_data
+        elif self.datatype.startswith('valid'):
+            with PathManager.open(valid_path) as f:
+                valid_data = {line.strip(): self.messages[line.strip()] for line in f}
+                self.messages = valid_data
+        else:
+            with PathManager.open(test_path) as f:
+                for line in f:
+                    if line.strip() in self.messages:
+                        del self.messages[line.strip()]
+            with PathManager.open(valid_path) as f:
+                for line in f:
+                    if line.strip() in self.messages:
+                        del self.messages[line.strip()]
+        self.messages = list(self.messages.values())
+
+    def num_examples(self):
+        examples = 0
+        for data in self.messages:
+            examples += len(data['log']) // 2
+        return examples
+
+    def num_episodes(self):
+        return len(self.messages)
+
+    def get(self, episode_idx, entry_idx=0):
+        log_idx = entry_idx * 2
+        entry = self.messages[episode_idx]['log'][log_idx]['text']
+        episode_done = log_idx == len(self.messages[episode_idx]['log']) - 2
+        action = {
+            'id': self.id,
+            'text': entry,
+            'episode_done': episode_done,
+            'labels': [self.messages[episode_idx]['log'][log_idx + 1]['text']],
+        }
+        return action
+
+
+class MultiWozDSTTeacher(FixedDialogTeacher):
+    """
+    MultiWOZ2.1 DST Teacher.
+    """
+
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
+        self.id = 'multiwoz_trade'
+
+        # # # reading args
+        self.just_test = opt.get('just_test', False)
+        self.seed = opt.get('rand_seed', 0)
+
+        # # # set random seeds
+        random.seed(self.seed)
+
+        opt['datafile'], data_dir = self._path(opt)
+        self._setup_data(opt['datafile'], data_dir)
+
+        self.reset()
+
+    @classmethod
+    def add_cmdline_args(cls, argparser):
+        agent = argparser.add_argument_group('MultiWozDST Teacher Args')
+        agent.add_argument(
+            '--just_test',
+            type='bool',
+            default=False,
+            help="True if one would like to test agent's training with small amount of data (default: False).",
+        )
+        agent.add_argument(
+            '--rand_seed',
+            type=int,
+            default=0,
+            help="specify to set random seed (default: 0).",
+        )
+
+    def _load_json(self, file_path):
+        with open(file_path) as df:
+            data = json.loads(df.read().lower())
+        return data
+
+    def _path(self, opt):
+        # set up path to data (specific to each dataset)
+        data_dir = os.path.join(opt['datapath'], 'multiwoz_trade', 'MULTIWOZ2.1')
+        data_path = os.path.join(data_dir, 'data_reformat_trade_dst.json')
+
+        # build the data if it does not exist
+        build(opt)
+
+        # process the data with TRADE's code, if it does not exist
+        if not os.path.exists(os.path.join(data_dir, 'dials_trade.json')):
+            trade_process(data_dir)
+
+        # reformat data for DST
+        if not os.path.exists(data_path):
+            reformat_dst(data_dir)
+
+        return data_path, data_dir
+
+    def _setup_data(self, data_path, jsons_path):
+        # # # loading directly from test file or val file
+        if self.datatype.startswith('test'):
+            test_path = data_path.replace(".json", "_test.json")
+            test_data = self._load_json(test_path)
+            self.messages = list(test_data.values())
+        elif self.datatype.startswith('valid'):
+            valid_path = data_path.replace(".json", "_valid.json")
+            valid_data = self._load_json(valid_path)
+            self.messages = list(valid_data.values())
+        else:
+            train_path = data_path.replace(".json", "_train.json")
+            train_data = self._load_json(train_path)
+            self.messages = list(train_data.values())
+            random.shuffle(self.messages)
+        
+        if self.just_test:
+            self.messages = self.messages[:100]
+
+
+    def _extract_slot_from_string(self, slots_string):
+        """
+        Either ground truth or generated result should be in the format:
+        "dom slot_type slot_val, dom slot_type slot_val, ..., dom slot_type slot_val,"
+        and this function would reformat the string into list:
+        ["dom--slot_type--slot_val", ... ]
+        """
+        domains    = ["attraction", "hotel", "hospital", "restaurant", "police", "taxi", "train"]
+
+        slot_types = ["stay", "price", "addr",  "type", "arrive", "day", "depart", "dest",
+                    "area", "leave", "stars", "department", "people", "time", "food", 
+                    "post", "phone", "name", 'internet', 'parking',
+                    'book stay', 'book people','book time', 'book day',
+                    'pricerange', 'destination', 'leaveat', 'arriveby', 'departure']
+        slots_list = []
+
+        # # # split according to ","
+        str_split = slots_string.strip().split(",")
+        if str_split[-1] == "":
+            str_split = str_split[:-1]
+        str_split = [slot.strip() for slot in str_split]
+
+        for slot_ in str_split:
+            slot = slot_.split()
+            if len(slot) > 2 and slot[0] in domains:
+                domain = slot[0]
+                if slot[1] == "book" and slot[2] in ["day", "time", "people", "stay"]:
+                    slot_type = slot[1]+" "+slot[2]
+                    slot_val  = " ".join(slot[3:])
+                else:
+                    slot_type = slot[1]
+                    slot_val  = " ".join(slot[2:])
+                if not slot_val == 'dontcare':
+                    slots_list.append(domain+"--"+slot_type+"--"+slot_val)
+        return slots_list
+
+    def custom_evaluation(self, teacher_action: Message, labels, model_response: Message):
+        resp = model_response.get('text')
+        if not resp:
+            return
+
+        # # # extract ground truth from labels
+        slots_truth = self._extract_slot_from_string(labels[0])
+        
+        # # # extract generated slots from model_response
+        slots_pred = self._extract_slot_from_string(resp)
+
+        self.metrics.add('joint goal acc', AverageMetric(set(slots_truth) == set(slots_pred)))
+
+    def num_examples(self):
+        # each turn be seen as a individual dialog
+        return len(self.messages)
+
+    def num_episodes(self):
+        return len(self.messages)
+
+    def get(self, episode_idx, entry_idx=0):
+        # log_idx = entry_idx
+        entry = self.messages[episode_idx]['context']
+        episode_done = True
+        action = {
+            'id': self.id,
+            'text': entry,
+            'episode_done': episode_done,
+            'labels': [self.messages[episode_idx]['slots_inf']],
+            'dial_id': self.messages[episode_idx]['dial_id'],
+            'turn_num': self.messages[episode_idx]['turn_num'],
+        }
+        return action
+
+class DefaultTeacher(MultiWozDSTTeacher):
+    pass

--- a/parlai/tasks/multiwoz_trade/build.py
+++ b/parlai/tasks/multiwoz_trade/build.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import parlai.core.build_data as build_data
+import os
+from parlai.core.build_data import DownloadableFile
+
+RESOURCES = [
+    DownloadableFile(
+        'https://www.repository.cam.ac.uk/bitstream/handle/1810/294507/MULTIWOZ2.1.zip?sequence=1&isAllowed=y',
+        'MULTIWOZ2.1.zip',
+        'd377a176f5ec82dc9f6a97e4653d4eddc6cad917704c1aaaa5a8ee3e79f63a8e',
+    )
+]
+
+
+def build(opt):
+    dpath = os.path.join(opt['datapath'], 'multiwoz_trade')
+    version = '1.0'
+
+    if not build_data.built(dpath, version_string=version):
+        print('[building data: ' + dpath + ']')
+
+        # make a clean directory if needed
+        if build_data.built(dpath):
+
+            # an older version exists, so remove these outdated files.
+            build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # Download the data.
+        for downloadable_file in RESOURCES:
+            downloadable_file.download_file(dpath)
+
+        # mark the data as built
+        build_data.mark_done(dpath, version_string=version)

--- a/parlai/tasks/multiwoz_trade/utils/mapping.pair
+++ b/parlai/tasks/multiwoz_trade/utils/mapping.pair
@@ -1,0 +1,83 @@
+it's	it is
+don't	do not
+doesn't	does not
+didn't	did not
+you'd	you would
+you're	you are
+you'll	you will
+i'm	i am
+they're	they are
+that's	that is
+what's	what is
+couldn't	could not
+i've	i have
+we've	we have
+can't	cannot
+i'd	i would
+i'd	i would
+aren't	are not
+isn't	is not
+wasn't	was not
+weren't	were not
+won't	will not
+there's	there is
+there're	there are
+. .	.
+restaurants	restaurant -s
+hotels	hotel -s
+laptops	laptop -s
+cheaper	cheap -er
+dinners	dinner -s
+lunches	lunch -s
+breakfasts	breakfast -s
+expensively	expensive -ly
+moderately	moderate -ly
+cheaply	cheap -ly
+prices	price -s
+places	place -s
+venues	venue -s
+ranges	range -s
+meals	meal -s
+locations	location -s
+areas	area -s
+policies	policy -s
+children	child -s
+kids	kid -s
+kidfriendly	kid friendly
+cards	card -s
+upmarket	expensive
+inpricey	cheap
+inches	inch -s
+uses	use -s
+dimensions	dimension -s
+driverange	drive range
+includes	include -s
+computers	computer -s
+machines	machine -s
+families	family -s
+ratings	rating -s
+constraints	constraint -s
+pricerange	price range
+batteryrating	battery rating
+requirements	requirement -s
+drives	drive -s
+specifications	specification -s
+weightrange	weight range
+harddrive	hard drive
+batterylife	battery life
+businesses	business -s
+hours	hour -s
+one	1
+two	2
+three	3
+four	4
+five	5
+six	6
+seven	7
+eight	8
+nine	9
+ten	10
+eleven	11
+twelve	12
+anywhere	any where
+good bye	goodbye

--- a/parlai/tasks/multiwoz_trade/utils/reformat.py
+++ b/parlai/tasks/multiwoz_trade/utils/reformat.py
@@ -230,10 +230,16 @@ class Reformat_Multiwoz(object):
             json.dump(self.dials_form, tf, indent=2)
 
 def reformat_dst(data_dir):
+    """
+    reformat multiwoz for dialog state tracking task
+    """
     reformat = Reformat_Multiwoz(data_dir)
     reformat.reformat_dst()
 
 def reformat_dial(data_dir):
+    """
+    reformat multiwoz for dialog response generation
+    """
     reformat = Reformat_Multiwoz(data_dir)
     reformat.reformat_dial()
 

--- a/parlai/tasks/multiwoz_trade/utils/reformat.py
+++ b/parlai/tasks/multiwoz_trade/utils/reformat.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import os, sys, json
+import math, argparse, random, re
+from tqdm import tqdm
+import pdb
+
+class Reformat_Multiwoz(object):
+    """
+    reformat multiwoz (maybe sgd later) into 
+    utt-to-slots
+    """
+    def __init__(self, data_dir):
+        self.data_dir = data_dir
+        self.data_path = os.path.join(self.data_dir, "data.json")
+        self.reformat_data_name = "data_reformat_trade_dst.json"
+        self.reformat_data_path = os.path.join(self.data_dir, self.reformat_data_name)
+
+        self.val_path = os.path.join(self.data_dir, "valListFile.json")
+        self.test_path = os.path.join(self.data_dir, "testListFile.json")
+        self.val_list = self.load_txt(self.val_path)
+        self.test_list = self.load_txt(self.test_path)
+
+    def load_dials(self, data_path=None):
+        if data_path is None:
+            data_path = self.data_path
+        with open(data_path) as df:
+            self.dials = json.loads(df.read().lower())
+    
+    def load_txt(self, file_path):
+        with open(file_path) as df:
+            data=df.read().lower().split("\n")
+            data.remove('')
+        return data
+
+    def save_dials(self):
+        with open(self.reformat_data_path, "w") as tf:
+            json.dump(self.dials_form, tf, indent=2)
+        print(f"Saved reformatted data to {self.reformat_data_path} ...")
+
+    def reformat_from_trade_proc_to_turn(self):
+        """
+        following trade's code for normalizing multiwoz*
+        now the data has format:
+        file=[{
+            "dialogue_idx": dial_id,
+            "domains": [dom],
+            "dialogue": [
+                    {
+                        "turn_idx": 0,
+                        "domain": "hotel",
+                        "system_transcript": "system response",
+                        "transcript": "user utterance",
+                        "system_act": [],
+                        "belief_state": [{
+                            "slots":[["domain-slot_type","slot_vale"]],
+                            "act":  "inform"
+                        }, ...], # accumulated
+                        "turn_label": [["domain-slot_type","slot_vale"],...],    # for current turn
+                    },
+                    ...
+                ],
+                ...
+            },
+            ]
+        and output with format like:
+        file={
+            dial_id-turn_num:
+                    {
+                        "dial_id": dial_id
+                        "turn_num": 0,
+                        "slots_inf": slot sequence ("dom slot_type1 slot_val1, dom slot_type2 ..."),\
+                        "context" : "User: ... Sys: ... User:..."
+                    },
+            ...
+            }
+        """
+        self.data_trade_proc_path = os.path.join(self.data_dir, "dials_trade.json")
+        self.load_dials(data_path = self.data_trade_proc_path)
+        self.dials_form = {}
+        self.dials_train, self.dials_val, self.dials_test = {}, {}, {}
+
+        for dial in tqdm(self.dials):
+            # self.dials_form[dial["dialogue_idx"]] = []
+            context = []
+            for turn in dial["dialogue"]:
+                turn_form = {}
+                # # # turn number
+                turn_form["turn_num"] = turn["turn_idx"]
+
+                # # # # dialog id
+                turn_form["dial_id"] = dial["dialogue_idx"]
+                
+                # # # slots/dialog states
+                slots_inf = []
+                
+                # # # ACCUMULATED dialog states, extracted based on "belief_state"
+                for state in turn["belief_state"]:
+                    if state["act"] == "inform":
+                        domain = state["slots"][0][0].split("-")[0]
+                        slot_type = state["slots"][0][0].split("-")[1]
+                        slot_val  = state["slots"][0][1]
+                        slots_inf += [domain, slot_type, slot_val+","]
+
+                turn_form["slots_inf"] = " ".join(slots_inf)
+
+                # # # dialog history
+                if turn["system_transcript"] != "":
+                    context.append("<system> " + turn["system_transcript"])
+
+                # # # adding current turn to dialog history
+                context.append("<user> " + turn["transcript"])
+
+                turn_form["context"] = " ".join(context)
+
+                self.dials_form[dial["dialogue_idx"] + "-" + str(turn_form["turn_num"])] = turn_form
+                if dial["dialogue_idx"] in self.test_list:
+                    self.dials_test[dial["dialogue_idx"] + "-" + str(turn_form["turn_num"])] = turn_form
+                elif dial["dialogue_idx"] in self.val_list:
+                    self.dials_val[dial["dialogue_idx"] + "-" + str(turn_form["turn_num"])] = turn_form
+                else:
+                    self.dials_train[dial["dialogue_idx"] + "-" + str(turn_form["turn_num"])] = turn_form
+
+        self.reformat_train_data_path = self.reformat_data_path.replace(".json", "_train.json")
+        self.reformat_valid_data_path = self.reformat_data_path.replace(".json", "_valid.json")
+        self.reformat_test_data_path = self.reformat_data_path.replace(".json", "_test.json")
+
+        with open(self.reformat_train_data_path, "w") as tf:
+            json.dump(self.dials_train, tf, indent=2)
+        with open(self.reformat_valid_data_path, "w") as tf:
+            json.dump(self.dials_val, tf, indent=2)
+        with open(self.reformat_test_data_path, "w") as tf:
+            json.dump(self.dials_test, tf, indent=2)
+        with open(self.reformat_data_path, "w") as tf:
+            json.dump(self.dials_form, tf, indent=2)
+
+def reformat_dst(data_dir):
+    reformat = Reformat_Multiwoz(data_dir)
+    reformat.reformat_from_trade_proc_to_turn()
+
+def Parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--dataset",   default="multiwoz")
+    parser.add_argument(      "--reformat_data_name", default=None)
+    parser.add_argument(      "--save_dial", default=True, type=bool)
+    parser.add_argument(      "--data_dir", default=None)
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = Parse_args()
+    reformat = Reformat_Multiwoz(args)
+    if args.reformat_data_name is not None:
+        reformat.reformat_data_path = os.path.join(reformat.data_dir, args.reformat_data_name)
+    if args.trade:
+        reformat.reformat_from_trade_proc_to_turn()
+    
+
+if __name__ == "__main__":
+    main()

--- a/parlai/tasks/multiwoz_trade/utils/trade_proc.py
+++ b/parlai/tasks/multiwoz_trade/utils/trade_proc.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json, os, re
+from collections import OrderedDict
+import numpy as np
+
+np.set_printoptions(precision=3)
+np.random.seed(2)
+
+'''
+Most of the codes are from https://github.com/budzianowski/multiwoz
+'''
+
+
+# GLOBAL VARIABLES
+DICT_SIZE = 400
+MAX_LENGTH = 50
+IGNORE_KEYS_IN_GOAL = ['eod', 'topic', 'messageLen', 'message']
+
+fin = open('./parlai/tasks/multiwoz_trade/utils/mapping.pair','r')
+replacements = []
+for line in fin.readlines():
+    tok_from, tok_to = line.replace('\n', '').split('\t')
+    replacements.append((' ' + tok_from + ' ', ' ' + tok_to + ' '))
+
+def is_ascii(s):
+    return all(ord(c) < 128 for c in s)
+
+def insertSpace(token, text):
+    sidx = 0
+    while True:
+        sidx = text.find(token, sidx)
+        if sidx == -1:
+            break
+        if sidx + 1 < len(text) and re.match('[0-9]', text[sidx - 1]) and \
+                re.match('[0-9]', text[sidx + 1]):
+            sidx += 1
+            continue
+        if text[sidx - 1] != ' ':
+            text = text[:sidx] + ' ' + text[sidx:]
+            sidx += 1
+        if sidx + len(token) < len(text) and text[sidx + len(token)] != ' ':
+            text = text[:sidx + 1] + ' ' + text[sidx + 1:]
+        sidx += 1
+    return text
+
+def normalize(text, clean_value=True):
+    # lower case every word
+    text = text.lower()
+
+    # replace white spaces in front and end
+    text = re.sub(r'^\s*|\s*$', '', text)
+
+    # hotel domain pfb30
+    text = re.sub(r"b&b", "bed and breakfast", text)
+    text = re.sub(r"b and b", "bed and breakfast", text)
+
+    if clean_value:
+        # normalize phone number
+        ms = re.findall('\(?(\d{3})\)?[-.\s]?(\d{3})[-.\s]?(\d{4,5})', text)
+        if ms:
+            sidx = 0
+            for m in ms:
+                sidx = text.find(m[0], sidx)
+                if text[sidx - 1] == '(':
+                    sidx -= 1
+                eidx = text.find(m[-1], sidx) + len(m[-1])
+                text = text.replace(text[sidx:eidx], ''.join(m))
+
+        # normalize postcode
+        ms = re.findall('([a-z]{1}[\. ]?[a-z]{1}[\. ]?\d{1,2}[, ]+\d{1}[\. ]?[a-z]{1}[\. ]?[a-z]{1}|[a-z]{2}\d{2}[a-z]{2})',
+                        text)
+        if ms:
+            sidx = 0
+            for m in ms:
+                sidx = text.find(m, sidx)
+                eidx = sidx + len(m)
+                text = text[:sidx] + re.sub('[,\. ]', '', m) + text[eidx:]
+
+    # weird unicode bug
+    text = re.sub(u"(\u2018|\u2019)", "'", text)
+
+    if clean_value:
+        # replace time and and price
+        text = re.sub(timepat, ' [value_time] ', text)
+        text = re.sub(pricepat, ' [value_price] ', text)
+        #text = re.sub(pricepat2, '[value_price]', text)
+
+    # replace st.
+    text = text.replace(';', ',')
+    text = re.sub('$\/', '', text)
+    text = text.replace('/', ' and ')
+
+    # replace other special characters
+    text = text.replace('-', ' ')
+    text = re.sub('[\"\<>@\(\)]', '', text) # remove
+
+    # insert white space before and after tokens:
+    for token in ['?', '.', ',', '!']:
+        text = insertSpace(token, text)
+
+    # insert white space for 's
+    text = insertSpace('\'s', text)
+
+    # replace it's, does't, you'd ... etc
+    text = re.sub('^\'', '', text)
+    text = re.sub('\'$', '', text)
+    text = re.sub('\'\s', ' ', text)
+    text = re.sub('\s\'', ' ', text)
+    for fromx, tox in replacements:
+        text = ' ' + text + ' '
+        text = text.replace(fromx, tox)[1:-1]
+
+    # remove multiple spaces
+    text = re.sub(' +', ' ', text)
+
+    # concatenate numbers
+    tmp = text
+    tokens = text.split()
+    i = 1
+    while i < len(tokens):
+        if re.match(u'^\d+$', tokens[i]) and \
+                re.match(u'\d+$', tokens[i - 1]):
+            tokens[i - 1] += tokens[i]
+            del tokens[i]
+        else:
+            i += 1
+    text = ' '.join(tokens)
+
+    return text
+
+def fixDelex(filename, data, data2, idx, idx_acts):
+    """Given system dialogue acts fix automatic delexicalization."""
+    try:
+        turn = data2[filename.strip('.json')][str(idx_acts)]
+    except:
+        return data
+
+    if not isinstance(turn, str):# and not isinstance(turn, unicode):
+        for k, act in turn.items():
+            if 'Attraction' in k:
+                if 'restaurant_' in data['log'][idx]['text']:
+                    data['log'][idx]['text'] = data['log'][idx]['text'].replace("restaurant", "attraction")
+                if 'hotel_' in data['log'][idx]['text']:
+                    data['log'][idx]['text'] = data['log'][idx]['text'].replace("hotel", "attraction")
+            if 'Hotel' in k:
+                if 'attraction_' in data['log'][idx]['text']:
+                    data['log'][idx]['text'] = data['log'][idx]['text'].replace("attraction", "hotel")
+                if 'restaurant_' in data['log'][idx]['text']:
+                    data['log'][idx]['text'] = data['log'][idx]['text'].replace("restaurant", "hotel")
+            if 'Restaurant' in k:
+                if 'attraction_' in data['log'][idx]['text']:
+                    data['log'][idx]['text'] = data['log'][idx]['text'].replace("attraction", "restaurant")
+                if 'hotel_' in data['log'][idx]['text']:
+                    data['log'][idx]['text'] = data['log'][idx]['text'].replace("hotel", "restaurant")
+
+    return data
+
+def getDialogueAct(filename, data, data2, idx, idx_acts):
+    """Given system dialogue acts fix automatic delexicalization."""
+    acts = []
+    try:
+        turn = data2[filename.strip('.json')][str(idx_acts)]
+    except:
+        return acts
+
+    if not isinstance(turn, str): # and not isinstance(turn, unicode):
+        for k in turn.keys():
+            # temp = [k.split('-')[0].lower(), k.split('-')[1].lower()]
+            # for a in turn[k]:
+            #     acts.append(temp + [a[0].lower()])
+
+            if k.split('-')[1].lower() == 'request':
+                for a in turn[k]:
+                    acts.append(a[0].lower())
+            elif k.split('-')[1].lower() == 'inform':
+                for a in turn[k]:
+                    acts.append([a[0].lower(), normalize(a[1].lower(), False)])
+
+    return acts
+
+def get_summary_bstate(bstate, get_domain=False):
+    """Based on the mturk annotations we form multi-domain belief state"""
+    domains = [u'taxi',u'restaurant',  u'hospital', u'hotel',u'attraction', u'train', u'police']
+    summary_bstate = []
+    summary_bvalue = []
+    active_domain = []
+    for domain in domains:
+        domain_active = False
+
+        booking = []
+        #print(domain,len(bstate[domain]['book'].keys()))
+        for slot in sorted(bstate[domain]['book'].keys()):
+            if slot == 'booked':
+                if len(bstate[domain]['book']['booked'])!=0:
+                    booking.append(1)
+                    # summary_bvalue.append("book {} {}:{}".format(domain, slot, "Yes"))
+                else:
+                    booking.append(0)
+            else:
+                if bstate[domain]['book'][slot] != "":
+                    booking.append(1)
+                    summary_bvalue.append(["{}-book {}".format(domain, slot.strip().lower()), normalize(bstate[domain]['book'][slot].strip().lower(), False)]) #(["book", domain, slot, bstate[domain]['book'][slot]])
+                else:
+                    booking.append(0)
+        if domain == 'train':
+            if 'people' not in bstate[domain]['book'].keys():
+                booking.append(0)
+            if 'ticket' not in bstate[domain]['book'].keys():
+                booking.append(0)
+        summary_bstate += booking
+
+        for slot in bstate[domain]['semi']:
+            slot_enc = [0, 0, 0]  # not mentioned, dontcare, filled
+            if bstate[domain]['semi'][slot] == 'not mentioned':
+                slot_enc[0] = 1
+            elif bstate[domain]['semi'][slot] in ['dont care', 'dontcare', "don't care", "do not care"]:
+                slot_enc[1] = 1
+                summary_bvalue.append(["{}-{}".format(domain, slot.strip().lower()), "dontcare"]) #(["semi", domain, slot, "dontcare"])
+            elif bstate[domain]['semi'][slot]:
+                summary_bvalue.append(["{}-{}".format(domain, slot.strip().lower()), normalize(bstate[domain]['semi'][slot].strip().lower(), False)]) #(["semi", domain, slot, bstate[domain]['semi'][slot]])
+            if slot_enc != [0, 0, 0]:
+                domain_active = True
+            summary_bstate += slot_enc
+
+        # quasi domain-tracker
+        if domain_active:
+            summary_bstate += [1]
+            active_domain.append(domain)
+        else:
+            summary_bstate += [0]
+
+    #print(len(summary_bstate))
+    assert len(summary_bstate) == 94
+    if get_domain:
+        return active_domain
+    else:
+        return summary_bstate, summary_bvalue
+
+def analyze_dialogue(dialogue, maxlen):
+    """Cleaning procedure for all kinds of errors in text and annotation."""
+    d = dialogue
+    # do all the necessary postprocessing
+    if len(d['log']) % 2 != 0:
+        #print path
+        print('odd # of turns')
+        return None  # odd number of turns, wrong dialogue
+    d_pp = {}
+    d_pp['goal'] = d['goal']  # for now we just copy the goal
+    usr_turns = []
+    sys_turns = []
+    # last_bvs = []
+    for i in range(len(d['log'])):
+        if len(d['log'][i]['text'].split()) > maxlen:
+            print('too long')
+            return None  # too long sentence, wrong dialogue
+        if i % 2 == 0:  # usr turn
+            text = d['log'][i]['text']
+            if not is_ascii(text):
+                print('usr turn not ascii')
+                return None
+            usr_turns.append(d['log'][i])
+        else:  # sys turn
+            text = d['log'][i]['text']
+            if not is_ascii(text):
+                print('sys turn not ascii')
+                return None
+            belief_summary, belief_value_summary = get_summary_bstate(d['log'][i]['metadata'])
+            d['log'][i]['belief_summary'] = str(belief_summary)
+            d['log'][i]['belief_value_summary'] = belief_value_summary
+            sys_turns.append(d['log'][i])
+    d_pp['usr_log'] = usr_turns
+    d_pp['sys_log'] = sys_turns
+
+    return d_pp
+
+def get_dial(dialogue):
+    """Extract a dialogue from the file"""
+    dial = []
+    d_orig = analyze_dialogue(dialogue, MAX_LENGTH)  # max turn len is 50 words
+    if d_orig is None:
+        return None
+    usr = [t['text'] for t in d_orig['usr_log']]
+    sys = [t['text'] for t in d_orig['sys_log']]
+    sys_a = [t['dialogue_acts'] for t in d_orig['sys_log']]
+    bvs = [t['belief_value_summary'] for t in d_orig['sys_log']]
+    domain = [t['domain'] for t in d_orig['usr_log']]
+    for item in zip(usr, sys, sys_a, domain, bvs):
+        dial.append({'usr':item[0],'sys':item[1], 'sys_a':item[2], 'domain':item[3], 'bvs':item[4]})
+    return dial
+
+def getDomain(idx, log, domains, last_domain):
+    if idx == 1:
+        active_domains = get_summary_bstate(log[idx]["metadata"], True) 
+        crnt_doms = active_domains[0] if len(active_domains)!=0 else domains[0]
+        return crnt_doms
+    else:
+        ds_diff = get_ds_diff(log[idx-2]["metadata"], log[idx]["metadata"])
+        if len(ds_diff.keys()) == 0: # no clues from dialog states
+            crnt_doms = last_domain
+        else:
+            crnt_doms = list(ds_diff.keys())
+        return crnt_doms[0] # How about multiple domains in one sentence senario ?
+
+def get_ds_diff(prev_d, crnt_d):
+    diff = {}
+    # Sometimes, metadata is an empty dictionary, bug?
+    if not prev_d or not crnt_d:
+        return diff
+
+    for ((k1, v1), (k2, v2)) in zip(prev_d.items(), crnt_d.items()):
+        assert k1 == k2
+        if v1 != v2: # updated
+            diff[k2] = v2
+    return diff
+
+def createData(data_dir):
+    delex_data = {}
+
+    fin1 = open(os.path.join(data_dir,'data.json'), 'r')
+    data = json.load(fin1)
+
+    fin2 = open(os.path.join(data_dir,'dialogue_acts.json'), 'r')
+    data2 = json.load(fin2)
+
+    for didx, dialogue_name in enumerate(data):
+
+        dialogue = data[dialogue_name]
+
+        domains = []
+        for dom_k, dom_v in dialogue['goal'].items():
+            if dom_v and dom_k not in IGNORE_KEYS_IN_GOAL: # check whether contains some goal entities
+                domains.append(dom_k)
+
+        idx_acts = 1
+        last_domain, last_slot_fill = "", []
+        for idx, turn in enumerate(dialogue['log']):
+            # normalization, split and delexicalization of the sentence
+            origin_text = normalize(turn['text'], False)
+            # origin_text = delexicalize.markEntity(origin_text, dic)
+            dialogue['log'][idx]['text'] = origin_text
+
+            if idx % 2 == 1:  # if it's a system turn
+
+                cur_domain = getDomain(idx, dialogue['log'], domains, last_domain)
+                last_domain = [cur_domain]
+
+                dialogue['log'][idx - 1]['domain'] = cur_domain
+                dialogue['log'][idx]['dialogue_acts'] = getDialogueAct(dialogue_name, dialogue, data2, idx, idx_acts)
+                idx_acts += 1
+
+            # FIXING delexicalization:
+            dialogue = fixDelex(dialogue_name, dialogue, data2, idx, idx_acts)
+        
+        delex_data[dialogue_name] = dialogue
+
+    return delex_data
+
+def SaveData(data, data_dir):
+    dials = []
+    count = 0
+    # data = self.delex_data
+    for dialogue_name in data:
+        # print dialogue_name
+        dial_item = data[dialogue_name]
+        domains = []
+        for dom_k, dom_v in dial_item['goal'].items():
+            if dom_v and dom_k not in IGNORE_KEYS_IN_GOAL: # check whether contains some goal entities
+                domains.append(dom_k)
+
+        dial = get_dial(data[dialogue_name])
+        if dial:
+            dialogue = {}
+            dialogue['dialogue_idx'] = dialogue_name
+            dialogue['domains'] = list(set(domains)) #list(set([d['domain'] for d in dial]))
+            last_bs = []
+            dialogue['dialogue'] = []
+
+            for turn_i, turn in enumerate(dial):
+                # usr, usr_o, sys, sys_o, sys_a, domain
+                turn_dialog = {}
+                turn_dialog['system_transcript'] = dial[turn_i-1]['sys'] if turn_i > 0 else ""
+                turn_dialog['turn_idx'] = turn_i
+                turn_dialog['belief_state'] = [{"slots": [s], "act": "inform"} for s in turn['bvs']]
+                turn_dialog['turn_label'] = [bs["slots"][0] for bs in turn_dialog['belief_state'] if bs not in last_bs] 
+                turn_dialog['transcript'] = turn['usr']
+                turn_dialog['system_acts'] = dial[turn_i-1]['sys_a'] if turn_i > 0 else []
+                turn_dialog['domain'] = turn['domain']
+                last_bs = turn_dialog['belief_state']
+                dialogue['dialogue'].append(turn_dialog)
+            
+            dials.append(dialogue)
+            count += 1
+
+        else:
+            print(dialogue_name)
+
+    # save all dialogues
+    with open(os.path.join(data_dir, "dials_trade.json"), 'w') as f:
+        json.dump(dials, f, indent=2)
+
+def trade_process(data_dir=None, force_proc=False):
+    if os.path.exists(os.path.join(data_dir, "dials_trade.json")) and not force_proc:
+        pass
+        # print("already preprocessed before, skipping this time ...")
+    else:
+        delex_data = createData(data_dir)
+        SaveData(delex_data, data_dir)
+
+def main():
+    print('Create WOZ-like dialogues. Get yourself a coffee, this might take a while.')
+    delex_data = createData()
+    print('Divide dialogues...')
+    divideData(delex_data)
+
+if __name__ == "__main__":
+    main()

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -1143,6 +1143,17 @@ task_list = [
         "links": {"website": "http://dialogue.mi.eng.cam.ac.uk/index.php/corpus/"},
     },
     {
+        "id": "MultiWOZ_TRADE",
+        "display_name": "MultiWOZ 2.1 trade preprocess",
+        "task": "multiwoz_trade",
+        "tags": ["All", "Goal"],
+        "description": (
+            "A fully labeled collection of human-written conversations spanning"
+            "over multiple domains and topics."
+        ),
+        "links": {"website": "http://dialogue.mi.eng.cam.ac.uk/index.php/corpus/"},
+    },
+    {
         "id": "SelfChat",
         "display_name": "SelfChat",
         "task": "self_chat",


### PR DESCRIPTION
**Patch description**
adding a new task for multiwoz2.1 dataset with TRADE preprocess, including two teacher model, one for dialog state tracking and one for dialog response generation (seq-to-seq without dst nor db search, similar with multiwoz_v2.1); besides, reformat data as each turn would be an individual episode, and the input sequence includes all dialog history in previous turns. 

**Testing steps**
Before training model, please use 
`parlai display_data -t multiwoz_trade`
to generate and preprocess data.
Then, for DST task:
`parlai multiprocessing_train \
    -m hugging_face/gpt2 -t multiwoz_trade -eps 20 -bs 8 -opt adam -lr 5e-4 \
    --eval-batchsize 8 \
    --fp16 true \
    --warmup_updates 100 \
    --warmup_rate 1e-5 \
    --log-every-n-secs 100 \
    --validation-every-n-epochs 1 \
    --model-file experiment/gen_gpt2/model \
    --validation-metric 'joint goal acc' \
    --validation-metric-mode max \
    --add-special-tokens True`
For dialog response generation task:
`parlai multiprocessing_train \
    -m hugging_face/gpt2 -t multiwoz_trade -eps 20 -bs 8 -opt adam -lr 5e-4 \
    --eval-batchsize 8 \
    --fp16 true \
    --warmup_updates 100 \
    --warmup_rate 1e-5 \
    --log-every-n-secs 100 \
    --validation-every-n-epochs 1 \
    --model-file experiment/gen_gpt2/model \
    --add-special-tokens True`
