### PR TITLE
Simple model_chat final turn rating fix

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
+++ b/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
@@ -46,7 +46,7 @@ function FinalSurvey({ taskConfig, onMessageSend, active, currentCheckboxes}) {
         setSending(false);
       });
     }
-  }, [active, sending, onMessageSend]);
+  }, [active, sending, rating, onMessageSend]);
 
   const ratingOptions = [<option key="empty_option" />].concat(
     ["1", "2", "3", "4", "5"].map((option_label, index) => {


### PR DESCRIPTION
**Patch description**
The final turn in `model_chat` would always provide a rating of 0, no matter what the rating actually was, on the currently used version of react. This patch includes the `rating` as a dependency for the submit callback, allowing the rating to be sent over properly.

**Testing steps**
Ran model_chat and gave a rating, noted the rating was 0. Now I give a rating, and the rating is sent over:
```
Got act for agent idx 0, act was: {'text': '', 'task_data': {'problem_data_for_prior_message': {'bucket_0': False, 'bucket_1': False, 'bucket_2': True, 'bucket_3': False, 'bucket_4': False}, 'final_rating': '3'}, 'id': 'Worker', 'episode_done': False, 'message_id': 'ce883242-19e4-41f5-bf04-c3c4de2d5345'} and self.task_turn_idx: 11.
{'bucket_0': False, 'bucket_1': False, 'bucket_2': True, 'bucket_3': False, 'bucket_4': False}
```
