### PR TITLE
-v back

### DIFF
--- a/parlai/core/opt.py
+++ b/parlai/core/opt.py
@@ -25,7 +25,7 @@ __AUTOCLEAN_KEYS__: List[str] = [
     "batchindex",
     "download_path",
     "datapath",
-    "batchindex",
+    "verbose",
     # we don't save interactive mode or load from checkpoint, it's only decided by scripts or CLI
     "interactive_mode",
     "load_from_checkpoint",

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -739,10 +739,10 @@ class ParlaiParser(argparse.ArgumentParser):
             help='Use dynamic batching',
         )
         parlai.add_argument(
+            '-v',
             '--verbose',
             dest='verbose',
-            type='bool',
-            default=False,
+            action='store_true',
             help='Print all messages',
         )
         self.add_parlai_data_path(parlai)


### PR DESCRIPTION
**Patch description**
Add -v back to verbose and revert back to store_true

**Testing steps**
CI

**Logs**
<!-- If applicable, please paste the command line from your testing: -->
```
parlai dd -t convai2 -dt valid -v
```
<img width="749" alt="Screen Shot 2020-11-03 at 10 58 47 AM" src="https://user-images.githubusercontent.com/60988468/98009542-a8a2c580-1dc3-11eb-996c-6d07fc2a3fed.png">

```
parlai display_model -mf zoo:blender/blender_90M/model -t convai2 -v
```
<img width="752" alt="Screen Shot 2020-11-03 at 11 02 50 AM" src="https://user-images.githubusercontent.com/60988468/98009940-2070f000-1dc4-11eb-8b98-078de81bc46b.png">

```
parlai i -mf zoo:blender/blender_90M/model  -v
```
<img width="750" alt="Screen Shot 2020-11-03 at 11 04 12 AM" src="https://user-images.githubusercontent.com/60988468/98010097-50b88e80-1dc4-11eb-8a41-2344f20789b3.png">

**Other information**
<!-- Any other information or context you would like to provide. -->

**Data tests (if applicable)**
If you added a new teacher, you will be asked to run
`python tests/datatests/test_new_tasks.py`. Please paste this log here.
