### PR TITLE
Messages instead of dicts for get() in ED, DNLI

### DIFF
--- a/parlai/tasks/dialogue_nli/agents.py
+++ b/parlai/tasks/dialogue_nli/agents.py
@@ -13,6 +13,7 @@ from parlai.core.opt import Opt
 import json
 import os
 
+from parlai.core.message import Message
 from parlai.core.teachers import FixedDialogTeacher
 from .build import build
 from parlai.tasks.multinli.agents import convert_to_dialogData
@@ -134,7 +135,7 @@ class DialogueNliTeacher(FixedDialogTeacher):
             binary_classes=self.binary_classes,
         )
         new_entry = {k: entry[k] for k in ENTRY_FIELDS if k in entry}
-        return new_entry
+        return Message(new_entry)
 
 
 class ExtrasTeacher(DialogueNliTeacher):

--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -13,6 +13,7 @@ from typing import Any, List
 import numpy as np
 
 from parlai.utils.io import PathManager
+from parlai.core.message import Message
 from parlai.core.teachers import FixedDialogTeacher
 from .build import build
 
@@ -220,18 +221,21 @@ class EmpatheticDialoguesTeacher(FixedDialogTeacher):
         ep = self.data[episode_idx]
         ep_i = ep[entry_idx]
         episode_done = entry_idx >= (len(ep) - 1)
-        action = {
-            'situation': ep_i[3],
-            'emotion': ep_i[2],
-            'text': ep_i[0],
-            'labels': [ep_i[1]],
-            'prepend_ctx': ep_i[6],
-            'prepend_cand': ep_i[7],
-            'deepmoji_ctx': ep_i[4],
-            'deepmoji_cand': ep_i[5],
-            'episode_done': episode_done,
-            'label_candidates': ep_i[8],
-        }
+        action = Message(
+            {
+                'situation': ep_i[3],
+                'emotion': ep_i[2],
+                'text': ep_i[0],
+                'labels': [ep_i[1]],
+                'prepend_ctx': ep_i[6],
+                'prepend_cand': ep_i[7],
+                'deepmoji_ctx': ep_i[4],
+                'deepmoji_cand': ep_i[5],
+                'episode_done': episode_done,
+                'label_candidates': ep_i[8],
+            }
+        )
+
         return action
 
     def share(self):
@@ -268,7 +272,7 @@ class EmotionClassificationSituationTeacher(EmpatheticDialoguesTeacher):
         ex = self.data[episode_idx]
         episode_done = True
 
-        return {'labels': [ex[2]], 'text': ex[3], 'episode_done': episode_done}
+        return Message({'labels': [ex[2]], 'text': ex[3], 'episode_done': episode_done})
 
 
 class DefaultTeacher(EmpatheticDialoguesTeacher):


### PR DESCRIPTION
**Patch description**
When running EmpatheticDialogues and Dialogue NLI, I get the following warning messages:
`parlai.tasks.empathetic_dialogues.agents.DefaultTeacher' is outputting dicts instead of messages. If this is a teacher that is part of ParlAI, please file an issue on GitHub. If it is your own teacher, please return a Message object instead.`
`parlai.tasks.dialogue_nli.agents.DefaultTeacher' is outputting dicts instead of messages. If this is a teacher that is part of ParlAI, please file an issue on GitHub. If it is your own teacher, please return a Message object instead.`

So, I wrapped the dicts with the Message object.

**Testing steps**
Ran
`pytest parlai/tasks/empathetic_dialogues/test.py`
`pytest parlai/tasks/dialogue_nli/test.py`
for the test.
