### PR TITLE
Make batch'd beam_texts print correctly

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -16,7 +16,6 @@ Contains the following utilities:
   agents.
 * Beam class which provides some generic beam functionality for classes to use
 """
-
 from parlai.core.params import ParlaiParser
 from abc import ABC, abstractmethod
 from typing import TypeVar, List, Dict, Optional, Tuple, Set, Iterable
@@ -905,6 +904,11 @@ class TorchGeneratorAgent(TorchAgent, ABC):
                     except KeyError:
                         logging.error("Decoding error: %s", tokens)
                         continue
+            # reorder slightly so match_batch() handles correctly
+            stride = int(len(beam_texts) / batch.batchsize)
+            beam_texts = [
+                beam_texts[i : i + stride] for i in range(0, len(beam_texts), stride)
+            ]
 
         cand_choices = None
         # TODO: abstract out the scoring here


### PR DESCRIPTION
Summary: When batching, the index ordering for beam_texts is funky.

Test plan:
Run with `-v`

Prior to change:

```
[--batchsize 4--]
[batch world 0:]
[id]: internal:natural_questions_retrieval
[answers]: ["Wilhelm Conrad R\u00f6ntgen"]
[checked_sentence]: The first Nobel Prize in Physics was awarded in 1901 to Wilhelm Conrad Röntgen , of Germany , who received 150,782 SEK , which is equal to 7,731,004 SEK in December 2007 . John Bardeen is the only laureate to win the prize twice -- in 1956 and 1972 . Maria Skłodowska - Curie also won two Nobel Prizes , for physics in 1903 and chemistry in 1911 . William Lawrence Bragg was , until October 2014 , the youngest ever Nobel laureate ; he won the prize in 1915 at the age of 25 . Two women have won the prize : Curie and Maria Goeppert - Mayer ( 1963 ) . As of 2017 , the prize has been awarded to 206 individuals . There have been six years in which the Nobel Prize in Physics was not awarded ( 1916 , 1931 , 1934 , 1940 -- 1942 ) .
[title]: List of Nobel laureates in Physics
[text]: who got the first nobel prize in physics
[eval_labels]: Wilhelm Conrad Röntgen
   [id]: Rag
   [beam_texts]: ('Alfred Nobel', -0.4915494918823242)
  ('Wilhelm Röntgen', -0.6514154672622681)
  ('Alfred Nobel in Chemistry', -3.022096872329712)
  ('Royal Swedish Academy', -3.2390499114990234)
   [text]: Alfred Nobel
   [metrics]:
    accuracy  bleu-1  bleu-2  bleu-3  bleu-4  doc_r@1  doc_r@20  exact_match  exs  f1  interdistinct-1  interdistinct-2  intradistinct-1  intradistinct-2  loss  passage_r@1  passage_r@20   ppl  rouge_1  rouge_2  rouge_L  token_acc_max  token_acc_mean
           0       0       0       0       0        0         0            0    1   0                1                1                1                1 .9841            0             0 2.675        0        0        0          .8462           .7729
- - - - - - - END OF EPISODE - - - - - - - - - -
[batch world 1:]
[id]: internal:natural_questions_retrieval
[answers]: ["May 18 , 2018"]
[checked_sentence]: Deadpool 2 is scheduled to be released in the United States on May 18 , 2018 . A sequel , Deadpool 3 , is in development .
[title]: Deadpool 2
[text]: when is the next deadpool movie being released
[eval_labels]: May 18 , 2018
   [id]: Rag
   [beam_texts]: ("Jacobus Henricus van 't Hoff", -0.2451983094215393)
  ('Alfred Nobel', -1.1414905786514282)
  ('Jacobus Henricus van ‘t Hoff', -2.360704183578491)
  ("Henricus van 't Hoff", -3.1693713665008545)
  ('Jacobus Henricus', -3.710947275161743)
  ... (5 of 6 shown)
   [text]: May 18 , 2018
   [metrics]:
    accuracy  bleu-1  bleu-2  bleu-3  bleu-4  doc_r@1  doc_r@20  exact_match  exs  f1  interdistinct-1  interdistinct-2  intradistinct-1  intradistinct-2   loss  passage_r@1  passage_r@20   ppl  rouge_1  rouge_2  rouge_L  token_acc_max  token_acc_mean
           1       1       1       1   .0010        0         1            1    1   1                1                1                1                1 .03659            0             0 1.037        1
```

After this change:

```
[title]: List of Nobel laureates in Physics
[text]: who got the first nobel prize in physics
[eval_labels]: Wilhelm Conrad Röntgen
   [id]: Rag                                                                                 [beam_texts]: [('Philosopher Rhazes', -1.9699757099151611), ('Einstein', -3.44024658203125), ('Albert Einstein', -3.54020094871521), ('Richard Feynman', -3.7713513374328613), ('
Philosopher Rhaze', -7.10105562210083)]
  [('Aaron', -1.4629191160202026), ('Korah', -2.109790802001953), ('Eleazar', -2.270516872
406006), ('Levite', -2.429509401321411)]
  [('John F. Kennedy', -3.4256482124328613), ('Richard Feynman', -4.046080112457275), ('Josef Bican', -4.140071392059326), ('Joseph Fiennes', -5.3450140953063965)]
   [text]: Philosopher Rhazes
   [metrics]:
    accuracy  bleu-1  bleu-2  bleu-3  bleu-4  doc_r@1  doc_r@2  exact_match  exs  f1  inte
rdistinct-1  interdistinct-2  \                                                                      0       0       0       0       0        0        0            0    1   0
          1                1
    intradistinct-1  intradistinct-2  loss  passage_r@1  passage_r@2   ppl  rouge_1  rouge
_2  rouge_L  token_acc_max  \
                  1                1 1.188            0            0 3.279        0
 0        0          .8462
    token_acc_mean
             .7692
- - - - - - - END OF EPISODE - - - - - - - - - -
[batch world 1:]
[id]: internal:natural_questions_retrieval
[answers]: ["May 18 , 2018"]
[checked_sentence]: Deadpool 2 is scheduled to be released in the United States on May 18
, 2018 . A sequel , Deadpool 3 , is in development .
[title]: Deadpool 2
[text]: when is the next deadpool movie being released
[eval_labels]: May 18 , 2018
   [id]: Rag
   [beam_texts]: [('2018', -2.2126660346984863), ('April 24 , 2018', -4.08855676651001), (
'April 22 , 2018', -4.124880790710449), ('July 11 , 2018', -4.504889011383057), ('July 22
, 2018', -4.675393104553223)]
  [('2018', -1.8958760499954224), ('April 18 , 2018', -3.979194402694702), ('October 12 ,
2017', -4.123569965362549), ('April 24 , 2018', -4.137174129486084), ('April 22 , 2018', -
4.213203430175781)]
  [('2018', -2.088653564453125), ('October 12 , 2017', -3.701641798019409), ('October 24 ,
 2017', -4.187483310699463), ('August 22 , 2018', -4.273313045501709), ('August 21 , 2018'
, -4.307030200958252)]
   [text]: 2018
```

**Patch description**
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them. 
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
