### PR TITLE
Differentiate block name for static turn annotations

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/impl.py
+++ b/parlai/crowdsourcing/tasks/model_chat/impl.py
@@ -41,7 +41,9 @@ def run_task(cfg: DictConfig, task_directory: str):
         task_name = f"{task_name}_sandbox"
     cfg.mephisto.task.task_name = task_name
 
-    soft_block_qual_name = f"{task_name}_ineligible"
+    soft_block_qual_name = cfg.mephisto.task.get(
+        'block_qualification', f'{task_name}_block'
+    )
     # Default to a task-specific name to avoid soft-block collisions
     soft_block_mturk_workers(cfg=cfg, db=db, soft_block_qual_name=soft_block_qual_name)
 

--- a/parlai/crowdsourcing/tasks/model_chat/impl.py
+++ b/parlai/crowdsourcing/tasks/model_chat/impl.py
@@ -41,7 +41,7 @@ def run_task(cfg: DictConfig, task_directory: str):
         task_name = f"{task_name}_sandbox"
     cfg.mephisto.task.task_name = task_name
 
-    soft_block_qual_name = cfg.mephisto.task.get(
+    soft_block_qual_name = cfg.mephisto.blueprint.get(
         'block_qualification', f'{task_name}_block'
     )
     # Default to a task-specific name to avoid soft-block collisions

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/util.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/util.py
@@ -24,7 +24,9 @@ def run_static_task(cfg: DictConfig, task_directory: str):
 
     random.seed(42)
 
-    soft_block_qual_name = cfg.mephisto.task.get('task_name', 'turn_annotations_static')
+    soft_block_qual_name = cfg.mephisto.task.get(
+        'task_name', 'turn_annotations_static_block'
+    )
     # Default to a task-specific name to avoid soft-block collisions
     soft_block_mturk_workers(cfg=cfg, db=db, soft_block_qual_name=soft_block_qual_name)
 

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/util.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/util.py
@@ -24,8 +24,9 @@ def run_static_task(cfg: DictConfig, task_directory: str):
 
     random.seed(42)
 
+    task_name = cfg.mephisto.task.get('task_name', 'turn_annotations_static')
     soft_block_qual_name = cfg.mephisto.task.get(
-        'task_name', 'turn_annotations_static_block'
+        'block_qualification', f'{task_name}_block'
     )
     # Default to a task-specific name to avoid soft-block collisions
     soft_block_mturk_workers(cfg=cfg, db=db, soft_block_qual_name=soft_block_qual_name)

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/util.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/util.py
@@ -25,7 +25,7 @@ def run_static_task(cfg: DictConfig, task_directory: str):
     random.seed(42)
 
     task_name = cfg.mephisto.task.get('task_name', 'turn_annotations_static')
-    soft_block_qual_name = cfg.mephisto.task.get(
+    soft_block_qual_name = cfg.mephisto.blueprint.get(
         'block_qualification', f'{task_name}_block'
     )
     # Default to a task-specific name to avoid soft-block collisions


### PR DESCRIPTION
Fix the default block qualification name for static turn annotations to differentiate it from other qualification names (i.e. onboarding)