### PR TITLE
Make directory at start of dict.save()

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -626,6 +626,7 @@ class DictionaryAgent(Agent):
         If ``sort`` (default ``True``), then first sort the dictionary before saving.
         """
         filename = self.opt['dict_file'] if filename is None else filename
+        make_dir(os.path.dirname(filename))
 
         if self.tokenizer in ['bpe', 'gpt2', 'bytelevelbpe', 'slow_bytelevel_bpe']:
             needs_removal = self.bpe.finalize(
@@ -643,7 +644,6 @@ class DictionaryAgent(Agent):
 
         logging.info(f'Saving dictionary to {filename}')
 
-        make_dir(os.path.dirname(filename))
         mode = 'a' if append else 'w'
         with PathManager.open(filename, mode, encoding='utf-8') as write:
             for i in self.ind2tok.keys():


### PR DESCRIPTION
**Patch description**
If `self.bpe.copy_codecs_file` is hit before the directory is created, a "path does not exist" exception will be thrown. This won't happen until validation, which can waste a lot of time.

**Testing steps**
```
parlai train_model -t convai2 --model transformer/generator --dict-file /path/to/existing/model.dict --model-file /path/to/new/model --embedding-size 32 --n-positions 32 --truncate 32 --validation-every-n-epochs 0.01 --dict-tokenizer bpe
```
Where `/path/to/existing/model.dict` exists, but `/path/to/new/` doesn't exist yet.
