### PR TITLE
Release distilled BlenderBot models

### DIFF
--- a/parlai/zoo/blender/blender_3B_2x.py
+++ b/parlai/zoo/blender/blender_3B_2x.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+2.7B parameter Blender model distilled to 1.4B parameters (~2x inference speedup).
+
+Please see <parl.ai/project/blender>.
+"""
+
+from .build import build
+
+VERSION = 'v1.0'
+
+
+def download(datapath):
+    build(datapath, 'BST3B2x.tgz', model_type='blender_3B_2x', version=VERSION)

--- a/parlai/zoo/blender/blender_3B_2x.py
+++ b/parlai/zoo/blender/blender_3B_2x.py
@@ -16,4 +16,6 @@ VERSION = 'v1.0'
 
 
 def download(datapath):
-    build(datapath, 'BST3B2x.tgz', model_type='blender_3B_2x', version=VERSION)
+    build(
+        datapath, f'BST3B2x_{VERSION}.tgz', model_type='blender_3B_2x', version=VERSION
+    )

--- a/parlai/zoo/blender/blender_3B_5x.py
+++ b/parlai/zoo/blender/blender_3B_5x.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+2.7B parameter Blender model distilled to 365M parameters (~5x inference speedup).
+
+Please see <parl.ai/project/blender>.
+"""
+
+from .build import build
+
+VERSION = 'v1.0'
+
+
+def download(datapath):
+    build(datapath, 'BST3B5x.tgz', model_type='blender_3B_5x', version=VERSION)

