### PR TITLE
Implement __str__ for History

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -295,7 +295,7 @@ class History(object):
 
         self.temp_history = temp_history
 
-    def get_history_str(self):
+    def get_history_str(self) -> Optional[str]:
         """
         Return the string version of the history.
         """
@@ -345,6 +345,9 @@ class History(object):
             return '\n'.join(split)
         else:
             return token + ' ' + text
+
+    def __str__(self) -> str:
+        return self.get_history_str() or ''
 
 
 class TorchAgent(ABC, Agent):


### PR DESCRIPTION
**Patch description**
Super small thing, but sometimes while I'm stepping through the code I want to print the History object and I find myself looking up the `get_history_str` function every time. This PR just wraps that function so we can call `str(history)`.

**Testing steps**
(from CMU_DoG dataset)
```
>>> str(self.history)
"cast:Leonardo DiCaprio as Frank Abagnale, Jr.,Tom Hanks as Carl Hanratty,Christopher Walken as Frank Abagnale, Sr.,Nathalie Baye as Paula Abagnale.,Amy Adams as Brenda Strong;critical_response: This is not a major Spielberg film, although it is an effortlessly watchable one ,the range and ease and cleverness that Martin Scorsese so underutilized in Gangs of New York, Catch Me if You Can never takes itself or its subjects too seriously, and contains more genuinely funny material than about 90% of the so-called 'comedies' found in multiplexes these days ,bogged down over 140 minutes. A film that took off like a hare on speed ends like a winded tortoise.;director:Steven Spielberg;genre:biographical, crime;introduction:Catch Me If You Can is a 2002 American biographical crime film directed and co-produced by Steven Spielberg from a screenplay by Jeff Nathanson. The film is based on the life of Frank Abagnale, who, before his 19th birthday, successfully performed cons worth millions of dollars by posing as a Pan American World Airways pilot, a Georgia doctor and a Louisiana parish prosecutor. His primary crime was check fraud; he became so experienced that the FBI eventually turned to him for help in catching other checking forgers. The film stars Leonardo DiCaprio and Tom Hanks, with Christopher Walken, Martin Sheen, and Nathalie Baye in supporting roles.;movieName:Catch me if you can;rating:Rotten Tomatoes: 96% and average: 7.9/10,Metacritic Score: 76/100,CinemaScore: A-;year:2002"
>>> self.history.history_strings = []
>>> str(self.history)
''
>>>
```