### PR TITLE
[torch_generator] sort the special token by length

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -865,7 +865,10 @@ class TorchAgent(ABC, Agent):
         Made easily overridable for special cases.
         """
         if self.opt.get('special_tok_lst'):
-            return self.opt['special_tok_lst'].split(',')
+            special_tok_lst = self.opt['special_tok_lst'].split(',')
+            # sort the tokens by length
+            special_tok_lst = sorted(special_tok_lst, key=len, reverse=True)
+            return special_tok_lst
         return []
 
     @abstractmethod


### PR DESCRIPTION
sort the special token list by length, because in https://github.com/facebookresearch/ParlAI/blob/master/parlai/utils/bpe.py#L159-L167, 
`split = text.split(special_token)`.

e.g. if text = "ABCDEF", and special_token=['A', 'AB'], if they are not sorted, then text would become ['A', 'BCDEF'], instead of ['AB', 'CDEF']. 