### PR TITLE
Fix analysis arg help

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/README.md
+++ b/parlai/crowdsourcing/tasks/model_chat/README.md
@@ -51,4 +51,4 @@ Note that onboarding is not currently supported with human+model image chat: use
 
 ## Analysis
 
-Run `analysis/compile_results.py` to compile and save statistics about collected human+model chats. The `ModelChatResultsCompiler` in that script uses dummy annotation buckets by default; set `--problem-buckets` in order to define your own.
+Run `analysis/compile_results.py` to compile and save statistics about collected human+model chats. The `ModelChatResultsCompiler` in that script uses dummy annotation buckets by default; set `--problem-buckets` in order to define your own. Set `--results-folders` to the value of `mephisto.blueprint.chat_data_folder` used when running HITs.

--- a/parlai/crowdsourcing/tasks/model_chat/README.md
+++ b/parlai/crowdsourcing/tasks/model_chat/README.md
@@ -10,6 +10,8 @@ Call `run.py` to run this task with the default parameters, as set by `conf/exam
 
 Set `mephisto.blueprint.model_opt_path` to specify a path to a YAML file listing all models to be chatted with, as well as the ParlAI flags for running each one. See `task_config/model_opts.yaml` for an example.
 
+Set `mephisto.blueprint.chat_data_folder` to the root folder that you want all results of HITs to be saved in: all results will be saved to a date folder (of format `2021_01_15`) within that root folder.
+
 ## Passing in task config files
 
 The following flags can be passed in to specify filepaths for overriding the text shown to the workers and the settings of the annotation categories. If they are not specified, the defaults in the `task_config/` folder will be used.

--- a/parlai/crowdsourcing/tasks/model_chat/worlds.py
+++ b/parlai/crowdsourcing/tasks/model_chat/worlds.py
@@ -248,11 +248,14 @@ class BaseModelChatWorld(CrowdTaskWorld, ABC):
                         self.__add_problem_data_to_utterance(p, turn_idx=turn_idx)
 
                 # Save the final chat data
+                date_folder = time.strftime('%Y_%m_%d')
                 time_string = time.strftime('%Y%m%d_%H%M%S')
-                chat_data_folder = self.opt['chat_data_folder']
-                os.makedirs(chat_data_folder, exist_ok=True)
+                chat_data_subfolder = os.path.join(
+                    self.opt['chat_data_folder'], date_folder
+                )
+                os.makedirs(chat_data_subfolder, exist_ok=True)
                 chat_data_path = os.path.join(
-                    chat_data_folder,
+                    chat_data_subfolder,
                     f'{time_string}_{np.random.randint(0, 1000)}_{self.task_type}.json',
                 )
                 final_chat_data = self.get_final_chat_data()

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/README.md
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/README.md
@@ -19,4 +19,4 @@ The validation of the response field is handled by `validateFreetextResponse` fu
 
 ## Analysis
 
-Run `analysis/compile_results.py` to compile and save statistics about collected static turn annotations. The `TurnAnnotationsStaticResultsCompiler` in that script uses dummy annotation buckets by default; set `--problem-buckets` in order to define your own.
+Run `analysis/compile_results.py` to compile and save statistics about collected static turn annotations. The `TurnAnnotationsStaticResultsCompiler` in that script uses dummy annotation buckets by default; set `--problem-buckets` in order to define your own. Set `--results-folders` to a comma-separated list of the folders that the data was saved to (likely of the format `"/basefolder/mephisto/data/runs/NO_PROJECT/123"`)

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -24,7 +24,7 @@ class AbstractResultsCompiler(ABC):
         parser.add_argument(
             '--results-folders',
             type=str,
-            help='Comma-separated list of result folders (example: "/basefolder/mephisto/data/runs/NO_PROJECT/123")',
+            help='Comma-separated list of result folders',
         )
         parser.add_argument(
             '--output-folder', type=str, help='Folder to save output files to'

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -22,9 +22,7 @@ class AbstractResultsCompiler(ABC):
     def setup_args(cls):
         parser = argparse.ArgumentParser('Compile crowdsourcing results')
         parser.add_argument(
-            '--results-folders',
-            type=str,
-            help='Comma-separated list of result folders',
+            '--results-folders', type=str, help='Comma-separated list of result folders'
         )
         parser.add_argument(
             '--output-folder', type=str, help='Folder to save output files to'

--- a/tests/crowdsourcing/tasks/model_chat/test_model_chat.py
+++ b/tests/crowdsourcing/tasks/model_chat/test_model_chat.py
@@ -163,7 +163,7 @@ fixed_response: >
                 with open(expected_chat_data_path) as f:
                     expected_chat_data = json.load(f)
                 results_path = list(
-                    glob.glob(os.path.join(chat_data_folder, '*_*_*_sandbox.json'))
+                    glob.glob(os.path.join(chat_data_folder, '*/*_*_*_sandbox.json'))
                 )[0]
                 with open(results_path) as f:
                     actual_chat_data = json.load(f)

--- a/tests/crowdsourcing/tasks/model_chat/test_model_image_chat.py
+++ b/tests/crowdsourcing/tasks/model_chat/test_model_image_chat.py
@@ -172,7 +172,7 @@ try:
                 with open(expected_chat_data_path) as f:
                     expected_chat_data = json.load(f)
                 results_path = list(
-                    glob.glob(os.path.join(chat_data_folder, '*_*_*_sandbox.json'))
+                    glob.glob(os.path.join(chat_data_folder, '*/*_*_*_sandbox.json'))
                 )[0]
                 with open(results_path) as f:
                     actual_chat_data = json.load(f)


### PR DESCRIPTION
**Patch description**
For the model chat task, save the results to a date folder (i.e. `2021_01_15`) inside the root folder, so that the user doesn't have to create a date folder manually, since a date folder is expected by the analysis code. Also clean up a misleading arg help string and document the use of the arg

**Testing steps**
CI checks have good coverage of the change
