### PR TITLE
[TFIDF] Fix for Interactive Web

### DIFF
--- a/parlai/agents/tfidf_retriever/tfidf_retriever.py
+++ b/parlai/agents/tfidf_retriever/tfidf_retriever.py
@@ -271,9 +271,9 @@ class TfidfRetrieverAgent(Agent):
                     picks = ['\n'.join(p.split('\n')[1:]) for p in picks]
                     pick = '\n'.join(pick.split('\n')[1:])
                 reply['text_candidates'] = picks
-                reply['candidate_scores'] = doc_scores
+                reply['candidate_scores'] = list(doc_scores)
 
                 reply['text'] = pick
-                reply['candidate_ids'] = doc_ids
+                reply['candidate_ids'] = list(doc_ids)
 
         return reply

--- a/parlai/agents/tfidf_retriever/tfidf_retriever.py
+++ b/parlai/agents/tfidf_retriever/tfidf_retriever.py
@@ -271,9 +271,9 @@ class TfidfRetrieverAgent(Agent):
                     picks = ['\n'.join(p.split('\n')[1:]) for p in picks]
                     pick = '\n'.join(pick.split('\n')[1:])
                 reply['text_candidates'] = picks
-                reply['candidate_scores'] = list(doc_scores)
+                reply['candidate_scores'] = doc_scores.tolist()
 
                 reply['text'] = pick
-                reply['candidate_ids'] = list(doc_ids)
+                reply['candidate_ids'] = doc_ids.tolist()
 
         return reply


### PR DESCRIPTION
**Patch description**
The TFIDF retriever was putting numpy arrays in its responses, which are not JSON serializable (and thus, not able to be used with interactive web script). This patch changes that (fix for discussion in #3366) 

**Testing steps**
Ran `parlai interactive_web --model tfidf_retriever -mf zoo:wikipedia_full/tfidf_retriever/model` to verify that [error here](https://github.com/facebookresearch/ParlAI/discussions/3366#discussioncomment-280963) does not surface