### PR TITLE
Speed up conversation openers for self chat.

### DIFF
--- a/parlai/tasks/self_chat/worlds.py
+++ b/parlai/tasks/self_chat/worlds.py
@@ -8,7 +8,7 @@ import copy
 import random
 from typing import Any, Dict, List, Optional
 
-from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
+from parlai.agents.fixed_response.fixed_response import FixedResponseAgent
 from parlai.core.agents import Agent
 from parlai.core.worlds import create_task, DialogPartnerWorld, validate
 from parlai.core.message import Message
@@ -31,7 +31,8 @@ def load_openers(opt) -> Optional[List[str]]:
         task_opt['datatype'] = f'{datatype}:evalmode'
     task_opt['interactive_task'] = False
     task_opt['selfchat_task'] = False
-    task_agent = RepeatLabelAgent(task_opt)
+    task_opt['fixed_response'] = None
+    task_agent = FixedResponseAgent(task_opt)
     task_world = create_task(task_opt, task_agent)
 
     # run through task data, collecting all first messages

--- a/tests/test_self_chat.py
+++ b/tests/test_self_chat.py
@@ -20,7 +20,8 @@ class TestSelfChat(unittest.TestCase):
     def test_ed(self):
         SelfChat.main(
             task='empathetic_dialogues',
-            model_file='zoo:tutorial_transformer_generator/model',
+            model='fixed_response',
+            fixed_response='hi',
             seed_messages_from_task=True,
         )
 


### PR DESCRIPTION
**Patch description**
Speed up `tests/test_self_chat.py` from ~30s to ~1.5s

Methods:
- Avoid using a real model in the test, which is unnecessarily slow on CPU for unit tests
- Avoid using `repeat_label` when loading conversation openers, which causes metrics to be computed, slowing down things significantly.


**Testing steps**
CI