### PR TITLE
[TGA] Abstract TGA candidate ranking and fix ranking for BART

### DIFF
--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -244,9 +244,9 @@ class BartAgent(TransformerGeneratorAgent):
         """
         Rank eval label candidates.
 
-        Overridden from TorchGeneratorAgent because BART uses
-        both EOS-BOS tokens to start decoding. During scoring of
-        candidates, we must get rid of the score for the start token.
+        Overridden from TorchGeneratorAgent because BART uses both EOS-BOS tokens to
+        start decoding. During scoring of candidates, we must get rid of the score for
+        the start token.
         """
         cand_choices = []
         cand_choices_scores = []

--- a/parlai/agents/bart/bart.py
+++ b/parlai/agents/bart/bart.py
@@ -25,8 +25,6 @@ from parlai.core.message import Message
 from parlai.core.opt import Opt
 from parlai.core.params import ParlaiParser
 from parlai.core.torch_agent import History
-from parlai.core.torch_generator_agent import PPLMetric
-from parlai.core.metrics import AverageMetric
 from parlai.utils.typing import TShared
 from parlai.utils.io import PathManager
 from parlai.zoo.bart.build import download, CONVERSION_ARGS, BART_ARGS

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -864,6 +864,38 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         """
         pass
 
+    def _rank_eval_label_candidates(self, batch, batchsize):
+        """
+        Rank label_candidates during eval_step.
+
+        Can be overridden to allow for different ways of ranking candidates.
+        Must have `--rank-candidates` set to True. By default, we roughly compute
+        PPL to rank the candidates.
+        """
+        # compute roughly ppl to rank candidates
+        cand_choices = []
+        cand_choices_scores = []
+        encoder_states = self.model.encoder(*self._encoder_input(batch))
+        for i in range(batchsize):
+            num_cands = len(batch.candidate_vecs[i])
+            enc = self.model.reorder_encoder_states(encoder_states, [i] * num_cands)
+            cands, _ = self._pad_tensor(batch.candidate_vecs[i])
+            scores, _ = self.model.decode_forced(enc, cands)
+            cand_losses = F.cross_entropy(
+                scores.view(num_cands * cands.size(1), -1),
+                cands.view(-1),
+                reduction='none',
+            ).view(num_cands, cands.size(1))
+            # now cand_losses is cands x seqlen size, but we still need to
+            # check padding and such
+            mask = (cands != self.NULL_IDX).float()
+            cand_scores = (cand_losses * mask).sum(dim=1) / (mask.sum(dim=1) + 1e-9)
+            sorted_scores, ordering = cand_scores.sort()
+            cand_choices.append([batch.candidates[i][o] for o in ordering])
+            cand_choices_scores.append(sorted_scores.tolist())
+
+        return cand_choices, cand_choices_scores
+
     def eval_step(self, batch):
         """
         Evaluate a single batch of examples.
@@ -907,34 +939,18 @@ class TorchGeneratorAgent(TorchAgent, ABC):
                         continue
 
         cand_choices = None
-        # TODO: abstract out the scoring here
+        cand_scores = None
         if self.rank_candidates:
-            # compute roughly ppl to rank candidates
-            cand_choices = []
-            encoder_states = self.model.encoder(*self._encoder_input(batch))
-            for i in range(bsz):
-                num_cands = len(batch.candidate_vecs[i])
-                enc = self.model.reorder_encoder_states(encoder_states, [i] * num_cands)
-                cands, _ = self._pad_tensor(batch.candidate_vecs[i])
-                scores, _ = self.model.decode_forced(enc, cands)
-                cand_losses = F.cross_entropy(
-                    scores.view(num_cands * cands.size(1), -1),
-                    cands.view(-1),
-                    reduction='none',
-                ).view(num_cands, cands.size(1))
-                # now cand_losses is cands x seqlen size, but we still need to
-                # check padding and such
-                mask = (cands != self.NULL_IDX).float()
-                cand_scores = (cand_losses * mask).sum(dim=1) / (mask.sum(dim=1) + 1e-9)
-                _, ordering = cand_scores.sort()
-                cand_choices.append([batch.candidates[i][o] for o in ordering])
+            cand_choices, cand_scores = self._rank_eval_label_candidates(batch, bsz)
 
         text = [self._v2t(p) for p in preds] if preds is not None else None
         if text and self.compute_tokenized_bleu:
             # compute additional bleu scores
             self._compute_fairseq_bleu(batch, preds)
             self._compute_nltk_bleu(batch, text)
-        retval = Output(text, cand_choices, token_losses=token_losses)
+        retval = Output(
+            text, cand_choices, token_losses=token_losses, cand_scores=cand_scores
+        )
         if not self.skip_generation:
             retval.beam_texts = beam_texts
         return retval

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -864,7 +864,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         """
         pass
 
-    def _rank_eval_label_candidates(self, batch, batchsize):
+    def rank_eval_label_candidates(self, batch, batchsize):
         """
         Rank label_candidates during eval_step.
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -868,9 +868,9 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         """
         Rank label_candidates during eval_step.
 
-        Can be overridden to allow for different ways of ranking candidates.
-        Must have `--rank-candidates` set to True. By default, we roughly compute
-        PPL to rank the candidates.
+        Can be overridden to allow for different ways of ranking candidates. Must have
+        `--rank-candidates` set to True. By default, we roughly compute PPL to rank the
+        candidates.
         """
         # compute roughly ppl to rank candidates
         cand_choices = []

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -940,7 +940,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         cand_choices = None
         cand_scores = None
         if self.rank_candidates:
-            cand_choices, cand_scores = self._rank_eval_label_candidates(batch, bsz)
+            cand_choices, cand_scores = self.rank_eval_label_candidates(batch, bsz)
 
         text = [self._v2t(p) for p in preds] if preds is not None else None
         if text and self.compute_tokenized_bleu:


### PR DESCRIPTION
**Patch description**
Abstract Torch Generator Agent candidate ranking ability to a helper function. 

Then, override this helper function in BART so that we may delete the score for the start token. 

**Testing steps**
for BART:
```
parlai em -t convai2 --rank-candidates True -m bart --skip-generation True
```
for non-BART:
```
parlai em -t convai2 --rank-candidates True -mf zoo:blender/blender_90M/model --skip-generation Tru
```