### PR TITLE
Fixing test flakiness

### DIFF
--- a/tests/test_multiworld.py
+++ b/tests/test_multiworld.py
@@ -79,7 +79,7 @@ class TestMultiworld(unittest.TestCase):
         # stochastic so wide range
         ratio = report['teacher1/exs'].value() / report['teacher2/exs'].value()
         assert ratio > 18
-        assert ratio < 22
+        assert ratio < 45
 
     def test_with_stream(self):
         """


### PR DESCRIPTION
The test `test_stochastic` is flaky. Currently it is being re-run 10 times to ensure it passes. In this PR, I propose to adjust the assertion bound instead to save on re-running time and make the test pass without re-runs.

To find a solution, I collected samples of value of `ratio` in the assertion on line 82 from several test executions and computed the tail distribution. I computed the extreme percentiles to check how high can the values be. The computed percentiles are as follows:

```
0.9 :: 9.980972491730343
0.99 :: 42.90769623290866
0.999 :: 44.45376722096181
0.9999 :: 44.45454509406085
```

Based on this analysis, I think updating the assertion bound to 45 would reduce the flakiness a lot.  I think setting the bound using the statistical evaluation might be a good way to ensure the test is not too flaky.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions. Also, here I assume there are no bugs in the code under test.