### PR TITLE
[Safeways] Add persona to the teacher

### DIFF
--- a/parlai/tasks/bot_adversarial_dialogue/agents.py
+++ b/parlai/tasks/bot_adversarial_dialogue/agents.py
@@ -18,6 +18,7 @@ import parlai.utils.logging as logging
 from parlai.utils.io import PathManager
 from parlai.utils.misc import str_to_msg
 from parlai.tasks.dialogue_safety.agents import OK_CLASS, NOT_OK_CLASS
+from parlai.core.message import Message
 
 # Constants
 SAFETY_DICT = {'safe': OK_CLASS, 'unsafe': NOT_OK_CLASS}
@@ -33,7 +34,7 @@ def _adversarial_dialogue_datapath(opt: Opt) -> str:
     dt = opt['datatype'].split(':')[0]
     data_path = os.path.join(
         get_adversarial_dialogue_folder(opt['datapath']),
-        'bot_adversarial_dialogue_datasets',
+        'bot_adversarial_dialogue_datasets_with_persona',
         dt + '.txt',
     )
     return data_path
@@ -46,28 +47,42 @@ class BotAdversarialDialogueTeacher(ParlAIDialogTeacher):
 
     def add_cmdline_args(argparser):
         agent = argparser.add_argument_group('Bot Adversarial Dialogue options')
-        agent.add_argument('--bad-num-turns', type=int, default=-1)
+        agent.add_argument(
+            '--bad-num-turns',
+            type=int,
+            default=-1,
+            help="Number of dialogue turns to be truncated",
+        )
         agent.add_argument(
             '--bad-speaker-to-eval',
             type=str,
             default='all',
             choices=['bot', 'human', 'all'],
+            help="The speaker of the utterances labeled",
         )
         agent.add_argument(
             '--bad-safety-mix',
             type=str,
             default='all',
             choices=['safe', 'unsafe', 'all'],
+            help="The set of language being included. If 'safe', only display language labeled as __ok__",
+        )
+        agent.add_argument(
+            '--bad-include-persona',
+            type=bool,
+            default=False,
+            help="Whether to include bot persona or not in the message",
         )
 
     def __init__(self, opt, shared=None):
         opt['parlaidialogteacher_datafile'] = _adversarial_dialogue_datapath(opt=opt)
         super().__init__(opt, shared=shared)
-        self.id = '{}.numTurns_{}_speakerToEval_{}_safetyMix_{}'.format(
+        self.id = '{}.numTurns_{}_speakerToEval_{}_safetyMix_{}_persona_{}'.format(
             self.id,
             self.opt['bad_num_turns'],
             self.opt['bad_speaker_to_eval'],
             self.opt['bad_safety_mix'],
+            self.opt['bad_include_persona'],
         )
 
     def _setup_data(self, path):
@@ -109,12 +124,18 @@ class BotAdversarialDialogueTeacher(ParlAIDialogTeacher):
                     and SAFETY_DICT[self.opt['bad_safety_mix']] != msg['labels'][0]
                 ):
                     continue
+                msg_text = msg['text']
+                dialog = msg_text.split('\n')
+                if self.opt['bad_include_persona'] and msg['speaker_to_eval'] == 'bot':
+                    # only display persona if it's asked to and if the last turn is bot.
+                    if len(msg['bot_persona'].strip()) > 0:
+                        dialog[0] = msg['bot_persona'] + '\n' + dialog[0]
                 if self.opt['bad_num_turns'] > 0:
-                    dialog = msg['text'].split('\n')
-                    msg.force_set(
-                        'text', '\n'.join(dialog[-self.opt['bad_num_turns'] :])
-                    )
+                    msg_text = '\n'.join(dialog[-self.opt['bad_num_turns'] :])
+                else:
+                    msg_text = '\n'.join(dialog)
                 if msg:
+                    msg.force_set('text', msg_text)
                     self.num_exs += 1
                     eps.append(msg)
                     if msg.get('episode_done', False):
