### PR TITLE
Make MD Gender classifier compatible with Batch refactor

### DIFF
--- a/parlai/tasks/md_gender/yelp.py
+++ b/parlai/tasks/md_gender/yelp.py
@@ -189,9 +189,7 @@ class YelpTeacher(FixedDialogTeacher):
         extra_data = []
         if self.add_unknown_classes:
             # load about data (unknown but inferred)
-            extra_data = gend_utils.get_inferred_about_data(
-                self.opt['task'], self.opt['datatype']
-            )
+            extra_data = gend_utils.get_inferred_about_data(self.opt['task'], self.opt)
 
             # now create partner/TO data: true neutral
             for ex in data:


### PR DESCRIPTION
**Patch description**
https://github.com/facebookresearch/ParlAI/pull/3389 changed how data is stored in Batches, removing the 'observations' field, adding a canonical `.labels` field, etc., and projects/style_gen/classifier.py was refactored as part of that. This PR modifies projects/md_gender/bert_ranker_classifier/agents.py similarly to as was done in that PR.  

**Testing steps**
Gender classifier sweep
