### PR TITLE
Background Preprocessing

### DIFF
--- a/docs/source/tutorial_fast.md
+++ b/docs/source/tutorial_fast.md
@@ -12,10 +12,11 @@ Note that you will want to freshly tune your learning rate when using
 these tricks, or simply use these options in the first place.
 
 This tutorial is only for illustration purposes of how to speed up training,
-and may not get you the best _performing_ model.
+and may not get you the best _performing_ model. You will need to tune
+other hyperparameters like Learning Rate.
 :::
 
-A summary of the speedups is in this table:
+A summary of the speedups, for an 8 layer Transformer, is in this table:
 
 | Method                   | Train | Eval | Total | Speedup |
 | ------------------------ | ----: | ---: | ----: | ------: |
@@ -109,10 +110,10 @@ batching, to compensate for the fewer steps.
 ## FP16
 
 If you have access to an NVIDIA GPU with FP16 CUDA Cores (V100, GTX 2080, etc),
-then you can get large speedups by switching on the option `--fp16 true`. The
-default version of FP16 requires that you install
-[APEX](https://github.com/NVIDIA/apex), but you can use a simplified version
-(which doesn't depend on APEX) with `--fp16 true --fp16-impl mem_efficient`.
+then you can get large speedups by switching on the option `--fp16 true`. There
+are two version of FP16 you may use: `--fp16-impl safe` and
+`--fp16-impl mem_efficient`. The latter trades some numerical stability in exhange
+for lower memory consumption, and typically works well in practice.
 
 Note that in order to get the full benefit of fp16, we need to make sure all
 our hidden dimensions are _multiples of 8_, otherwise the hardware won't use
@@ -153,8 +154,7 @@ We can further speed things up by doing some preprocessing, such as
 tokenization and dialogue state tracking, in the background thread. This can be
 enabled by setting `--num-workers` to a value greater than 0. A good rule of
 thumb is to set `--num-workers` to the number of CPU cores you have PER GPU.
-Sometimes you can go a bit over, but you will need to play. On my server, there
-are 4 cores per GPU, so I will set it to 4.
+On my server, there are 8 cores per GPU, so I will set it to 8.
 
     parlai train --dict-file dictfile --model transformer/generator --task \
         --task convai2 --num-epochs 1.0 --batchsize 64 --n-layers 8  \
@@ -186,8 +186,8 @@ Note that launching a multiprocessing train can take time to "warm up" and it
 may take time for you to realize speed improvements when using small, toy
 training runs like in this document. If we train for 4 epochs instead, our FP16
 large-batch run takes 614 seconds and the multi-GPU training takes 222 seconds.
-Also, if you have access to a SLURM cluster, distributed_train is sometimes
-faster than multiprocessin_train. With SLURM, multi-GPU training takes 167 seconds
+Also, if you have access to a SLURM cluster, `distributed_train` is sometimes
+faster than `multiprocessing_train`. With SLURM, multi-GPU training takes 167 seconds
 for 4 epochs, or about a 3.7x speedup compared to single GPU.
 
 Similarly, we also have the `multiprocessing_eval` command, for using multiple

--- a/docs/source/tutorial_fast.md
+++ b/docs/source/tutorial_fast.md
@@ -2,33 +2,43 @@
 
 Author: Stephen Roller
 
-This tutorial walks you through a few ways to massively speed up your training runs
-in ParlAI. These tricks tend to work best with generative models, but some can also be
-used with others.
+This tutorial walks you through a few ways to massively speed up your training
+runs in ParlAI. These tricks tend to work best with generative models, but some
+can also be used with others.
+
+:::{warning} Retuning-hyperparameters
+Many of these options are effectively tricks for changing the batchsize.
+Note that you will want to freshly tune your learning rate when using
+these tricks, or simply use these options in the first place.
+
+This tutorial is only for illustration purposes of how to speed up training,
+and may not get you the best _performing_ model.
+:::
 
 A summary of the speedups is in this table:
 
-| Method                  | Train | Eval | Total | Speedup |
-| ----------------------- | ----: | ---: | ----: | ------: |
-| Baseline                |  504s |  48s |  552s |    1.0x |
-| Skip generation         |  504s |  16s |  520s |    1.1x |
-| Dynamic batching        |  254s |  11s |  265s |    2.1x |
-| FP16                    |  197s |   8s |  205s |    2.7x |
-| Larger batchsize (FP16) |  151s |   7s |  158s |    3.5x |
-| Using 4 GPUs            |   47s |   3s |   50s |   11.0x |
+| Method                   | Train | Eval | Total | Speedup |
+| ------------------------ | ----: | ---: | ----: | ------: |
+| Baseline                 |  579s |  60s |  639s |   1.00x |
+| Skip generation          |  579s |  20s |  599s |   1.07x |
+| Dynamic batching         |  289s |  18s |  307s |   2.08x |
+| FP16                     |  212s |  11s |  223s |   2.60x |
+| Larger batchsize (FP16)  |  168s |  10s |  178s |   3.59x |
+| Background preprocessing |  144s |  10s |  154s |   4.15x |
+| Using 4 GPUs             |   63s |   4s |   67s |   8.64x |
 
 ## Setting a baseline
 
 We'll start with an example training command, which trains a
-transformer/generator on ConvAI2 for one epoch, using a batchsize of 64, with a
+transformer/generator on ConvAI2 for 1 epoch, using a batchsize of 64, with a
 roughly 20M parameter model. We'll train using ADAM optimizer, with a learning
 rate of 1e-3. We'll build the dictionary ahead of time to ensure it's kept the
-same.
+same. *This will be our baseline*.
 
-    mkdir fastmodels
     parlai build_dict --task convai2 --dict-file dictfile
-    parlai train --dict-file dictfile --model transformer/generator --task convai2 --num-epochs 1.0 --batchsize 64 \
-        --embedding-size 250 --ffn-size 1000 --n-layers 8 --optimizer adam --learningrate 1e-3
+    parlai train --dict-file dictfile --model transformer/generator --task \
+        --task convai2 --num-epochs 1.0 --batchsize 64 --n-layers 8  \
+        --embedding-size 250 --ffn-size 1000 --optimizer adam --learningrate 1e-3
 
 On my computer using a 16gb V100, this takes about 550s. 500s is spend in training,
 and another 50s is spent in evaluation.
@@ -36,16 +46,21 @@ and another 50s is spent in evaluation.
 We will continuously modify this training command in this tutorial, but you are
 free to mix and match options.
 
-## Skip generation
+## Skip generation & larger eval batchsize
 
 You may notice your model is taking a long time to evaluate, even though the
 evaluation dataset is much smaller. This is because we are doing full
 generation through the model, including beam search. You can get a massive
 speedup by turning off this generation step, with `--skip-generation true`.
 
-    parlai train --dict-file dictfile --model transformer/generator --task convai2 --num-epochs 1.0 --batchsize 64 \
-        --embedding-size 250 --ffn-size 1000 --n-layers 8 --optimizer adam --learningrate 1e-3 \
-        --skip-generation true
+Note that during evaluation, we don't need to keep activations around for
+backpropagation, so we can also afford to increase the batchsize. About 2x
+commonly works, but 1.5x is more conservative.
+
+    parlai train --dict-file dictfile --model transformer/generator --task \
+        --task convai2 --num-epochs 1.0 --batchsize 64 --n-layers 8  \
+        --embedding-size 250 --ffn-size 1000 --optimizer adam --learningrate 1e-3 \
+        --skip-generation true --eval-batchsize 128
 
 This brings evaluation time down to 16s, but doesn't affect training time.  Just
 remember you will need to _turn `--skip-generation` back off_ if you want
@@ -68,12 +83,12 @@ memory available on your GPU.
 Add `--dynamic-batching full` (`-dynb full`) to your training command. Note
 that in order to use dynamic batching, we must also set a `--truncate` option.
 We'll use 256, since that is longer than almost all the conversations in our
-data.
+data. Note you can use the `clen` metric to help you set a good truncation.
 
-    parlai train --dict-file dictfile --model transformer/generator --task convai2 --num-epochs 1.0 --batchsize 64 \
-        --embedding-size 250 --ffn-size 1000 --n-layers 8 --optimizer adam --learningrate 1e-3 \
-        --skip-generation true \
-        --eval-batchsize 128 \
+    parlai train --dict-file dictfile --model transformer/generator --task \
+        --task convai2 --num-epochs 1.0 --batchsize 64 --n-layers 8  \
+        --embedding-size 250 --ffn-size 1000 --optimizer adam --learningrate 1e-3 \
+        --skip-generation true --eval-batchsize 128 \
         --dynamic-batching full --truncate 256
 
 You should notice that your memory utilization is much higher in this mode.
@@ -105,23 +120,23 @@ CUDA cores. We will slightly adjust the size of the network to support this.
 We'll slightly adjust the network parameters (--embedding-size and --ffn-size)
 to conform to this.
 
-    parlai train --dict-file dictfile --model transformer/generator --task convai2 --num-epochs 1.0 --batchsize 64 \
-        --embedding-size 256 --ffn-size 1024 --n-layers 8 --optimizer adam --learningrate 1e-3 \
-        --skip-generation true \
-        --eval-batchsize 128 \
-        --dynamic-batching full \
+    parlai train --dict-file dictfile --model transformer/generator --task \
+        --task convai2 --num-epochs 1.0 --batchsize 64 --n-layers 8  \
+        --embedding-size 256 --ffn-size 1024 --optimizer adam --learningrate 1e-3 \
+        --skip-generation true --eval-batchsize 128 \
+        --dynamic-batching full --truncate 256
         --fp16 true --fp16-impl mem_efficient
 
 Further notice that FP16 often significantly lowers the memory size of your model
 and activations (almost by a factor of 2). This means you can usually get away with
 significantly increasing the batchsize (and eval batchsize).
 
-    parlai train --dict-file dictfile --model transformer/generator --task convai2 --num-epochs 1.0 \
-        --embedding-size 256 --ffn-size 1024 --n-layers 8 --optimizer adam --learningrate 1e-3 \
+    parlai train --dict-file dictfile --model transformer/generator --task \
+        --task convai2 --num-epochs 1.0 --batchsize 64 --n-layers 8  \
+        --embedding-size 256 --ffn-size 1024 --optimizer adam --learningrate 1e-3 \
         --skip-generation true \
-        --eval-batchsize 256 \
         --dynamic-batching full \
-        --fp16 true --batchsize 128
+        --fp16 true --fp16-impl mem_efficient --batchsize 128 --eval-batchsize 256
 
 In this example, we see about a 25% speedup. Generally you can expect a larger
 speedup with larger models, with models of >300M often getting a ~50% speedup.
@@ -132,6 +147,23 @@ Without a GPU with FP16 CUDA cores, you may find that FP16 actually slows
 your program. You may still see a benefit from the reduced memory usage though.
 :::
 
+## Background preprocessing
+
+We can further speed things up by doing some preprocessing, such as
+tokenization and dialogue state tracking, in the background thread. This can be
+enabled by setting `--num-workers` to a value greater than 0. A good rule of
+thumb is to set `--num-workers` to the number of CPU cores you have PER GPU.
+Sometimes you can go a bit over, but you will need to play. On my server, there
+are 4 cores per GPU, so I will set it to 4.
+
+    parlai train --dict-file dictfile --model transformer/generator --task \
+        --task convai2 --num-epochs 1.0 --batchsize 64 --n-layers 8  \
+        --embedding-size 256 --ffn-size 1024 --optimizer adam --learningrate 1e-3 \
+        --skip-generation true \
+        --dynamic-batching full \
+        --fp16 true --fp16-impl mem_efficient --batchsize 128 --eval-batchsize 256 \
+        --num-workers 8
+
 ## Use multiple GPUs
 
 If you have multiple GPUs, you can utilize them by switching from `train` to
@@ -139,15 +171,24 @@ If you have multiple GPUs, you can utilize them by switching from `train` to
 roughly 3.5x faster. The arguments for the training are left otherwise the same.
 
     parlai multiprocessing_train \
-        --dict-file dictfile --model transformer/generator --task convai2 --num-epochs 1.0 --batchsize 64 \
-        --embedding-size 256 --ffn-size 1024 --n-layers 8 --optimizer adam --learningrate 1e-3 \
+        --dict-file dictfile --model transformer/generator --task \
+        --task convai2 --num-epochs 1.0 --batchsize 64 --n-layers 8  \
+        --embedding-size 256 --ffn-size 1024 --optimizer adam --learningrate 1e-3 \
         --skip-generation true \
-        --eval-batchsize 128 \
         --dynamic-batching full \
-        --fp16 true
+        --fp16 true --fp16-impl mem_efficient --batchsize 128 --eval-batchsize 256 \
+        --num-workers 8
 
-Note that we leave batchsize the same: we use the batchsize PER GPU. In my
-system, I have 4 GPUs, so things are a little under 4x faster.
+Note that we leave batchsize the same: we use the batchsize PER GPU. We expect
+the batchsize will be effectively 4x'd by using 4 GPUs.
+
+Note that launching a multiprocessing train can take time to "warm up" and it
+may take time for you to realize speed improvements when using small, toy
+training runs like in this document. If we train for 4 epochs instead, our FP16
+large-batch run takes 614 seconds and the multi-GPU training takes 222 seconds.
+Also, if you have access to a SLURM cluster, distributed_train is sometimes
+faster than multiprocessin_train. With SLURM, multi-GPU training takes 167 seconds
+for 4 epochs, or about a 3.7x speedup compared to single GPU.
 
 Similarly, we also have the `multiprocessing_eval` command, for using multiple
 GPUs in evaluation.

--- a/parlai/agents/test_agents/counter.py
+++ b/parlai/agents/test_agents/counter.py
@@ -52,6 +52,12 @@ class UniqueMetric(_CounterMetric):
         return len(self._counter)
 
 
+class FakeList(list):
+    @property
+    def batchsize(self):
+        return len(self)
+
+
 class CounterAgent(TorchAgent):
     """
     Simple agent that counts the number of unique things it has seen.
@@ -101,6 +107,9 @@ class CounterAgent(TorchAgent):
 
     def eval_step(self):
         pass
+
+    def batchify(self, observations):
+        return FakeList(observations)
 
     def _to_tuple(self, msg: Message) -> Tuple:
         # turned into an indexable object

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2304,7 +2304,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
             ]
 
         # deal with --num-workers
-        self.threading = not (opt.get('num_workers') > 0 and self.is_train)
+        self.threading = not (opt.get('num_workers', 0) > 0 and self.is_train)
         if not self.threading and opt.get('background_index') is None:
             # don't start loading data on the main driver, we don't need it
             opt['no_auto_enqueues'] = True

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -145,7 +145,7 @@ class _ErrorThrowingDataLoader(object):
     def request_load(self, receive_fn, load_fn, args):
         raise RuntimeError(
             'One of your teachers uses a DataLoader or a thread. You may only '
-            'combine this with --num-wokers 0.'
+            'combine this with --num-workers 0.'
         )
 
     def start(self):
@@ -2319,6 +2319,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
             self.samples = shared['samples']
             self.reset_counter = shared['reset_counter']
             self.rng = shared['rng']
+            self.tot_samples_loaded = shared['tot_samples_loaded']
         else:
             self.is_root_teacher = True
             self.samples = queue.Queue(maxsize=self.buffersize)
@@ -2389,6 +2390,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
         shared['chunks'] = self.chunks
         shared['reset_counter'] = self.reset_counter
         shared['rng'] = self.rng
+        shared['tot_samples_loaded'] = self.tot_samples_loaded
         return shared
 
     def _setup_data(self, datatype):
@@ -2555,9 +2557,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
             self._drain(self.samples)
             self._drain(self.chunks)
             self._enqueue_chunks()
-            self.tot_samples_loaded = defaultdict(
-                int
-            )  # reset the count of samples loaded
+            self.tot_samples_loaded.clear()  # reset the count of samples loaded
             self._enqueue_request()
 
     def shutdown(self):

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2308,7 +2308,6 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
         if not self.threading and opt.get('background_index') is None:
             # don't start loading data on the main driver, we don't need it
             opt['no_auto_enqueues'] = True
-            logging.error("Let's skip")
         if not self.threading:
             # if we're in single-threaded (background preprocessing mode), we
             # can't have a max queue size or we will hang if we overfill it

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -335,7 +335,7 @@ class FixedDialogTeacher(Teacher):
             self.index = AttrDict(value=-1)
 
         if not hasattr(self, 'data_loader'):
-            if opt.get('num_workers', 0) <= 0:
+            if opt.get('background_index') is None:
                 self.data_loader = DataLoader(opt)
             else:
                 self.data_loader = _ErrorThrowingDataLoader(opt)

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -133,10 +133,10 @@ class _ErrorThrowingDataLoader(object):
     """
     A fake DataLoader which throws an exception when a work order is placed.
 
-    Since threads cannot be mixed with spawn_method='fork', we need to disallow
-    users from combining --num-workers with teachers that utilize threads.
-    This placeholder object is only useful for ensuring the user sees a loud
-    error message when they accidentally use a thread.
+    Since threads cannot be mixed with spawn_method='fork', we need to disallow users
+    from combining --num-workers with teachers that utilize threads. This placeholder
+    object is only useful for ensuring the user sees a loud error message when they
+    accidentally use a thread.
     """
 
     def __init__(self, opt):

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -162,20 +162,26 @@ class Batch(AttrDict):
         """
         Move all tensors in the batch to a device.
 
+        NOT in place.
+
         Note that valid_indices and fields starting with an underscore are
-        always kept on CPU and never moved GPU.
+        always kept on CPU.
 
         :return:
             self
         """
+        output = {}
         for key in self.keys():
+            value = getattr(self, key)
             # never move valid_indices or keys starting with a _
             if key == 'valid_indices' or key.startswith('_'):
+                output[key] = value
                 continue
-            if torch.is_tensor(self[key]):
-                self[key] = self[key].to(dev)
-        # just to enable batch = batch.to(dev) idomatics
-        return self
+            if torch.is_tensor(value):
+                output[key] = value.to(dev)
+            else:
+                output[key] = value
+        return type(self)(**output)
 
     def __repr__(self):
         output = ['Batch({']
@@ -1712,8 +1718,11 @@ class TorchAgent(ABC, Agent):
         # make sure we're only passing around tensors
         valid_inds = torch.LongTensor(valid_inds)
 
+        is_training = any('labels' in obs for obs in obs_batch)
+
         return Batch(
             batchsize=len(valid_inds),
+            is_training=is_training,
             text_vec=xs,
             label_vec=ys,
             labels=labels,
@@ -2110,16 +2119,22 @@ class TorchAgent(ABC, Agent):
         # clear local metrics before anything else
         self._local_metrics.clear()
 
+        # create a batch from the vectors
+        if isinstance(observations, Batch):
+            # it may already be batchified by a background worker
+            batch = observations
+            num_observations = batch.valid_indices.max() + 1
+        else:
+            batch = self.batchify(observations)
+            num_observations = len(observations)
+
         # initialize a list of replies with this agent's id
         batch_reply = [
-            Message({'id': self.getID(), 'episode_done': False}) for _ in observations
+            Message({'id': self.getID(), 'episode_done': False})
+            for _ in range(num_observations)
         ]
 
-        # check if there are any labels available, if so we will train on them
-        self.is_training = any('labels' in obs for obs in observations)
-
-        # create a batch from the vectors
-        batch = self.batchify(observations)
+        self.is_training = batch.is_training
 
         # truncation statistics
         if batch._context_original_length is not None:

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -105,6 +105,7 @@ class Batch(AttrDict):
     """
 
     batchsize: int
+    is_training: bool
     text_vec: Optional[torch.LongTensor]
     label_vec: Optional[torch.LongTensor]
     labels: Optional[List[str]]
@@ -131,6 +132,7 @@ class Batch(AttrDict):
         candidate_vecs=None,
         reward=None,
         image=None,
+        is_training: Optional[bool] = None,
         _context_original_length: Optional[torch.LongTensor] = None,
         _context_truncate_rate: Optional[torch.LongTensor] = None,
         _context_truncated_length: Optional[torch.LongTensor] = None,
@@ -149,6 +151,7 @@ class Batch(AttrDict):
             candidates=candidates,
             candidate_vecs=candidate_vecs,
             image=image,
+            is_training=is_training,
             _context_original_length=_context_original_length,
             _context_truncate_rate=_context_truncate_rate,
             _context_truncated_length=_context_truncated_length,

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1310,7 +1310,6 @@ class BackgroundWorkerDynamicBatchWorld(DynamicBatchWorld):
 
     def handle_batch(self, batch):
         batchified = self.world.get_model_agent().batchify(batch)
-        logging.debug(f"Putting batch onto queue (Worker {self.index})")
         self.process_queue.put((self.index, batchified))
         acts = [{} for i in batch]
         return acts

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1287,7 +1287,7 @@ class BackgroundDriverWorld(World):
         return aggregate_unnamed_reports([self.world.report(), self.metrics.report()])
 
     def __del__(self):
-        logging.error("Calling delete!")
+        logging.debug("Killing all the worker processes")
         for p in self._process_pool.processes:
             p.kill()
 

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1237,8 +1237,8 @@ class BackgroundDriverWorld(World):
 
         return mp.start_processes(
             fn=BackgroundWorkerDynamicBatchWorld.launch_process,
-            args=(self.opt, self.get_model_agent(), self._process_queue),
             nprocs=self._num_workers,
+            args=(self.opt, self.get_model_agent(), self._process_queue),
             join=False,
             start_method='fork',
         )

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1286,10 +1286,11 @@ class BackgroundDriverWorld(World):
     def report(self):
         return aggregate_unnamed_reports([self.world.report(), self.metrics.report()])
 
-    def __del__(self):
+    def shutdown(self):
         logging.debug("Killing all the worker processes")
         for p in self._process_pool.processes:
             p.kill()
+        super().shutdown()
 
 
 class BackgroundWorkerDynamicBatchWorld(DynamicBatchWorld):

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1231,6 +1231,9 @@ class BackgroundDriverWorld(World):
         import torch.multiprocessing as mp
 
         self._num_workers = self.opt['num_workers']
+        # 4 per worker is somewhat arbitrary. 1 is potentially too few:
+        # every worker is prevented from queuing up multiple batches.
+        # Unbounded could fill up our memory too much. So 4 per worker.
         self._process_queue = mp.Queue(maxsize=4 * self._num_workers)
         self._process_pool = self._start_processes()
 

--- a/parlai/scripts/multiprocessing_eval.py
+++ b/parlai/scripts/multiprocessing_eval.py
@@ -52,13 +52,14 @@ def launch_and_eval(opt, port):
     Perform a fork() to many processes.
     """
     # Launch multiple subprocesses
-    spawncontext = torch.multiprocessing.spawn(
+    spawncontext = torch.multiprocessing.start_processes(
         multiprocess_eval,
         # need to give rank offset as 1 to cover the fact that the main
         # process is rank 0, but that spawn() doesn't let you control rank
-        (opt, port, 1),
+        args=(opt, port, 1),
         nprocs=opt['distributed_world_size'] - 1,  # main proc will also run loop
         join=False,
+        start_method='fork',
     )
 
     try:

--- a/parlai/scripts/multiprocessing_eval.py
+++ b/parlai/scripts/multiprocessing_eval.py
@@ -59,7 +59,7 @@ def launch_and_eval(opt, port):
         args=(opt, port, 1),
         nprocs=opt['distributed_world_size'] - 1,  # main proc will also run loop
         join=False,
-        start_method='fork',
+        start_method='spawn',  # never fork, or will cause hangs with chunkteacher
     )
 
     try:

--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -49,13 +49,14 @@ def launch_and_train(opt, port):
     Perform a fork() to many processes.
     """
     # Launch multiple subprocesses
-    spawncontext = torch.multiprocessing.spawn(
+    spawncontext = torch.multiprocessing.start_processes(
         multiprocess_train,
         # need to give rank offset as 1 to cover the fact that the main
         # process is rank 0, but that spawn() doesn't let you control rank
         (opt, port, 1),
         nprocs=opt['distributed_world_size'] - 1,  # main proc will also run loop
         join=False,
+        start_method='fork',
     )
 
     try:

--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -56,7 +56,7 @@ def launch_and_train(opt, port):
         (opt, port, 1),
         nprocs=opt['distributed_world_size'] - 1,  # main proc will also run loop
         join=False,
-        start_method='fork',
+        start_method='spawn',
     )
 
     try:

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -104,6 +104,12 @@ def setup_args(parser=None) -> ParlaiParser:
             'setting as --dynamic-batching.'
         ),
     )
