### PR TITLE
Add truncate stats to training logs

### DIFF
--- a/docs/source/tutorial_metrics.md
+++ b/docs/source/tutorial_metrics.md
@@ -422,6 +422,8 @@ please [file an issue on GitHub](https://github.com/facebookresearch/ParlAI/issu
 | `accuracy`              | Exact match text accuracy |
 | `bleu-4`                | BLEU-4 of the generation, under a standardized (model-independent) tokenizer |
 | `clip`                  | Fraction of batches with clipped gradients |
+|`context_truncate`       | Ratio of samples' contexts being truncated per batch |
+|`context_length`         | Average length of context tokens per batch |
 | `ctpb`                  | Context tokens per batch |
 | `ctps`                  | Context tokens per second |
 | `exps`                  | Examples per second |
@@ -433,6 +435,8 @@ please [file an issue on GitHub](https://github.com/facebookresearch/ParlAI/issu
 | `interdistinct-1`, `interdictinct-2` | Fraction of n-grams unique across _all_ generations |
 | `intradistinct-1`, `intradictinct-2` | Fraction of n-grams unique _within_ each utterance |
 | `jga`                   | Joint Goal Accuracy |
+|`label_length`           | Average length of label tokens per batch |
+|`label_truncate`         | Ratio of samples' labels being truncated per batch |
 | `loss`                  | Loss |
 | `lr`                    | The most recent learning rate applied |
 | `ltpb`                  | Label tokens per batch |

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1998,7 +1998,7 @@ class TorchAgent(ABC, Agent):
         self.is_training = any('labels' in obs for obs in observations)
 
         # check if we should add truncate stats
-        if any('if_text_truncate' in obs for obs in observations):
+        if all('if_text_truncate' in obs for obs in observations):
             self.record_local_metric(
                 'tr',
                 AverageMetric.many(

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1357,7 +1357,9 @@ class TorchAgent(ABC, Agent):
             Truncate from the left side (keep the rightmost tokens). You
             probably want this True for inputs, False for targets.
         """
-        return self._vectorize_text_with_truncate_stats(**locals())[0]
+        return self._vectorize_text_with_truncate_stats(
+            text, add_start, add_end, truncate, truncate_left
+        )[0]
 
     def _check_truncate(self, vec, truncate, truncate_left=False):
         """

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1305,7 +1305,7 @@ class TorchAgent(ABC, Agent):
             new_vec.append(i)
         return self.dict.vec2txt(new_vec)
 
-    def _vectorize_text(
+    def _vectorize_text_with_truncate_stats(
         self, text, add_start=False, add_end=False, truncate=None, truncate_left=True
     ):
         """
@@ -1334,6 +1334,30 @@ class TorchAgent(ABC, Agent):
         if_truncated = original_length > len(vec)
         tensor = torch.LongTensor(vec)
         return tensor, original_length, if_truncated
+
+    def _vectorize_text(
+        self, text, add_start=False, add_end=False, truncate=None, truncate_left=True
+    ):
+        """
+        Return vector from text.
+
+        :param text:
+            String to vectorize.
+
+        :param add_start:
+            Add the start token to the front of the tensor.
+
+        :param add_end:
+            Add the end token to the end of the tensor.
+
+        :param truncate:
+            Truncate to this many tokens >= 0, or None.
+
+        :param truncate_left:
+            Truncate from the left side (keep the rightmost tokens). You
+            probably want this True for inputs, False for targets.
+        """
+        return self._vectorize_text_with_truncate_stats(**locals())[0]
 
     def _check_truncate(self, vec, truncate, truncate_left=False):
         """
@@ -1412,7 +1436,7 @@ class TorchAgent(ABC, Agent):
             # pick one label if there are multiple
             lbls = obs[label_type]
             label = lbls[0] if len(lbls) == 1 else self.random.choice(lbls)
-            vec_label, vec_label_length, vec_label_truncated = self._vectorize_text(
+            vec_label, vec_label_length, vec_label_truncated = self._vectorize_text_with_truncate_stats(
                 label, add_start, add_end, truncate, False
             )
             obs.force_set('original_label_length', vec_label_length)

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1376,7 +1376,7 @@ class TorchAgent(ABC, Agent):
             truncated_vec = self._check_truncate(
                 obs['text_vec'], truncate, truncate_left
             )
-            obs['if_text_truncate'] = text_length != len(truncated_vec)
+            obs.force_set('if_text_truncate', text_length != len(truncated_vec))
             obs.force_set('text_vec', torch.LongTensor(truncated_vec))
 
         return obs

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -1051,3 +1051,17 @@ class TestTorchAgent(unittest.TestCase):
             init_model_file, is_finetune = agent._get_init_model(popt, None)
             self.assertEqual(init_model_file, '{}.checkpoint'.format(mf))
             self.assertFalse(is_finetune)
+
+    def test_truncate_metrics(self):
+        agent = get_agent(model='test_agents/unigram', truncate=5)
+        obs = {
+            'text': "I'll be back. I'll be back. I'll be back.",
+            'labels': ["I'll be back. I'll be back. I'll be back."],
+            'episode_done': True,
+        }
+        obs = agent.observe(obs)
+        agent.act()
+        self.assertEqual(agent._local_metrics['context_truncate'][0].value(), 1.0)
+        self.assertEqual(agent._local_metrics['label_truncate'][0].value(), 1.0)
+        self.assertEqual(agent._local_metrics['context_length'][0].value(), 9)
+        self.assertEqual(agent._local_metrics['label_length'][0].value(), 11)


### PR DESCRIPTION
a**Patch description**
this adds a truncate stat to Torch Agent

**Testing steps**
Testing with existing training or evaluation script.
For example
```
 parlai em  -t wizard_of_wikipedia:Generator --prepend-gold-knowledge true  -mf ./model
```
```
13:32:30 | 0.1% complete (3 / 3,939), 0:00:10 elapsed, 3:46:03 eta
    accuracy    bleu-4  context_length  context_truncate  ctpb  ctps  exps  exs     f1  gpu_mem  label_length  label_truncate  loss       lr  ltpb  ltps   ppl  token_acc  total_train_updates   tpb  tps
           0 4.531e-11           184.3             .6667   103  29.9 .2903    3 .08522    .3847         31.33               0 2.693 1.51e-06 31.33 9.096 14.77      .4894               202171 134.3   39
13:32:40 | 0.2% complete (8 / 3,939), 0:00:20 elapsed, 2:50:51 eta
    accuracy    bleu-4  context_length  context_truncate  ctpb  ctps  exps  exs     f1  gpu_mem  label_length  label_truncate  loss       lr  ltpb  ltps   ppl  token_acc  total_train_updates   tpb   tps
           0 2.994e-09           227.2             .7500 111.8 42.86 .3835    8 .06685    .3337          26.5               0 2.724 1.51e-06  26.5 10.16 15.25      .4481               202171 138.2 53.02
13:32:55 | 0.4% complete (17 / 3,939), 0:00:35 elapsed, 2:17:40 eta
    accuracy  bleu-4  context_length  context_truncate  ctpb  ctps  exps  exs    f1  gpu_mem  label_length  label_truncate  loss       lr  ltpb  ltps  ppl  token_acc  total_train_updates   tpb   tps
           0  .01764           210.3             .6471 108.5 51.54 .4749   17 .1281    .3333         25.94               0  2.46 1.51e-06 25.94 12.32 11.7      .5125               202171 134.5 63.86
13:33:08 | 0.5% complete (20 / 3,939), 0:00:48 elapsed, 2:39:52 eta
    accuracy  bleu-4  context_length  context_truncate  ctpb  ctps  exps  exs    f1  gpu_mem  label_length  label_truncate  loss       lr  ltpb  ltps   ppl  token_acc  total_train_updates   tpb   tps
           0  .01499           216.1             .7000 111.5 45.54 .4086   20 .1383    .3339          27.7               0 2.523 1.51e-06  27.7 11.32 12.47      .4856               202171 139.2 56.86
13:33:20 | 0.6% complete (23 / 3,939), 0:01:01 elapsed, 2:54:19 eta
    accuracy  bleu-4  context_length  context_truncate  ctpb  ctps  exps  exs    f1  gpu_mem  label_length  label_truncate  loss       lr  ltpb  ltps   ppl  token_acc  total_train_updates   tpb   tps
           0  .01304           208.9             .6957 111.3 41.68 .3744   23 .1272    .3339         27.48               0 2.401 1.51e-06 27.48 10.29 11.03      .5127               202171 138.8 51.97
```

**Other information**
<!-- Any other information or context you would like to provide. -->
