### PR TITLE
Increase wait time for parlai.crowdsourcing check

### DIFF
--- a/parlai/crowdsourcing/utils/tests.py
+++ b/parlai/crowdsourcing/utils/tests.py
@@ -298,8 +298,8 @@ class AbstractParlAIChatTest(AbstractCrowdsourcingTest):
         # # Check that the inputs and outputs are as expected
 
         # Wait until all messages have arrived
-        wait_time = 1  # In seconds
-        max_num_tries = 60  # max_num_tries * wait_time is the max time to wait
+        wait_time = 5.0  # In seconds
+        max_num_tries = 30  # max_num_tries * wait_time is the max time to wait
         num_tries = 0
         while num_tries < max_num_tries:
             actual_states = [agent.state.get_data() for agent in self.db.find_agents()]
@@ -313,13 +313,14 @@ class AbstractParlAIChatTest(AbstractCrowdsourcingTest):
             if expected_num_messages == actual_num_messages:
                 break
             else:
+                num_tries += 1
                 print(
                     f'The expected number of messages is '
                     f'{expected_num_messages:d}, but the actual number of messages '
-                    f'is {actual_num_messages:d}! Waiting for more messages to '
-                    f'arrive...'
+                    f'is {actual_num_messages:d}! Waiting for {wait_time:0.1f} seconds '
+                    f'for more messages to arrive (try #{num_tries:d} of '
+                    f'{max_num_tries:d})...'
                 )
-                num_tries += 1
                 time.sleep(wait_time)
         else:
             raise ValueError('The expected number of messages never arrived!')


### PR DESCRIPTION
**Patch description**
Occasionally the model-chat test will fail due to the Blender 90M bot agent taking surprisingly long to respond to our fake human (maybe ~20 s per message in the case of https://app.circleci.com/pipelines/github/facebookresearch/ParlAI/8282/workflows/b59066f6-ddae-489d-89f5-922970f7989b/jobs/67149/steps ). If the bot agent keeps taking arbitrarily long to respond, we will have to find another solution, but we can perhaps fix the flakiness of the test by giving the conversation 2.5 minutes to complete, up from 1 minute currently

**Testing steps**
`pytest tests/crowdsourcing/tasks/model_chat/test_model_chat.py::TestModelChat::test_base_task`