### PR TITLE
Fix valid data file location issue with Natural Questions dataset

### DIFF
--- a/parlai/tasks/natural_questions/build.py
+++ b/parlai/tasks/natural_questions/build.py
@@ -81,9 +81,11 @@ def _untar_dataset_files(dpath):
 
 def _move_valid_files_from_dev_to_valid(dpath):
     """
-    Files from Google are stored at `nq-dev-##.jsonl.gz` and get untar'd to 
-    `nq-dev-##.jsonl`. The agent expects them to be stored at `nq-valid-00.jsonl`.
-    This moves them over if need be.
+    Files from Google are stored at `nq-dev-##.jsonl.gz` and get untar'd to `nq-
+    dev-##.jsonl`.
+
+    The agent expects them to be stored at `nq-valid-00.jsonl`. This moves them over if
+    need be.
     """
     valid_path = os.path.join(dpath, 'valid')
     for f in os.listdir(valid_path):

--- a/parlai/tasks/natural_questions/build.py
+++ b/parlai/tasks/natural_questions/build.py
@@ -79,6 +79,20 @@ def _untar_dataset_files(dpath):
         _untar_dir_files(unzip_files_path)
 
 
+def _move_valid_files_from_dev_to_valid(dpath):
+    """
+    Files from Google are stored at `nq-dev-##.jsonl.gz` and get untar'd to 
+    `nq-dev-##.jsonl`. The agent expects them to be stored at `nq-valid-00.jsonl`.
+    This moves them over if need be.
+    """
+    valid_path = os.path.join(dpath, 'valid')
+    for f in os.listdir(valid_path):
+        print(f)
+        if "dev" in f:
+            new = f.replace('dev', 'valid')
+            os.rename(os.path.join(valid_path, f), os.path.join(valid_path, new))
+
+
 def build(opt):
     dpath = os.path.join(opt['datapath'], DATASET_NAME_LOCAL)
     version = 'v1.0'
@@ -92,4 +106,5 @@ def build(opt):
         build_data.make_dir(dpath)
         _download_with_cloud_storage_client(dpath)
         _untar_dataset_files(dpath)
+        _move_valid_files_from_dev_to_valid(dpath)
         build_data.mark_done(dpath, version_string=version)

--- a/parlai/tasks/natural_questions/build.py
+++ b/parlai/tasks/natural_questions/build.py
@@ -87,7 +87,6 @@ def _move_valid_files_from_dev_to_valid(dpath):
     """
     valid_path = os.path.join(dpath, 'valid')
     for f in os.listdir(valid_path):
-        print(f)
         if "dev" in f:
             new = f.replace('dev', 'valid')
             os.rename(os.path.join(valid_path, f), os.path.join(valid_path, new))


### PR DESCRIPTION
Happened to run

```
parlai display_data -t natural_questions -dt valid:stream
```

and ran into an issue about how it couldn't find the files. Digging into the built script and the output directory at `~/ParlAI/data/NaturalQuestions/valid`, I noticed the files were being stored at `nq-dev-00.jsonl` rather than `nq-valid-00.jsonl` as expected by the agent. This does a quick "move the files over" fix.

Test Plan:
Ran the build script, commenting out the steps to redownload + untar all the data. Verified that

```
parlai display_data -t natural_questions -dt valid:stream
```

was indeed successful.