### PR TITLE
[BART] Add BART-Base model

### DIFF
--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -248,7 +248,8 @@ class BartBaseAgent(BartAgent):
     """
     BART Base Agent.
 
-    Relies on the BART model implemented in fairseq.
+    Relies on the BART model implemented in fairseq. Compared to the BART large model (`BartAgent`),
+    it has only 6 encoder/decoder layer and an embedding size of 768.
     """
 
     @staticmethod

--- a/parlai/agents/bart/base.py
+++ b/parlai/agents/bart/base.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# hack to make sure calling '-m bart/base' works.
+from .bart import BartBaseAgent as BaseAgent  # noqa: F401

--- a/parlai/agents/bart/convert_fairseq_to_parlai.py
+++ b/parlai/agents/bart/convert_fairseq_to_parlai.py
@@ -18,7 +18,6 @@ python parlai/agents/bart/convert_fairseq_to_parlai.py \
 """
 
 from collections import OrderedDict
-import os
 import torch
 from torch.serialization import default_restore_location
 from typing import Any, Dict, List
@@ -248,17 +247,14 @@ class ConversionScript(ParlaiScript):
             loaded fairseq state
         """
         with PathManager.open(path, "rb") as f:
-            state = torch.load(
-                f, map_location=lambda s, l: default_restore_location(s, "cpu")
-            )
-            # try:
-            #     state = torch.load(
-            #         f, map_location=lambda s, l: default_restore_location(s, "cpu")
-            #     )
-            # except ModuleNotFoundError:
-            #     raise ModuleNotFoundError(
-            #         "Please install fairseq: https://github.com/pytorch/fairseq#requirements-and-installation"
-            #     )
+            try:
+                state = torch.load(
+                    f, map_location=lambda s, l: default_restore_location(s, "cpu")
+                )
+            except ModuleNotFoundError:
+                raise ModuleNotFoundError(
+                    "Please install fairseq: https://github.com/pytorch/fairseq#requirements-and-installation"
+                )
 
         return state
 

--- a/parlai/agents/bart/convert_fairseq_to_parlai.py
+++ b/parlai/agents/bart/convert_fairseq_to_parlai.py
@@ -325,7 +325,7 @@ class ConversionScript(ParlaiScript):
         state_dict = state['model']
         return_dict = OrderedDict()
         # 0. For BART-base, we truncate the embeddings
-        # See issues: https://github.com/pytorch/fairseq/issues/2242 for more details
+        # See issue: https://github.com/pytorch/fairseq/issues/2242 for more details
         if opt['model'] == 'bart/base':
             for key in ['encoder.embed_tokens.weight', 'decoder.embed_tokens.weight']:
                 orig_value = state_dict[key]

--- a/parlai/zoo/bart/build.py
+++ b/parlai/zoo/bart/build.py
@@ -26,7 +26,7 @@ CONVERSION_ARGS = {
     'history_add_global_end_token': None,
 }
 
-BART_ARGS = {
+BART_LARGE_ARGS = {
     'embedding_size': 1024,
     'ffn_size': 4096,
     'dropout': 0.1,
@@ -45,8 +45,16 @@ BART_ARGS = {
     'learn_positional_embeddings': True,
 }
 
+base_args = BART_LARGE_ARGS.copy()
+base_args['embedding_size'] = 768
+base_args['n_positions'] = 1024
+base_args['ffn_size'] = 3072
+base_args['n_encoder_layers'] = 6
+base_args['n_decoder_layers'] = 6
+BART_BASE_ARGS = base_args
 
-def download(datapath, version='v1.0'):
+
+def download(datapath, version='v2.0'):
     dpath = os.path.join(datapath, 'models', 'bart')
 
     if not build_data.built(dpath, version):
@@ -57,14 +65,18 @@ def download(datapath, version='v1.0'):
         build_data.make_dir(dpath)
 
         # Download the data.
-        model_name = 'bart.large'
-        url = f'http://dl.fbaipublicfiles.com/fairseq/models/{model_name}.tar.gz'
-        build_data.download(url, dpath, f'{model_name}.tar.gz')
-        build_data.untar(dpath, f'{model_name}.tar.gz')
-        args = CONVERSION_ARGS.copy()
-        args['input'] = [os.path.join(dpath, model_name, 'model.pt')]
-        args['output'] = os.path.join(dpath, model_name.replace('.', '_'), 'model')
-        ConversionScript.main(**args)
+        models = ['bart.large', 'bart.base']
+        for model_name in models:
+            # url = f'http://dl.fbaipublicfiles.com/fairseq/models/{model_name}.tar.gz'
+            # build_data.download(url, dpath, f'{model_name}.tar.gz')
+            # build_data.untar(dpath, f'{model_name}.tar.gz')
+            args = CONVERSION_ARGS.copy()
+            if model_name == 'bart.base':
+                args['model'] = 'bart/base'
+            args['orig_dict_file'] = os.path.join(dpath, 'bart.large/dict.txt')
+            args['input'] = [os.path.join(dpath, model_name, 'model.pt')]
+            args['output'] = os.path.join(dpath, model_name.replace('.', '_'), 'model')
+            ConversionScript.main(**args)
 
         # Mark the data as built.
         build_data.mark_done(dpath, version)

--- a/parlai/zoo/bart/build.py
+++ b/parlai/zoo/bart/build.py
@@ -67,9 +67,9 @@ def download(datapath, version='v2.0'):
         # Download the data.
         models = ['bart.large', 'bart.base']
         for model_name in models:
-            # url = f'http://dl.fbaipublicfiles.com/fairseq/models/{model_name}.tar.gz'
-            # build_data.download(url, dpath, f'{model_name}.tar.gz')
-            # build_data.untar(dpath, f'{model_name}.tar.gz')
+            url = f'http://dl.fbaipublicfiles.com/fairseq/models/{model_name}.tar.gz'
+            build_data.download(url, dpath, f'{model_name}.tar.gz')
+            build_data.untar(dpath, f'{model_name}.tar.gz')
             args = CONVERSION_ARGS.copy()
             if model_name == 'bart.base':
                 args['model'] = 'bart/base'


### PR DESCRIPTION
**Patch description**
Add BART-base (smaller version, only 6 enc/dec layers, emb size of 768) to ParlAI. Due to some dictionary weirdness, we add an additional conversion step to truncate the embedding size, explained in the comments.