### PR TITLE
Remove APEX

### DIFF
--- a/parlai/agents/image_seq2seq/modules.py
+++ b/parlai/agents/image_seq2seq/modules.py
@@ -16,7 +16,6 @@ import torch.nn as nn
 from parlai.agents.transformer.modules import (
     TransformerGeneratorModel,
     TransformerEncoder,
-    _normalize,
 )
 from parlai.core.dict import DictionaryAgent
 from parlai.core.opt import Opt
@@ -328,14 +327,14 @@ class ContextWithImageEncoder(TransformerEncoder):
 
         # WARNING: Below follows the rest of TransformerEncoder.forward
         if self.variant == 'xlm':
-            tensor = _normalize(tensor, self.norm_embeddings)
+            tensor = self.norm_embeddings(tensor)
         # --dropout on the embeddings
         tensor = self.dropout(tensor)
         tensor *= mask.unsqueeze(-1).type_as(tensor)
         # apply transformer layers
         tensor = self.forward_layers(tensor, mask)
         if self.variant == 'prelayernorm':
-            tensor = _normalize(tensor, self.norm_embeddings)
+            tensor = self.norm_embeddings(tensor)
         # reduce output
         tensor, out_mask = self.reduce_output(tensor, mask)
         return tensor, out_mask

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -719,7 +719,7 @@ class TorchAgent(ABC, Agent):
         self.fp16 = self.use_cuda and self.opt.get('fp16', False)
         if self.fp16:
             # check that the implementation requested is available
-            self.fp16_impl = self.opt.get('fp16_impl', 'pytorch')
+            self.fp16_impl = self.opt.get('fp16_impl', 'safe')
 
         if shared is None:
             # intitialize any important structures from scratch

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -2154,7 +2154,6 @@ class TorchAgent(ABC, Agent):
             self.global_metrics.add('gnorm', GlobalAverageMetric(grad_norm))
 
         if self.fp16:
-            print(self.optimizer.loss_scale, self.scheduler.get_last_lr())
             self.global_metrics.add(
                 'fp16_loss_scalar', GlobalAverageMetric(self.optimizer.loss_scale)
             )

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -899,7 +899,7 @@ class TorchAgent(ABC, Agent):
         is_train = 'train' in datatype and 'evalmode' not in datatype
         return is_train
 
-    def init_optim(self, params, optim_states=None, saved_optim_type=None):
+    def init_optim(self, params, optim_states=None, saved_optim_type=None) -> bool:
         """
         Initialize optimizer with model parameters.
 
@@ -912,6 +912,10 @@ class TorchAgent(ABC, Agent):
         :param saved_optim_type:
             type of optimizer being loaded, if changed will skip loading
             optimizer states
+
+        :returns:
+            boolean indicating whether the optimizer was initialized with
+            optim_states.
         """
         if hasattr(self, 'resized_embeddings') and self.resized_embeddings:
             optim_states = None

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -630,7 +630,6 @@ class TorchGeneratorAgent(TorchAgent, ABC):
 
         This is also used in distributed mode to force a worker to sync with others.
         """
-        return
         if self.use_cuda and (force or not hasattr(self, 'buffer_initialized')):
             try:
                 self._control_local_metrics(disabled=True)

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -523,9 +523,6 @@ class TorchGeneratorAgent(TorchAgent, ABC):
                 f"Total parameters: {total_params:,d} ({train_params:,d} trainable)"
             )
 
-            if self.fp16:
-                self.model = self.model.half()
-
             if init_model is not None:
                 # load model parameters if available
                 logging.info(f'Loading existing model params from {init_model}')
@@ -550,6 +547,9 @@ class TorchGeneratorAgent(TorchAgent, ABC):
             self.model = torch.nn.parallel.DistributedDataParallel(
                 self.model, device_ids=device_ids, broadcast_buffers=False
             )
+
+        if shared is None and self.fp16:
+            self.model = self.model.half()
 
         self.reset()
 

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -366,6 +366,10 @@ class TrainLoop:
                 self.train_time.total = obj.get('train_time', 0)
                 self.impatience = obj.get('impatience', 0)
                 self.valid_reports = obj.get('valid_reports', [])
+                if self.valid_reports:
+                    self.last_valid_epoch = self.valid_reports[-1].get(
+                        'total_epochs', 0.0
+                    )
                 self.train_reports = obj.get('train_reports', [])
                 if 'best_valid' in obj:
                     self.best_valid = obj['best_valid']

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -276,10 +276,15 @@ class SafeFP16Optimizer(torch.optim.Optimizer):
 
 class DynamicLossScaler(object):
     """
