### PR TITLE
Terminal chat fix

### DIFF
--- a/parlai/chat_service/services/terminal_chat/client.py
+++ b/parlai/chat_service/services/terminal_chat/client.py
@@ -11,6 +11,7 @@ import time
 import threading
 from parlai.core.params import ParlaiParser
 
+RUNNING = True
 
 def _get_rand_id():
     """
@@ -35,6 +36,8 @@ def on_message(ws, message):
     :param ws: a WebSocketApp
     :param message: json with 'text' field to be printed
     """
+    if not RUNNING:
+        return
     incoming_message = json.loads(message)
     print("\033[0m\n")
     print("Bot: " + incoming_message['text'])
@@ -71,16 +74,22 @@ def _run(ws, id):
 
     :param ws: websocket.WebSocketApp
     """
+    global RUNNING
     while True:
         x = input("\033[44m Me: ")
         print("\033[0m", end="")
         data = {}
         data['id'] = id
         data['text'] = x
+        if x == "[DONE]":
+            RUNNING = False
         json_data = json.dumps(data)
         ws.send(json_data)
         time.sleep(1)
         if x == "[DONE]":
+            time.sleep(1)
+            data['text'] = 'EXIT'
+            ws.send(json.dumps(data))
             break
     ws.close()
 

--- a/parlai/chat_service/services/terminal_chat/client.py
+++ b/parlai/chat_service/services/terminal_chat/client.py
@@ -13,6 +13,7 @@ from parlai.core.params import ParlaiParser
 
 RUNNING = True
 
+
 def _get_rand_id():
     """
     :return: The string of a random id using uuid4

--- a/parlai/chat_service/services/terminal_chat/client.py
+++ b/parlai/chat_service/services/terminal_chat/client.py
@@ -11,6 +11,11 @@ import time
 import threading
 from parlai.core.params import ParlaiParser
 
+# the socket callback functions operate asynchronously.
+# upon exit of a chat, we do not want the user to view any additional messages from the server.
+# alas, it is necessary to send two messages ([DONE], and EXIT) in order to fully exist the world pool
+# to prevent receiving a message after sending [DONE], we track the user's state with
+# this global variable.
 RUNNING = True
 
 

--- a/parlai/chat_service/tasks/chatbot/worlds.py
+++ b/parlai/chat_service/tasks/chatbot/worlds.py
@@ -121,12 +121,15 @@ class MessengerOverworld(World):
                 {
                     'id': 'Overworld',
                     'text': 'Welcome to the overworld for the ParlAI messenger '
-                    'chatbot demo. Please type "begin" to start.',
-                    'quick_replies': ['begin'],
+                    'chatbot demo. Please type "begin" to start, or "exit" to exit',
+                    'quick_replies': ['begin', 'exit'],
                 }
             )
             self.first_time = False
         a = self.agent.act()
+        if a is not None and a['text'].lower() == 'exit':
+            self.episode_done = True
+            return 'EXIT'
         if a is not None and a['text'].lower() == 'begin':
             self.episodeDone = True
             return 'default'


### PR DESCRIPTION
**Patch description**
Fix for terminal chat, as raised in #3451. (Fixes #3451)

Basically, the terminal chat client would close a connection when a user sent the `"[DONE]"` message; however, this did not cleanup the executing future in the background. Thus, if one reached greater than `max_workers` connections, the terminal chat server would ignore further incoming connections. 

Thus, we now have the terminal chat client send the `exit` message to close the overworld accordingly (as is handled [here](https://github.com/facebookresearch/ParlAI/blob/master/parlai/chat_service/core/world_runner.py#L174)).

**Testing steps**
I changed the `chatbot` config to `max_workers: 1`, and verified that, after the fix, new incoming connections are allowed.

**Logs**
![image](https://user-images.githubusercontent.com/8562788/108539230-b6fee980-72ad-11eb-85f3-6150823b9be3.png)
