### PR TITLE
Add cmdline args method to DialogPartnerWorld

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -39,17 +39,18 @@ All worlds are initialized with the following parameters:
 import copy
 import random
 
-from typing import List, Dict, Union
+from typing import Dict, List, Optional, Union
 
+import parlai.utils.logging as logging
 from parlai.core.agents import create_agents_from_shared
 from parlai.core.loader import load_task_module, load_world_module
 from parlai.core.metrics import aggregate_named_reports
 from parlai.core.opt import Opt
+from parlai.core.params import ParlaiParser
 from parlai.core.teachers import Teacher, create_task_agent_from_taskname
 from parlai.utils.data import DatatypeHelper
 from parlai.utils.misc import Timer, display_messages
 from parlai.tasks.tasks import ids_to_tasks
-import parlai.utils.logging as logging
 
 
 def validate(observation):
@@ -303,6 +304,17 @@ class DialogPartnerWorld(World):
     This basic world switches back and forth between two agents, giving each agent one
     chance to speak per turn and passing that back to the other one.
     """
+
+    @classmethod
+    def add_cmdline_args(
+        cls, parser: ParlaiParser, partial_opt: Optional[Opt] = None
+    ) -> ParlaiParser:
+        """
+        Return the parser as-is.
+
+        Self-chat-specific world flags can be added here.
+        """
+        return parser
 
     def __init__(self, opt: Opt, agents=None, shared=None):
         if not ((agents is not None) ^ (shared is not None)):

--- a/parlai/tasks/md_gender/worlds.py
+++ b/parlai/tasks/md_gender/worlds.py
@@ -116,14 +116,14 @@ class InteractiveWorld(DialogPartnerWorld):
         cls, parser: ParlaiParser, partial_opt: Optional[Opt] = None
     ) -> ParlaiParser:
         super().add_cmdline_args(parser, partial_opt)
-        parser = parser.add_argument_group('Gender Multiclass Interactive World')
-        parser.add_argument(
+        group = parser.add_argument_group('Gender Multiclass Interactive World')
+        group.add_argument(
             '--self-threshold',
             type=float,
             default=0.52,
             help='Threshold for choosing unknown for self',
         )
-        parser.add_argument(
+        group.add_argument(
             '--partner-threshold',
             type=float,
             default=0.52,

--- a/parlai/tasks/self_chat/worlds.py
+++ b/parlai/tasks/self_chat/worlds.py
@@ -10,8 +10,6 @@ from typing import Any, Dict, List, Optional
 
 from parlai.agents.fixed_response.fixed_response import FixedResponseAgent
 from parlai.core.agents import Agent
-from parlai.core.opt import Opt
-from parlai.core.params import ParlaiParser
 from parlai.core.worlds import create_task, DialogPartnerWorld, validate
 from parlai.core.message import Message
 
@@ -53,17 +51,6 @@ def load_openers(opt) -> Optional[List[str]]:
 
 
 class SelfChatWorld(DialogPartnerWorld):
-    @classmethod
-    def add_cmdline_args(
-        cls, parser: ParlaiParser, partial_opt: Optional[Opt] = None
-    ) -> ParlaiParser:
-        """
-        Return the parser as-is.
-
-        Self-chat-specific world flags can be added here.
-        """
-        return parser
-
     def __init__(self, opt, agents, shared=None):
         super().__init__(opt, agents, shared)
         self.init_contexts(shared=shared)


### PR DESCRIPTION
**Patch description**
https://github.com/facebookresearch/ParlAI/pull/3480 added an `.add_cmdline_args()` method to `SelfChatWorld`, given the recent work on mutators; this PR moves that method up one level to `DialogPartnerWorld` so that it can be used by any interactive world (such as the multi-dimensional gender classifier) *or* any self-chat world.

**Testing steps**

Testing interactive mode with multi-dimensional gender classifier, made working again by this PR:
```
parlai interactive \
-t md_gender \
-m projects.md_gender.bert_ranker_classifier.agents:BertRankerClassifierAgent \
-mf zoo:md_gender/model \
-ecands inline \
-cands inline \
--interactive_mode False \
--data-parallel False
```

Testing self-chat, made working by the https://github.com/facebookresearch/ParlAI/pull/3480 but refactored here:
```
parlai self_chat \
--model-file zoo:blender/blender_90M/model \
--task blended_skill_talk \
--outfile ~/__test_self_chat.jsonl
```
