### PR TITLE
Full Tensorboard metric titles

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,5 +32,6 @@ clean:
 	cd "${SOURCEDIR}"; python generate_task_list.py
 	cd "${SOURCEDIR}"; python generate_zoo_list.py
 	cd "${SOURCEDIR}"; python generate_mutator_list.py
+	cd "${SOURCEDIR}"; python generate_metric_list.py
 	cd "${SOURCEDIR}"; python generate_cli.py
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/generate_metric_list.py
+++ b/docs/source/generate_metric_list.py
@@ -11,7 +11,7 @@ fout = open('metric_list.inc', 'w')
 
 fout.write('| Metric | Explanation |\n')
 fout.write('| ------ | ----------- |\n')
-for metric, display in METRICS_DISPLAY_DATA.items():
+for metric, display in sorted(METRICS_DISPLAY_DATA.items()):
     fout.write(f'| `{metric}` | {display.description} |\n')
 
 fout.close()

--- a/docs/source/generate_metric_list.py
+++ b/docs/source/generate_metric_list.py
@@ -12,6 +12,6 @@ fout = open('metric_list.inc', 'w')
 fout.write('| Metric | Explanation |\n')
 fout.write('| ------ | ----------- |\n')
 for metric, display in METRICS_DISPLAY_DATA.items():
-    fout.write(f'| {metric} | {display.description} |\n')
+    fout.write(f'| `{metric}` | {display.description} |\n')
 
 fout.close()

--- a/docs/source/generate_metric_list.py
+++ b/docs/source/generate_metric_list.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from parlai.core.logs import METRICS_DISPLAY_DATA
+
+
+fout = open('metric_list.inc', 'w')
+
+fout.write('| Metric | Explanation |\n')
+fout.write('| ------ | ----------- |\n')
+for metric, display in METRICS_DISPLAY_DATA.items():
+    fout.write(f'| {metric} | {display.description} |\n')
+
+fout.close()

--- a/docs/source/generate_metric_list.py
+++ b/docs/source/generate_metric_list.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from parlai.core.logs import METRICS_DISPLAY_DATA
+from parlai.core.metrics import METRICS_DISPLAY_DATA
 
 
 fout = open('metric_list.inc', 'w')

