### PR TITLE
Upgrade metrics.py to use new type annotations.

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -7,6 +7,8 @@
 Provides standard metric evaluations for dialog, as well as an aggregator.
 """
 
+from __future__ import annotations
+
 import re
 from abc import ABC, abstractmethod
 from collections import Counter
@@ -55,7 +57,7 @@ re_art = re.compile(r'\b(a|an|the)\b')
 re_punc = re.compile(r'[!"#$%&()*+,-./:;<=>?@\[\]\\^`{|}~_\']')
 
 
-@functools.total_ordering
+@functools.total_ordering  # type: ignore
 class Metric(ABC):
     """
     Base class for storing metrics.
@@ -85,7 +87,7 @@ class Metric(ABC):
         pass
 
     @abstractmethod
-    def __add__(self, other: Any) -> 'Metric':
+    def __add__(self, other: Any) -> Metric:
         raise NotImplementedError
 
     def __iadd__(self, other):
@@ -156,7 +158,7 @@ class Metric(ABC):
         return int(cls.as_number(obj))
 
     @classmethod
-    def many(cls, *objs: List[TVector]) -> List['Metric']:
+    def many(cls, *objs: List[TVector]) -> List[Metric]:
         """
         Construct many of a Metric from the base parts.
 
@@ -181,7 +183,7 @@ class FixedMetric(Metric):
     def __init__(self, value: TScalar):
         self._value = self.as_number(value)
 
-    def __add__(self, other: Optional['FixedMetric']) -> 'FixedMetric':
+    def __add__(self, other: Optional[FixedMetric]) -> FixedMetric:
         if other is None:
             return self
         if self != other:
@@ -209,7 +211,7 @@ class SumMetric(Metric):
             assert isinstance(sum_, (int, float))
             self._sum = sum_
 
-    def __add__(self, other: Optional['SumMetric']) -> 'SumMetric':
+    def __add__(self, other: Optional[SumMetric]) -> SumMetric:
         # NOTE: hinting can be cleaned up with "from __future__ import annotations" when
         # we drop Python 3.6
         if other is None:
@@ -243,7 +245,7 @@ class AverageMetric(Metric):
         self._numer = self.as_number(numer)
         self._denom = self.as_number(denom)
 
-    def __add__(self, other: Optional['AverageMetric']) -> 'AverageMetric':
+    def __add__(self, other: Optional[AverageMetric]) -> AverageMetric:
         # NOTE: hinting can be cleaned up with "from __future__ import annotations" when
         # we drop Python 3.6
         if other is None:
@@ -275,7 +277,7 @@ class MacroAverageMetric(Metric):
     def __init__(self, metrics: Dict[str, Metric]) -> None:
         self._values = metrics
 
-    def __add__(self, other: Optional['MacroAverageMetric']) -> 'MacroAverageMetric':
+    def __add__(self, other: Optional[MacroAverageMetric]) -> MacroAverageMetric:
         if other is None:
             return self
         output = dict(**self._values)
@@ -297,14 +299,14 @@ class TimerMetric(Metric):
     __slots__ = ('_value', '_start', '_end')
 
     @classmethod
-    def _now(cls) -> int:
+    def _now(cls) -> float:
         return datetime.datetime.utcnow().timestamp()
 
     def __init__(
         self,
         value: TScalar,
-        start_time: Optional[int] = None,
-        end_time: Optional[int] = None,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
     ):
         self._value = self.as_number(value)
         if start_time is None:
@@ -314,14 +316,14 @@ class TimerMetric(Metric):
         self._start = start_time
         self._end = end_time
 
-    def __add__(self, other: Optional['TimerMetric']) -> 'TimerMetric':
+    def __add__(self, other: Optional[TimerMetric]) -> TimerMetric:
         # NOTE: hinting can be cleaned up with "from __future__ import annotations" when
         # we drop Python 3.6
         if other is None:
             return self
         total: TScalar = self._value + other._value
-        start: int = min(self._start, other._start)
-        end: int = max(self._start, other._end)
+        start: float = min(self._start, other._start)
+        end: float = max(self._start, other._end)
         return type(self)(total, start, end)
 
     def value(self) -> float:
@@ -416,7 +418,7 @@ class F1Metric(AverageMetric):
         return precision, recall, f1
 
     @staticmethod
-    def compute(guess: str, answers: List[str]) -> 'F1Metric':
+    def compute(guess: str, answers: List[str]) -> F1Metric:
         if guess is None or answers is None:
             return AverageMetric(0, 0)
         g_tokens = normalize_answer(guess).split()
@@ -429,7 +431,7 @@ class F1Metric(AverageMetric):
 
 class ExactMatchMetric(AverageMetric):
     @staticmethod
-    def compute(guess: str, answers: List[str]) -> 'ExactMatchMetric':
+    def compute(guess: str, answers: List[str]) -> ExactMatchMetric:
         if guess is None or answers is None:
             return None
         guess = normalize_answer(guess)
@@ -441,7 +443,7 @@ class ExactMatchMetric(AverageMetric):
 
 class BleuMetric(AverageMetric):
     @staticmethod
-    def compute(guess: str, answers: List[str], k: int = 4) -> Optional['BleuMetric']:
+    def compute(guess: str, answers: List[str], k: int = 4) -> Optional[BleuMetric]:
         """
         Compute approximate BLEU score between guess and a set of answers.
         """
@@ -487,9 +489,7 @@ class RougeMetric(AverageMetric):
     @staticmethod
     def compute_many(
         guess: str, answers: List[str]
-    ) -> Tuple[
-        Optional['RougeMetric'], Optional['RougeMetric'], Optional['RougeMetric']
-    ]:
+    ) -> Tuple[Optional[RougeMetric], Optional[RougeMetric], Optional[RougeMetric]]:
         """
         Compute ROUGE score between guess and *any* answer.
 
@@ -548,7 +548,7 @@ class IntraDistinctMetric(AverageMetric):
             n-gram length
         """
         tokens = normalize_answer(text).split()
-        counts = Counter(cls._ngram(tokens, ngram))
+        counts: Counter[Any] = Counter(cls._ngram(tokens, ngram))
         # computed per-example, macro averaged across examples
         intra = max(len(counts), 1e-12) / max(sum(counts.values()), 1e-5)
         return IntraDistinctMetric(intra, 1.0)


### PR DESCRIPTION
**Patch description**
Old cleanup that has been possible since we moved to python 3.7. Type annotations no longer need to be fake strings.

**Testing steps**
CI. Mypy passes locally.