### PR TITLE
fix: call custom dictionary agent's add_cmdline_args()

### DIFF
--- a/parlai/scripts/build_dict.py
+++ b/parlai/scripts/build_dict.py
@@ -25,6 +25,7 @@ from parlai.utils.io import PathManager
 import parlai.utils.logging as logging
 import copy
 import tqdm
+import sys
 
 
 def setup_args(parser=None, hidden=True):
@@ -55,7 +56,14 @@ def setup_args(parser=None, hidden=True):
     dict_loop.add_argument(
         '-ltim', '--log-every-n-secs', type=float, default=10, hidden=hidden
     )
-    DictionaryAgent.add_cmdline_args(parser)
+
+    # If dictionay agent class is specified
+    if '--dict-class' in sys.argv:
+        idx = sys.argv.index('--dict-class') + 1
+        str2class(sys.argv[idx]).add_cmdline_args(parser)
+    else:
+        DictionaryAgent.add_cmdline_args(parser)
+
     return parser
 
 


### PR DESCRIPTION
When build_dict.py is executed, an argument '**--dict-class**' can be given to specify which dictionary class to use when building dictionary.
However, this custom **dict-class** is not able to add any command line arguments since DictionaryAgent's static method add_cmdline_args is always called instead of custom **dict-class**'s one.

This pull request fixes this by parsing given python arguments before argparser takes an effect.
This it sort of dirty, but I could not find a better solution for this.