### PR TITLE
Ignore unimportant coverage lines.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,5 @@ coverage:
     project: off
     patch: off
     changes: off
+ignore:
+  - parlai/tasks/*/build.py


### PR DESCRIPTION
**Patch description**
Stuff in build.py for various teachers only gets called randomly, as we have caches for our data. This patch excludes them from our coverage, as it's up to the cache whether we hit them or not, preventing fluctuations in our coverage.

**Testing steps**
CI