### PR TITLE
WoW Custom Metrics

### DIFF
--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -15,7 +15,9 @@ for unseen) after the last colon in the task.
 E.g. `wizard_of_wikipedia:WizardDialogKnowledgeTeacher:random_split`
 """
 
-from typing import Optional
+from typing import Optional, Tuple
+from parlai.core.message import Message
+from parlai.core.metrics import AverageMetric, normalize_answer, F1Metric
 from parlai.core.params import ParlaiParser
 from parlai.core.opt import Opt
 import copy
@@ -353,6 +355,81 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
             action['title'] = title
             action['checked_sentence'] = sentence
         return action
+
+    def custom_evaluation(
+        self,
+        teacher_action: Message,
+        labels: Optional[Tuple[str]],
+        model_response: Message,
+    ):
+        """
+        Custom Evaluations for Wizard of Wikipedia.
+
+        When the label is `chosen_sent`, evaluate whether the model response...
+        1) Is the correct document (title)
+        2) _contains_ the correct chosen sentence (even if it's not wholly the answer)
+
+        When the label is `response`, we compute F1 of model generation w.r.t checked sentence.
+
+        :param teacher_action:
+            The message last sent from this teacher.
+        :param labels:
+            The previous correct labels, if there were any.
+        :param model_response:
+            The raw response from the model. Generally you want to rely on the
+            text field, but others may be necessary in specific situations.
+        """
+        if (
+            self.label_type == 'response'
+            and 'text' in model_response
+            and 'checked_sentence' in teacher_action
+        ):
+            self.metrics.add(
+                'knowledge_f1',
+                F1Metric.compute(
+                    model_response['text'], [teacher_action['checked_sentence']]
+                ),
+            )
+        elif (
+            self.label_type == 'chosen_sent'
+            and TOKEN_KNOWLEDGE in model_response['text']
+        ):
+            try:
+                correct_title, correct_passage = [
+                    normalize_answer(a) for a in labels[0].split(TOKEN_KNOWLEDGE)
+                ]
+            except ValueError:
+                # Knowledge not chosen
+                correct_title, correct_passage = TOKEN_NOCHOSEN, TOKEN_NOCHOSEN
+            title, passage = [
+                normalize_answer(a)
+                for a in model_response['text'].split(TOKEN_KNOWLEDGE)
+            ]
+
+            self.metrics.add('title_r@1', AverageMetric(int(correct_title == title)))
+            self.metrics.add(
+                'passage_r@1', AverageMetric(int(correct_passage in passage))
+            )
+            if 'title_candidates' in model_response:
+                title_candidates = [
+                    normalize_answer(t) for t in model_response['title_candidates']
+                ][:5]
+                self.metrics.add(
+                    'title_r@5',
+                    AverageMetric(
+                        int(any(correct_title == t for t in title_candidates))
+                    ),
+                )
+            if 'text_candidates' in model_response:
+                text_candidates = [
+                    normalize_answer(t) for t in model_response['text_candidates']
+                ][:5]
+                self.metrics.add(
+                    'passage_r@5',
+                    AverageMetric(
+                        int(any(correct_passage in t for t in text_candidates))
+                    ),
+                )
 
 
 class BasicdialogTeacher(WizardOfWikipediaTeacher):

--- a/tests/tasks/test_wizard_of_wikipedia.py
+++ b/tests/tasks/test_wizard_of_wikipedia.py
@@ -5,7 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 from parlai.scripts.display_data import display_data as display, setup_args
 from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
+from parlai.core.message import Message
+from parlai.core.metrics import F1Metric, AverageMetric
+from parlai.core.teachers import create_task_agent_from_taskname
 from parlai.core.worlds import create_task
+from parlai.tasks.wizard_of_wikipedia.agents import TOKEN_KNOWLEDGE
 
 import unittest
 import itertools
@@ -24,6 +28,7 @@ class TestWoW(unittest.TestCase):
     Basic tests on the train_model.py example.
     """
 
+    @unittest.skip
     def test_output(self):
         dts = ['train', 'valid', 'test']
         main_task = 'wizard_of_wikipedia'
@@ -90,6 +95,121 @@ class TestWoW(unittest.TestCase):
             in str_output,
             'Wizard of Wikipedia failed with following args: {}'.format(opt),
         )
