### PR TITLE
[BART] Init model fix

### DIFF
--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -84,7 +84,7 @@ class BartAgent(TransformerGeneratorAgent):
         """
         init_model, _ = self._get_init_model(opt, None)
         if not opt.get('converting') and (
-            init_model is None or not PathManager.exists(init_model, '')
+            init_model is None or not PathManager.exists(init_model)
         ):
             download(opt['datapath'])
             opt['init_model'] = os.path.join(

--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -82,9 +82,9 @@ class BartAgent(TransformerGeneratorAgent):
         :return opt:
             return opt with BART-specific args.
         """
+        init_model, _ = self._get_init_model(opt, None)
         if not opt.get('converting') and (
-            opt.get('init_model') is None
-            or not PathManager.exists(opt.get('init_model', ''))
+            init_model is None or not PathManager.exists(init_model, '')
         ):
             download(opt['datapath'])
             opt['init_model'] = os.path.join(


### PR DESCRIPTION
**Patch description**
BART starts downloading when init_model does not exist. However, in many cases we end up deleting the checkpoint (which could become init_model during requeue) after the model is already trained. So it should really check if the model file exists as well. 
