### PR TITLE
Implement BART incremental decoding

### DIFF
--- a/parlai/agents/bart/modules.py
+++ b/parlai/agents/bart/modules.py
@@ -56,7 +56,19 @@ class BartModel(TransformerGeneratorModel):
         """
         Incremental state is weird to handle when we seed decoder with two inputs
         initially.
-
-        We leave as a future exercise.
         """
-        return None
+        # we only have this method called when it's actually being used
+        assert incremental_state is not None
+        assert len(incremental_state) > 0
+
+        for layer in incremental_state.keys():
+            incr_state_l = incremental_state[layer]
+            assert 'self_attn' in incr_state_l
+            assert 'prev_mask' in incr_state_l['self_attn']
+            self_attn_mask = incr_state_l['self_attn']['prev_mask']
+            # check this is on the very first run with incremental state
+            if self_attn_mask.ndim == 3 and tuple(self_attn_mask.shape[1:]) == (2, 2):
+                # cut off the inappropriate incremental state
+                incr_state_l['self_attn']['prev_mask'] = self_attn_mask[:, -1:, :]
+
+        return super().reorder_decoder_incremental_state(incremental_state, inds)

--- a/parlai/agents/bart/modules.py
+++ b/parlai/agents/bart/modules.py
@@ -61,8 +61,7 @@ class BartModel(TransformerGeneratorModel):
         assert incremental_state is not None
         assert len(incremental_state) > 0
 
-        for layer in incremental_state.keys():
-            incr_state_l = incremental_state[layer]
+        for incr_state_l in incremental_state.values():
             assert 'self_attn' in incr_state_l
             assert 'prev_mask' in incr_state_l['self_attn']
             self_attn_mask = incr_state_l['self_attn']['prev_mask']

--- a/tests/nightly/gpu/test_gpt2.py
+++ b/tests/nightly/gpu/test_gpt2.py
@@ -10,7 +10,6 @@ import torch.distributed as dist
 import parlai.utils.testing as testing_utils
 import parlai.scripts.multiprocessing_train as mp_train
 import parlai.scripts.build_dict as build_dict
-import copy
 import os
 
 


### PR DESCRIPTION
**Patch description**
Adds support for incremental decoding with bart.

**Testing steps**
Ran an evaluation of a model with -bs 1, -bs 8, and mp_eval -bs 16 -dynb full. Verified results were the same. Discussed speedups with @EricMichaelSmith and they were congruent with his experiences.