### PR TITLE
Allow specifying output format of results compiler script

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py
+++ b/parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py
@@ -85,10 +85,10 @@ class ModelChatResultsCompiler(AbstractTurnAnnotationResultsCompiler):
 
         self.acceptability_checker = AcceptabilityChecker()
 
-    def get_results_path(self) -> str:
+    def get_results_path_base(self) -> str:
         now = datetime.now()
         return os.path.join(
-            self.output_folder, f'results_{now.strftime("%Y%m%d_%H%M%S")}.csv'
+            self.output_folder, f'results_{now.strftime("%Y%m%d_%H%M%S")}'
         )
 
     def compile_results(self) -> pd.DataFrame:

--- a/parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py
+++ b/parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py
@@ -483,4 +483,4 @@ class ModelChatResultsCompiler(AbstractTurnAnnotationResultsCompiler):
 if __name__ == '__main__':
     parser_ = ModelChatResultsCompiler.setup_args()
     args_ = parser_.parse_args()
-    ModelChatResultsCompiler(vars(args_)).save_compiled_results()
+    ModelChatResultsCompiler(vars(args_)).compile_and_save_results()

--- a/parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py
+++ b/parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py
@@ -114,7 +114,6 @@ class ModelChatResultsCompiler(AbstractTurnAnnotationResultsCompiler):
         print(f'Date folders: ' + ', '.join(date_strings))
 
         now = datetime.now()
-        results_file = self.get_results_path()
         worker_results_file = os.path.join(
             self.output_folder, f'worker_results_{now.strftime("%Y%m%d_%H%M%S")}.csv'
         )
@@ -476,8 +475,6 @@ class ModelChatResultsCompiler(AbstractTurnAnnotationResultsCompiler):
         all_conversations_df = pd.DataFrame()
         for df in conversation_dfs:
             all_conversations_df = all_conversations_df.append(df)
-        all_conversations_df.to_csv(results_file, index=False)
-        print(f'\nWrote all conversation results to: {results_file}')
         print(f'\nWorker conversation counts: {worker_conversation_counts}')
 
         return all_conversations_df

--- a/parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py
+++ b/parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py
@@ -483,4 +483,4 @@ class ModelChatResultsCompiler(AbstractTurnAnnotationResultsCompiler):
 if __name__ == '__main__':
     parser_ = ModelChatResultsCompiler.setup_args()
     args_ = parser_.parse_args()
-    ModelChatResultsCompiler(vars(args_)).compile_results()
+    ModelChatResultsCompiler(vars(args_)).save_compiled_results()

--- a/parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py
+++ b/parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py
@@ -85,6 +85,12 @@ class ModelChatResultsCompiler(AbstractTurnAnnotationResultsCompiler):
 
         self.acceptability_checker = AcceptabilityChecker()
 
+    def get_results_path(self) -> str:
+        now = datetime.now()
+        return os.path.join(
+            self.output_folder, f'results_{now.strftime("%Y%m%d_%H%M%S")}.csv'
+        )
+
     def compile_results(self) -> pd.DataFrame:
 
         read_folders = []
@@ -108,13 +114,9 @@ class ModelChatResultsCompiler(AbstractTurnAnnotationResultsCompiler):
         print(f'Date folders: ' + ', '.join(date_strings))
 
         now = datetime.now()