--- a/parlai/zoo/blender/blender_3B_5x.py
+++ b/parlai/zoo/blender/blender_3B_5x.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-2.7B parameter Blender model distilled to 365M parameters (~5x inference speedup).
+2.7B parameter Blender model distilled to 360M parameters (~5x inference speedup).
 
 Please see <parl.ai/project/blender>.
 """
@@ -16,4 +16,6 @@ VERSION = 'v1.0'
 
 
 def download(datapath):
-    build(datapath, 'BST3B5x.tgz', model_type='blender_3B_5x', version=VERSION)
+    build(
+        datapath, f'BST3B5x_{VERSION}.tgz', model_type='blender_3B_5x', version=VERSION
+    )

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1175,7 +1175,7 @@ model_list = [
             "2.7B parameter generative model finetuned on blended_skill_talk tasks and then distilled to 1.4B parameters and roughly 2x the inference speed."
         ),
         "example": (
-            "python parlai/scripts/safe_interactive.py -mf zoo:blender/blender_3B_2x/model -t blended_skill_talk"
+            "python parlai/scripts/safe_interactive.py -mf zoo:blender/blender_3B_2x/model -t blended_skill_talk -m transformer/generator"
         ),
         "result": (None),  # TODO: add
     },
@@ -1190,7 +1190,7 @@ model_list = [
             "2.7B parameter generative model finetuned on blended_skill_talk tasks and then distilled to 360M parameters and roughly 5x the inference speed."
         ),
         "example": (
-            "python parlai/scripts/safe_interactive.py -mf zoo:blender/blender_3B_5x/model -t blended_skill_talk"
+            "python parlai/scripts/safe_interactive.py -mf zoo:blender/blender_3B_5x/model -t blended_skill_talk -m transformer/generator"
         ),
         "result": (None),  # TODO: add
     },

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1165,6 +1165,36 @@ model_list = [
         ),
     },
     {
+        "title": "Blender 2.7B 2x",
+        "id": "blender",
+        "path": "zoo:blender/blender_3B_2x/model",
+        "agent": "transformer/generator",
+        "task": "blended_skill_talk",
+        "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/blender",
+        "description": (
+            "2.7B parameter generative model finetuned on blended_skill_talk tasks and then distilled to 1.4B parameters and roughly 2x the inference speed."
+        ),
+        "example": (
+            "python parlai/scripts/safe_interactive.py -mf zoo:blender/blender_3B_2x/model -t blended_skill_talk"
+        ),
+        "result": (None),  # TODO: add
+    },
+    {
+        "title": "Blender 2.7B 5x",
+        "id": "blender",
+        "path": "zoo:blender/blender_3B_5x/model",
+        "agent": "transformer/generator",
+        "task": "blended_skill_talk",
+        "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/blender",
+        "description": (
+            "2.7B parameter generative model finetuned on blended_skill_talk tasks and then distilled to 360M parameters and roughly 5x the inference speed."
+        ),
+        "example": (
+            "python parlai/scripts/safe_interactive.py -mf zoo:blender/blender_3B_5x/model -t blended_skill_talk"
+        ),
+        "result": (None),  # TODO: add
+    },
+    {
         "title": "Blender 9.4B",
         "id": "blender",
         "path": "zoo:blender/blender_9B/model",

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1177,7 +1177,10 @@ model_list = [
         "example": (
             "python parlai/scripts/safe_interactive.py -mf zoo:blender/blender_3B_2x/model -t blended_skill_talk -m transformer/generator"
         ),
-        "result": (None),  # TODO: add
+        "result": (
+            "Enter Your Message: Hi how are you?\n"
+            "[TransformerGenerator]: I'm good. Just playing some video games and relaxing. How about you? What are you up to?"
+        ),
     },
     {
         "title": "Blender 2.7B 5x",
@@ -1192,7 +1195,10 @@ model_list = [
         "example": (
             "python parlai/scripts/safe_interactive.py -mf zoo:blender/blender_3B_5x/model -t blended_skill_talk -m transformer/generator"
         ),
-        "result": (None),  # TODO: add
+        "result": (
+            "Enter Your Message: Hi how are you?\n"
+            "[TransformerGenerator]: I'm doing well. How about you? What do you like to do in your spare time?"
+        ),
     },
     {
         "title": "Blender 9.4B",

--- a/projects/recipes/README.md
+++ b/projects/recipes/README.md
@@ -32,16 +32,6 @@ We also provide two smaller variants of the 2.7B-parameter model that were creat
 python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_90M/model
 ```
 
-**360M** (distilled from 2.7B)
-```
-python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_3B_5x/model -m transformer/generator
-```
-
-**1.4B** (distilled from 2.7B)
-```
-python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_3B_2x/model -m transformer/generator
-```
-
 **2.7B**
 ```
 python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_3B/model
@@ -50,6 +40,16 @@ python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/
 **9.4B**
 ```
 python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_9B/model
+```
+
+**2.7B distilled to 1.4B**
+```
+python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_3B_2x/model -m transformer/generator
+```
+
+**2.7B distilled to 360M**
+```
+python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_3B_5x/model -m transformer/generator
 ```
 
 ## Fine-tuning your own models

--- a/projects/recipes/README.md
+++ b/projects/recipes/README.md
@@ -32,7 +32,15 @@ We also provide two smaller variants of the 2.7B-parameter model that were creat
 python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_90M/model
 ```
 
-(((TODO: add + revise)))
+**360M** (distilled from 2.7B)
+```
+python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_3B_5x/model -m transformer/generator
+```
+
+**1.4B** (distilled from 2.7B)
+```
+python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_3B_2x/model -m transformer/generator
+```
 
 **2.7B**
 ```

--- a/projects/recipes/README.md
+++ b/projects/recipes/README.md
@@ -23,12 +23,16 @@ We show that large scale models can learn these skills when given appropriate tr
 
 You may talk with our models. The 2.7B can be interacted with on a 16gb P100 GPU or better. The 9.4B parameter model requires at least two 32gb V100 GPUs to interact with.
 
+We also provide two smaller variants of the 2.7B-parameter model that were created using [knowledge distillation](https://github.com/facebookresearch/ParlAI/blob/master/projects/anti_scaling/README.md#knowledge-distillation). The 1.4B-parameter model is roughly 2x faster than the 2.7B-parameter model during inference and performs very nearly as well as it, and the 360M-parameter one is roughly 5x faster and has performance in between that of the 2.7B-parameter and 90M-parameter models.
+
 **Safety** We have studied improved safety from toxic language ([Dinan et al., 2019b](http://parl.ai/projects/dialogue_safety/)), but much work remains to be done. While we have made our models publicly available, and added a safety layer to the interaction, we have not mitigated all safety issues. We believe their release can help the community work together to understand further and fix these issues, and we recommend their use for that line of research.
 
 **90M**
 ```
 python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_90M/model
 ```
+
+(((TODO: add + revise)))
 
 **2.7B**
 ```


### PR DESCRIPTION
Open-source two versions of the 2.7B-parameter BlenderBot model sped up via knowledge distillation:
- A 1.4B-parameter model with roughly 2x faster inference time
- A 360M-parameter model with roughly 5x faster inference time
Models will be downloaded to `{datapath}/models/blender/blender_3B_2x/` and `{datapath}/models/blender/blender_3B_5x/`, respectively.