### PR TITLE
Allow varying number of student model heads during distillation

### DIFF
--- a/projects/anti_scaling/distillation.py
+++ b/projects/anti_scaling/distillation.py
@@ -767,7 +767,8 @@ class DistillTransformerAgentMixin(AbstractDistillTransformerAgentMixin):
                 "with --init-model!"
             )
         super().__init__(opt, shared)
-        assert self.teacher_agent_opt['n_heads'] == opt['n_heads']
+        if shared is None:
+            assert self.teacher_agent_opt['n_heads'] == opt['n_heads']
 
     def build_model(self):
 
@@ -861,9 +862,10 @@ class DistillNarrowTransformerAgentMixin(AbstractDistillTransformerAgentMixin):
         self.self_attn_loss_coeff = opt['self_attn_loss_coeff']
         self.enc_dec_attn_loss_coeff = opt['enc_dec_attn_loss_coeff']
         super().__init__(opt, shared)
-        assert self.teacher_agent_opt['n_heads'] == opt['n_heads'] or (
-            self.self_attn_loss_coeff == 0 and self.enc_dec_attn_loss_coeff == 0
-        ), 'The number of attention heads can only differ between the student and teacher models if both attention loss coefficients are 0!'
+        if shared is None:
+            assert self.teacher_agent_opt['n_heads'] == opt['n_heads'] or (
+                self.self_attn_loss_coeff == 0 and self.enc_dec_attn_loss_coeff == 0
+            ), 'The number of attention heads can only differ between the student and teacher models if both attention loss coefficients are 0!'
 
     def build_model(self):
         student_model = super().build_model()


### PR DESCRIPTION
**Patch description**
When doing knowledge distillation, allow for the number of attention heads in the student model to differ from that in the teacher model, provided that:
(1) We are doing TinyBERT-style distillation, in which the weights of the teacher model are not copied to the student
(2) The coefficients on the loss terms of the MSE of the attention matrices between the two models are both exactly 0, meaning that we do not have to minimize the differences between them, which would be impossible with a different number of attention heads in each model

**Testing steps**
Existing distillation CI checks