-    Shamelessly stolen from Fairseq.
+    Dynamically adjusts the loss scaling factor.
 
-    Dynamically adjusts the loss scaling factor. Useful for mixed-precision training.
-    Fairseq implementation can be found here:
+    Dynamic loss scalers are important in mixed-precision training. They help
+    us avoid underflows and overflows in low-precision gradients.
+
+    See here for information:
+    <https://docs.nvidia.com/deeplearning/performance/mixed-precision-training/index.html#lossscaling>
+
+    Shamelessly stolen and adapted from Fairseq.
     <https://github.com/pytorch/fairseq/blob/master/fairseq/optim/fp16_optimizer.py>
     """
 
@@ -365,7 +370,7 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
     <https://github.com/pytorch/fairseq/blob/master/fairseq/optim/fp16_optimizer.py#L382>
 
     This allows you to train bigger models on a single GPU, but can be unstable.
-    Opt for the Pytorch implementation if you do not have concerns about memory.
+    Prefer the SafeFP16 implementation if you do not have concerns about memory.
 
     :param params:
         Model parameters

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -496,7 +496,7 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         Return the optimizer's state dict.
         """
         state_dict = self.optimizer.state_dict()
-        state_dict['loss_scaler'] = self.scaler
+        state_dict['loss_scaler'] = self.scaler.loss_scale
         return state_dict
 
     def load_state_dict(self, state_dict):
@@ -507,7 +507,12 @@ class MemoryEfficientFP16Optimizer(torch.optim.Optimizer):
         """
         if 'loss_scaler' in state_dict:
             # init from the state dict
-            self.scaler = state_dict['loss_scaler']
+            if isinstance(state_dict['loss_scaler'], float):
+                # new method, restore the float
+                self.scaler.loss_scale = state_dict['loss_scaler']
+            else:
+                # old method, we stored the entire loss scaler
+                self.scaler.loss_scale = state_dict['loss_scaler'].loss_scale
 
         self.optimizer.load_state_dict(state_dict)
 

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -60,9 +60,12 @@ def clip_grad_norm(params, max_norm):
     """
     Clips grad norm.
     """
+    if isinstance(params, torch.Tensor):
+        params = [params]
+    # make sure any generators are expanded
     params = list(params)
     if len(params) == 1:
-        p = params[0]
+        p = params[0].grad
         grad_norm = torch.norm(p)
         if grad_norm > max_norm > 0:
             clip_coef = max_norm / (grad_norm + 1e-6)
@@ -85,68 +88,173 @@ def has_overflow(grad_norm):
     return False
 
 
-###################################################
-## APEX Wrapper
-###################################################
+class PytorchFP16Optimizer(torch.optim.Optimizer):
+    def __init__(self, optimizer):
+        self.fp16_params = self._get_parameters(optimizer)
+        self.fp32_params = self._build_fp32_params(self.fp16_params, flatten=False)
+        self.optimizer = optimizer
 
+        # we want the optimizer to be tracking the fp32 parameters
+        if len(optimizer.param_groups) != 1:
+            # future implementers: this should hopefully be a matter of just
+            # iterating through the param groups and keeping track of the pointer
+            # through the fp32_params
+            raise NotImplementedError("Need to implement the parameter group transfer.")
+        optimizer.param_groups[0]['params'] = self.fp32_params
 
-def fp16_optimizer_wrapper(
-    optimizer: torch.optim.Optimizer,  # type: ignore
-    verbose: bool = False,
-    dynamic_loss_scale: bool = True,
-    loss_initial_scale: float = 2.0 ** 17,
-):
-    """
-    Wrap the an optimizer with FP16 loss scaling protection.
+        self.scaler = DynamicLossScaler(2.0 ** 15)
+        self.min_loss_scale = 2 ** -5
 
