### PR TITLE
Distinct metrics (inter- and intra-distinct)

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -526,7 +526,8 @@ class RougeMetric(AverageMetric):
 
 class InterDistinctMetric(Metric):
     def __init__(self, counts):
-        """compute distinct metric over corpus-level (InterDistinct)
+        """
+        Compute inter-distinct metric over corpus-level.
 
         :param counts:
             collections.Counter of ngram -> frequency

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -528,8 +528,8 @@ class InterDistinctMetric(Metric):
     def __init__(self, counts):
         """compute distinct metric over corpus-level (InterDistinct)
 
-        Args:
-            counts (dict): {n-gram: counts}
+        :param counts:
+            collections.Counter of ngram -> frequency
         """
         self._counts = counts
 

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -27,7 +27,7 @@ DISTINCT_METRICS = {
     'interdistinct-1',
     'interdistinct-2',
     'intradistinct-1',
-    'instradistinct-2',
+    'intradistinct-2',
 }
 ALL_METRICS = DEFAULT_METRICS | ROUGE_METRICS | BLEU_METRICS | DISTINCT_METRICS
 
@@ -795,7 +795,7 @@ class TeacherMetrics(Metrics):
                 if 'rouge-L' in self._metrics_list and rL:
                     self.add('rouge_L', rL)
             # compute distinct-k
-            for k in [1, 2]:  # 1,2
+            for k in [1, 2]:
                 if f'interdistinct-{k}' in self._metrics_list:
                     self.add(
                         f'interdistinct-{k}', InterDistinctMetric.compute(prediction, k)

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -23,7 +23,8 @@ from parlai.utils.typing import TScalar, TVector
 DEFAULT_METRICS = {'bleu-4', 'accuracy', 'f1'}
 ROUGE_METRICS = {'rouge-1', 'rouge-2', 'rouge-L'}
 BLEU_METRICS = {'bleu-1', 'bleu-2', 'bleu-3', 'bleu-4'}
-ALL_METRICS = DEFAULT_METRICS | ROUGE_METRICS | BLEU_METRICS
+DISTINCT_METRICS = {'distinct-1', 'distinct-2'}
+ALL_METRICS = DEFAULT_METRICS | ROUGE_METRICS | BLEU_METRICS | DISTINCT_METRICS
 
 
 try:
@@ -523,6 +524,32 @@ class RougeMetric(AverageMetric):
         )
 
 
