### PR TITLE
Generalize projection-matrix-removal script

### DIFF
--- a/projects/anti_scaling/scripts/remove_projection_matrices.py
+++ b/projects/anti_scaling/scripts/remove_projection_matrices.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
-import shutil
 
 import torch
 
@@ -19,12 +18,12 @@ def remove_projection_matrices(model_file: str):
     Remove all projection matrices used for distillation from the model and re-save it.
     """
 
-    print(f'Creating a backup copy of the original model at {model_file}.')
-    shutil.copyfile(model_file, f'{model_file}._orig')
-
     print(f"Loading {model_file}.")
     with PathManager.open(model_file, 'rb') as f:
         states = torch.load(f, map_location=lambda cpu, _: cpu, pickle_module=pickle)
+
+    print(f'Creating a backup copy of the original model at {model_file}._orig.')
+    atomic_save(states, f'{model_file}._orig')
 
     print('Deleting projection matrices.')
     orig_num_keys = len(states['model'])

--- a/projects/anti_scaling/scripts/remove_projection_matrices.py
+++ b/projects/anti_scaling/scripts/remove_projection_matrices.py
@@ -18,12 +18,12 @@ def remove_projection_matrices(model_file: str):
     Remove all projection matrices used for distillation from the model and re-save it.
     """
 
+    print(f'Creating a backup copy of the original model at {model_file}._orig.')
+    PathManager.copy(model_file, f'{model_file}._orig')
+
     print(f"Loading {model_file}.")
     with PathManager.open(model_file, 'rb') as f:
         states = torch.load(f, map_location=lambda cpu, _: cpu, pickle_module=pickle)
-
-    print(f'Creating a backup copy of the original model at {model_file}._orig.')
-    atomic_save(states, f'{model_file}._orig')
 
     print('Deleting projection matrices.')
     orig_num_keys = len(states['model'])


### PR DESCRIPTION
When running TinyBERT-style knowledge distillation, projection matrices that are not used for evaluation will be stored in the model checkpoint. This PR generalizes the script used for removing these matrices to make it work on filesystems that do not support `shutil.copyfile()`.