-    Requires apex to be installed. Will throw an ImportError if it is not.
+    @classmethod
+    def _get_parameters(cls, optimizer):
+        params = []
+        for pg in optimizer.param_groups:
+            params += list(pg['params'])
+        return params
 
-    :param optimizer:
-        Any torch optimizer
-    :param bool verbose:
-        Enables verbose output in the FP16 optimizer. Turning this on can help
-        debug when FP16 is underperforming.
-    :param bool dynamic_loss_scaling:
-        FP16 requires loss scaling to avoid underflows. It is recommended this
-        stays on, but advanced users may want it off.
-    :param float loss_initial_scale:
-        Initial loss scaling. Default chosen empirically, but models with very low
-        or high loss values may need this adjusted. Stick with powers of 2.
+    @classmethod
+    def _build_fp32_params(cls, params, flatten=True):
+        # create FP32 copy of parameters and grads
+        if flatten:
+            total_param_size = sum(p.data.numel() for p in params)
+            fp32_params = torch.zeros(
+                total_param_size, dtype=torch.float, device=params[0].device
+            )
+            offset = 0
+            for p in params:
+                numel = p.data.numel()
+                fp32_params[offset : offset + numel].copy_(p.data.view(-1))
+                offset += numel
+            fp32_params = torch.nn.Parameter(fp32_params)
+            fp32_params.grad = fp32_params.data.new(total_param_size)
+            return fp32_params
+        else:
+            fp32_params = []
+            for p in params:
+                p32 = torch.nn.Parameter(p.data.float())
+                p32.grad = torch.zeros_like(p32.data)
+                fp32_params.append(p32)
+            return fp32_params
 
-    :returns:
-        An APEX FP16 optimizer. Please note this has different requirements on
-        how backward() and step() are called.
-    """
-    try:
-        import apex.fp16_utils
-    except ImportError:
-        raise ImportError(
-            'No fp16 support without apex. Please install it from '
-            'https://github.com/NVIDIA/apex'
-        )
-    return apex.fp16_utils.FP16_Optimizer(
-        optimizer,
-        dynamic_loss_scale=dynamic_loss_scale,
-        verbose=verbose,
-        # TODO: We may later want to remove this flag. Right now it
-        # empirically improves the first few backward passes, but future APEX
-        # improvements may make this unnecessary.
-        dynamic_loss_args={'init_scale': loss_initial_scale},
-    )
+    def state_dict(self):
+        """Return the optimizer's state dict."""
+        state_dict = self.optimizer.state_dict()
+        if self.scaler is not None:
+            state_dict['loss_scale'] = self.scaler.loss_scale
+        return state_dict
 
+    def load_state_dict(self, state_dict, optimizer_overrides=None):
+        """Load an optimizer state dict.
 
-def fp16_apex_available() -> bool:
-    try:
-        import apex.fp16_utils  # noqa: F401
+        In general we should prefer the configuration of the existing optimizer
+        instance (e.g., learning rate) over that found in the state_dict. This
+        allows us to resume training from a checkpoint using a new set of
+        optimizer args.
+        """
+        if 'loss_scale' in state_dict and self.scaler is not None:
+            self.scaler.loss_scale = state_dict['loss_scale']
+        self.optimizer.load_state_dict(state_dict, optimizer_overrides)
 
