### PR TITLE
Turn-annotations results compiler class

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py
+++ b/parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py
@@ -14,10 +14,10 @@ import numpy as np
 import pandas as pd
 
 from parlai.crowdsourcing.utils.acceptability import AcceptabilityChecker
-from parlai.crowdsourcing.utils.analysis import AbstractResultsCompiler
+from parlai.crowdsourcing.utils.analysis import AbstractTurnAnnotationResultsCompiler
 
 
-class ModelChatResultsCompiler(AbstractResultsCompiler):
+class ModelChatResultsCompiler(AbstractTurnAnnotationResultsCompiler):
     """
     Compile and save results of human+model chats.
 

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py
@@ -13,10 +13,10 @@ from typing import Any, Dict, Optional, Tuple
 import numpy as np
 import pandas as pd
 
-from parlai.crowdsourcing.utils.analysis import AbstractResultsCompiler
+from parlai.crowdsourcing.utils.analysis import AbstractTurnAnnotationResultsCompiler
 
 
-class TurnAnnotationsStaticResultsCompiler(AbstractResultsCompiler):
+class TurnAnnotationsStaticResultsCompiler(AbstractTurnAnnotationResultsCompiler):
     """
     Class to compile results from static turn annotations.
 

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -30,9 +30,9 @@ class AbstractResultsCompiler(ABC):
         self.output_folder = opt.get('output_folder')
 
     @abstractmethod
-    def compile_results(self) -> pd.DataFrame:
+    def compile_results(self) -> Any:
         """
-        Method for returning the final results dataframe.
+        Method for returning the final results object.
         """
 
 
@@ -77,3 +77,11 @@ class AbstractTurnAnnotationResultsCompiler(AbstractResultsCompiler):
             raise ValueError(
                 'There must be a "none_all_good" category in self.problem_buckets!'
             )
+
+    @abstractmethod
+    def compile_results(self) -> pd.DataFrame:
+        """
+        Method for returning the final results dataframe.
+
+        Each row of the dataframe consists of one utterance of one conversation.
+        """

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -22,10 +22,34 @@ class AbstractResultsCompiler(ABC):
     def setup_args(cls):
         parser = argparse.ArgumentParser('Compile crowdsourcing results')
         parser.add_argument(
-            '--results-folders', type=str, help='Comma-separated list of result folders'
-        )
-        parser.add_argument(
             '--output-folder', type=str, help='Folder to save output files to'
+        )
+        return parser
+
+    def __init__(self, opt: Dict[str, Any]):
+        self.output_folder = opt.get('output_folder')
+
+    @abstractmethod
+    def compile_results(self) -> pd.DataFrame:
+        """
+        Method for returning the final results dataframe.
+        """
+
+
+class AbstractTurnAnnotationResultsCompiler(AbstractResultsCompiler):
+    """
+    Results compiler subclass to provide utility code for turn annotations.
+
+    Currently incompatible with Mephisto's DataBrowser: all subclasses load results
+    files directly from disk.
+    TODO: make all subclasses compatible with DataBrowser
+    """
+
+    @classmethod
+    def setup_args(cls):
+        parser = super().setup_args()
+        parser.add_argument(
+            '--results-folders', type=str, help='Comma-separated list of result folders'
         )
         parser.add_argument(
             '--problem-buckets',
@@ -37,12 +61,13 @@ class AbstractResultsCompiler(ABC):
 
     def __init__(self, opt: Dict[str, Any]):
 
+        super().__init__(opt)
+
         # Handle inputs
         if 'results_folders' in opt:
             self.results_folders = opt['results_folders'].split(',')
         else:
             self.results_folders = None
-        self.output_folder = opt.get('output_folder')
         self.problem_buckets = opt['problem_buckets'].split(',')
 
         # Validate problem buckets
@@ -52,9 +77,3 @@ class AbstractResultsCompiler(ABC):
             raise ValueError(
                 'There must be a "none_all_good" category in self.problem_buckets!'
             )
-
-    @abstractmethod
-    def compile_results(self) -> pd.DataFrame:
-        """
-        Method for returning the final results dataframe.
-        """

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -30,9 +30,11 @@ class AbstractResultsCompiler(ABC):
         self.output_folder = opt.get('output_folder')
 
     @abstractmethod
-    def compile_results(self) -> Any:
+    def compile_results(self) -> pd.DataFrame:
         """
-        Method for returning the final results object.
+        Method for returning the final results dataframe.
+
+        Each row of the dataframe consists of one utterance of one conversation.
         """
 
 
@@ -77,11 +79,3 @@ class AbstractTurnAnnotationResultsCompiler(AbstractResultsCompiler):
             raise ValueError(
                 'There must be a "none_all_good" category in self.problem_buckets!'
             )
-
-    @abstractmethod
-    def compile_results(self) -> pd.DataFrame:
-        """
-        Method for returning the final results dataframe.
-
-        Each row of the dataframe consists of one utterance of one conversation.
-        """


### PR DESCRIPTION
**Patch description**
Split off all attributes in `AbstractResultsCompiler` that are specific to turn annotations tasks into a new `AbstractTurnAnnotationResultsCompiler` subclass. This way, code that compiles results that *aren't* based on turn annotations can subclass `AbstractResultsCompiler` without inheriting turn-annotations attributes.

One use case of this will be to create a new subclass of `AbstractResultsCompiler` called `AbstractDataBrowserResultsCompiler` that will provide utility code for pulling results directly from Mephisto's `DataBrowser`. (Eventually, it'll be good to convert all existing analysis code to pull from `DataBrowser`, since this is the canonical way of reading in results.) 

**Testing steps**
Existing CI checks provide test coverage of analysis scripts
