### PR TITLE
Delete DictionaryAgent.parse

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -694,21 +694,6 @@ class DictionaryAgent(Agent):
         assert len(self.freq) == len(self.ind2tok) == len(self.tok2ind)
         return sorted_pairs
 
-    def parse(self, txt_or_vec, vec_type=list):
-        """
-        Parse either text or a vector of indices.
-
-        Calls `~txt2vec` if `txt_or_vec is a string, or `~vec2txt` otherwise.
-
-        :param vec_type:
-            type of the returned vector if the input is a string.
-        """
-        # TODO: try to deprecate this, preferring straight txt2vec
-        if type(txt_or_vec) == str:
-            return self.txt2vec(txt_or_vec, vec_type)
-        else:
-            return self.vec2txt(txt_or_vec)
-
     def txt2vec(self, text, vec_type=list):
         """
         Convert a string to a vector (list of ints).

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -152,17 +152,17 @@ class TestDictionary(unittest.TestCase):
         dictionary.act()
         assert len(dictionary) - num_builtin == 2
 
-        vec = dictionary.parse('hello world')
+        vec = dictionary.txt2vec('hello world')
         assert len(vec) == 2
         assert vec[0] == num_builtin
         assert vec[1] == num_builtin + 1
 
-        vec = dictionary.parse('hello world', vec_type=list)
+        vec = dictionary.txt2vec('hello world', vec_type=list)
         assert len(vec) == 2
         assert vec[0] == num_builtin
         assert vec[1] == num_builtin + 1
 
-        vec = dictionary.parse('hello world', vec_type=tuple)
+        vec = dictionary.txt2vec('hello world', vec_type=tuple)
         assert len(vec) == 2
         assert vec[0] == num_builtin
         assert vec[1] == num_builtin + 1


### PR DESCRIPTION
**Patch description**
With all the recently retired code, this obtuse method is no longer used except and testing, and can be safely deleted.

**Testing steps**
CI.