-        return True
-    except ImportError:
-        error_once(
-            'You set --fp16 true with --fp16-impl apex, but fp16 '
-            'with apex is unavailable. To use apex fp16, please '
-            'install APEX from https://github.com/NVIDIA/apex.'
-        )
-        return False
+    def backward(self, loss, update_master_grads=False):
+        """Computes the sum of gradients of the given tensor w.r.t. graph leaves.
+
+        Compared to :func:`fairseq.optim.FairseqOptimizer.backward`, this
+        function additionally dynamically scales the loss to avoid gradient
+        underflow.
+        """
+        if self.scaler is not None:
+            loss = loss * self.scaler.loss_scale
+        loss.backward()
+        self._needs_sync = True
+        if update_master_grads:
+            self.update_master_grads()
+
+    def _sync_fp16_grads_to_fp32(self, multiply_grads=1.0):
+        if self._needs_sync:
+            if self.scaler is not None:
+                # correct for dynamic loss scaler
+                multiply_grads /= self.scaler.loss_scale
+
+            # copy FP16 grads to FP32
+            for p, p32 in zip(self.fp16_params, self.fp32_params):
+                if not p.requires_grad:
+                    continue
+                if p.grad is not None:
+                    p32.grad.data.copy_(p.grad.data)
+                    p32.grad.data.mul_(multiply_grads)
+                else:
+                    p32.grad = torch.zeros_like(p.data, dtype=torch.float)
+
+            self._needs_sync = False
+
+    def multiply_grads(self, c):
+        """Multiplies grads by a constant ``c``."""
+        if self._needs_sync:
+            self._sync_fp16_grads_to_fp32(c)
+        else:
+            for p32 in self.fp32_params:
+                p32.grad.data.mul_(c)
+
+    def update_master_grads(self):
+        self._sync_fp16_grads_to_fp32()
+
+    def clip_master_grads(self, max_norm):
+        """Clips gradient norm and updates dynamic loss scaler."""
+        self._sync_fp16_grads_to_fp32()
+        grad_norm = clip_grad_norm(self.fp32_params, max_norm)
+
+        # detect overflow and adjust loss scale
+        if self.scaler is not None:
+            overflow = has_overflow(grad_norm)
+            prev_scale = self.scaler.loss_scale
+            self.scaler.update_scale(overflow)
+            if overflow:
+                if self.scaler.loss_scale <= self.min_loss_scale:
+                    # Use FloatingPointError as an uncommon error that parent
+                    # functions can safely catch to stop training.
+                    self.scaler.loss_scale = prev_scale
+                    raise FloatingPointError(
+                        (
+                            'Minimum loss scale reached ({}). Your loss is probably exploding. '
+                            'Try lowering the learning rate, using gradient clipping or '
+                            'increasing the batch size.'
+                        ).format(self.min_loss_scale)
+                    )
+                logging.info('setting loss scale to: ' + str(self.scaler.loss_scale))
+
+        return grad_norm
+
+    def step(self, closure=None):
+        """Performs a single optimization step."""
+        self._sync_fp16_grads_to_fp32()
+        self.optimizer.step(closure)
+
+        # copy FP32 params back into FP16 model
+        for p, p32 in zip(self.fp16_params, self.fp32_params):
+            if not p.requires_grad:
+                continue
+            p.data.copy_(p32.data)
+
+    def zero_grad(self):
+        """Clears the gradients of all optimized parameters."""
+        for p in self.fp16_params:
+            p.grad = None
+        for p32 in self.fp32_params:
+            p32.grad.zero_()
+        self._needs_sync = False
+
+    def get_lr(self):
+        return self.optimizer.get_lr()
+
+    def set_lr(self, lr):
+        self.optimizer.set_lr(lr)
+
+    @property
+    def loss_scale(self):
+        """
+        Convenience function which TorchAgent calls to get current scale value.
+        """
+        return self.scaler.loss_scale
 
 
 ###################################################

--- a/projects/style_gen/modules.py
+++ b/projects/style_gen/modules.py
@@ -18,7 +18,6 @@ from torch import nn as nn
 from parlai.agents.transformer.modules import (
     TransformerDecoder,
     TransformerGeneratorModel,
-    _normalize,
 )
 from parlai.core.agents import Agent
 from parlai.core.message import Message
