### PR TITLE
Fixing world logger filename issue

### DIFF
--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -32,6 +32,7 @@ from parlai.utils.io import PathManager
 import parlai.utils.logging as logging
 
 import json
+import os
 import random
 
 from parlai.utils.distributed import (
@@ -56,11 +57,11 @@ def setup_args(parser=None):
         'file path. Set to the empty string to not save at all.',
     )
     parser.add_argument(
-        '--save-world-logs',
-        type='bool',
-        default=False,
-        help='Saves a jsonl file containing all of the task examples and '
-        'model replies. Must also specify --report-filename.',
+        '--world-logs',
+        type=str,
+        default='',
+        help='Saves a jsonl file of the world logs.'
+        'Set to the empty string to not save at all.',
     )
     parser.add_argument(
         '--save-format',
@@ -120,7 +121,7 @@ def _save_eval_stats(opt, report):
 def _eval_single_world(opt, agent, task):
     logging.info(f'Evaluating task {task} using datatype {opt.get("datatype")}.')
     # set up world logger
-    world_logger = WorldLogger(opt) if opt['save_world_logs'] else None
+    world_logger = WorldLogger(opt) if opt['world_logs'] else None
 
     task_opt = opt.copy()  # copy opt since we're editing the task
     task_opt['task'] = task
@@ -158,12 +159,12 @@ def _eval_single_world(opt, agent, task):
     if world_logger is not None:
         # dump world acts to file
         world_logger.reset()  # add final acts to logs
-        base_outfile = opt['report_filename'].split('.')[0]
         if is_distributed():
             rank = get_rank()
-            outfile = base_outfile + f'_{task}_{rank}_replies.jsonl'
+            base_outfile, extension = os.path.splitext(opt['world_logs'])
+            outfile = base_outfile + f'_{rank}' + extension
         else:
-            outfile = base_outfile + f'_{task}_replies.jsonl'
+            outfile = opt['world_logs']
         world_logger.write(outfile, world, file_format=opt['save_format'])
 
     report = aggregate_unnamed_reports(all_gather_list(world.report()))
@@ -184,12 +185,6 @@ def eval_model(opt):
         raise ValueError(
             'You should use --datatype train:evalmode if you want to evaluate on '
             'the training set.'
-        )
-
-    if opt['save_world_logs'] and not opt['report_filename']:
-        raise RuntimeError(
-            'In order to save model replies, please specify the save path '
-            'with --report-filename'
         )
 
     # load model and possibly print opt

--- a/tests/test_dynamicbatching.py
+++ b/tests/test_dynamicbatching.py
@@ -106,17 +106,14 @@ class TestDynamicBatching(unittest.TestCase):
                 dict(
                     model_file='zoo:unittest/transformer_generator2/model',
                     task='integration_tests:multiturn_candidate',
-                    save_world_logs=True,
+                    world_logs=save_report,
                     report_filename=save_report,
                     truncate=1024,
                     dynamic_batching='full',
                     batchsize=4,
                 )
             )
-            convo_fle = (
-                str(save_report)
-                + '_integration_tests:multiturn_candidate_replies.jsonl'
-            )
+            convo_fle = str(save_report) + '.jsonl'
             convos = Conversations(convo_fle)
             for convo in convos:
                 self.assertEquals(len(convo), 2 * 4)  # each episode is 4 turns

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -216,7 +216,7 @@ class TestEvalModel(unittest.TestCase):
                 datatype='valid',
                 num_examples=5,
                 display_examples=False,
-                save_world_logs=True,
+                world_logs=save_report,
                 report_filename=save_report,
             )
             valid, test = testing_utils.eval_model(opt)


### PR DESCRIPTION
**Patch description**
We now take an argument "world-logs" which takes a string indicating the file path to save the world logs. We scrap the "save-world-logs" boolean argument.

