### PR TITLE
[dist] Allow arbitrary sizes for object syncs.

### DIFF
--- a/parlai/utils/distributed.py
+++ b/parlai/utils/distributed.py
@@ -113,7 +113,7 @@ def override_print(suppress=False, prefix=None):
         logging.enable()
 
 
-def all_gather_list(data, max_size=16384):
+def all_gather_list(data):
     """
     Gather arbitrary data from all nodes into a list.
 
@@ -122,8 +122,6 @@ def all_gather_list(data, max_size=16384):
 
     :param data:
         data from the local worker to be gathered on other workers
-    :param int max_size:
-        maximum size of the data to be gathered across workers
 
     :returns:
         a list containing [data1, data2, ...] of all workers
@@ -137,47 +135,43 @@ def all_gather_list(data, max_size=16384):
     rank = dist.get_rank()
     world_size = dist.get_world_size()
 
-    buffer_size = max_size * world_size
-    if (
-        not hasattr(all_gather_list, '_buffer')
-        or all_gather_list._buffer.numel() < buffer_size
-    ):
-        all_gather_list._buffer = torch.cuda.ByteTensor(buffer_size)
-
-    buffer = all_gather_list._buffer
-    buffer.zero_()
-
-    enc = pickle.dumps(data)
+    enc = list(pickle.dumps(data))
     enc_size = len(enc)
-    if enc_size + 2 > max_size:
-        raise ValueError('encoded data exceeds max_size: {}'.format(enc_size + 2))
-    assert max_size < 255 * 256
 
-    buffer_rank = buffer[rank * max_size : (rank + 1) * max_size]
-    buffer_rank[0] = enc_size // 255  # this encoding works for max_size < 65k
-    buffer_rank[1] = enc_size % 255
-    buffer_rank[2 : enc_size + 2] = torch.ByteTensor(list(enc))
+    # find the sizes of all the serialized items
+    sizes = torch.zeros(world_size, dtype=torch.long).cuda()
+    sizes[rank] = enc_size
+    dist.all_reduce(sizes)
+
+    # need to know our positions
+    sizes = sizes.cpu()
+    positions = sizes.cumsum(dim=0)
+
+    buffer_size = positions[-1].item()
+    buffer = torch.cuda.ByteTensor(buffer_size).zero_()
+
+    start = positions[rank] - enc_size
+    end = positions[rank]
+    buffer[start:end] = torch.ByteTensor(enc)
 
     dist.all_reduce(buffer)
 
     result = []
     for i in range(world_size):
-        out_buffer = buffer[i * max_size : (i + 1) * max_size]
-        size = (255 * out_buffer[0].item()) + out_buffer[1].item()
-        if size > 0:
-            try:
-                result.append(pickle.loads(bytes(out_buffer[2 : size + 2].tolist())))
-            except pickle.UnpicklingError:
-                raise RuntimeError(
-                    'There was an unpickling error in all_gather_list. This likely '
-                    'means your workers got out of syncronization (e.g. one is '
-                    'expecting to sync and another is not.)'
-                )
+        out_buffer = buffer[positions[i] - sizes[i] : positions[i]]
+        try:
+            result.append(pickle.loads(bytes(out_buffer.tolist())))
+        except pickle.UnpicklingError:
+            raise RuntimeError(
+                'There was an unpickling error in all_gather_list. This likely '
+                'means your workers got out of syncronization (e.g. one is '
+                'expecting to sync and another is not.)'
+            )
 
     return result
 
 
-def sync_object(data, max_size=16384):
+def sync_object(data):
     """
     Sync an object among all workers.
 
@@ -187,48 +181,11 @@ def sync_object(data, max_size=16384):
 
     :param object data:
         The object to synchronize. Must be pickleable.
-    :param int max_size:
-        The maximum size of this object in bytes. Large values than 255^2 are not
-        supported.
 
     :return: the synchronized data
     """
-    if not is_distributed():
-        return data
-
-    # prepare the buffer
-    if not hasattr(sync_object, '_buffer') or sync_object._buffer.numel() < max_size:
-        # cuda is safe because distributed mode is only okay with CUDA
-        sync_object._buffer = torch.cuda.ByteTensor(max_size)
-
-    buffer = sync_object._buffer
-
-    if is_primary_worker():
-        enc = pickle.dumps(data)
-        enc_size = len(enc)
-        if (enc_size + 2 > max_size) or (enc_size > 255 * 255):
-            # can't store the size in the first 2 bytes
-            raise ValueError('encoded data exceeds max_size')
-
-        buffer[0] = enc_size // 255
-        buffer[1] = enc_size % 255
-        buffer[2 : enc_size + 2] = torch.ByteTensor(list(enc))
-
-    dist.broadcast(buffer, 0)
-
-    if not is_primary_worker():
-        # deserialize the data
-        enc_size = buffer[0].item() * 255 + buffer[1].item()
-        try:
-            data = pickle.loads(bytes(buffer[2 : enc_size + 2].tolist()))
-        except pickle.UnpicklingError:
-            raise RuntimeError(
-                'There was an unpickling error in sync_object. This likely '
-                'means your workers got out of syncronization (e.g. one is '
-                'expecting to sync and another is not.)'
-            )
-
-    return data
+    value = all_gather_list(data if get_rank() == 0 else None)[0]
+    return value
 
 
 def sync_parameters(model: torch.nn.Module) -> bool:

--- a/parlai/utils/distributed.py
+++ b/parlai/utils/distributed.py
@@ -164,7 +164,7 @@ def all_gather_list(data):
         except pickle.UnpicklingError:
             raise RuntimeError(
                 'There was an unpickling error in all_gather_list. This likely '
-                'means your workers got out of syncronization (e.g. one is '
+                'means your workers got out of synchronization (e.g. one is '
                 'expecting to sync and another is not.)'
             )
 


### PR DESCRIPTION
**Patch description**
Gathering objects from distributed settings no longer has a limit, via two syncs: first the buffer size, then the buffer. Necessary since we seem to have recently hit that limit in a few places.

**Testing steps**
CI