### PR TITLE
How to switch Worlds

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/README.md
+++ b/parlai/crowdsourcing/tasks/model_chat/README.md
@@ -45,6 +45,7 @@ Some options for running human+model image chat are as follows:
 - `mephisto.blueprint.image_context_path`: the path to the file saved by `scripts/save_image_contexts.py` during setup.
 - `mephisto.blueprint.stack_folder`: a folder in which to store a stack file that will keep track of which crowdsource workers have chatted with which models about which images. The stack will ensure that no worker chats about the same image more than once and that conversations about images are collected uniformly among all models.
 - `mephisto.blueprint.evals_per_image_model_combo`: the maximum number of conversations collected for each combination of image and model. For instance, if this is set to 3 and your 2 models are `model_1` and `model_2`, each image will have 6 conversations collected about it, 3 with `model_1` and 3 with `model_2`.
+- `mephisto.blueprint.world_file`: the path to the Python module containing the class definition for the chat World, used for setting the logic for each turn of the conversation, when to end the conversation, actions upon shutdown, etc. (The onboarding World, if it exists, will be defined in this module as well.) Modify this value if you would like to write your own World class without having to create a new Blueprint class.
 
 Note that onboarding is not currently supported with human+model image chat: use `ModelChatOnboardWorld` in `worlds.py` as a guide for how to set up onboarding for your specific task.
 

--- a/parlai/crowdsourcing/tasks/qa_data_collection/README.md
+++ b/parlai/crowdsourcing/tasks/qa_data_collection/README.md
@@ -8,6 +8,7 @@ a crowdsource worker could supply the question "Who called the bishops to the Fi
 
 Some useful parameters to set:
 - `mephisto.blueprint.task_description_file`: HTML describing the data collection task, shown on the left-hand pane of the chat window
+- `mephisto.blueprint.world_file`: the path to the Python module containing the class definition for the chat World, used for setting the logic for each turn of the task, when to end the task, actions upon shutdown, etc. (The onboarding World, if it exists, will be defined in this module as well.) Modify this value if you would like to write your own World class without having to create a new Blueprint class.
 - `mephisto.teacher.task`: the ParlAI dataset to pull passages from. Defaults to SQuAD
 - `mephisto.teacher.datatype`: the fold of the dataset in `mephisto.teacher.task` to pull passages from. Defaults to the training set
 


### PR DESCRIPTION
**Patch description**
Add notes to the READMEs of 2 ParlAI chat tasks describing how to specify a custom chat World and onboarding World independently of setting a new Blueprint. This is useful for demonstrating the modularity of the Mephisto and `parlai.crowdsourcing` code 

**Testing steps**
(NA - only README changes)