### PR TITLE
Add command for viewing all Hydra parameters

### DIFF
--- a/parlai/crowdsourcing/tasks/README.md
+++ b/parlai/crowdsourcing/tasks/README.md
@@ -4,7 +4,7 @@ Code for crowdsourcing tasks that use Mephisto. See https://github.com/facebookr
 
 ## Running tasks
 
-Tasks are launched by calling the appropriate run script: for instance, an ACUTE-Eval run can be launched with `python parlai/crowdsourcing/tasks/acute_eval/run.py`, followed by any appropriate flags. All run parameters are set using [Hydra](https://github.com/facebookresearch/hydra): append the flag `-c job` to your run command to see a list of all available parameters, grouped by the package name (`mephisto.blueprint`, `mephisto.task`, etc.) that indicates how they are called. Each run script has a YAML file of default parameters that will be loaded, found in the `conf/` subfolder of each task.
+Tasks are launched by calling the appropriate run script: for instance, an ACUTE-Eval run can be launched with `python parlai/crowdsourcing/tasks/acute_eval/run.py`, followed by any appropriate flags. All run parameters are set using [Hydra](https://github.com/facebookresearch/hydra): append the flag `-c job` to your run command to see a list of all available parameters, grouped by their package name (`mephisto.blueprint`, `mephisto.task`, etc.), which determines how they are called. Each run script has a YAML file of default parameters that will be loaded, found in the `conf/` subfolder of each task.
  
 ### Specifying your own YAML file
  

--- a/parlai/crowdsourcing/tasks/README.md
+++ b/parlai/crowdsourcing/tasks/README.md
@@ -4,7 +4,7 @@ Code for crowdsourcing tasks that use Mephisto. See https://github.com/facebookr
 
 ## Running tasks
 
-Tasks are launched by calling the appropriate run script: for instance, an ACUTE-Eval run can be launched with `python parlai/crowdsourcing/tasks/acute_eval/run.py`, followed by any appropriate flags. All run parameters are set using [Hydra](https://github.com/facebookresearch/hydra), and each run script has a YAML file of default parameters that will be loaded, found in the `conf/` subfolder of each task.
+Tasks are launched by calling the appropriate run script: for instance, an ACUTE-Eval run can be launched with `python parlai/crowdsourcing/tasks/acute_eval/run.py`, followed by any appropriate flags. All run parameters are set using [Hydra](https://github.com/facebookresearch/hydra): append the flag `-c job` to your run command to see a list of all available parameters, grouped by the package name (`mephisto.blueprint`, `mephisto.task`, etc.) that indicates how they are called. Each run script has a YAML file of default parameters that will be loaded, found in the `conf/` subfolder of each task.
  
 ### Specifying your own YAML file
  


### PR DESCRIPTION
Add a note to the main `parlai.crowdsourcing.tasks` README to specify how to view all Hydra parameters, grouped by package.