### PR TITLE
Fix: deprecated argument when calling transformers>4.0.0

### DIFF
--- a/parlai/agents/hugging_face/gpt2.py
+++ b/parlai/agents/hugging_face/gpt2.py
@@ -115,7 +115,7 @@ class GPT2Decoder(torch.nn.Module):
         model_input = model_input.clamp_(min=0)
         transformer_outputs = self.transformer(
             model_input,
-            past=incr_state,
+            past_key_values=incr_state,
             attention_mask=attention_mask,
             position_ids=position_ids,
         )


### PR DESCRIPTION
**Patch description**
Fixes #3353

It is a simple fix to the following errors:
````
TypeError: forward() got an unexpected keyword argument 'past'
````
When using the transformers>4.0.0
And:
````
/opt/conda/lib/python3.8/site-packages/transformers/modeling_gpt2.py:534: FutureWarning: The `past` argument is deprecated and will be removed in a future version, use `past_key_values` instead.
````
When using the transformers==3.5.1

<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->
As described in the issue [3353](https://github.com/facebookresearch/ParlAI/issues/3353)
```past_key_values=incr_state,```
solves the issue

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them. -->
parlai interactive -m hugging_face/gpt2 --add-special-tokens False --gpt2-size medium --inference beam --beam-size 10 --beam-context-block-ngram 3 --beam-block-ngram 3 --beam-min-length 25

**Other information**
<!-- Any other information or context you would like to provide. -->
Tested in transformers 3.5.1 and 4.2.1, no error or deprecation warning appears, code works.
