### PR TITLE
[RFC] Initialize TransformerEncoder and TransformerDecoder with opt instead of individual flags

### DIFF
--- a/parlai/agents/transformer/crossencoder.py
+++ b/parlai/agents/transformer/crossencoder.py
@@ -8,7 +8,6 @@ from typing import Optional
 from parlai.core.params import ParlaiParser
 from parlai.core.opt import Opt
 from .modules import TransformerEncoder
-from .modules import get_n_positions_from_options
 from parlai.core.torch_ranker_agent import TorchRankerAgent
 from .transformer import TransformerRankerAgent
 from parlai.utils.torch import concat_without_padding
@@ -85,30 +84,17 @@ class CrossEncoderModule(torch.nn.Module):
 
     def __init__(self, opt, dict, null_idx):
         super(CrossEncoderModule, self).__init__()
-        n_positions = get_n_positions_from_options(opt)
         embeddings = torch.nn.Embedding(
             len(dict), opt['embedding_size'], padding_idx=null_idx
         )
         torch.nn.init.normal_(embeddings.weight, 0, opt['embedding_size'] ** -0.5)
         self.encoder = TransformerEncoder(
-            n_heads=opt['n_heads'],
-            n_layers=opt['n_layers'],
-            embedding_size=opt['embedding_size'],
-            ffn_size=opt['ffn_size'],
-            vocabulary_size=len(dict),
+            opt=opt,
             embedding=embeddings,
-            dropout=opt['dropout'],
-            attention_dropout=opt['attention_dropout'],
-            relu_dropout=opt['relu_dropout'],
+            vocabulary_size=len(dict),
             padding_idx=null_idx,
-            learn_positional_embeddings=opt['learn_positional_embeddings'],
-            embeddings_scale=opt['embeddings_scale'],
             reduction_type=opt.get('reduction_type', 'first'),
-            n_positions=n_positions,
             n_segments=2,
-            activation=opt['activation'],
-            variant=opt['variant'],
-            output_scaling=opt['output_scaling'],
         )
         self.linear_layer = torch.nn.Linear(opt['embedding_size'], 1)
 

--- a/parlai/agents/transformer/functions.py
+++ b/parlai/agents/transformer/functions.py
@@ -26,3 +26,27 @@ def create_position_codes(n_pos, dim, out):
     out.requires_grad = False
     out[:, 0::2] = torch.FloatTensor(np.sin(position_enc)).type_as(out)
     out[:, 1::2] = torch.FloatTensor(np.cos(position_enc)).type_as(out)
+
+
+def get_n_positions_from_options(opt):
+    """
+    Determine n_positions from options dict.
+    """
+    if opt.get('n_positions'):
+        # if the number of positions is explicitly provided, use that
+        n_positions = opt['n_positions']
+    else:
+        # else, use the worst case from truncate
+        n_positions = max(
+            opt.get('truncate') or 0,
+            opt.get('text_truncate') or 0,
+            opt.get('label_truncate') or 0,
+        )
+        if n_positions == 0:
+            # default to 1024
+            n_positions = 1024
+
+    if n_positions < 0:
+        raise ValueError('n_positions must be positive')
+
+    return n_positions

--- a/parlai/agents/transformer/modules/encoder.py
+++ b/parlai/agents/transformer/modules/encoder.py
@@ -62,7 +62,14 @@ class TransformerEncoder(nn.Module):
     """
 
     def __init__(
-        self, opt, vocabulary_size, embedding=None, padding_idx=0, reduction_type='mean'
+        self,
+        opt,
+        vocabulary_size,
+        embedding=None,
+        padding_idx=0,
+        reduction_type='mean',
+        n_segments=None,
+        embeddings_scale=None,
     ):
         super(TransformerEncoder, self).__init__()
 
@@ -75,14 +82,14 @@ class TransformerEncoder(nn.Module):
         )
         self.n_heads = opt['n_heads']
         self.dim = self.embedding_size
-        self.embeddings_scale = opt['embeddings_scale']
+        self.embeddings_scale = embeddings_scale or opt['embeddings_scale']
         self.reduction_type = reduction_type
         self.padding_idx = padding_idx
         # this is --dropout, not --relu-dropout or --attention-dropout
         self.dropout_frac = opt['dropout']
         self.dropout = nn.Dropout(p=self.dropout_frac)
         self.variant = opt['variant']
-        self.n_segments = opt.get('n_segments', 0)
+        self.n_segments = n_segments or opt.get('n_segments', 0)
 
         self.n_positions = get_n_positions_from_options(opt)
         self.out_dim = self.embedding_size

--- a/parlai/agents/transformer/polyencoder.py
+++ b/parlai/agents/transformer/polyencoder.py
@@ -19,12 +19,7 @@ from parlai.utils.misc import recursive_getattr
 from parlai.utils.logging import logging
 
 from .biencoder import AddLabelFixedCandsTRA
-from .modules import (
-    BasicAttention,
-    MultiHeadAttention,
-    TransformerEncoder,
-    get_n_positions_from_options,
-)
+from .modules import BasicAttention, MultiHeadAttention, TransformerEncoder
 from .transformer import TransformerRankerAgent
 
 
@@ -358,29 +353,15 @@ class PolyEncoderModule(torch.nn.Module):
         :return:
             a TransformerEncoder, initialized correctly
         """
