### PR TITLE
Fix broken CI checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ commands:
             python -m pip install --progress-bar off 'torchtext==0.7.0'
             python -m pip install --progress-bar off pytorch-pretrained-bert
             python -m pip install --progress-bar off transformers
-            python -m pip install --progress-bar off fairseq
+            python -m pip install --progress-bar off 'fairseq==0.10.0'
             python -c 'import torch; print("Torch version:", torch.__version__)'
             python -m torch.utils.collect_env
 

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -34,7 +34,7 @@ except ImportError:
     nltkbleu = None
 
 try:
-    from fairseq import bleu as fairseqbleu
+    from fairseq.scoring import bleu as fairseqbleu
 except ImportError:
     fairseqbleu = None
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -55,7 +55,7 @@ except ImportError:
     nltkbleu = None
 
 try:
-    from fairseq import bleu as fairseq_bleu
+    from fairseq.scoring import bleu as fairseq_bleu
 
 except ImportError:
     fairseq_bleu = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ tornado==6.0.4
 tqdm==4.36.1
 typing-extensions==3.7.4.1
 Unidecode==1.1.1
+urllib3~=1.25.9
 websocket-client==0.56.0
 websocket-server==0.4
 jsonlines==1.2.0


### PR DESCRIPTION
**Patch description**
Fix issues with:
- urllib3 drifting to 1.26.x
- fairseq drifting to 0.10.0 (released this morning), which has a different location for `fairseq.bleu`
Without this, the cleaninstall_36 and/or unittests_gpu16 checks fail

**Testing steps**
CI checks passing