+    train.add_argument(
+        '--num-workers',
+        default=0,
+        type=int,
+        help='Number of background workers (training only)',
+    )
     train.add_argument('--display-examples', type='bool', default=False, hidden=True)
     train.add_argument('-eps', '--num-epochs', type=float, default=-1)
     train.add_argument('-ttim', '--max-train-time', type=float, default=-1)

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -823,7 +823,10 @@ class TrainLoop:
                     logging.info(f'max_train_time elapsed:{train_time}s')
                     break
                 if self._train_steps >= self.max_train_steps:
-                    logging.info(f'max_train_steps elapsed:{self._train_steps}')
+                    logging.info(
+                        f'max_train_steps elapsed:{self._train_steps} '
+                        f'time elapsed:{train_time}s'
+                    )
                     break
                 if (
                     log_time > self.log_every_n_secs

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -487,7 +487,7 @@ class ChunkyTeacher(ChunkTeacher):
 
     def create_message(self, sample_item, entry_idx=0):
         text, label = sample_item
-        return {'text': text, 'labels': [label], 'episode_done': True}
+        return Message({'text': text, 'labels': [label], 'episode_done': True})
 
 
 class ChunkySmallBufferTeacher(ChunkyTeacher):

--- a/parlai/utils/bpe.py
+++ b/parlai/utils/bpe.py
@@ -9,7 +9,6 @@ Byte pair encoding (BPE).
 
 Lots of BPE things for ParlAI
 """
-from typing import Optional
 from parlai.core.params import ParlaiParser
 from abc import ABC, abstractmethod
 from functools import lru_cache

--- a/parlai/utils/distributed.py
+++ b/parlai/utils/distributed.py
@@ -290,7 +290,10 @@ def distributed_context(
         # force a sync so that no one gets ahead, and all are seeded together
         sync_object(None)
 
-        yield opt
+        try:
+            yield opt
+        finally:
+            dist.destroy_process_group()
 
 
 @contextlib.contextmanager

--- a/tests/nightly/gpu/test_gpt2.py
+++ b/tests/nightly/gpu/test_gpt2.py
@@ -173,7 +173,6 @@ class TestDistributed(unittest.TestCase):
             build_dict.build_dict(popt)
 
             valid, test = mp_train.launch_and_train(popt, 31338)
-            dist.destroy_process_group()
 
         return (valid, test)
 

--- a/tests/nightly/gpu/test_gpt2.py
+++ b/tests/nightly/gpu/test_gpt2.py
@@ -6,7 +6,6 @@
 
 import unittest
 from parlai.core.agents import create_agent
-import torch.distributed as dist
 import parlai.utils.testing as testing_utils
 import parlai.scripts.multiprocessing_train as mp_train
 import parlai.scripts.build_dict as build_dict

--- a/tests/test_chunkteacher.py
+++ b/tests/test_chunkteacher.py
@@ -15,19 +15,19 @@ from parlai.tasks.integration_tests.agents import NUM_TEST
 import torch.distributed as dist
 import parlai.scripts.multiprocessing_train as mp_train
 
-BASE_ARGS = {
-    'model': 'test_agents/counter',
-    'dict_file': 'zoo:unittest/transformer_generator2/model.dict',
-    'dict_tokenizer': 'space',
-    'truncate': 8,
-    'num_epochs': 2,
-    'datatype': 'train:stream',
-}
-
 
 class TestNumExamples(TestCase):
+    BASE_ARGS = {
+        'model': 'test_agents/counter',
+        'dict_file': 'zoo:unittest/transformer_generator2/model.dict',
+        'dict_tokenizer': 'space',
+        'truncate': 8,
+        'num_epochs': 2,
+        'datatype': 'train:stream',
+    }
+
     def _run(self, **kwargs):
-        opt = {**BASE_ARGS, **kwargs}
+        opt = {**self.BASE_ARGS, **kwargs}
         valid_report, test_report = testing_utils.train_model(opt)
         assert valid_report['unique'] == NUM_TEST
         assert valid_report['times_seen'] == 1
@@ -36,7 +36,7 @@ class TestNumExamples(TestCase):
         return valid_report, test_report
 
     def _run_mp(self, **kwargs):
-        opt = {**BASE_ARGS, **kwargs}
+        opt = {**self.BASE_ARGS, **kwargs}
         with testing_utils.tempdir() as tmpdir:
             if 'model_file' not in opt:
                 opt['model_file'] = os.path.join(tmpdir, 'model')
@@ -193,3 +193,15 @@ class TestNumExamples(TestCase):
             batchsize=2,
             dynamic_batching='batchsort',
         )
+
+
+class TestBackgroundPreprocessorNumExamples(TestNumExamples):
+    BASE_ARGS = {
+        'model': 'test_agents/counter',
+        'dict_file': 'zoo:unittest/transformer_generator2/model.dict',
+        'dict_tokenizer': 'space',
+        'truncate': 8,
+        'num_epochs': 2,
+        'datatype': 'train:stream',
+        'num_workers': 4,
+    }

--- a/tests/test_chunkteacher.py
+++ b/tests/test_chunkteacher.py
@@ -42,7 +42,6 @@ class TestNumExamples(TestCase):
                 opt['model_file'] = os.path.join(tmpdir, 'model')
 
             valid_report, test_report = mp_train.MultiProcessTrain.main(**opt)
-            dist.destroy_process_group()
             assert valid_report['unique'] == NUM_TEST
             assert valid_report['times_seen'] == 1
             assert test_report['unique'] == NUM_TEST

--- a/tests/test_chunkteacher.py
+++ b/tests/test_chunkteacher.py
@@ -12,7 +12,6 @@ from unittest import TestCase
 import os
 import parlai.utils.testing as testing_utils
 from parlai.tasks.integration_tests.agents import NUM_TEST
-import torch.distributed as dist
 import parlai.scripts.multiprocessing_train as mp_train
 
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -65,7 +65,6 @@ class TestDistributed(unittest.TestCase):
             build_dict.build_dict(popt)
 
             valid, test = mp_train.launch_and_train(popt, 31338)
-            dist.destroy_process_group()
 
         return (valid, test)
 
@@ -202,8 +201,6 @@ class TestDistributed(unittest.TestCase):
                 pass
             else:
                 self.fail('Did not raise RuntimeError')
-            finally:
-                dist.destroy_process_group()
 
 
 @testing_utils.skipUnlessGPU
@@ -227,7 +224,6 @@ class TestDistributedEval(unittest.TestCase):
             self.assertAlmostEquals(
                 valid[key].value(), valid_mp[key].value(), delta=0.001
             )
-        dist.destroy_process_group()
 
 
 if __name__ == '__main__':

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -7,7 +7,6 @@
 import os
 import copy
 import unittest
-import torch.distributed as dist
 import parlai.utils.testing as testing_utils
 import parlai.scripts.build_dict as build_dict
 import parlai.scripts.multiprocessing_train as mp_train


### PR DESCRIPTION
**Patch description**
The fabled background preprocessing is here. You can enable it by setting `--num-workers` to a value greater than 0!

Some rough estimates of performance increases:
- Fine tuning BlenderBot: 5-10%
- Fine tuning BART: 15-25%
- Training a Bart-sized model on CommonCrawl-like data: 110% speedup (2.1x faster)

**Testing steps**
Sooooo much manual testing. There is also new CI.