### PR TITLE
Docs on crowdsourcing utility code

### DIFF
--- a/parlai/crowdsourcing/README.md
+++ b/parlai/crowdsourcing/README.md
@@ -45,3 +45,7 @@ By default, Mephisto data is saved in the following directory:
 - Internally, `<mephisto_root_dir>` defaults to `/scratch/${USER}/mephisto`.
 - The `NO_PROJECT` and `data` subfolders may be renamed in later versions of Mephisto.
 - `<agent_id>` can be mapped to MTurk `worker_id` with the `workers` table in the Mephisto SQLite3 database.
+
+### Utility functions
+
+See [this README](https://github.com/facebookresearch/ParlAI/blob/master/parlai/crowdsourcing/utils/README.md) for documentation on utility functions in the `utils` folder.

--- a/parlai/crowdsourcing/utils/README.md
+++ b/parlai/crowdsourcing/utils/README.md
@@ -1,8 +1,15 @@
 # Crowdsourcing utilities
 
+## Overview
+- `acceptability.py`: Used to ensure that a worker's messages throughout a conversation meet certain criteria (not too short, not all caps, not a lot of repetition, safety, etc.). More details about the acceptability checker can be found in the `acceptability.AcceptabilityChecker` section below.
+- `analysis.py`: Abstract base classes for compiling the results of crowdsourcing runs.
+- `frontend.py`: Method for compiling the frontend code of crowdsourcing tasks.
+- `mturk.py`: Code for soft-blocking MTurk crowdsourcing workers (preventing them from working on this specific task), as well as a Hydra flag to pass in lists of workers to soft-block.
+- `tests.py`: Abstract base classes for testing different categories of crowdsourcing tasks.
+- `worlds.py`: Abstract base classes for onboarding and chat worlds.
+
 ## `acceptability.AcceptabilityChecker`
 
-* Used to make sure that a worker's messages throughout a conversation meet certain criteria (not too short, not all caps, not a lot of repetition, safety, etc.)
 ### How to add a new check
 - Add the code for this in `.check_messages()`, inside a `if 'check_name' in violation_types:` condition
 - Add the name of the check to `self.ALL_VIOLATION_TYPES`; otherwise, this check will not be recognized, and an error will be raised if the check is specified when calling `.check_messages()`!


### PR DESCRIPTION
**Patch description**
Adds more documentation about the code in `crowdsourcing/utils/`, as well as a link to the `utils/` README in the main crowdsourcing README

**Testing steps**
None (only changing docs)