### PR TITLE
Fix error with using GPT2 + DistributedDataParallel

### DIFF
--- a/parlai/agents/hugging_face/gpt2.py
+++ b/parlai/agents/hugging_face/gpt2.py
@@ -272,9 +272,14 @@ class Gpt2Agent(TorchGeneratorAgent):
                 "--add-start-token true requires --add-special-tokens true"
             )
         super().__init__(opt, shared)
-        self.START_IDX = self.model.START_IDX
-        self.END_IDX = self.model.END_IDX
-        self.NULL_IDX = self.model.NULL_IDX
+        if hasattr(self.model, "module"):
+            self.START_IDX = self.model.module.START_IDX
+            self.END_IDX = self.model.module.END_IDX
+            self.NULL_IDX = self.model.module.NULL_IDX
+        else:
+            self.START_IDX = self.model.START_IDX
+            self.END_IDX = self.model.END_IDX
+            self.NULL_IDX = self.model.NULL_IDX
 
     @staticmethod
     def dictionary_class():

--- a/tests/nightly/gpu/test_gpt2.py
+++ b/tests/nightly/gpu/test_gpt2.py
@@ -161,7 +161,7 @@ class TestDistributed(unittest.TestCase):
     def test_distributed(self):
         config = copy.deepcopy(self._base_config)
         config['num_epochs'] = 50
-        config['task'] = 'integration_tests:overfit'
+        config['task'] = 'integration_tests:short_fixed'
         config['dynb'] = 'full'
         valid, test = self._distributed_train_model(config)
 

--- a/tests/nightly/gpu/test_gpt2.py
+++ b/tests/nightly/gpu/test_gpt2.py
@@ -6,6 +6,13 @@
 
 import unittest
 from parlai.core.agents import create_agent
+import torch.distributed as dist
+import parlai.utils.testing as testing_utils
+import parlai.scripts.multiprocessing_train as mp_train
+import parlai.scripts.build_dict as build_dict
+import parlai.tasks.integration_tests.agents as inttests
+import copy
+import os
 
 
 class TestGpt2(unittest.TestCase):
@@ -95,3 +102,76 @@ class TestGpt2(unittest.TestCase):
         gpt2.observe({'text': 'My name is', 'episode_done': True})
         response = gpt2.act()
         assert response['text'] == " John. I'm a man of"
+
+
+BATCHSIZE = 4
+
+
+@testing_utils.skipUnlessGPU
+class TestDistributed(unittest.TestCase):
+    _base_config = {
+        'task': 'integration_tests:overfit',
+        'model': 'hugging_face/gpt2',
+        'gpt2_size': 'small',
+        'text_truncate': 16,
+        'label_truncate': 8,
+        'beam_min_length': 8,
+        'inference': 'beam',
+        'beam_size': 1,
+        'batchsize': BATCHSIZE,
+        'add_special_tokens': True,
+    }
+
+    def setUp(self):
+        print(f'[Setting up test {self._testMethodName}]')
+
+    def _forced_parse(self, parser, opt):
+        parser.set_params(**opt)
+        parser.set_params(log_every_n_sec=10)
+        popt = parser.parse_args([])
+        # in some rare cases, like for instance if the model class also
+        # overrides its default params, the params override will not
+        # be taken into account.
+        for k, v in opt.items():
+            popt[k] = v
+        return popt
+
+    def _distributed_train_model(self, opt):
+        with testing_utils.tempdir() as tmpdir:
+            if 'model_file' not in opt:
+                opt['model_file'] = os.path.join(tmpdir, 'model')
+            if 'dict_file' not in opt:
+                opt['dict_file'] = os.path.join(tmpdir, 'model.dict')
+
+            parser = mp_train.setup_args()
+            popt = self._forced_parse(parser, opt)
+
+            # we need a prebuilt dictionary
+            parser = build_dict.setup_args()
+            build_dict.build_dict(popt)
+
+            valid, test = mp_train.launch_and_train(popt, 31338)
+            dist.destroy_process_group()
+
+        return (valid, test)
+
+    @testing_utils.retry()
+    def test_multitask_distributed(self):
+        config = copy.deepcopy(self._base_config)
+        config['num_epochs'] = 50
+        config['task'] = 'integration_tests:overfit,integration_tests:overfit_multiturn'
+        config['dynb'] = 'full'
+        valid, test = self._distributed_train_model(config)
+
+        self.assertLessEqual(valid['ppl'], 1.20)
+        self.assertLessEqual(test['ppl'], 1.20)
+
+        # Tests that DialogData.get() is doing the right thing
+        # Ensure no duplication of examples among workers
+        # It would be 200 if each worker did all the examples
+        self.assertEqual(
+            valid['exs'].value(), BATCHSIZE * inttests.EXAMPLE_SIZE + BATCHSIZE
+        )
+        self.assertEqual(
+            test['exs'].value(), BATCHSIZE * inttests.EXAMPLE_SIZE + BATCHSIZE
+        )


### PR DESCRIPTION
**Patch description**

DistributedDataParallel adds another name to the module path. Fix this with an if check. 

**Testing steps**

Tested by running GPT2 training with DistributedDataParallel.
Also
```
pytest test_gpt2.py::TestDistributed::test_multitask_distributed
```
both with and without the change; verifies it breaks in latter and passes in the former.