@@ -154,9 +175,61 @@ class HumanSafetyEvaluationTeacher(ParlAIDialogTeacher):
     Teacher for human safety evaluation on bot adversarial dialogues.
     """
 
+    def add_cmdline_args(argparser):
+        agent = argparser.add_argument_group(
+            'Bot Adversarial Dialogue Human Evaluation options'
+        )
+        agent.add_argument(
+            '--bad-include-persona',
+            type=bool,
+            default=False,
+            help="Whether to include bot persona or not in the message",
+        )
+        agent.add_argument(
+            '--flatten-dialogue',
+            type=bool,
+            default=True,
+            help="Whether to flatten the dialogue context",
+        )
+
     def __init__(self, opt, shared=None):
         opt['parlaidialogteacher_datafile'] = _human_safety_eval_datapath(opt=opt)
         super().__init__(opt, shared=shared)
+        self.id = '{}.persona_{}_flatten_{}'.format(
+            self.id, self.opt['bad_include_persona'], self.opt['flatten_dialogue']
+        )
+
+    def _setup_data(self, path):
+        super()._setup_data(path)
+        new_episodes = []
+        for ep in self.episodes:
+            if self.opt['bad_include_persona'] is False:
+                text_without_persona = '\n'.join(
+                    [
+                        str_
+                        for str_ in ep[0]['text'].split('\n')
+                        if not str_.startswith('your persona: ')
+                    ]
+                )
+                ep[0].force_set('text', text_without_persona)
+            if self.opt['flatten_dialogue']:
+                dialog_text = '\n'.join(
+                    [(exs['text'] + '\n' + exs['labels'][0]) for exs in ep[:-1]]
+                )
+                dialog_text = dialog_text + '\n' + ep[-1]['text']
+                msg = {
+                    'text': dialog_text,
+                    'labels': ep[-1]['labels'],
+                    'episode_done': True,
+                    'id': ep[0]['id'],
+                    'human_eval_turn_range': ep[0]['human_eval_turn_range'],
+                    'convo_id': ep[0]['convo_id'],
+                }
+                msg = Message(msg)
+                new_episodes.append([msg])
+        if self.opt['flatten_dialogue']:
+            self.episodes = new_episodes
+            self.num_exs = len(self.episodes)
 
 
 class DefaultTeacher(BotAdversarialDialogueTeacher):

--- a/parlai/tasks/bot_adversarial_dialogue/build.py
+++ b/parlai/tasks/bot_adversarial_dialogue/build.py
@@ -12,7 +12,7 @@ from parlai.core.build_data import DownloadableFile
 from parlai.core.opt import Opt
 
 
-BOT_ADVERSARIAL_DIALOGUE_DATASETS_VERSION = 'v0.1'
+BOT_ADVERSARIAL_DIALOGUE_DATASETS_VERSION = 'v0.2'
 HUMAN_SAFETY_EVAL_TESTSET_VERSION = 'v0.1'
 
 TASK_FOLDER_NAME = 'bot_adversarial_dialogue'
@@ -21,7 +21,7 @@ BOT_ADVERSARIAL_DIALOGUE_DATASETS_RESOURCES = [
     DownloadableFile(
         f'http://parl.ai/downloads/bot_adversarial_dialogue/dialogue_datasets_{BOT_ADVERSARIAL_DIALOGUE_DATASETS_VERSION}.tar.gz',
         f'dialogue_datasets_{BOT_ADVERSARIAL_DIALOGUE_DATASETS_VERSION}.tar.gz',
-        '28fc3ed25e1e302b873406394e98e6f7eb3531552a79957fb432b748a7a535e7',
+        '2178b022fac154ddd9b570f6386abc4cd3e7ceb4476f0bebfbce5941424461eb',
     )
 ]
 HUMAN_SAFETY_EVAL_TESTSET_RESOURCES = [


### PR DESCRIPTION
**Patch description**
Current bot_adversarial_dialogue teacher does not has the option to include bot persona in the dialogue. And the fixed test set display in a dialogue format (180 episodes with 772 examples, which is 772 turns) which can be confusing to the users.
In this change:
- Add ``` --bad-include-persona``` option to display persona lines if the last turn is bot and if the dialogue truncation includes the very first turn of the dialogue.
- Add ```--flatten-dialogue``` option to HumanSafetyEvaluation teacher (the fixed test set) to flatten the dialogue context.

**Testing steps**
CI

**Logs**
<!-- If applicable, please paste the command line from your testing: -->

``` parlai dd -t bot_adversarial_dialogue --bad-include-persona True --bad-num-turns 4 ```
<img width="988" alt="Screen Shot 2020-10-27 at 9 59 00 AM" src="https://user-images.githubusercontent.com/60988468/97311762-13d81f00-183b-11eb-9101-1d63ab508c47.png">

``` parlai dd -t bot_adversarial_dialogue:HumanSafetyEvaluation --flatten-dialogue True --bad-include-persona True```
<img width="865" alt="Screen Shot 2020-10-27 at 10 08 26 AM" src="https://user-images.githubusercontent.com/60988468/97312891-6108c080-183c-11eb-8431-e6866fe855f2.png">


**Data tests (if applicable)**
If you added a new teacher, you will be asked to run
`python tests/datatests/test_new_tasks.py`. Please paste this log here.

```
(conda_parlai) jingxu23@devfair0173:~/ParlAI$ python tests/datatests/test_new_tasks.py
07:09:09 | Opt:
07:09:09 |     allow_missing_init_opts: False
07:09:09 |     bad_include_persona: False
07:09:09 |     bad_num_turns: -1
07:09:09 |     bad_safety_mix: all
07:09:09 |     bad_speaker_to_eval: all
07:09:09 |     batchsize: 1
07:09:09 |     datapath: /private/home/jingxu23/ParlAI/data
07:09:09 |     datatype: train:stream:ordered
07:09:09 |     dict_class: None
07:09:09 |     display_examples: False
07:09:09 |     download_path: None
07:09:09 |     dynamic_batching: None
07:09:09 |     hide_labels: False
07:09:09 |     image_cropsize: 224
07:09:09 |     image_mode: raw
07:09:09 |     image_size: 256
07:09:09 |     init_model: None
07:09:09 |     init_opt: None
07:09:09 |     log_every_n_secs: 2
07:09:09 |     loglevel: info
07:09:09 |     model: None
07:09:09 |     model_file: None
07:09:09 |     multitask_weights: [1]
07:09:09 |     override: "{'task': 'bot_adversarial_dialogue:BotAdversarialDialogueTeacher'}"
07:09:09 |     parlai_home: /private/home/jingxu23/ParlAI
07:09:09 |     starttime: Oct27_07-09
07:09:09 |     task: bot_adversarial_dialogue:BotAdversarialDialogueTeacher
07:09:09 |     verbose: False
07:09:09 | Current ParlAI commit: 7e5ad3faeaccfa6d3f8af48eda67555303b7759e
07:09:09 | Current internal commit: 4e153a2aff44d62dba3d3621608ac33d4d39a515
07:09:09 | creating task(s): bot_adversarial_dialogue:BotAdversarialDialogueTeacher
07:09:09 | Loading ParlAI text data: /private/home/jingxu23/ParlAI/data/bot_adversarial_dialogue/dialogue_datasets/bot_adversarial_dialogue_datasets_with_persona/train.txt
07:09:37 | Loaded 69274 episodes with a total of 69274 examples
07:09:37 | Opt:
07:09:37 |     allow_missing_init_opts: False
07:09:37 |     bad_include_persona: False
07:09:37 |     bad_num_turns: -1
07:09:37 |     bad_safety_mix: all
07:09:37 |     bad_speaker_to_eval: all
07:09:37 |     batchsize: 1
07:09:37 |     datapath: /private/home/jingxu23/ParlAI/data
07:09:37 |     datatype: train:stream:ordered
07:09:37 |     dict_class: None
07:09:37 |     display_examples: False
07:09:37 |     download_path: None
07:09:37 |     dynamic_batching: None
07:09:37 |     hide_labels: False
07:09:37 |     image_cropsize: 224
07:09:37 |     image_mode: raw
07:09:37 |     image_size: 256
07:09:37 |     init_model: None
07:09:37 |     init_opt: None
07:09:37 |     log_every_n_secs: 2
07:09:37 |     loglevel: info
07:09:37 |     model: None
07:09:37 |     model_file: None
07:09:37 |     multitask_weights: [1]
07:09:37 |     override: "{'task': 'bot_adversarial_dialogue:DefaultTeacher'}"
07:09:37 |     parlai_home: /private/home/jingxu23/ParlAI
07:09:37 |     starttime: Oct27_07-09
07:09:37 |     task: bot_adversarial_dialogue:DefaultTeacher
07:09:37 |     verbose: False
07:09:37 | Current ParlAI commit: 7e5ad3faeaccfa6d3f8af48eda67555303b7759e
07:09:37 | Current internal commit: 4e153a2aff44d62dba3d3621608ac33d4d39a515
07:09:37 | creating task(s): bot_adversarial_dialogue:DefaultTeacher
07:09:37 | Loading ParlAI text data: /private/home/jingxu23/ParlAI/data/bot_adversarial_dialogue/dialogue_datasets/bot_adversarial_dialogue_datasets_with_persona/train.txt
07:10:04 | Loaded 69274 episodes with a total of 69274 examples
07:10:04 | Opt:
07:10:04 |     allow_missing_init_opts: False
07:10:04 |     bad_include_persona: False
07:10:04 |     batchsize: 1
07:10:04 |     datapath: /private/home/jingxu23/ParlAI/data
07:10:04 |     datatype: train:stream:ordered
07:10:04 |     dict_class: None
07:10:04 |     display_examples: False
07:10:04 |     download_path: None
07:10:04 |     dynamic_batching: None
07:10:04 |     flatten_dialogue: True
07:10:04 |     hide_labels: False
07:10:04 |     image_cropsize: 224
07:10:04 |     image_mode: raw
07:10:04 |     image_size: 256
07:10:04 |     init_model: None
07:10:04 |     init_opt: None
07:10:04 |     log_every_n_secs: 2
07:10:04 |     loglevel: info
07:10:04 |     model: None
07:10:04 |     model_file: None
07:10:04 |     multitask_weights: [1]
07:10:04 |     override: "{'task': 'bot_adversarial_dialogue:HumanSafetyEvaluationTeacher'}"
07:10:04 |     parlai_home: /private/home/jingxu23/ParlAI
07:10:04 |     starttime: Oct27_07-10
07:10:04 |     task: bot_adversarial_dialogue:HumanSafetyEvaluationTeacher
07:10:04 |     verbose: False
07:10:04 | Current ParlAI commit: 7e5ad3faeaccfa6d3f8af48eda67555303b7759e
07:10:04 | Current internal commit: 4e153a2aff44d62dba3d3621608ac33d4d39a515
07:10:04 | creating task(s): bot_adversarial_dialogue:HumanSafetyEvaluationTeacher
07:10:04 | The data for human safety evaluation is test set only regardless of your chosen datatype, which is train:stream:ordered 
07:10:04 | Loading ParlAI text data: /private/home/jingxu23/ParlAI/data/bot_adversarial_dialogue/human_eval/human_safety_eval/test.txt
07:10:04 | Loaded 180 episodes with a total of 180 examples
07:10:04 | Opt:
07:10:04 |     allow_missing_init_opts: False
07:10:04 |     bad_include_persona: False
07:10:04 |     bad_num_turns: -1
07:10:04 |     bad_safety_mix: all
07:10:04 |     bad_speaker_to_eval: all
07:10:04 |     batchsize: 1
07:10:04 |     datapath: /private/home/jingxu23/ParlAI/data
07:10:04 |     datatype: train:stream:ordered
07:10:04 |     dict_class: None
07:10:04 |     display_examples: False
07:10:04 |     download_path: None
07:10:04 |     dynamic_batching: None
07:10:04 |     hide_labels: False
07:10:04 |     image_cropsize: 224
07:10:04 |     image_mode: raw
07:10:04 |     image_size: 256
07:10:04 |     init_model: None
07:10:04 |     init_opt: None
07:10:04 |     log_every_n_secs: 2
07:10:04 |     loglevel: info
07:10:04 |     model: None
07:10:04 |     model_file: None
07:10:04 |     multitask_weights: [1]
07:10:04 |     override: "{'task': 'bot_adversarial_dialogue:BotAdversarialDialogueTeacher'}"
07:10:04 |     parlai_home: /private/home/jingxu23/ParlAI
07:10:04 |     starttime: Oct27_07-10
07:10:04 |     task: bot_adversarial_dialogue:BotAdversarialDialogueTeacher
07:10:04 |     verbose: False
07:10:04 | Current ParlAI commit: 7e5ad3faeaccfa6d3f8af48eda67555303b7759e
07:10:04 | Current internal commit: 4e153a2aff44d62dba3d3621608ac33d4d39a515
07:10:04 | creating task(s): bot_adversarial_dialogue:BotAdversarialDialogueTeacher
07:10:04 | Loading ParlAI text data: /private/home/jingxu23/ParlAI/data/bot_adversarial_dialogue/dialogue_datasets/bot_adversarial_dialogue_datasets_with_persona/train.txt
07:10:31 | Loaded 69274 episodes with a total of 69274 examples
07:10:31 | Opt:
07:10:31 |     allow_missing_init_opts: False
07:10:31 |     bad_include_persona: False
07:10:31 |     bad_num_turns: -1
07:10:31 |     bad_safety_mix: all
07:10:31 |     bad_speaker_to_eval: all
07:10:31 |     batchsize: 1
07:10:31 |     datapath: /private/home/jingxu23/ParlAI/data
07:10:31 |     datatype: train:stream:ordered
07:10:31 |     dict_class: None
07:10:31 |     display_examples: False
07:10:31 |     download_path: None
07:10:31 |     dynamic_batching: None
07:10:31 |     hide_labels: False
07:10:31 |     image_cropsize: 224
07:10:31 |     image_mode: raw
07:10:31 |     image_size: 256
07:10:31 |     init_model: None
07:10:31 |     init_opt: None
07:10:31 |     log_every_n_secs: 2
07:10:31 |     loglevel: info
07:10:31 |     model: None
07:10:31 |     model_file: None
07:10:31 |     multitask_weights: [1]
07:10:31 |     override: "{'task': 'bot_adversarial_dialogue:DefaultTeacher'}"
07:10:31 |     parlai_home: /private/home/jingxu23/ParlAI
07:10:31 |     starttime: Oct27_07-10
07:10:31 |     task: bot_adversarial_dialogue:DefaultTeacher
07:10:31 |     verbose: False
07:10:31 | Current ParlAI commit: 7e5ad3faeaccfa6d3f8af48eda67555303b7759e
07:10:31 | Current internal commit: 4e153a2aff44d62dba3d3621608ac33d4d39a515
07:10:31 | creating task(s): bot_adversarial_dialogue:DefaultTeacher
07:10:31 | Loading ParlAI text data: /private/home/jingxu23/ParlAI/data/bot_adversarial_dialogue/dialogue_datasets/bot_adversarial_dialogue_datasets_with_persona/train.txt
07:10:56 | Loaded 69274 episodes with a total of 69274 examples
07:10:57 | Opt:
07:10:57 |     allow_missing_init_opts: False
07:10:57 |     bad_include_persona: False
07:10:57 |     batchsize: 1
07:10:57 |     datapath: /private/home/jingxu23/ParlAI/data
07:10:57 |     datatype: train:stream:ordered
07:10:57 |     dict_class: None
07:10:57 |     display_examples: False
07:10:57 |     download_path: None
07:10:57 |     dynamic_batching: None
07:10:57 |     flatten_dialogue: True
07:10:57 |     hide_labels: False
07:10:57 |     image_cropsize: 224
07:10:57 |     image_mode: raw
07:10:57 |     image_size: 256
07:10:57 |     init_model: None
07:10:57 |     init_opt: None
07:10:57 |     log_every_n_secs: 2
07:10:57 |     loglevel: info
07:10:57 |     model: None
07:10:57 |     model_file: None
07:10:57 |     multitask_weights: [1]
07:10:57 |     override: "{'task': 'bot_adversarial_dialogue:HumanSafetyEvaluationTeacher'}"
07:10:57 |     parlai_home: /private/home/jingxu23/ParlAI
07:10:57 |     starttime: Oct27_07-10
07:10:57 |     task: bot_adversarial_dialogue:HumanSafetyEvaluationTeacher
07:10:57 |     verbose: False
07:10:57 | Current ParlAI commit: 7e5ad3faeaccfa6d3f8af48eda67555303b7759e
07:10:57 | Current internal commit: 4e153a2aff44d62dba3d3621608ac33d4d39a515
07:10:57 | creating task(s): bot_adversarial_dialogue:HumanSafetyEvaluationTeacher
07:10:57 | The data for human safety evaluation is test set only regardless of your chosen datatype, which is train:stream:ordered 
07:10:57 | Loading ParlAI text data: /private/home/jingxu23/ParlAI/data/bot_adversarial_dialogue/human_eval/human_safety_eval/test.txt
07:10:57 | Loaded 180 episodes with a total of 180 examples
.
----------------------------------------------------------------------
Ran 1 test in 108.231s

OK
```