### PR TITLE
Fix argparse issues in python 3.8

### DIFF
--- a/parlai/core/script.py
+++ b/parlai/core/script.py
@@ -156,7 +156,7 @@ class _SupercommandParser(ParlaiParser):
             # the add extra args, to prevent parse errors in other commands.
             sa.choices[args[0]].add_extra_args(args)
         else:
-            for k, v in sa.choices.items():
+            for _, v in sa.choices.items():
                 v.add_extra_args(args)
 
     def parse_known_args(self, args=None, namespace=None, nohelp=False):

--- a/parlai/core/script.py
+++ b/parlai/core/script.py
@@ -14,6 +14,7 @@ completed easily.
 Also contains helper classes for loading scripts, etc.
 """
 
+import sys
 import io
 import argparse
 from typing import List, Optional, Dict, Any
@@ -148,8 +149,15 @@ class _SupercommandParser(ParlaiParser):
         sa = [a for a in self._actions if isinstance(a, argparse._SubParsersAction)]
         assert len(sa) == 1
         sa = sa[0]
-        for _, v in sa.choices.items():
-            v.add_extra_args(args)
+        if args is None:
+            args = sys.argv[1:]
+        if args and args[0] in sa.choices:
+            # if at all possible, try to use the actual subcommand only for
+            # the add extra args, to prevent parse errors in other commands.
+            sa.choices[args[0]].add_extra_args(args)
+        else:
+            for k, v in sa.choices.items():
+                v.add_extra_args(args)
 
     def parse_known_args(self, args=None, namespace=None, nohelp=False):
         known, unused = super().parse_known_args(args, namespace, nohelp)

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -35,6 +35,18 @@ class TestParlaiParser(unittest.TestCase):
     Test ParlaiParser.
     """
 
+    def test_shortopt(self):
+        """
+        Tests whether short opts like -mtw work.
+
+        Known to be tricky in python 3.8.
+        """
+        pp = ParlaiParser(False, False)
+        pp.add_argument("-m", "--model")
+        pp.add_argument("-mtw", "--multitask-weights")
+        opt = pp.parse_args(["-m", "memnn"])
+        print(opt)
+
     def test_upgrade_opt(self):
         """
         Test whether upgrade_opt works.

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -25,6 +25,25 @@ class _TestScript(script.ParlaiScript):
         return self.opt
 
 
+@script.register_script("short_opt")
+class _TestShortOptScript(script.ParlaiScript):
+    """
+    Tests whether short opts with multiple letters parse correctly.
+
+    Known tricky in python 3.8.
+    """
+
+    @classmethod
+    def setup_args(cls):
+        parser = ParlaiParser(False, False, description="Short opt test")
+        parser.add_argument('-m', '--model')
+        parser.add_argument('-mxx', '--my-other-option')
+        return parser
+
+    def run(self):
+        return self.opt
+
+
 @script.register_script("hidden_script", hidden=True)
 class _HiddenScript(_TestScript):
     pass
@@ -79,6 +98,15 @@ class TestScriptRegistry(unittest.TestCase):
 
 
 class TestSuperCommand(unittest.TestCase):
+    def test_shortopt(self):
+        """
+        Tests whether short opts with multiple letters parse correctly.
+
+        Known tricky in python 3.8.
+        """
+        opt = script.superscript_main(args=['short_opt', '-m', 'repeat_query'])
+        assert opt.get('model') == 'repeat_query'
+
     def test_supercommand(self):
         opt = script.superscript_main(args=['test_script', '--foo', 'test'])
         assert opt.get('foo') == 'test'


### PR DESCRIPTION
**Patch description**
Long standing bug.

In python 3.8, our parlai supercommand would frequently fail with this error message:
```
$ parlai i -m repeat_query
Parse Error: argument -mtw/--multitask-weights: invalid 'multitask_weights' value: 'repeat_query'
```
This doesn't happen in python 3.7, because `allow_abbrev=False` is ignored for short options starting in python 3.8. Annoying!

Tracing down the issue, this is what was happening:
1. We would try to add_known_args on every single subcommand
2. We would hit a command that has task parameters, but not model parameters. display_data is a good example.
3. The parse_known_args would be called for display_data with `-m` being interpreted as short for `-mtw` due to the python 3.8 change
4. This would cause a type error, as `-mtw` didn't accept arbitrary arguments. The type error would be propagated into a parse error.

The fix involves just making sure that `add_known_args` is only being called on the sub command we need, not all the subcommands. That way, `-m` gets properly mapped to `--model` in its correct command, and problematic commands are skipped.

**Testing steps**
New CI. Manually ran the above interactive command before/after the change in both python 3.7 and 3.8.