### PR TITLE
Fix bug introduced by killing APEX

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -504,6 +504,9 @@ class TorchGeneratorAgent(TorchAgent, ABC):
                 f"Total parameters: {total_params:,d} ({train_params:,d} trainable)"
             )
 
+            if self.fp16:
+                self.model = self.model.half()
+
             if init_model is not None:
                 # load model parameters if available
                 logging.info(f'Loading existing model params from {init_model}')
@@ -530,9 +533,6 @@ class TorchGeneratorAgent(TorchAgent, ABC):
             self.model = torch.nn.parallel.DistributedDataParallel(
                 self.model, device_ids=device_ids, broadcast_buffers=False
             )
-
-        if shared is None and self.fp16:
-            self.model = self.model.half()
 
         self.reset()
 


### PR DESCRIPTION
**Patch description**
This change was introduced in #3469. At some point, it seemed necessary to get things working for our FP16 safe optimizer. After debugging with @jaseweston, it seems like it was actually significantly increasing numerical instability. I've isolated this change as the problematic change, and confirmed that it does not have issues in either `--fp16-impl safe` or `--fp16-impl mem_efficient`

**Testing steps**
Manual testing.