### PR TITLE
[Safety] Set data parallel to False in default Offensive Language Classifier

### DIFF
--- a/parlai/utils/safety.py
+++ b/parlai/utils/safety.py
@@ -49,6 +49,7 @@ class OffensiveLanguageClassifier:
             model='transformer/classifier',
             model_file=custom_model_file,
             print_scores=True,
+            data_parallel=False,
         )
         safety_opt = parser.parse_args([])
         return create_agent(safety_opt, requireModelExists=True)


### PR DESCRIPTION
**Patch description**
The Offensive Language Classifier utility is not equipped for batching and yet data parallel is set to True by default. This can cause issues when you only wnat to load the model on a specific GPU.