+class InterDistinctMetric(Metric):
+    def __init__(self, counts):
+        """compute distinct metric over corpus-level (InterDistinct)
+
+        Args:
+            counts (dict): {n-gram: counts}
+        """
+        self._counts = counts
+
+    def __add__(self, other):
+        return InterDistinctMetric(self._counts + other._counts)
+
+    def value(self):
+        return (len(self._counts) + 1e-12) / (sum(self._counts.values()) + 1e-5)
+
+    @classmethod
+    def _ngram(cls, seq, n):
+        for i in range(len(seq) - n + 1):
+            yield tuple(seq[i : i + n])
+
+    @classmethod
+    def compute(cls, text, ngram=1):
+        tokens = normalize_answer(text).split()
+        return InterDistinctMetric(Counter(cls._ngram(tokens, ngram)))
+
+
 def normalize_answer(s):
     """
     Lower text and remove punctuation, articles and extra whitespace.
@@ -679,6 +706,8 @@ class TeacherMetrics(Metrics):
                 col |= ROUGE_METRICS
             elif n == 'bleu':
                 col |= BLEU_METRICS
+            elif n == 'distinct':
+                col |= DISTINCT_METRICS
             elif n == 'all':
                 col |= ALL_METRICS
             else:
@@ -732,6 +761,10 @@ class TeacherMetrics(Metrics):
                     self.add('rouge_2', r2)
                 if 'rouge-L' in self._metrics_list and rL:
                     self.add('rouge_L', rL)
+            # compute distinct-k
+            for k in range(1, 3):  # 1,2
+                if f'distinct-{k}' in self._metrics_list:
+                    self.add(f'distinct-{k}', InterDistinctMetric.compute(prediction, k))
 
         # Ranking metrics.
         self._update_ranking_metrics(observation, labels)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -18,6 +18,8 @@ from parlai.core.metrics import (
     TimerMetric,
     aggregate_unnamed_reports,
     aggregate_named_reports,
+    InterDistinctMetric,
+    IntraDistinctMetric,
 )
 from parlai.core.torch_classifier_agent import ConfusionMatrixMetric, WeightedF1Metric
 
@@ -383,6 +385,31 @@ class TestAggregators(unittest.TestCase):
         assert agg['task2/weighted_f1'] == (2 / 3) * 0.5 + (4 / 7) * 0.5
         # all
         assert agg['weighted_f1'] == (0.5 + (2 / 3) * 0.5 + (4 / 7) * 0.5) / 2
+
+
+class TestDistinct(unittest.TestCase):
+    def test_inter_distinct(self):
+        # 3 n-grams, all appearing once
+        m = InterDistinctMetric.compute("this is some test", 2)
+        self.assertAlmostEqual(m, 1.0)
+        # 3-grams, each appearing twice
+        self.assertAlmostEqual(m + m, 0.5)
+
+    def test_inter_distinct_unigram(self):
+        m1 = InterDistinctMetric.compute("this test", 1)
+        self.assertAlmostEqual(m1, 1.0, delta=0.001)
+        m2 = InterDistinctMetric.compute("another test", 1)
+        self.assertAlmostEqual(m2, 1.0, delta=0.001)
+        # we now have 4 tokens, 3 words
+        self.assertAlmostEqual(m1 + m2, 3 / 4)
+
+    def test_intra_distinct(self):
+        # 4/5 are unique
+        m1 = IntraDistinctMetric.compute("this is some test test", 1)
+        self.assertAlmostEqual(m1, 4 / 5)
+        m2 = IntraDistinctMetric.compute("this test test test test", 1)
+        self.assertAlmostEqual(m2, 2 / 5)
+        self.assertAlmostEqual(m1 + m2, 3 / 5)
 
 
 if __name__ == '__main__':

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -152,7 +152,7 @@ class TestMetrics(unittest.TestCase):
         m2.add('key', SumMetric(1))
         m3.add('key', SumMetric(2))
         m.add('key', SumMetric(3))
-        m.report()['key'] == 6
+        assert m.report()['key'] == 6
 
     def test_verymultithreaded(self):
         # legacy test, but useful all the same, for ensuring


### PR DESCRIPTION
**Patch description**
Adds support for `interdistinct` and `intradistinct` metrics.

Fixes #3255 and replaces #3265.

**Testing steps**
New CI test for correctness. Manual eval_model for integration.

```
$ parlai em -t convai2 --model repeat_label --metrics distinct
18:21:08 | Opt:
18:21:08 |     aggregate_micro: False
18:21:08 |     allow_missing_init_opts: False
18:21:08 |     batchsize: 1
18:21:08 |     cant_answer_message: "I don't know."
18:21:08 |     cant_answer_percent: 0
18:21:08 |     datapath: /private/home/roller/working/parlai/data
18:21:08 |     datatype: valid
18:21:08 |     dict_class: None
18:21:08 |     display_examples: False
18:21:08 |     download_path: None
18:21:08 |     dynamic_batching: None
18:21:08 |     hide_labels: False
18:21:08 |     image_cropsize: 224
18:21:08 |     image_mode: raw
18:21:08 |     image_size: 256
18:21:08 |     init_model: None
18:21:08 |     init_opt: None
18:21:08 |     log_every_n_secs: 10
18:21:08 |     log_keep_fields: all
18:21:08 |     loglevel: info
18:21:08 |     metrics: distinct
18:21:08 |     model: repeat_label
18:21:08 |     model_file: None
18:21:08 |     multitask_weights: [1]
18:21:08 |     num_examples: -1
18:21:08 |     override: "{'task': 'convai2', 'model': 'repeat_label', 'metrics': 'distinct'}"
18:21:08 |     parlai_home: /private/home/roller/working/parlai
18:21:08 |     report_filename:
18:21:08 |     return_one_random_answer: True
18:21:08 |     save_format: conversations
18:21:08 |     save_world_logs: False
18:21:08 |     starttime: Jan05_18-21
18:21:08 |     task: convai2
18:21:08 |     tensorboard_log: False
18:21:08 |     tensorboard_logdir: None
18:21:08 |     verbose: False
18:21:08 | Current ParlAI commit: 31eb9ab6a7044d0300f678e36534ace456596d3e
18:21:08 | Current internal commit: c0abb1b7f5e6841c9d046c04e988744756dde675
18:21:08 | Current fb commit: 4db2d5690edc7b1fd5523a495de346dcbcb4bb57
18:21:08 | Evaluating task convai2 using datatype valid.
18:21:08 | creating task(s): convai2
18:21:08 | loading fbdialog data: /private/home/roller/working/parlai/data/ConvAI2/valid_self_original.txt
18:21:19 | 35.6% complete (2,775 / 7,801), 0:00:10 elapsed, 0:00:18 eta
    accuracy  exs  f1  interdistinct-1  interdistinct-2  intradistinct-1  intradistinct-2
           1 2775   1            .1091            .5404            .9576            .9968
18:21:29 | 52.5% complete (4,094 / 7,801), 0:00:20 elapsed, 0:00:18 eta
    accuracy  exs  f1  interdistinct-1  interdistinct-2  intradistinct-1  intradistinct-2
           1 4094   1           .08957            .4973            .9586            .9967
18:21:39 | 66.6% complete (5,194 / 7,801), 0:00:30 elapsed, 0:00:15 eta
    accuracy  exs  f1  interdistinct-1  interdistinct-2  intradistinct-1  intradistinct-2
           1 5194   1           .07928            .4711            .9587            .9968
18:21:49 | 78.6% complete (6,134 / 7,801), 0:00:40 elapsed, 0:00:11 eta
    accuracy  exs  f1  interdistinct-1  interdistinct-2  intradistinct-1  intradistinct-2
           1 6134   1           .07264            .4532            .9586            .9967
18:21:59 | 89.6% complete (6,986 / 7,801), 0:00:50 elapsed, 0:00:06 eta
    accuracy  exs  f1  interdistinct-1  interdistinct-2  intradistinct-1  intradistinct-2
           1 6986   1           .06808            .4400            .9582            .9968
18:22:09 | 99.5% complete (7,760 / 7,801), 0:01:00 elapsed, 0:00:00 eta
    accuracy  exs  f1  interdistinct-1  interdistinct-2  intradistinct-1  intradistinct-2
           1 7760   1           .06439            .4285            .9586            .9968
18:22:09 | Finished evaluating tasks ['convai2'] using datatype valid
    accuracy  exs  f1  interdistinct-1  interdistinct-2  intradistinct-1  intradistinct-2
           1 7801   1           .06425            .4280            .9587            .9968
parlai em -t convai2 --model repeat_label --metrics distinct  65.09s user 3.51s system 107% cpu 1:04.06 total
```