-        n_positions = get_n_positions_from_options(opt)
         embeddings = self._get_embeddings(
             dict_=dict_, null_idx=null_idx, embedding_size=opt['embedding_size']
         )
         return TransformerEncoder(
-            n_heads=opt['n_heads'],
-            n_layers=opt['n_layers'],
-            embedding_size=opt['embedding_size'],
-            ffn_size=opt['ffn_size'],
-            vocabulary_size=len(dict_),
+            opt=opt,
             embedding=embeddings,
-            dropout=opt['dropout'],
-            attention_dropout=opt['attention_dropout'],
-            relu_dropout=opt['relu_dropout'],
+            vocabulary_size=len(dict_),
             padding_idx=null_idx,
-            learn_positional_embeddings=opt['learn_positional_embeddings'],
-            embeddings_scale=opt['embeddings_scale'],
             reduction_type=reduction_type,
-            n_positions=n_positions,
-            n_segments=opt.get('n_segments', 2),
-            activation=opt['activation'],
-            variant=opt['variant'],
-            output_scaling=opt['output_scaling'],
         )
 
     def _get_embeddings(self, dict_, null_idx, embedding_size):

--- a/projects/image_chat/transresnet_multimodal/modules.py
+++ b/projects/image_chat/transresnet_multimodal/modules.py
@@ -176,22 +176,11 @@ class TransresnetMultimodalModel(TransresnetModel):
                     len(self.dictionary), self.opt["embedding_size"]
                 )
             self.context_encoder = TransformerEncoder(
-                n_heads=self.opt["n_heads"],
-                n_layers=self.opt["n_layers"],
-                embedding_size=self.opt["embedding_size"],
-                ffn_size=self.opt["ffn_size"],
-                vocabulary_size=len(self.dictionary),
+                opt=self.opt,
                 embedding=embeddings,
-                dropout=self.opt["dropout"],
-                attention_dropout=self.opt["attention_dropout"],
-                relu_dropout=self.opt["relu_dropout"],
+                vocabulary_size=len(self.dictionary),
                 padding_idx=self.dictionary.tok2ind[self.dictionary.null_token],
-                learn_positional_embeddings=self.opt["learn_positional_embeddings"],
                 embeddings_scale=False,
-                n_positions=self.opt["n_positions"],
-                activation=self.opt["activation"],
-                variant=self.opt["variant"],
-                n_segments=self.opt["n_segments"],
             )
             if self.opt.get("load_context_encoder_from") is not None:
                 self._load_context_encoder_state()

--- a/projects/personality_captions/transresnet/modules.py
+++ b/projects/personality_captions/transresnet/modules.py
@@ -163,22 +163,11 @@ class TransresnetModel(nn.Module):
             )
 
         self.text_encoder = TransformerEncoder(
-            n_heads=self.opt['n_heads'],
-            n_layers=self.opt['n_layers'],
-            embedding_size=self.opt['embedding_size'],
-            ffn_size=self.opt['ffn_size'],
-            vocabulary_size=len(self.dictionary),
+            opt=self.opt,
             embedding=self.embeddings,
-            dropout=self.opt['dropout'],
-            attention_dropout=self.opt['attention_dropout'],
-            relu_dropout=self.opt['relu_dropout'],
+            vocabulary_size=len(self.dictionary),
             padding_idx=self.dictionary.tok2ind[self.dictionary.null_token],
-            learn_positional_embeddings=self.opt['learn_positional_embeddings'],
             embeddings_scale=False,
-            n_positions=self.opt['n_positions'],
-            activation=self.opt['activation'],
-            variant=self.opt['variant'],
-            n_segments=self.opt['n_segments'],
         )
         if self.opt.get('load_encoder_from') is not None:
             self._load_text_encoder_state()

--- a/projects/self_feeding/modules.py
+++ b/projects/self_feeding/modules.py
@@ -186,17 +186,10 @@ class SelfFeedingModel(nn.Module):
 
     def build_encoder(self, opt, embeddings):
         return TransformerEncoder(
-            n_heads=opt['n_heads'],
-            n_layers=opt['n_layers'],
-            embedding_size=opt['embedding_size'],
-            ffn_size=opt['ffn_size'],
-            vocabulary_size=self.vocab_size,
+            opt=opt,
             embedding=embeddings,
-            attention_dropout=opt['attention_dropout'],
-            relu_dropout=opt['relu_dropout'],
+            vocabulary_size=self.vocab_size,
             padding_idx=self.pad_idx,
-            learn_positional_embeddings=opt.get('learn_positional_embeddings', False),
-            embeddings_scale=opt['embeddings_scale'],
         )
 
     def build_head(self, opt, outdim=1, num_layers=1):


### PR DESCRIPTION
**Patch description**
This is one small step in a larger effort to refactor the transformer code to make it easier to modify and extend. There shouldn't be any functional changes as part of this diff, just organizational.

Some reasons for this change:
- Make these modules less cumbersome to reuse
- Move toward a pattern of using opt (by default) to configure modules instead of explicit values in the code

Let me know if this makes the code more confusing for anyone instead of less!

**Testing steps**
Leaning on the existing unit tests. Will also run some small local runs to sanity check.

