### PR TITLE
[TFIDF] Remove duplicate arg, add cosine similarity utility function

### DIFF
--- a/parlai/agents/tfidf_retriever/tfidf_retriever.py
+++ b/parlai/agents/tfidf_retriever/tfidf_retriever.py
@@ -82,12 +82,6 @@ class TfidfRetrieverAgent(Agent):
             help='How many docs to retrieve.',
         )
         parser.add_argument(
-            '--retriever-mode',
-            choices=['keys', 'values'],
-            default='values',
-            help='Whether to retrieve the stored key or the stored value.',
-        )
-        parser.add_argument(
             '--remove-title',
             type='bool',
             default=False,

--- a/parlai/agents/tfidf_retriever/utils.py
+++ b/parlai/agents/tfidf_retriever/utils.py
@@ -251,3 +251,12 @@ def filter_ngram(gram, mode='any'):
         list of tokens (length N)
     """
     return any(filter_word(w) for w in gram)
+
+
+def cosine_similarity(vec1, vec2) -> float:
+    """
+    Cosine similarity between two scipy sparse row matricies.
+    """
+    numerator = np.dot(vec1, vec2.transpose())[0, 0]
+    denominator = np.linalg.norm(vec1.data) * np.linalg.norm(vec2.data)
+    return numerator / max(denominator, 1e-8)


### PR DESCRIPTION
**Patch description**
I found cosine similarity useful in a project, so I thought I'd add it here!

**Testing steps**
Set pdb trace and tested in interactive:
```
>>> q = tfidf_ranker.text2spvec(label)
>>> c = tfidf_ranker.text2spvec(sentence)
>>> cosine_similarity(q, c)
0.5348931739406508
```
