### PR TITLE
Revise names/flags of distilled BlenderBot models

### DIFF
--- a/parlai/zoo/blender/blender_1Bdistill.py
+++ b/parlai/zoo/blender/blender_1Bdistill.py
@@ -12,10 +12,13 @@ Please see <parl.ai/project/blender>.
 
 from .build import build
 
-VERSION = 'v1.0'
+VERSION = 'v1.1'
 
 
 def download(datapath):
     build(
-        datapath, f'BST3B2x_{VERSION}.tgz', model_type='blender_3B_2x', version=VERSION
+        datapath,
+        f'BST1Bdistill_{VERSION}.tgz',
+        model_type='blender_1Bdistill',
+        version=VERSION,
     )

--- a/parlai/zoo/blender/blender_400Mdistill.py
+++ b/parlai/zoo/blender/blender_400Mdistill.py
@@ -12,10 +12,13 @@ Please see <parl.ai/project/blender>.
 
 from .build import build
 
-VERSION = 'v1.0'
+VERSION = 'v1.1'
 
 
 def download(datapath):
     build(
-        datapath, f'BST3B5x_{VERSION}.tgz', model_type='blender_3B_5x', version=VERSION
+        datapath,
+        f'BST400Mdistill_{VERSION}.tgz',
+        model_type='blender_400Mdistill',
+        version=VERSION,
     )

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1165,17 +1165,17 @@ model_list = [
         ),
     },
     {
-        "title": "Blender 2.7B 2x",
+        "title": "Blender 1B distilled",
         "id": "blender",
-        "path": "zoo:blender/blender_3B_2x/model",
+        "path": "zoo:blender/blender_1Bdistill/model",
         "agent": "transformer/generator",
         "task": "blended_skill_talk",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/blender",
         "description": (
-            "2.7B parameter generative model finetuned on blended_skill_talk tasks and then distilled to 1.4B parameters and roughly 2x the inference speed."
+            "2.7B parameter generative model finetuned on blended_skill_talk tasks and then distilled to ~1.4B parameters and roughly 2x the inference speed."
         ),
         "example": (
-            "python parlai/scripts/safe_interactive.py -mf zoo:blender/blender_3B_2x/model -t blended_skill_talk -m transformer/generator"
+            "python parlai/scripts/safe_interactive.py -mf zoo:blender/blender_1Bdistill/model -t blended_skill_talk"
         ),
         "result": (
             "Enter Your Message: Hi how are you?\n"
@@ -1183,17 +1183,17 @@ model_list = [
         ),
     },
     {
-        "title": "Blender 2.7B 5x",
+        "title": "Blender 400M distilled",
         "id": "blender",
-        "path": "zoo:blender/blender_3B_5x/model",
+        "path": "zoo:blender/blender_400Mdistill/model",
         "agent": "transformer/generator",
         "task": "blended_skill_talk",
         "project": "https://github.com/facebookresearch/ParlAI/tree/master/projects/blender",
         "description": (
-            "2.7B parameter generative model finetuned on blended_skill_talk tasks and then distilled to 360M parameters and roughly 5x the inference speed."
+            "2.7B parameter generative model finetuned on blended_skill_talk tasks and then distilled to ~360M parameters and roughly 5x the inference speed."
         ),
         "example": (
-            "python parlai/scripts/safe_interactive.py -mf zoo:blender/blender_3B_5x/model -t blended_skill_talk -m transformer/generator"
+            "python parlai/scripts/safe_interactive.py -mf zoo:blender/blender_400Mdistill/model -t blended_skill_talk"
         ),
         "result": (
             "Enter Your Message: Hi how are you?\n"

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1179,7 +1179,7 @@ model_list = [
         ),
         "result": (
             "Enter Your Message: Hi how are you?\n"
-            "[TransformerGenerator]: I'm good. Just playing some video games and relaxing. How about you? What are you up to?"
+            "[TransformerGenerator]: I'm doing well. How about yourself? What do you do for a living? I'm a creative writer."
         ),
     },
     {
@@ -1197,7 +1197,7 @@ model_list = [
         ),
         "result": (
             "Enter Your Message: Hi how are you?\n"
-            "[TransformerGenerator]: I'm doing well. How about you? What do you like to do in your spare time?"
+            "[TransformerGenerator]: I'm doing well. How about you? What do you like to do in your free time?"
         ),
     },
     {

--- a/projects/recipes/README.md
+++ b/projects/recipes/README.md
@@ -44,12 +44,12 @@ python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/
 
 **2.7B distilled to 1.4B**
 ```
-python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_3B_2x/model -m transformer/generator
+python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_1Bdistill/model
 ```
 
 **2.7B distilled to 360M**
 ```
-python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_3B_5x/model -m transformer/generator
+python parlai/scripts/safe_interactive.py -t blended_skill_talk -mf zoo:blender/blender_400Mdistill/model
 ```
 
 ## Fine-tuning your own models


### PR DESCRIPTION
As suggested - this PR renames the distilled BlenderBot models to make them easier to understand (i.e. to focus on the size of the distilled model rather than its relative speedup vs. BB3B). The `-m transformer/generator` flag is now no longer needed, because the models' `model.opt`s have been updated to specify this model type.