@@ -182,7 +181,7 @@ class TransformerDecoderWithEmbeds(TransformerDecoder):
         if self.embeddings_scale:
             tensor = tensor * np.sqrt(self.dim)
         if self.variant == 'xlm':
-            tensor = _normalize(tensor, self.norm_embeddings)
+            tensor = self.norm_embeddings(tensor)
         if positions.max().item() > self.n_positions:
             warn_once(
                 'You are inputting a sequence of {x} length, but only have '
@@ -208,7 +207,7 @@ class TransformerDecoderWithEmbeds(TransformerDecoder):
                 )
 
         if self.variant == 'prelayernorm':
-            tensor = _normalize(tensor, self.norm_embeddings)
+            tensor = self.norm_embeddings(tensor)
 
         return tensor, new_incr_state
 

--- a/tests/nightly/gpu/test_tutorial_generator.py
+++ b/tests/nightly/gpu/test_tutorial_generator.py
@@ -22,4 +22,4 @@ class TestTutorialTransformerGenerator(unittest.TestCase):
             skip_test=True,
         )
         self.assertAlmostEqual(valid['ppl'], 19.59, places=2)
-        self.assertAlmostEqual(valid['token_acc'], 0.4239, places=4)
+        self.assertAlmostEqual(valid['token_acc'], 0.424, places=4)

--- a/tests/test_apex.py
+++ b/tests/test_apex.py
@@ -4,21 +4,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-try:
-    import apex  # noqa: F401
-
-    APEX_AVAILABLE = True
-except ImportError:
-    APEX_AVAILABLE = False
-
-
 import unittest
 from parlai.core.agents import create_agent
 from parlai.core.params import ParlaiParser
 import parlai.utils.testing as testing_utils
 
 
-@unittest.skipIf(APEX_AVAILABLE, "Apex is installed, can't test its absence.")
 class TestNoApex(unittest.TestCase):
     """
     Test if some models that were pretrained with APEX.

--- a/tests/test_mem_efficient_fp16.py
+++ b/tests/test_mem_efficient_fp16.py
@@ -61,28 +61,28 @@ class TestMemEfficientFP16(unittest.TestCase):
             valid1, test1 = testing_utils.train_model(
                 dict(
                     model_file=model_file,
-                    task='integration_tests:candidate',
-                    model='transformer/ranker',
+                    task='integration_tests',
+                    model='transformer/generator',
                     optimizer='adam',
                     fp16=True,
                     fp16_impl='safe',
-                    learningrate=7e-3,
+                    learningrate=1e-3,
                     batchsize=32,
                     num_epochs=0.25,
                     n_layers=1,
                     n_heads=1,
                     ffn_size=32,
                     embedding_size=32,
-                    warmup_updates=1,
+                    warmup_updates=100,
                     lr_scheduler='invsqrt',
+                    skip_generation=True,
                 )
             )
 
             valid2, test2 = testing_utils.train_model(
                 dict(
                     model_file=model_file,
-                    task='integration_tests:candidate',
-                    model='transformer/ranker',
+                    task='integration_tests',
                     fp16_impl='mem_efficient',
                     num_epochs=0.5,
                     fp16=True,
@@ -106,8 +106,8 @@ class TestMemEfficientFP16(unittest.TestCase):
             valid1, test1 = testing_utils.train_model(
                 dict(
                     model_file=model_file,
-                    task='integration_tests:candidate',
-                    model='transformer/ranker',
+                    task='integration_tests',
+                    model='transformer/generator',
                     optimizer='adam',
                     fp16=True,
                     fp16_impl='mem_efficient',
@@ -120,17 +120,17 @@ class TestMemEfficientFP16(unittest.TestCase):
                     embedding_size=32,
                     warmup_updates=1,
                     lr_scheduler='invsqrt',
+                    skip_generation=True,
                 )
             )
 
             valid2, test2 = testing_utils.train_model(
                 dict(
                     model_file=model_file,
-                    task='integration_tests:candidate',
-                    model='transformer/ranker',
+                    task='integration_tests',
+                    model='transformer/generator',
                     fp16_impl='safe',
                     num_epochs=0.5,
-                    fp16=True,
                 )
             )
 

--- a/tests/test_mem_efficient_fp16.py
+++ b/tests/test_mem_efficient_fp16.py
@@ -53,7 +53,7 @@ class TestMemEfficientFP16(unittest.TestCase):
 
     def test_resuming_safe2memeff(self):
         """
