### PR TITLE
Add teacher-metrics to agent observations for display_model.

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -459,7 +459,7 @@ class FixedDialogTeacher(Teacher):
             # metrics back into the original observation. This is an abuse of
             # Messages being pointers
             if 'metrics' in observation:
-                # override agent-level metrics for all ones
+                # override agent-level metrics if present
                 observation.pop('metrics')
             observation['metrics'] = recent_metrics
         return observation

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -448,10 +448,20 @@ class FixedDialogTeacher(Teacher):
         """
         Process observation for metrics.
         """
+        self.metrics.clear_recent()
         if hasattr(self, 'lastY') and self.lastY is not None:
             self.metrics.evaluate_response(observation, self.lastY)
             self.custom_evaluation(self.last_act, self.lastY, observation)
             self.lastY = None
+        recent_metrics = self.metrics.report_recent()
+        if recent_metrics:
+            # for display purposes (display_model), take all accumulated
+            # metrics back into the original observation. This is an abuse of
+            # Messages being pointers
+            if 'metrics' in observation:
+                # override agent-level metrics for all ones
+                observation.pop('metrics')
+            observation['metrics'] = recent_metrics
         return observation
 
     def custom_evaluation(

--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -43,6 +43,7 @@ SPECIAL_FORMATED_DISPLAY_MESSAGE_FIELDS = {
     'text_candidates',
     'reward',
     'token_losses',
+    'metrics',
 }
 
 MUST_SHOW_MESSAGE_FIELDS = {'image', 'text', 'labels', 'eval_labels', 'reward'}
@@ -630,6 +631,16 @@ def display_messages(
                     style=field,
                 )
                 lines.append(line)
+        if msg.get('metrics') and verbose:
+            lines.append(
+                _pretty_lines(
+                    indent_space=space,
+                    field='metrics',
+                    value="\n" + nice_report(msg['metrics']),
+                    style='text',
+                )
+            )
+
         # Handling this separately since we need to clean up the raw output before displaying.
         token_loss_line = _token_losses_line(msg, fields_to_show, space)
         if token_loss_line:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -179,6 +179,24 @@ class TestMetrics(unittest.TestCase):
 
         assert m.report()['key'] == 32768 + 1
 
+    def test_recent(self):
+        m = Metrics()
+        m2 = Metrics(shared=m.share())
+        m.add('test', SumMetric(1))
+        assert m.report() == {'test': 1}
+        assert m.report_recent() == {'test': 1}
+        m.clear_recent()
+        m.add('test', SumMetric(2))
+        assert m.report() == {'test': 3}
+        assert m.report_recent() == {'test': 2}
+        assert m2.report() == {'test': 3}
+        assert m2.report_recent() == {}
+        m2.add('test', SumMetric(3))
+        assert m2.report() == {'test': 6}
+        assert m.report() == {'test': 6}
+        assert m2.report_recent() == {'test': 3}
+        assert m.report_recent() == {'test': 2}
+
 
 class TestAggregators(unittest.TestCase):
     def test_unnamed_aggregation(self):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -196,6 +196,15 @@ class TestMetrics(unittest.TestCase):
         assert m.report() == {'test': 6}
         assert m2.report_recent() == {'test': 3}
         assert m.report_recent() == {'test': 2}
+        m2.clear_recent()
+        assert m2.report() == {'test': 6}
+        assert m.report() == {'test': 6}
+        assert m2.report_recent() == {}
+        assert m.report_recent() == {'test': 2}
+        m.clear_recent()
+        assert m2.report() == {'test': 6}
+        assert m.report() == {'test': 6}
+        assert m.report_recent() == {}
 
 
 class TestAggregators(unittest.TestCase):

--- a/tests/test_other_scripts.py
+++ b/tests/test_other_scripts.py
@@ -13,6 +13,24 @@ import unittest
 import parlai.utils.testing as testing_utils
 
 
+class TestDisplayModel(unittest.TestCase):
+    def test_display_model(self):
+        from parlai.scripts.display_model import DisplayModel
+
+        with testing_utils.capture_output() as output:
+            DisplayModel.main(
+                model='fixed_response',
+                fixed_response='1 2 3 4',
+                task='integration_tests',
+                verbose=True,
+            )
+
+        output = output.getvalue()
+        assert 'metrics' in output
+        assert 'accuracy' in output
+        assert '1 2 3 4' in output
+
+
 class TestConvertToParlaiFormat(unittest.TestCase):
     def test_convert(self):
         from parlai.scripts.convert_data_to_parlai_format import (


### PR DESCRIPTION
**Patch description**
Adds teacher metrics into the model observation. This has the nice benefit that world logger and display model have access to this information and can log it.

**Testing steps**
New CI's covering the functionality.  Manual testing:

```
$ parlai dm -t convai2 -mf zoo:blender/blender_90M/model --inference topk --skip-generation false -v
[id]: convai2
[text]: my dad was always busy working at home depot
[eval_labels]: now that i am older home depot is my toy r us .
[label_candidates]: fun , i should take my kids out to do that . do you have a family ?|they were popular in my younger days lol|i sing and love rock especially while working . keeps me pumped .|i mean where i come from kitties do not play with birds .|i tend my rose garden and read books . i am deaf in one ear|... (5 of 20 shown)
   [id]: TransformerGenerator
   [beam_texts]: ("that ' s cool , what kind of things do they sell there ? i am looking for new shoes .", -13.5170259475708)
  ('my dad used to make money at home too , just not kosher food . . . lol', -14.683135032653809)
  ("i do not know what home depot is . but i ' ll have you know it is kosher !", -14.926774978637695)
  ("that is nice of him to do . did they have kosher food there ? that ' s what i ' d like to avoid .", -15.364789962768555)
  ('cool , i work at a grocery store , i love shopping . i only shop kosher though .', -15.92314338684082)
  ... (5 of 10 shown)
   [text]: that ' s cool , what kind of things do they sell there ? i am looking for new shoes .
   [metrics]:
    accuracy    bleu-4  exs    f1  loss   ppl  token_acc
           0 8.513e-08    1 .2069 3.236 25.44      .4286
   [token_losses]: now 6.837 | that 1.492 | i 2.398 | am 1.789 | older 2.599 | home 7.079 | depot 0.1772 | is 0.4172 | my 1.545 | toy 10.55 | r 9.772 | us 0.06661 | . 0.5078 | __end__ 0.07798 | __null__ 0.0 | __null__ 0.0
- - - - - - - END OF EPISODE - - - - - - - - - -
```