### PR TITLE
Fix issue #3502: "Message already contains key `dyn_batch_idx`"

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1094,7 +1094,7 @@ class DynamicBatchWorld(World):
             # we log the task act and the index of the act
             # in the buffer for world logging purposes
             self._task_acts[i] = act  # for world logging
-            self._task_acts[i]['dyn_batch_idx'] = i
+            self._task_acts[i].force_set('dyn_batch_idx', i)
 
             obs = self.worlds[i].get_model_agent().observe(act)
             self._obs[i] = obs

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1170,7 +1170,7 @@ class DynamicBatchWorld(World):
             # we log the task act and the index of the act
             # in the buffer for world logging purposes
             self._task_acts[i] = act
-            self._task_acts[i]['dyn_batch_idx'] = i
+            self._task_acts[i].force_set('dyn_batch_idx', i)
             # save the observations to form a batch
             obs = self.worlds[i].get_model_agent().observe(act)
             self._scores[i] = self._score(obs)


### PR DESCRIPTION
**Patch description**
This PR fixes issue #3502
`self._task_acts[i]['dyn_batch_idx'] = i` was setting a value for a key that was already set throwing error `Message already contains key 'dyn_batch_idx'`.

Simply replacing it with `self._task_acts[i].force_set('dyn_batch_idx', i)` fixed the problem.

**Testing steps**
Tested by running `python3 tests/test_dynamicbatching.py` without any problem.