-        Test switching from safe fp16 to memory efficient fp16
+        Test switching from safe fp16 to memory efficient fp16.
         """
         with testing_utils.tempdir() as tmpdir:
             model_file = os.path.join(tmpdir, 'model')

--- a/tests/test_mem_efficient_fp16.py
+++ b/tests/test_mem_efficient_fp16.py
@@ -51,11 +51,9 @@ class TestMemEfficientFP16(unittest.TestCase):
                 )
             )
 
-    # we don't currently install apex in CircleCI for a variety of reasons
-    @testing_utils.skipIfCircleCI
-    def test_resuming_apex2memeff(self):
+    def test_resuming_safe2memeff(self):
         """
-        Test switching from memory efficient fp16 to apex fp16.
+        Test switching from safe fp16 to memory efficient fp16
         """
         with testing_utils.tempdir() as tmpdir:
             model_file = os.path.join(tmpdir, 'model')
@@ -67,7 +65,7 @@ class TestMemEfficientFP16(unittest.TestCase):
                     model='transformer/ranker',
                     optimizer='adam',
                     fp16=True,
-                    fp16_impl='apex',
+                    fp16_impl='safe',
                     learningrate=7e-3,
                     batchsize=32,
                     num_epochs=0.25,
@@ -98,11 +96,9 @@ class TestMemEfficientFP16(unittest.TestCase):
                 'Number of updates is not increasing',
             )
 
-    # we don't currently install apex in CircleCI for a variety of reasons
-    @testing_utils.skipIfCircleCI
-    def test_resuming_memeff2apex(self):
+    def test_resuming_memeff2safe(self):
         """
-        Test switching from memory efficient fp16 to apex fp16.
+        Test switching from memory efficient fp16 to safe fp16.
         """
         with testing_utils.tempdir() as tmpdir:
             model_file = os.path.join(tmpdir, 'model')
@@ -115,7 +111,7 @@ class TestMemEfficientFP16(unittest.TestCase):
                     optimizer='adam',
                     fp16=True,
                     fp16_impl='mem_efficient',
-                    learningrate=7e-3,
+                    learningrate=1e-3,
                     batchsize=32,
                     num_epochs=0.25,
                     n_layers=1,
@@ -132,7 +128,7 @@ class TestMemEfficientFP16(unittest.TestCase):
                     model_file=model_file,
                     task='integration_tests:candidate',
                     model='transformer/ranker',
-                    fp16_impl='apex',
+                    fp16_impl='safe',
                     num_epochs=0.5,
                     fp16=True,
                 )


### PR DESCRIPTION
**Patch description**
This patch removes (most) of our dependency on APEX by re-implementing the important features.

This was done by:
- Killing the FusedLayerNorm usage. Historically, there was a ~10% speed difference IIRC, but Pytorch has improved and closed the gap to ~2% these days last I heard. This is sufficient for cleaner, simpler code.
- Copying and re-adapting Fairseq's apex-style fp16 optimizer. It has high compatibility with the mem efficient one.

We still have the dependency for FusedAdam. This will be removed in subsequent PRs where we introduce fairscale.

Additionally, there's a small bugfix setting tolerance to 0.0 of the DynamicLossScalar. This was affecting @hadasah and occasionally causing overflows to be ignored in long jobs. Upon investigation, it turns out the default in the _class_ in fairseq is 0.05, but the default in the CLI is 0.0. We move to the better default.

**Testing steps**
Manual testing. CI.