### PR TITLE
RCE Fixed

### DIFF
--- a/parlai/chat_service/utils/config.py
+++ b/parlai/chat_service/utils/config.py
@@ -36,7 +36,7 @@ def parse_configuration_file(config_path):
     result = {}
     result["configs"] = {}
     with open(config_path) as f:
-        cfg = yaml.load(f.read(), Loader=yaml.FullLoader)
+        cfg = yaml.load(f.read(), Loader=yaml.SafeLoader)
         # get world path
         result["world_path"] = cfg.get("world_module")
         if not result["world_path"]:


### PR DESCRIPTION
:pencil2: Change Description
:bar_chart: Metadata *

ParlAI (pronounced “par-lay”) is a python framework for sharing, training and testing dialogue models, from open-domain chitchat to VQA (Visual Question Answering).

Bounty URL: https://www.huntr.dev/bounties/1-pip-ParlAI
:gear: Description *

This package was vulnerable to YAML deserialization attack caused by unsafe loading.


:computer: Technical Description *

Fixed by avoiding unsafe loader.

:bug: Proof of Concept (PoC) *

Create the following PoC file:
exploit.py

```
import os
#os.system('pip3 install parlai')
from parlai.chat_service.utils import config
exploit = """!!python/object/new:type
  args: ["z", !!python/tuple [], {"extend": !!python/name:exec }]
  listitems: "__import__('os').system('xcalc')"
"""
open('config.yml','w+').write(exploit)
config.parse_configuration_file('config.yml')
```

Execute the following commands in another terminal:

```
python3 exploit.py
```

    Check the Output:

xcalc will pop up.

:fire: Proof of Fix (PoF) *

After fix it will not popup a calc.

:+1: User Acceptance Testing (UAT)

After fix functionality is unaffected.
