### PR TITLE
[parlaiparser] Fix bad parse of `-opt` in python 3.8

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -879,7 +879,7 @@ class ParlaiParser(argparse.ArgumentParser):
                 self._load_known_opts(parsed.get('init_opt'), parsed)
             except FileNotFoundError:
                 # don't die if -o isn't found here. See comment in second call
-                # later on
+                # later on.
                 pass
         parsed = self._infer_datapath(parsed)
 
@@ -910,8 +910,10 @@ class ParlaiParser(argparse.ArgumentParser):
             )
 
         # reparse args now that we've inferred some things.  specifically helps
-        # with a misparse of `-opt` as `-o pt` which may be ambigiuous until
-        # after we have added the model args.
+        # with a misparse of `-opt` as `-o pt`, which causes opt loading to
+        # try to load the file "pt" which doesn't exist.
+        # After adding model arguments, -opt becomes known (it's in TorchAgent),
+        # and we parse the `-opt` value correctly.
         parsed = vars(self.parse_known_args(args, nohelp=True)[0])
         if parsed.get('init_opt') is not None:
             self._load_known_opts(parsed.get('init_opt'), parsed)

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -945,10 +945,6 @@ class ParlaiParser(argparse.ArgumentParser):
 
         Called before args are parsed; ``_load_opts`` is used for actually overriding
         opts after they are parsed.
-
-        Called twice, hence the first_pass bool. The first time is used to
-        just set model/task/world, and the second time is to actually load
-        opts.
         """
         new_opt = Opt.load(optfile)
         for key, value in new_opt.items():

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -35,7 +35,7 @@ class _TestShortOptScript(script.ParlaiScript):
 
     @classmethod
     def setup_args(cls):
-        parser = ParlaiParser(False, False, description="Short opt test")
+        parser = ParlaiParser(True, True, description="Short opt test")
         parser.add_argument('-m', '--model')
         parser.add_argument('-mxx', '--my-other-option')
         return parser

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -107,6 +107,11 @@ class TestSuperCommand(unittest.TestCase):
         opt = script.superscript_main(args=['short_opt', '-m', 'repeat_query'])
         assert opt.get('model') == 'repeat_query'
 
+        opt = script.superscript_main(
+            args=['short_opt', '-m', 'transformer/generator', '-opt', 'adam']
+        )
+        assert opt.get('optimizer') == 'adam'
+
     def test_supercommand(self):
         opt = script.superscript_main(args=['test_script', '--foo', 'test'])
         assert opt.get('foo') == 'test'


### PR DESCRIPTION
**Patch description**
In Python 3.8, `-opt adam` is misparsed initially as `-o pt` and causes a FileNotFoundError. This hack works around this.

**Testing steps**
New test fails before this patch, passes after. Manual testing.