### PR TITLE
Support a rewards field in parlai format

### DIFF
--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -659,6 +659,11 @@ def str_to_msg(txt, ignore_fields=''):
             or key == 'text_candidates'
         ):
             return tolist(value)
+        elif key == 'reward':
+            try:
+                return int(value)
+            except ValueError:
+                return float(value)
         elif key == 'episode_done':
             return bool(value)
         else:


### PR DESCRIPTION
**Patch description**
A user requested that the rewards field be properly respected as an integer and/or float for use with the unlikelihood agent.

**Testing**
CI