### PR TITLE
Add user response option to Turn Annotations Static Task (new)

### DIFF
--- a/parlai/crowdsourcing/tasks/turn_annotations_static/README.md
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/README.md
@@ -13,6 +13,8 @@ For both variants of the blueprint, it is required to pass in your own file of c
 
 See `turn_annotations_blueprint.py` for various parameters of this task, including passing in custom annotation bucket definitions using the `annotation_buckets` YAML flag, being able to group multiple conversations into one HIT using the `subtasks_per_unit` flag, passing in onboarding data with answers, and being able to ask only for the final utterance as an annotation.
 
+The validation of the response field is handled by `validateFreetextResponse` function in `task_components.jsx` and checks for a minimum number of characters, words, and vowels specified by function parameters. To change this, modify the values passed in to the function call or override the function to set your own validation requirements.
+
 **NOTE**: See [parlai/crowdsourcing/README.md](https://github.com/facebookresearch/ParlAI/blob/master/parlai/crowdsourcing/README.md) for general tips on running `parlai.crowdsourcing` tasks, such as how to specify your own YAML file of configuration settings, how to run tasks live, how to set parameters on the command line, etc.
 
 ## Analysis

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/conf/example.yaml
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/conf/example.yaml
@@ -8,6 +8,7 @@ mephisto:
     units_per_assignment: 5
     onboarding_qualification: turn_annotations_static
     annotation_buckets: ${task_dir}/task_config/annotation_buckets.json
+    response_field: False
   task:
     allowed_concurrent: 1
     maximum_units_per_worker: 5

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/conf/example.yaml
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/conf/example.yaml
@@ -7,6 +7,7 @@ mephisto:
     extra_source_dir: ${task_dir}/webapp/src/static
     units_per_assignment: 5
     onboarding_qualification: turn_annotations_static
+    annotation_buckets: ${task_dir}/task_config/annotation_buckets.json
   task:
     allowed_concurrent: 1
     maximum_units_per_worker: 5

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/turn_annotations_blueprint.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/turn_annotations_blueprint.py
@@ -78,10 +78,10 @@ class TurnAnnotationsStaticBlueprintArgs(StaticReactBlueprintArgs):
             "help": "Path to data and answers for onboarding task in JSON format"
         },
     )
-    annotation_buckets: str = field(
-        default=os.path.join(get_task_path(), 'task_config/annotation_buckets.json'),
+    annotation_buckets: Optional[str] = field(
+        default=None,
         metadata={
-            "help": "As per Turn Annotations task, path to annotation buckets which will be checkboxes in the frontend for worker to annotate an utterance."
+            "help": "As per Turn Annotations task, path to annotation buckets which will be checkboxes in the frontend for worker to annotate an utterance. If none provided, no checkboxes."
         },
     )
 

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/turn_annotations_blueprint.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/turn_annotations_blueprint.py
@@ -84,6 +84,12 @@ class TurnAnnotationsStaticBlueprintArgs(StaticReactBlueprintArgs):
             "help": "As per Turn Annotations task, path to annotation buckets which will be checkboxes in the frontend for worker to annotate an utterance. If none provided, no checkboxes."
         },
     )
+    response_field: bool = field(
+        default=False,
+        metadata={
+            "help": "If we want a freeform textbox input for the crowdworker to respond to the message."
+        },
+    )
 
 
 @register_mephisto_abstraction()
@@ -170,10 +176,12 @@ class TurnAnnotationsStaticBlueprint(StaticReactBlueprint):
         with open(self.args.blueprint.onboarding_data, "r", encoding="utf-8-sig") as f:
             onboarding_data = json.loads(f.read())
 
-        with open(
-            self.args.blueprint.annotation_buckets, "r", encoding="utf-8-sig"
-        ) as f:
-            annotation_buckets = json.loads(f.read())
+        annotation_buckets = None
+        if self.args.blueprint.annotation_buckets:
+            with open(
+                self.args.blueprint.annotation_buckets, "r", encoding="utf-8-sig"
+            ) as f:
+                annotation_buckets = json.loads(f.read())
 
         return {
             "task_description": self.args.task.get('task_description', None),
@@ -182,6 +190,7 @@ class TurnAnnotationsStaticBlueprint(StaticReactBlueprint):
             "onboarding_data": onboarding_data,
             "annotation_buckets": annotation_buckets,
             "ask_reason": self.args.blueprint.ask_reason,
+            "response_field": self.args.blueprint.response_field,
             "frame_height": '100%',
             "num_subtasks": self.args.blueprint.subtasks_per_unit,
             "block_mobile": True,

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/webapp/package.json
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/webapp/package.json
@@ -13,6 +13,7 @@
     "bootstrap": "^4.3.1",
     "mephisto-task": "^1.0.3",
     "react": "16.13.1",
+    "react-bootstrap": "^0.32.4",
     "react-dom": "16.13.1",
     "serialize-javascript": "^3.1.0"
   },

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/webapp/src/app.jsx
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/webapp/src/app.jsx
@@ -28,7 +28,7 @@ function MainApp() {
   if (blockedReason !== null) {
     return (
       <section className="hero is-medium is-danger">
-        <div class="hero-body">
+        <div className="hero-body">
           <h2 className="title is-3">{blockedExplanation}</h2>{" "}
         </div>
       </section>
@@ -41,7 +41,7 @@ function MainApp() {
   if (isPreview) {
     return (
       <section className="hero is-medium is-link">
-        <div class="hero-body">
+        <div className="hero-body">
           <h3><span dangerouslySetInnerHTML={{ __html: taskConfig.task_title || 'Task Title Loading' }}></span></h3>
           <br />
           <span dangerouslySetInnerHTML={{ __html: taskConfig.task_description || 'Task Description Loading' }}></span>


### PR DESCRIPTION
This PR adds the option to have a response field textbox for each utterance so we can collect the user’s response (chat history is not updated with the user’s response).
- Validation of the user’s text input: requires more than 10 characters, at least 1 vowel, and at least 2 words

Annotation buckets can also be optional, if no annotation buckets file path is passed in there will be no annotation buckets.

<img width="1437" alt="Screen Shot 2021-01-04 at 2 35 09 PM" src="https://user-images.githubusercontent.com/20617868/103586518-18076500-4e9a-11eb-87f7-e309569fc8a5.png">

(take 2 of previous PR 3341)