-        results_file = os.path.join(
-            self.output_folder,
-            f'results_{"".join([d + "_" for d in date_strings])[:-1]}_{now.strftime("%Y%m%d_%H%M%S")}.csv',
-        )
+        results_file = self.get_results_path()
         worker_results_file = os.path.join(
-            self.output_folder,
-            f'worker_results_{"".join([d + "_" for d in date_strings])[:-1]}_{now.strftime("%Y%m%d_%H%M%S")}.csv',
+            self.output_folder, f'worker_results_{now.strftime("%Y%m%d_%H%M%S")}.csv'
         )
         # Read in each file
         num_incomplete_convos = 0

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py
@@ -87,6 +87,13 @@ class TurnAnnotationsStaticResultsCompiler(AbstractTurnAnnotationResultsCompiler
                         read_folders.append(full_path)
         return read_folders
 
+    def get_results_path(self) -> str:
+        now = datetime.now()
+        return os.path.join(
+            self.output_folder,
+            f'{self.FILENAME_STUB}_{now.strftime("%Y%m%d_%H%M%S")}.csv',
+        )
+
     def compile_results(self) -> pd.DataFrame:
         # Loads data from files and gets rid of incomplete or malformed convos
         conversations = self.compile_initial_results(self.results_folders)
@@ -104,10 +111,7 @@ class TurnAnnotationsStaticResultsCompiler(AbstractTurnAnnotationResultsCompiler
         # Write out to files
         os.makedirs(self.output_folder, exist_ok=True)
         now = datetime.now()
-        results_file = os.path.join(
-            self.output_folder,
-            f'{self.FILENAME_STUB}_{now.strftime("%Y%m%d_%H%M%S")}.csv',
-        )
+        results_file = self.get_results_path()
         master_dataframe.to_csv(results_file, index=False)
         print(f'Wrote aggregated utterance data to: {results_file}')
 

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py
@@ -108,13 +108,6 @@ class TurnAnnotationsStaticResultsCompiler(AbstractTurnAnnotationResultsCompiler
         if self.CALCULATE_STATS_INTERANNOTATOR_AGREEMENT:
             self.calculate_stats_interannotator_agreement(master_dataframe)
 
-        # Write out to files
-        os.makedirs(self.output_folder, exist_ok=True)
-        now = datetime.now()
-        results_file = self.get_results_path()
-        master_dataframe.to_csv(results_file, index=False)
-        print(f'Wrote aggregated utterance data to: {results_file}')
-
         return master_dataframe
 
     def _validate_hit(self, hit_data) -> Tuple[bool, Optional[str]]:

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py
@@ -530,4 +530,4 @@ class TurnAnnotationsStaticResultsCompiler(AbstractTurnAnnotationResultsCompiler
 if __name__ == '__main__':
     parser_ = TurnAnnotationsStaticResultsCompiler.setup_args()
     args = parser_.parse_args()
-    TurnAnnotationsStaticResultsCompiler(vars(args)).save_compiled_results()
+    TurnAnnotationsStaticResultsCompiler(vars(args)).compile_and_save_results()

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py
@@ -87,11 +87,10 @@ class TurnAnnotationsStaticResultsCompiler(AbstractTurnAnnotationResultsCompiler
                         read_folders.append(full_path)
         return read_folders
 
-    def get_results_path(self) -> str:
+    def get_results_path_base(self) -> str:
         now = datetime.now()
         return os.path.join(
-            self.output_folder,
-            f'{self.FILENAME_STUB}_{now.strftime("%Y%m%d_%H%M%S")}.csv',
+            self.output_folder, f'{self.FILENAME_STUB}_{now.strftime("%Y%m%d_%H%M%S")}'
         )
 
     def compile_results(self) -> pd.DataFrame:

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py
@@ -530,4 +530,4 @@ class TurnAnnotationsStaticResultsCompiler(AbstractTurnAnnotationResultsCompiler
 if __name__ == '__main__':
     parser_ = TurnAnnotationsStaticResultsCompiler.setup_args()
     args = parser_.parse_args()
-    TurnAnnotationsStaticResultsCompiler(vars(args)).compile_results()
+    TurnAnnotationsStaticResultsCompiler(vars(args)).save_compiled_results()

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -49,14 +49,14 @@ class AbstractResultsCompiler(ABC):
         self.output_folder = opt.get('output_folder')
         self.results_format = opt['results_format']
 
-    def get_results_path(self) -> str:
+    def get_results_path_base(self) -> str:
         """
-        Return the save path for the results file.
+        Return the save path for the results file, not including the file extension.
         """
         now = datetime.now()
         return os.path.join(
             self.output_folder,
-            f'{self.__class__.__name__}__{now.strftime("%Y%m%d_%H%M%S")}.csv',
+            f'{self.__class__.__name__}__{now.strftime("%Y%m%d_%H%M%S")}',
         )
 
     @abstractmethod
@@ -74,7 +74,8 @@ class AbstractResultsCompiler(ABC):
         Results will be saved in the format given by --results-format.
         """
         result_df = self.compile_results()
-        results_path = self.get_results_path()
+        results_path_base = self.get_results_path_base()
+        results_path = f'{results_path_base}.{self.results_format}'
         os.makedirs(self.output_folder, exist_ok=True)
         if self.results_format == 'csv':
             result_df.to_csv(results_path, index=False)

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -67,7 +67,7 @@ class AbstractResultsCompiler(ABC):
         Each row of the dataframe consists of one utterance of one conversation.
         """
 
-    def save_results(self):
+    def save_compiled_results(self):
         """
         Compile and save results.
 

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -75,6 +75,7 @@ class AbstractResultsCompiler(ABC):
         """
         result_df = self.compile_results()
         results_path = self.get_results_path()
+        os.makedirs(self.output_folder, exist_ok=True)
         if self.results_format == 'csv':
             result_df.to_csv(results_path, index=False)
         elif self.results_format == 'jsonl':
@@ -84,6 +85,7 @@ class AbstractResultsCompiler(ABC):
             raise ValueError(
                 f'Results save format of "{self.results_format}" currently unsupported!'
             )
+        print(f'Wrote results file to {results_path}.')
 
 
 class AbstractTurnAnnotationResultsCompiler(AbstractResultsCompiler):

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -7,8 +7,11 @@
 from __future__ import annotations
 
 import argparse
+import os
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Any, Dict, List
+
 import pandas as pd
 
 # Defining the class only if Mephisto is installed, since it relies on Mephisto
@@ -46,11 +49,15 @@ class AbstractResultsCompiler(ABC):
         self.output_folder = opt.get('output_folder')
         self.results_format = opt['results_format']
 
-    @abstractmethod
     def get_results_path(self) -> str:
         """
         Return the save path for the results file.
         """
+        now = datetime.now()
+        return os.path.join(
+            self.output_folder,
+            f'{self.__class__.__name__}__{now.strftime("%Y%m%d_%H%M%S")}.csv',
+        )
 
     @abstractmethod
     def compile_results(self) -> pd.DataFrame:

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -80,7 +80,8 @@ class AbstractResultsCompiler(ABC):
         if self.results_format == 'csv':
             result_df.to_csv(results_path, index=False)
         elif self.results_format == 'json':
-            result_df.to_json(results_path)
+            result_df.reset_index().to_json(results_path)
+            # Reset the index to make each row have a unique index value
         else:
             raise ValueError(
                 f'Results save format of "{self.results_format}" currently unsupported!'

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -67,9 +67,9 @@ class AbstractResultsCompiler(ABC):
         Each row of the dataframe consists of one utterance of one conversation.
         """
 
-    def save_compiled_results(self):
+    def compile_and_save_results(self):
         """
-        Compile and save results.
+        Compile results and save them.
 
         Results will be saved in the format given by --results-format.
         """

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -39,7 +39,7 @@ class AbstractResultsCompiler(ABC):
         parser.add_argument(
             '--results-format',
             type=str,
-            choices=['csv', 'jsonl'],
+            choices=['csv', 'json'],
             default='csv',
             help='Output format for results data',
         )
@@ -78,9 +78,8 @@ class AbstractResultsCompiler(ABC):
         os.makedirs(self.output_folder, exist_ok=True)
         if self.results_format == 'csv':
             result_df.to_csv(results_path, index=False)
-        elif self.results_format == 'jsonl':
-            # {{{TODO: save in the jsonl format}}}
-            pass  # TODO: remove
+        elif self.results_format == 'json':
+            result_df.to_json(results_path)
         else:
             raise ValueError(
                 f'Results save format of "{self.results_format}" currently unsupported!'

--- a/projects/anti_scaling/scripts/remove_projection_matrices.py
+++ b/projects/anti_scaling/scripts/remove_projection_matrices.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
-import shutil
 
 import torch
 
@@ -19,8 +18,8 @@ def remove_projection_matrices(model_file: str):
     Remove all projection matrices used for distillation from the model and re-save it.
     """
 
-    print(f'Creating a backup copy of the original model at {model_file}.')
-    shutil.copyfile(model_file, f'{model_file}._orig')
+    print(f'Creating a backup copy of the original model at {model_file}._orig.')
+    PathManager.copy(model_file, f'{model_file}._orig')
 
     print(f"Loading {model_file}.")
     with PathManager.open(model_file, 'rb') as f:

--- a/tests/crowdsourcing/tasks/model_chat/test_model_chat_analysis.py
+++ b/tests/crowdsourcing/tasks/model_chat/test_model_chat_analysis.py
@@ -62,7 +62,7 @@ try:
     """
                     parser_ = ModelChatResultsCompiler.setup_args()
                     args_ = parser_.parse_args(arg_string.split())
-                    ModelChatResultsCompiler(vars(args_)).compile_results()
+                    ModelChatResultsCompiler(vars(args_)).save_compiled_results()
                     stdout = output.getvalue()
 
                 # Define output structure

--- a/tests/crowdsourcing/tasks/model_chat/test_model_chat_analysis.py
+++ b/tests/crowdsourcing/tasks/model_chat/test_model_chat_analysis.py
@@ -62,7 +62,7 @@ try:
     """
                     parser_ = ModelChatResultsCompiler.setup_args()
                     args_ = parser_.parse_args(arg_string.split())
-                    ModelChatResultsCompiler(vars(args_)).save_compiled_results()
+                    ModelChatResultsCompiler(vars(args_)).compile_and_save_results()
                     stdout = output.getvalue()
 
                 # Define output structure

--- a/tests/crowdsourcing/tasks/turn_annotations_static/test_turn_annotations_static_analysis.py
+++ b/tests/crowdsourcing/tasks/turn_annotations_static/test_turn_annotations_static_analysis.py
@@ -107,7 +107,7 @@ try:
                     compiler = TurnAnnotationsStaticResultsCompiler(vars(args))
                     compiler.NUM_SUBTASKS = 3
                     compiler.NUM_ANNOTATIONS = 3
-                    compiler.save_compiled_results()
+                    compiler.compile_and_save_results()
                     actual_stdout = output.getvalue()
 
                 # Check the output against what it should be

--- a/tests/crowdsourcing/tasks/turn_annotations_static/test_turn_annotations_static_analysis.py
+++ b/tests/crowdsourcing/tasks/turn_annotations_static/test_turn_annotations_static_analysis.py
@@ -107,7 +107,7 @@ try:
                     compiler = TurnAnnotationsStaticResultsCompiler(vars(args))
                     compiler.NUM_SUBTASKS = 3
                     compiler.NUM_ANNOTATIONS = 3
-                    compiler.compile_results()
+                    compiler.save_compiled_results()
                     actual_stdout = output.getvalue()
 
                 # Check the output against what it should be


### PR DESCRIPTION
**Patch description**
Allows for saving the output of code to compile crowdsourcing conversations in an arbitrary file format. Currently, only CSV and a very rudimentary JSON format are supported, but other formats can easily be added in the future.

As part of this, a new method has been created in the abstract compiler class, `.compile_and_save_results()`, which will save compiled results, unlike the existing `.compile_results()` which will now only return the compiled results to be saved later.

**Testing steps**
CI checks:
```
pytest tests/crowdsourcing/tasks/model_chat/test_model_chat_analysis.py
pytest tests/crowdsourcing/tasks/turn_annotations_static/test_turn_annotations_static_analysis.py
```

Testing the full model-chat compilation script on the command line:
```
python parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py \
--results-folders ~/GitHub/facebookresearch/ParlAI/tests/crowdsourcing/tasks/model_chat/analysis_samples \
--output-folder ~/__temp
python parlai/crowdsourcing/tasks/model_chat/analysis/compile_results.py \
--results-folders ~/GitHub/facebookresearch/ParlAI/tests/crowdsourcing/tasks/model_chat/analysis_samples \
--output-folder ~/__temp \
--results-format json
```

Testing the full static-turn-annotations compilation script on the command line (required temporarily changing both NUM_SUBTASKS and NUM_ANNOTATIONS to 3 to analyze the sample results files):
```
ANALYSIS_SAMPLES_FOLDER=~/GitHub/facebookresearch/ParlAI/tests/crowdsourcing/tasks/turn_annotations_static/analysis_samples
python parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py \
--results-folders ${ANALYSIS_SAMPLES_FOLDER} \
--output-folder ~/__temp_turn_annotations_static \
--onboarding-in-flight-data-file ${ANALYSIS_SAMPLES_FOLDER}/onboarding_in_flight.jsonl
python parlai/crowdsourcing/tasks/turn_annotations_static/analysis/compile_results.py \
--results-folders ${ANALYSIS_SAMPLES_FOLDER} \
--output-folder ~/__temp_turn_annotations_static \
--onboarding-in-flight-data-file ${ANALYSIS_SAMPLES_FOLDER}/onboarding_in_flight.jsonl \
--results-format json
```
