### PR TITLE
Improve parlai cold start

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -49,19 +49,6 @@ from parlai.utils.torch import (
 )
 
 
-try:
-    from nltk.translate import bleu_score as nltkbleu
-
-except ImportError:
-    nltkbleu = None
-
-try:
-    from fairseq.scoring import bleu as fairseq_bleu
-
-except ImportError:
-    fairseq_bleu = None
-
-
 class SearchBlocklist(object):
     """
     Search block list facilitates blocking ngrams from being generated.


### PR DESCRIPTION
**Patch description**
Delay the import of a few very expensive imports.

**Testing steps**
Before:
```
$ time parlai -h
** fvcore version of PathManager will be deprecated soon. **
** Please migrate to the version in iopath repo. **
https://github.com/facebookresearch/iopath

usage: parlai [-h] [--helpall] [--version] COMMAND ...

       _
      /")
     //)
  ==//'=== ParlAI
   /

optional arguments:
  -h, --help               show this help message and exit
  --helpall                List all commands, including advanced ones.
  --version                Prints version info and exit.

Commands:

  eval_model (em, eval)    Evaluate a model
  display_data (dd)        Display data from a task
  display_model (dm)       Display model predictions.
  train_model (tm, train)  Train a model
  interactive (i)          Interactive chat with a model on the command line
  safe_interactive         Like interactive, but adds a safety filter
  self_chat                Generate self-chats of a model
parlai -h  7.02s user 4.20s system 36% cpu 30.978 total
```

After:
```
$ time parlai -h
usage: parlai [-h] [--helpall] [--version] COMMAND ...

       _
      /")
     //)
  ==//'=== ParlAI
   /

optional arguments:
  -h, --help                  show this help message and exit
  --helpall                   List all commands, including advanced ones.
  --version                   Prints version info and exit.

Commands:

  eval_model (em, eval)       Evaluate a model
  dump_data_to_conversations  Evaluate a model
  display_data (dd)           Display data from a task
  display_model (dm)          Display model predictions.
  train_model (tm, train)     Train a model
  interactive (i)             Interactive chat with a model on the command line
  safe_interactive            Like interactive, but adds a safety filter
  self_chat                   Generate self-chats of a model
parlai -h  0.87s user 0.54s system 11% cpu 12.440 total
```