### PR TITLE
Restore lint check to what it used to be.

### DIFF
--- a/autoformat.sh
+++ b/autoformat.sh
@@ -120,7 +120,7 @@ fi
 if [[ $RUN_ALL_FILES -eq 1 ]]; then
     CHECK_FILES="$(git $REPO ls-files | grep '\.py$' | reroot $ROOT | onlyexists $ROOT | tr '\n' ' ')"
 else
-    CHECK_FILES="$(git $REPO diff --name-only master | grep '\.py$' | reroot $ROOT | onlyexists | tr '\n' ' ')"
+    CHECK_FILES="$(git $REPO diff --name-only master... | grep '\.py$' | reroot $ROOT | onlyexists | tr '\n' ' ')"
 fi
 
 # if we're doing all the tests, we should run them in serial


### PR DESCRIPTION
**Patch description**
Recently, other devs have been complaining that autoformat.sh complains about parts of the codebase that they didn't touch. That parts of the codebase aren't linted is unsurprising: the linters get new rules all the time, and sometimes people merge while ignoring lint (such is).

What is new is the bit where random files are noted. I think this boils down to a recent change in autoformat.sh where it compares against `master`, rather than against `master...`

The semantics of without `...`:
> git diff [<options>] \<commit> [--] [<path>…​]
> This form is to view the changes you have in your working tree relative to the named \<commit>. You can use HEAD to compare it with the latest commit, or a branch name to compare with the tip of a different branch.

The semantics of `...`:
> git diff [<options>] \<commit>...\<commit> [--] [\<path>…​]
> This form is to view the changes on the branch containing and up to the second \<commit>, starting at a common ancestor of both \<commit>. "git diff A...B" is equivalent to "git diff $(git merge-base A B) B". You can omit any one of <commit>, which has the same effect as using HEAD instead.

So if the tree looks like this:
```
- - A - - B (Master)
    \
     -- C - - D (Branch)
```

`git diff master...D` will be equivalent of `git diff A`

while

`git diff master` will also include changes from B

**Testing steps**
None :( Relying on good hard thinking here, from me and reviewers.