### PR TITLE
[torch_classifier] freeze the encoder and update the classifier head only

### DIFF
--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -290,6 +290,12 @@ class TorchClassifierAgent(TorchAgent):
             default=None,
             help='Ignore labels provided to model',
         )
+        parser.add_argument(
+            '--update-classifier-head-only',
+            type='bool',
+            default=False,
+            help='Freeze the encoder and update the classifier head only',
+        )
         parser.set_defaults(use_reply='none')
 
     def __init__(self, opt: Opt, shared=None):
@@ -340,6 +346,12 @@ class TorchClassifierAgent(TorchAgent):
             self.model = shared['model']
         else:
             self.model = self.build_model()
+            # freeze the encoder and update the classifier only
+            if opt.get("update_classifier_head_only", False):
+                for _param_name, _param_value in self.model.named_parameters():
+                    if not _param_name.startswith('additional_linear_layer'):
+                        _param_value.requires_grad = False
+
             self.criterion = self.build_criterion()
             if self.model is None or self.criterion is None:
                 raise AttributeError(


### PR DESCRIPTION
**Patch description**
Freeze the encoder (bert, transformer, etc), and update the classifier head only

**Testing steps**
* bert
```
parlai tm -m bert_classifier -t snli --classes 'entailment' 'contradiction' 'neutral' -mf /tmp/BERT_snli -bs 2 --update-classifier-head-only True
```
--> logs
```
Total parameters: 109,484,547 (2,307 trainable)
```
* transformer
```
parlai tm -m transformer/classifier -t snli --classes 'entailment' 'contradiction' 'neutral' -mf /tmp/transformer_snli -bs 2 --update-classifier-head-only True
```
--> logs
```
Total parameters: 13,165,203 (903 trainable)
```