+
+    def test_custom_eval(self):
+        """
+        Test whether custom evaluation works.
+        """
+        with testing_utils.capture_output():
+            parser = setup_args()
+            opt = parser.parse_args(
+                [
+                    '--task',
+                    'wizard_of_wikipedia',
+                    '--datatype',
+                    'valid',
+                    '--label-type',
+                    'chosen_sent',
+                ]
+            )
+            teacher = create_task_agent_from_taskname(opt)[0]
+
+        title = 'Gardening'
+        cands = list('four')
+
+        text = "Gardening\nI like Gardening, even when I've only been doing it for a short time."
+        response = 'I live on a farm, we garden all year long, it is very relaxing.'
+        checked_sent = (
+            'Gardening is considered by many people to be a relaxing activity.'
+        )
+        checked_sent_label = f'{title}{TOKEN_KNOWLEDGE}{checked_sent}'
+
+        retrieval_metric_keys = ['passage_r@1', 'passage_r@5', 'title_r@1', 'title_r@5']
+
+        chosen_sent_teacher_action = Message(
+            {
+                'text': text,
+                'labels': [checked_sent_label],
+                'title': [title],
+                'checked_sentence': [checked_sent],
+            }
+        )
+        correct_chosen_sent_response = Message(
+            {
+                'text': checked_sent_label,
+                'title_candidates': [title] + cands,
+                'text_candidates': [checked_sent_label] + cands,
+            }
+        )
+        top5_chosen_sent_response = Message(
+            {
+                'text': f'hello{TOKEN_KNOWLEDGE}goodbye',
+                'title_candidates': cands + [title],
+                'text_candidates': cands + [checked_sent_label],
+            }
+        )
+        incorrect_chosen_sent_response = Message(
+            {
+                'text': f'hello{TOKEN_KNOWLEDGE}goodbye',
+                'title_candidates': cands,
+                'text_candidates': cands,
+            }
+        )
+
+        response_teacher_action = Message(
+            {'text': text, 'labels': [response], 'checked_sentence': checked_sent}
+        )
+        high_f1_response = Message({'text': checked_sent})
+        low_f1_response = Message({'text': 'incorrect'})
+
+        # 1) Test with correct top sentence
+        teacher.reset_metrics()
+        teacher.custom_evaluation(
+            chosen_sent_teacher_action,
+            [checked_sent_label],
+            correct_chosen_sent_response,
+        )
+        report = teacher.report()
+        for k in retrieval_metric_keys:
+            assert k in report
+            assert report[k] == AverageMetric(1)
+
+        # 2) Test with top sentence in top 5
+        teacher.reset_metrics()
+        teacher.custom_evaluation(
+            chosen_sent_teacher_action, [checked_sent_label], top5_chosen_sent_response
+        )
+        report = teacher.report()
+        for k in retrieval_metric_keys:
+            assert k in report
+            assert report[k] == AverageMetric(1) if '5' in k else AverageMetric(0)
+
+        # 3) Test with no top sentences
+        teacher.reset_metrics()
+        teacher.custom_evaluation(
+            chosen_sent_teacher_action,
+            [checked_sent_label],
+            incorrect_chosen_sent_response,
+        )
+        report = teacher.report()
+        for k in retrieval_metric_keys:
+            assert k in report
+            assert report[k] == AverageMetric(0)
+
+        # 4) Test knowledge f1 with high f1
+        teacher.label_type = 'response'
+        teacher.reset_metrics()
+        teacher.custom_evaluation(response_teacher_action, [response], high_f1_response)
+        report = teacher.report()
+        assert 'knowledge_f1' in report
+        assert report['knowledge_f1'] == F1Metric(1)
+
+        # 5) Test knowledge f1 with low f1
+        teacher.reset_metrics()
+        teacher.custom_evaluation(response_teacher_action, [response], low_f1_response)
+        report = teacher.report()
+        assert 'knowledge_f1' in report
+        assert report['knowledge_f1'] == F1Metric(0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Patch description**
Add a few custom evaluations for wizard of wikipedia:

1) When doing the knowledge selection task, the teacher will compute additional title/checked sentence recall metrics; the latter measures whether the checked sentence appears in the text of any of the returned candidates
2) When doing the response generation task, the teacher will compute f1 score of the generation w.r.t. the checked sentence

We skip the other test now because... it's not super necessary

**Testing steps**
Added tests to CI.

```
$ pytest tests/tasks/test_wizard_of_wikipedia.py
=====test session starts =====
platform linux -- Python 3.7.9, pytest-6.2.1, py-1.10.0, pluggy-1.0.0.dev0
rootdir: /private/home/kshuster/ParlAI, configfile: pytest.ini
plugins: hydra-core-1.0.0, requests-mock-1.8.0, regressions-2.1.1, datadir-1.3.1
collected 2 items

tests/tasks/test_wizard_of_wikipedia.py ..                                                                                                                                                                                                                                                                                                                           [100%]

=====slowest 10 durations =====
1.81s call     tests/tasks/test_wizard_of_wikipedia.py::TestWoW::test_custom_eval

(5 durations < 0.005s hidden.  Use -vv to show these durations.)
====2 passed in 3.65s =====
```
