### PR TITLE
Zoo import error message improvement

### DIFF
--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -496,11 +496,12 @@ def modelzoo_path(datapath, path):
                 module_name_ = 'parlai.zoo.{}'.format(animal_)
                 my_module = importlib.import_module(module_name_)
                 my_module.download(datapath)
-            except (ImportError, AttributeError):
+            except (ImportError, AttributeError) as exc:
                 # truly give up
                 raise ImportError(
                     f'Could not find pretrained model in {module_name} or {module_name_}.'
-                )
+                    ' Please check your spelling and make sure you\'ve pulled from master.'
+                ) from exc
 
         return os.path.join(datapath, 'models', model_path)
     else:


### PR DESCRIPTION
**Patch description**
Changed to chained exception, added a bit more detail to the import error message when you specify a zoo model that doesn't exist 

**Testing steps**
E.g., 
`parlai display_model -t convai2 -m zoo:zzz`

Running this now results in: 
```
Traceback (most recent call last):
  File "/Users/margaretli/gitrepos/ParlAI/parlai/core/build_data.py", line 490, in modelzoo_path
    my_module = importlib.import_module(module_name)
  File "/Users/margaretli/miniconda3/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'parlai.zoo.zzz'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/margaretli/gitrepos/ParlAI/parlai/core/build_data.py", line 497, in modelzoo_path
    my_module = importlib.import_module(module_name_)
  File "/Users/margaretli/miniconda3/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'parlai.zoo.zzz'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "parlai/scripts/display_model.py", line 95, in <module>
    DisplayModel.main()
  File "/Users/margaretli/gitrepos/ParlAI/parlai/core/script.py", line 110, in main
    return cls._run_args(None)
  File "/Users/margaretli/gitrepos/ParlAI/parlai/core/script.py", line 82, in _run_args
    opt = parser.parse_args(args=args)
  File "/Users/margaretli/gitrepos/ParlAI/parlai/core/params.py", line 1128, in parse_args
    self.add_extra_args(args)
  File "/Users/margaretli/gitrepos/ParlAI/parlai/core/params.py", line 929, in add_extra_args
    model = get_model_name(parsed)
  File "/Users/margaretli/gitrepos/ParlAI/parlai/core/params.py", line 136, in get_model_name
    model_file = modelzoo_path(opt.get('datapath'), model_file)
  File "/Users/margaretli/gitrepos/ParlAI/parlai/core/build_data.py", line 501, in modelzoo_path
    raise ImportError(
ImportError: Could not find pretrained model in parlai.zoo.zzz.build or parlai.zoo.zzz.build. Please check your spelling and make sure you've pulled from master.
```