### PR TITLE
[Transformer Opt] Add back default values to underspecified call sites

### DIFF
--- a/parlai/agents/transformer/modules.py
+++ b/parlai/agents/transformer/modules.py
@@ -304,6 +304,10 @@ class TransformerEncoder(nn.Module):
         n_positions: Optional[int] = None,
         n_segments: Optional[int] = None,
         embeddings_scale: Optional[bool] = None,
+        dropout: Optional[float] = None,
+        activation: Optional[str] = None,
+        variant: Optional[str] = None,
+        output_scaling: Optional[float] = None,
     ):
         super(TransformerEncoder, self).__init__()
 
@@ -325,9 +329,9 @@ class TransformerEncoder(nn.Module):
         self.reduction_type = reduction_type
         self.padding_idx = padding_idx
         # this is --dropout, not --relu-dropout or --attention-dropout
-        self.dropout_frac = opt.get('dropout', 0.0)
+        self.dropout_frac = _default(dropout, opt.get('dropout', 0.0))
         self.dropout = nn.Dropout(p=self.dropout_frac)
-        self.variant = opt.get('variant', 'aiayn')
+        self.variant = _default(variant, opt.get('variant', 'aiayn'))
         self.n_segments = _default(n_segments, opt.get('n_segments', 0))
 
         self.n_positions = _default(n_positions, get_n_positions_from_options(opt))
@@ -395,10 +399,10 @@ class TransformerEncoder(nn.Module):
                     relu_dropout=opt.get('relu_dropout', 0.0),
                     dropout=self.dropout_frac,
                     variant=self.variant,
-                    activation=opt.get('activation', 'relu'),
+                    activation=_default(activation, opt.get('activation', 'relu')),
                 )
             )
-        self.output_scaling = opt.get('output_scaling', 1.0)
+        self.output_scaling = _default(output_scaling, opt.get('output_scaling', 1.0))
 
     def forward_embedding(
         self,

--- a/projects/image_chat/transresnet_multimodal/modules.py
+++ b/projects/image_chat/transresnet_multimodal/modules.py
@@ -181,6 +181,7 @@ class TransresnetMultimodalModel(TransresnetModel):
                 vocabulary_size=len(self.dictionary),
                 padding_idx=self.dictionary.tok2ind[self.dictionary.null_token],
                 embeddings_scale=False,
+                output_scaling=1.0,
             )
             if self.opt.get("load_context_encoder_from") is not None:
                 self._load_context_encoder_state()

--- a/projects/personality_captions/transresnet/modules.py
+++ b/projects/personality_captions/transresnet/modules.py
@@ -168,6 +168,7 @@ class TransresnetModel(nn.Module):
             vocabulary_size=len(self.dictionary),
             padding_idx=self.dictionary.tok2ind[self.dictionary.null_token],
             embeddings_scale=False,
+            output_scaling=1.0,
         )
         if self.opt.get('load_encoder_from') is not None:
             self._load_text_encoder_state()

--- a/projects/self_feeding/modules.py
+++ b/projects/self_feeding/modules.py
@@ -190,6 +190,12 @@ class SelfFeedingModel(nn.Module):
             embedding=embeddings,
             vocabulary_size=self.vocab_size,
             padding_idx=self.pad_idx,
+            dropout=0.0,
+            n_positions=1024,
+            n_segments=0,
+            activation='relu',
+            variant='aiayn',
+            output_scaling=1.0,
         )
 
     def build_head(self, opt, outdim=1, num_layers=1):


### PR DESCRIPTION
**Patch description**
Some call sites didn't pass through opt values, and were therefore implicitly using the default __init__ values before. This diff adds back those default values explicitly.

**Testing steps**
Make sure CircleCI passes.
