### PR TITLE
Transfer tensors wholesale in Metric.many

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -163,9 +163,12 @@ class Metric(ABC):
         Useful if you separately compute numerators and denomenators, etc.
         """
         lengths = [len(o) for o in objs]
-        objs = list(objs)
+        objs = list(objs)  # convert from tuple for inplace modification
         for i, o in enumerate(objs):
             if isinstance(o, torch.Tensor):
+                # if the tensor is on GPU, make sure we transfer the whole thing
+                # at once, instead of one-element-at-a-time during our list
+                # comprehension
                 objs[i] = o.tolist()
         if len(set(lengths)) != 1:
             raise IndexError(f'Uneven {cls.__name__} constructions: {lengths}')

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -163,6 +163,10 @@ class Metric(ABC):
         Useful if you separately compute numerators and denomenators, etc.
         """
         lengths = [len(o) for o in objs]
+        objs = list(objs)
+        for i, o in enumerate(objs):
+            if isinstance(o, torch.Tensor):
+                objs[i] = o.tolist()
         if len(set(lengths)) != 1:
             raise IndexError(f'Uneven {cls.__name__} constructions: {lengths}')
         return [cls(*items) for items in zip(*objs)]


### PR DESCRIPTION
**Patch description**
After discussions with Jing about bottlenecks, realized the list comprehensions in `Metric.many` are probably calling `item()` separately for each bit. Not cool!

**Testing steps**

Testing this change in isolation:
```python
t = torch.rand(30).cuda()
%timeit AverageMetric.many(t)
```
Before: 406 µs ± 5.73 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
After: 51.6 µs ± 439 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

Tested it on an a very small model and observed ~5% speedup of training. Tested it on a 400M model and observed about a 1% speedup. Given that the change is simple and clear, seems worthwhile.