### PR TITLE
[minor] Check for idx not-existing in world_logging

### DIFF
--- a/parlai/utils/world_logging.py
+++ b/parlai/utils/world_logging.py
@@ -55,6 +55,8 @@ class WorldLogger:
         self._current_episodes = {}
 
     def reset_world(self, idx=0):
+        if idx not in self._current_episodes:
+            return
         self._add_episode(self._current_episodes[idx])
         self._current_episodes[idx] = []
 


### PR DESCRIPTION
Testing a world locally with a human agent... world logging crashes here if `_add_msgs` has never been called yet (such as when I've got the human agent respond with an "[EXIT]" as its first turn.  