### PR TITLE
Updating old Mephisto import reference

### DIFF
--- a/projects/safety_recipes/human_safety_evaluation/run.py
+++ b/projects/safety_recipes/human_safety_evaluation/run.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any, List
 
 import hydra
-from mephisto.core.hydra_config import register_script_config
+from mephisto.operations.hydra_config import register_script_config
 from omegaconf import DictConfig
 
 from parlai.crowdsourcing.tasks.turn_annotations_static.util import run_static_task


### PR DESCRIPTION
**Patch description**
Found a reference to `mephisto.core` while investigating how much of ParlAI is `v0.3.0` ready.