### PR TITLE
Chunk teacher drain bug

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2379,8 +2379,11 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
         return msg
 
     def _drain(self, q):
-        with q.mutex:
-            q.queue.clear()
+        while not q.empty():
+            try:
+                q.get()
+            except queue.Empty:
+                return
 
     def reset(self):
         super().reset()


### PR DESCRIPTION
**Patch description**
reverting change to chunk teacher drain. it caused a hang when a reset was called in the middle of offloading examples from a chunk, which caused the subsequent request to never really get enqueued.
