### PR TITLE
Use os.replace instead of os.rename for windows compatibility

### DIFF
--- a/parlai/utils/torch.py
+++ b/parlai/utils/torch.py
@@ -56,7 +56,7 @@ def atomic_save(state_dict: Any, path: str) -> None:
     if io_utils.USE_ATOMIC_TORCH_SAVE:
         with open(path + ".tmp", "wb") as f:
             torch.save(state_dict, f)
-        os.rename(path + ".tmp", path)
+        os.replace(path + ".tmp", path)
     else:
         with io_utils.PathManager.open(path, "wb") as f:
             torch.save(state_dict, f)


### PR DESCRIPTION
**Patch description**
os.rename silently overwrites the destination in linux, but throws an error in windows. os.replace silently overwrites the desitnation in both.

**Testing**
Manual testing (by Stephen), + CI