### PR TITLE
[Opt] Do not save load_from_checkpoint

### DIFF
--- a/parlai/core/opt.py
+++ b/parlai/core/opt.py
@@ -26,8 +26,9 @@ __AUTOCLEAN_KEYS__: List[str] = [
     "download_path",
     "datapath",
     "batchindex",
-    # we don't save interactive mode, it's only decided by scripts or CLI
+    # we don't save interactive mode or load from checkpoint, it's only decided by scripts or CLI
     "interactive_mode",
+    "load_from_checkpoint",
 ]
 
 


### PR DESCRIPTION
**Patch description**
Do not save `load_from_checkpoint` in opt. #3162 which fixed issues with loading from checkpoint caused this issue, as the init_model saved on disk was changed to a `.checkpoint` file during requeue. This caused torch agent to load checkpoint files, even when we are evaluating (as noticed by @klshuster).