### PR TITLE
Fix for OverflowError: out of range integral type conversion attempted in HF BPE

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -768,9 +768,9 @@ class DictionaryAgent(Agent):
             # end of Hugging Face dict, there is an offset of #(extra tokens) between them.
             extra_tokens = 4  # length of special tokens
             vector = [
-                self.bpe.special_tok_map[idx]
-                if idx in self.bpe.special_tok_map
-                else idx - extra_tokens
+                self.bpe.special_tok_map[int(idx)]
+                if int(idx) in self.bpe.special_tok_map
+                else int(idx) - extra_tokens
                 for idx in vector
             ]
             tokens = [self[int(idx)] for idx in vector]


### PR DESCRIPTION
Haven't been here for a long time, feel good!

**Patch description**
The vec2txt function for hugging face bpe is broken by ```OverflowError: out of range integral type conversion attempted```
This error was casued by vector has a list of tensor instead of a list of int, which cased ``` if idx in self.bpe.special_tok_map``` logic to fail. 


**Testing steps**
Tested by running this on any blender dict stuff. 