--- a/docs/source/tutorial_metrics.md
+++ b/docs/source/tutorial_metrics.md
@@ -426,7 +426,7 @@ please [file an issue on GitHub](https://github.com/facebookresearch/ParlAI/issu
 | `ctpb`                  | Context tokens per batch |
 | `ctps`                  | Context tokens per second |
 | `ctrunc`                | Fraction of samples with some context truncation |
-| `context_average_tokens_truncated` | Average length of context tokens truncated |
+| `ctrunclen`             | Average length of context tokens truncated |
 | `exps`                  | Examples per second |
 | `exs`                   | Number of examples processed since last print |
 | `f1`                    | Unigram F1 overlap, under a standardized (model-independent) tokenizer |
@@ -442,7 +442,7 @@ please [file an issue on GitHub](https://github.com/facebookresearch/ParlAI/issu
 | `ltpb`                  | Label tokens per batch |
 | `ltps`                  | Label tokens per second |
 | `ltrunc`                | Fraction of samples with some label truncation |
-| `label_average_tokens_truncated` | Average length of label tokens truncated |
+| `ltrunclen`             | Average length of label tokens truncated |
 | `rouge-1`, `rouge-1`, `rouge-L` | ROUGE metrics |
 | `token_acc`             | Token-wise accuracy (generative only) |
 | `token_em`              | Utterance-level token accuracy. Roughly corresponds to perfection under greedy search (generative only) |

--- a/docs/source/tutorial_metrics.md
+++ b/docs/source/tutorial_metrics.md
@@ -417,36 +417,5 @@ If you find a metric not listed here,
 please [file an issue on GitHub](https://github.com/facebookresearch/ParlAI/issues/new?assignees=&labels=Docs,Metrics&template=other.md).
 :::
 
-| Metric                  | Explanation  |
-| ----------------------- | ------------ |
-| `accuracy`              | Exact match text accuracy |
-| `bleu-4`                | BLEU-4 of the generation, under a standardized (model-independent) tokenizer |
-| `clen`                  | Average length of context in number of tokens |
-| `clip`                  | Fraction of batches with clipped gradients |
-| `ctpb`                  | Context tokens per batch |
-| `ctps`                  | Context tokens per second |
-| `ctrunc`                | Fraction of samples with some context truncation |
-| `ctrunclen`             | Average length of context tokens truncated |
-| `exps`                  | Examples per second |
-| `exs`                   | Number of examples processed since last print |
-| `f1`                    | Unigram F1 overlap, under a standardized (model-independent) tokenizer |
-| `gnorm`                 | Gradient norm |
-| `gpu_mem`               | Fraction of GPU memory used. May slightly underestimate true value. |
-| `hits@1`, `hits@5`, ... | Fraction of correct choices in K guesses. (Similar to recall@K) |
-| `interdistinct-1`, `interdictinct-2` | Fraction of n-grams unique across _all_ generations |
-| `intradistinct-1`, `intradictinct-2` | Fraction of n-grams unique _within_ each utterance |
-| `jga`                   | Joint Goal Accuracy |
-| `llen`                  | Average length of label in number of tokens |
-| `loss`                  | Loss |
-| `lr`                    | The most recent learning rate applied |
-| `ltpb`                  | Label tokens per batch |
-| `ltps`                  | Label tokens per second |
-| `ltrunc`                | Fraction of samples with some label truncation |
-| `ltrunclen`             | Average length of label tokens truncated |
-| `rouge-1`, `rouge-1`, `rouge-L` | ROUGE metrics |
-| `token_acc`             | Token-wise accuracy (generative only) |
-| `token_em`              | Utterance-level token accuracy. Roughly corresponds to perfection under greedy search (generative only) |
-| `total_train_updates`   | Number of SGD steps taken across all batches |
-| `tpb`                   | Total tokens (context + label) per batch |
-| `tps`                   | Total tokens (context + label) per second |
-| `ups`                   | Updates per second (approximate) |
+```{include} metric_list.inc
+```

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -14,7 +14,6 @@ extended to any other tool like visdom.
    tensorboard --logdir <PARLAI_DATA/tensorboard> --port 8888.
 """
 
-from collections import namedtuple
 import os
 from typing import Optional
 from parlai.core.params import ParlaiParser
@@ -22,104 +21,9 @@ import json
 import numbers
 import datetime
 from parlai.core.opt import Opt
-from parlai.core.metrics import Metric, dict_report
+from parlai.core.metrics import Metric, dict_report, get_metric_display_data
 from parlai.utils.io import PathManager
 import parlai.utils.logging as logging
-
-
-MetricDisplayData = namedtuple('MetricDisplayData', ('title', 'description'))
-
-METRICS_DISPLAY_DATA = {
-    "accuracy": MetricDisplayData("Accuracy", "Exact match text accuracy"),
-    "bleu-4": MetricDisplayData(
-        "BLEU-4",
-        "BLEU-4 of the generation, under a standardized (model-independent) tokenizer",
-    ),
-    "clen": MetricDisplayData(
-        "Context Length", "Average length of context in number of tokens"
-    ),
-    "clip": MetricDisplayData(
-        "Clipped Gradients", "Fraction of batches with clipped gradients"
-    ),
-    "ctpb": MetricDisplayData("Context Tokens Per Batch", "Context tokens per batch"),
-    "ctps": MetricDisplayData("Context Tokens Per Second", "Context tokens per second"),
-    "ctrunc": MetricDisplayData(
-        "Context Truncation", "Fraction of samples with some context truncation"
-    ),
-    "ctrunclen": MetricDisplayData(
-        "Context Truncation Length", "Average length of context tokens truncated"
-    ),
-    "exps": MetricDisplayData("Examples Per Second", "Examples per second"),
-    "exs": MetricDisplayData(
-        "Examples", "Number of examples processed since last print"
-    ),
-    "f1": MetricDisplayData(
-        "F1", "Unigram F1 overlap, under a standardized (model-independent) tokenizer"
-    ),
-    "gnorm": MetricDisplayData("Gradient Norm", "Gradient norm"),
-    "gpu_mem": MetricDisplayData(
-        "GPU Memory",
-        "Fraction of GPU memory used. May slightly underestimate true value.",
-    ),
-    "hits@1": MetricDisplayData(
-        "Hits@1", "Fraction of correct choices in 1 guess. (Similar to recall@K)"
-    ),
-    "hits@5": MetricDisplayData(
-        "Hits@5", "Fraction of correct choices in 5 guesses. (Similar to recall@K)"
-    ),
-    "interdistinct-1": MetricDisplayData(
-        "Interdistinct-1", "Fraction of n-grams unique across _all_ generations"
-    ),
-    "interdistinct-2": MetricDisplayData(
-        "Interdistinct-1", "Fraction of n-grams unique across _all_ generations"
-    ),
-    "intradistinct-1": MetricDisplayData(
-        "Intradictinct-1", "Fraction of n-grams unique _within_ each utterance"
-    ),
-    "intradictinct-2": MetricDisplayData(
-        "Intradictinct-2", "Fraction of n-grams unique _within_ each utterance"
-    ),
-    "jga": MetricDisplayData("Joint Goal Accuracy", "Joint Goal Accuracy"),
-    "llen": MetricDisplayData(
-        "Label Length", "Average length of label in number of tokens"
-    ),
-    "loss": MetricDisplayData("Loss", "Loss"),
-    "lr": MetricDisplayData("Learning Rate", "The most recent learning rate applied"),
-    "ltpb": MetricDisplayData("Label Tokens Per Batch", "Label tokens per batch"),
-    "ltps": MetricDisplayData("Label Tokens Per Second", "Label tokens per second"),
-    "ltrunc": MetricDisplayData(
-        "Label Truncation", "Fraction of samples with some label truncation"
-    ),
-    "ltrunclen": MetricDisplayData(
-        "Label Truncation Length", "Average length of label tokens truncated"
-    ),
-    "rouge-1": MetricDisplayData("ROUGE-1", "ROUGE metrics"),
-    "rouge-2": MetricDisplayData("ROUGE-2", "ROUGE metrics"),
-    "rouge-L": MetricDisplayData("ROUGE-L", "ROUGE metrics"),
-    "token_acc": MetricDisplayData(
-        "Token Accuracy", "Token-wise accuracy (generative only)"
-    ),
-    "token_em": MetricDisplayData(
-        "Token Exact Match",
-        "Utterance-level token accuracy. Roughly corresponds to perfection under greedy search (generative only)",
-    ),
-    "total_train_updates": MetricDisplayData(
-        "Total Train Updates", "Number of SGD steps taken across all batches"
-    ),
-    "tpb": MetricDisplayData(
-        "Tokens Per Batch", "Total tokens (context + label) per batch"
-    ),
-    "tps": MetricDisplayData(
-        "Tokens Per Second", "Total tokens (context + label) per second"
-    ),
-    "ups": MetricDisplayData("Updates Per Second", "Updates per second (approximate)"),
-}
-
-
-def _get_display_data(metric: str) -> MetricDisplayData:
-    return METRICS_DISPLAY_DATA.get(
-        metric, MetricDisplayData(title=metric, description="No description provided.")
-    )
 
 
 class TensorboardLogger(object):
@@ -187,12 +91,12 @@ class TensorboardLogger(object):
             if not isinstance(v, numbers.Number):
                 logging.error(f'k {k} v {v} is not a number')
                 continue
-            display = _get_display_data(metric=k)
+            display = get_metric_display_data(metric=k)
             self.writer.add_scalar(
                 f'{k}/{setting}',
                 v,
                 global_step=step,
-                display_name=f"{display.title} ({k})",
+                display_name=f"{display.title}",
                 summary_description=display.description,
             )
 

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -14,6 +14,7 @@ extended to any other tool like visdom.
    tensorboard --logdir <PARLAI_DATA/tensorboard> --port 8888.
 """
 
+from collections import namedtuple
 import os
 from typing import Optional
 from parlai.core.params import ParlaiParser
@@ -24,6 +25,101 @@ from parlai.core.opt import Opt
 from parlai.core.metrics import Metric, dict_report
 from parlai.utils.io import PathManager
 import parlai.utils.logging as logging
+
+
+MetricDisplayData = namedtuple('MetricDisplayData', ('title', 'description'))
+
+METRICS_DISPLAY_DATA = {
+    "accuracy": MetricDisplayData("Accuracy", "Exact match text accuracy"),
+    "bleu-4": MetricDisplayData(
+        "BLEU-4",
+        "BLEU-4 of the generation, under a standardized (model-independent) tokenizer",
+    ),
+    "clen": MetricDisplayData(
+        "Context Length", "Average length of context in number of tokens"
+    ),
+    "clip": MetricDisplayData(
+        "Clipped Gradients", "Fraction of batches with clipped gradients"
+    ),
+    "ctpb": MetricDisplayData("Context Tokens Per Batch", "Context tokens per batch"),
+    "ctps": MetricDisplayData("Context Tokens Per Second", "Context tokens per second"),
+    "ctrunc": MetricDisplayData(
+        "Context Truncation", "Fraction of samples with some context truncation"
+    ),
+    "ctrunclen": MetricDisplayData(
+        "Context Truncation Length", "Average length of context tokens truncated"
+    ),
+    "exps": MetricDisplayData("Examples Per Second", "Examples per second"),
+    "exs": MetricDisplayData(
+        "Examples", "Number of examples processed since last print"
+    ),
+    "f1": MetricDisplayData(
+        "F1", "Unigram F1 overlap, under a standardized (model-independent) tokenizer"
+    ),
+    "gnorm": MetricDisplayData("Gradient Norm", "Gradient norm"),
+    "gpu_mem": MetricDisplayData(
+        "GPU Memory",
+        "Fraction of GPU memory used. May slightly underestimate true value.",
+    ),
+    "hits@1": MetricDisplayData(
+        "Hits@1", "Fraction of correct choices in 1 guess. (Similar to recall@K)"
+    ),
+    "hits@5": MetricDisplayData(
+        "Hits@5", "Fraction of correct choices in 5 guesses. (Similar to recall@K)"
+    ),
+    "interdistinct-1": MetricDisplayData(
+        "Interdistinct-1", "Fraction of n-grams unique across _all_ generations"
+    ),
+    "interdistinct-2": MetricDisplayData(
+        "Interdistinct-1", "Fraction of n-grams unique across _all_ generations"
+    ),
+    "intradistinct-1": MetricDisplayData(
+        "Intradictinct-1", "Fraction of n-grams unique _within_ each utterance"
+    ),
+    "intradictinct-2": MetricDisplayData(
+        "Intradictinct-2", "Fraction of n-grams unique _within_ each utterance"
+    ),
+    "jga": MetricDisplayData("Joint Goal Accuracy", "Joint Goal Accuracy"),
+    "llen": MetricDisplayData(
+        "Label Length", "Average length of label in number of tokens"
+    ),
+    "loss": MetricDisplayData("Loss", "Loss"),
+    "lr": MetricDisplayData("Learning Rate", "The most recent learning rate applied"),
+    "ltpb": MetricDisplayData("Label Tokens Per Batch", "Label tokens per batch"),
+    "ltps": MetricDisplayData("Label Tokens Per Second", "Label tokens per second"),
+    "ltrunc": MetricDisplayData(
+        "Label Truncation", "Fraction of samples with some label truncation"
+    ),
+    "ltrunclen": MetricDisplayData(
+        "Label Truncation Length", "Average length of label tokens truncated"
+    ),
+    "rouge-1": MetricDisplayData("ROUGE-1", "ROUGE metrics"),
+    "rouge-2": MetricDisplayData("ROUGE-2", "ROUGE metrics"),
+    "rouge-L": MetricDisplayData("ROUGE-L", "ROUGE metrics"),
+    "token_acc": MetricDisplayData(
+        "Token Accuracy", "Token-wise accuracy (generative only)"
+    ),
+    "token_em": MetricDisplayData(
+        "Token Exact Match",
+        "Utterance-level token accuracy. Roughly corresponds to perfection under greedy search (generative only)",
+    ),
+    "total_train_updates": MetricDisplayData(
+        "Total Train Updates", "Number of SGD steps taken across all batches"
+    ),
+    "tpb": MetricDisplayData(
+        "Tokens Per Batch", "Total tokens (context + label) per batch"
+    ),
+    "tps": MetricDisplayData(
+        "Tokens Per Second", "Total tokens (context + label) per second"
+    ),
+    "ups": MetricDisplayData("Updates Per Second", "Updates per second (approximate)"),
+}
+
+
+def _get_display_data(metric: str) -> MetricDisplayData:
+    return METRICS_DISPLAY_DATA.get(
+        metric, MetricDisplayData(title=metric, description="No description provided.")
+    )
 
 
 class TensorboardLogger(object):
@@ -87,12 +183,18 @@ class TensorboardLogger(object):
             The report to log
         """
         for k, v in report.items():
-            if isinstance(v, numbers.Number):
-                self.writer.add_scalar(f'{k}/{setting}', v, global_step=step)
-            elif isinstance(v, Metric):
-                self.writer.add_scalar(f'{k}/{setting}', v.value(), global_step=step)
-            else:
+            v = v.value() if isinstance(v, Metric) else v
+            if not isinstance(v, numbers.Number):
                 logging.error(f'k {k} v {v} is not a number')
+                continue
+            display = _get_display_data(metric=k)
+            self.writer.add_scalar(
+                f'{k}/{setting}',
+                v,
+                global_step=step,
+                display_name=f"{display.title} ({k})",
+                summary_description=display.description,
+            )
 
     def flush(self):
         self.writer.flush()

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -11,11 +11,21 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
-from collections import Counter, namedtuple
+from collections import Counter
 import functools
 import datetime
 import math
-from typing import Union, List, Optional, Tuple, Set, Any, Dict, Counter as TCounter
+from typing import (
+    Any,
+    Counter as TCounter,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import torch
 
@@ -34,7 +44,11 @@ DISTINCT_METRICS = {
 }
 ALL_METRICS = DEFAULT_METRICS | ROUGE_METRICS | BLEU_METRICS | DISTINCT_METRICS
 
-MetricDisplayData = namedtuple('MetricDisplayData', ('title', 'description'))
+
+class MetricDisplayData(NamedTuple):
+    title: str
+    description: str
+
 
 METRICS_DISPLAY_DATA = {
     "accuracy": MetricDisplayData("Accuracy", "Exact match text accuracy"),
@@ -125,7 +139,11 @@ METRICS_DISPLAY_DATA = {
 
 def get_metric_display_data(metric: str) -> MetricDisplayData:
     return METRICS_DISPLAY_DATA.get(
-        metric, MetricDisplayData(title=metric, description="No description provided.")
+        metric,
+        MetricDisplayData(
+            title=metric,
+            description="No description provided. Please add it to metrics.py if this is an official metric in ParlAI.",
+        ),
     )
 
 

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
-from collections import Counter
+from collections import Counter, namedtuple
 import functools
 import datetime
 import math
@@ -33,6 +33,100 @@ DISTINCT_METRICS = {
     'intradistinct-2',
 }
 ALL_METRICS = DEFAULT_METRICS | ROUGE_METRICS | BLEU_METRICS | DISTINCT_METRICS
+
+MetricDisplayData = namedtuple('MetricDisplayData', ('title', 'description'))
+
+METRICS_DISPLAY_DATA = {
+    "accuracy": MetricDisplayData("Accuracy", "Exact match text accuracy"),
+    "bleu-4": MetricDisplayData(
+        "BLEU-4",
+        "BLEU-4 of the generation, under a standardized (model-independent) tokenizer",
+    ),
+    "clen": MetricDisplayData(
+        "Context Length", "Average length of context in number of tokens"
+    ),
+    "clip": MetricDisplayData(
+        "Clipped Gradients", "Fraction of batches with clipped gradients"
+    ),
+    "ctpb": MetricDisplayData("Context Tokens Per Batch", "Context tokens per batch"),
+    "ctps": MetricDisplayData("Context Tokens Per Second", "Context tokens per second"),
+    "ctrunc": MetricDisplayData(
+        "Context Truncation", "Fraction of samples with some context truncation"
+    ),
+    "ctrunclen": MetricDisplayData(
+        "Context Truncation Length", "Average length of context tokens truncated"
+    ),
+    "exps": MetricDisplayData("Examples Per Second", "Examples per second"),
+    "exs": MetricDisplayData(
+        "Examples", "Number of examples processed since last print"
+    ),
+    "f1": MetricDisplayData(
+        "F1", "Unigram F1 overlap, under a standardized (model-independent) tokenizer"
+    ),
+    "gnorm": MetricDisplayData("Gradient Norm", "Gradient norm"),
+    "gpu_mem": MetricDisplayData(
+        "GPU Memory",
+        "Fraction of GPU memory used. May slightly underestimate true value.",
+    ),
+    "hits@1": MetricDisplayData(
+        "Hits@1", "Fraction of correct choices in 1 guess. (Similar to recall@K)"
+    ),
+    "hits@5": MetricDisplayData(
+        "Hits@5", "Fraction of correct choices in 5 guesses. (Similar to recall@K)"
+    ),
+    "interdistinct-1": MetricDisplayData(
+        "Interdistinct-1", "Fraction of n-grams unique across _all_ generations"
+    ),
+    "interdistinct-2": MetricDisplayData(
+        "Interdistinct-1", "Fraction of n-grams unique across _all_ generations"
+    ),
+    "intradistinct-1": MetricDisplayData(
+        "Intradictinct-1", "Fraction of n-grams unique _within_ each utterance"
+    ),
+    "intradictinct-2": MetricDisplayData(
+        "Intradictinct-2", "Fraction of n-grams unique _within_ each utterance"
+    ),
+    "jga": MetricDisplayData("Joint Goal Accuracy", "Joint Goal Accuracy"),
+    "llen": MetricDisplayData(
+        "Label Length", "Average length of label in number of tokens"
+    ),
+    "loss": MetricDisplayData("Loss", "Loss"),
+    "lr": MetricDisplayData("Learning Rate", "The most recent learning rate applied"),
+    "ltpb": MetricDisplayData("Label Tokens Per Batch", "Label tokens per batch"),
+    "ltps": MetricDisplayData("Label Tokens Per Second", "Label tokens per second"),
+    "ltrunc": MetricDisplayData(
+        "Label Truncation", "Fraction of samples with some label truncation"
+    ),
+    "ltrunclen": MetricDisplayData(
+        "Label Truncation Length", "Average length of label tokens truncated"
+    ),
+    "rouge-1": MetricDisplayData("ROUGE-1", "ROUGE metrics"),
+    "rouge-2": MetricDisplayData("ROUGE-2", "ROUGE metrics"),
+    "rouge-L": MetricDisplayData("ROUGE-L", "ROUGE metrics"),
+    "token_acc": MetricDisplayData(
+        "Token Accuracy", "Token-wise accuracy (generative only)"
+    ),
+    "token_em": MetricDisplayData(
+        "Token Exact Match",
+        "Utterance-level token accuracy. Roughly corresponds to perfection under greedy search (generative only)",
+    ),
+    "total_train_updates": MetricDisplayData(
+        "Total Train Updates", "Number of SGD steps taken across all batches"
+    ),
+    "tpb": MetricDisplayData(
+        "Tokens Per Batch", "Total tokens (context + label) per batch"
+    ),
+    "tps": MetricDisplayData(
+        "Tokens Per Second", "Total tokens (context + label) per second"
+    ),
+    "ups": MetricDisplayData("Updates Per Second", "Updates per second (approximate)"),
+}
+
+
+def get_metric_display_data(metric: str) -> MetricDisplayData:
+    return METRICS_DISPLAY_DATA.get(
+        metric, MetricDisplayData(title=metric, description="No description provided.")
+    )
 
 
 re_art = re.compile(r'\b(a|an|the)\b')

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -2131,8 +2131,7 @@ class TorchAgent(ABC, Agent):
             )
         if batch._context_truncated_length is not None:
             self.record_local_metric(
-                'context_average_tokens_truncated',
-                AverageMetric.many(batch._context_truncated_length),
+                'ctrunclen', AverageMetric.many(batch._context_truncated_length)
             )
         if batch._label_original_length is not None:
             self.record_local_metric(
@@ -2143,8 +2142,7 @@ class TorchAgent(ABC, Agent):
             )
         if batch._label_truncated_length is not None:
             self.record_local_metric(
-                'label_average_tokens_truncated',
-                AverageMetric.many(batch._label_truncated_length),
+                'ltrunclen', AverageMetric.many(batch._label_truncated_length)
             )
 
         self.global_metrics.add('exps', GlobalTimerMetric(batch.batchsize))

--- a/tests/test_torch_agent.py
+++ b/tests/test_torch_agent.py
@@ -1048,9 +1048,5 @@ class TestTorchAgent(unittest.TestCase):
         self.assertEqual(agent._local_metrics['ltrunc'][0].value(), 1.0)
         self.assertEqual(agent._local_metrics['clen'][0].value(), 9)
         self.assertEqual(agent._local_metrics['llen'][0].value(), 11)
-        self.assertEqual(
-            agent._local_metrics['context_average_tokens_truncated'][0].value(), 4
-        )
-        self.assertEqual(
-            agent._local_metrics['label_average_tokens_truncated'][0].value(), 6
-        )
+        self.assertEqual(agent._local_metrics['ctrunclen'][0].value(), 4)
+        self.assertEqual(agent._local_metrics['ltrunclen'][0].value(), 6)


### PR DESCRIPTION
**Patch description**
The abbreviated metric titles are hard to get used to, but using longer metric identifiers makes the stdout print hard to parse.
This PR adds a separation between the metric identifier and the display name of the metric. It also adds a description. The title and description are included in tensorboard, but the abbreviated identifiers are used in the logs.
It moves the source of truth for metric titles and descriptions from the docs to the code, and generates the metrics table from this.

There are a few things I don't really have time to tackle right now, but would be nice for a later PR:
- Representing families of metrics more automatically in the source of truth dict (collapse rouge-* metrics and use appropriate name and description if any metrics matching that format are used).
- Collapsing multiple metrics of the same family in the metrics table
- Preserving the monospace formatting of the metrics in the docs table

**Testing steps**
Ran a basic test run locally:
```
parlai train_model --task babi:task10k:1 --model-file ~/tmp/babi_memnn --batchsize 1 --num-epochs 5 --model memnn --no-cuda -tblog True
```
Verified the metrics were short and fit on the screen:
<img width="921" alt="Screen Shot 2021-03-17 at 4 28 03 PM" src="https://user-images.githubusercontent.com/1254056/111534973-f69ae300-873e-11eb-9394-35a34ce05f21.png">

Verified that they were long and had descriptions on Tensorboard:
<img width="748" alt="Screen Shot 2021-03-17 at 4 27 16 PM" src="https://user-images.githubusercontent.com/1254056/111535031-05819580-873f-11eb-9b37-9ea3b7e27dbc.png">

Built website:
```
cd docs; make html
```
Verified the metrics list was rendered:
<img width="738" alt="Screen Shot 2021-03-17 at 4 50 19 PM" src="https://user-images.githubusercontent.com/1254056/111537218-8b064500-8741-11eb-9e52-5ef337124dc3.png">

