### PR TITLE
[TGA] rank candidates fix

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -844,7 +844,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
             num_cands = len(batch.candidate_vecs[i])
             enc = self.model.reorder_encoder_states(encoder_states, [i] * num_cands)
             cands, _ = self._pad_tensor(batch.candidate_vecs[i])
-            cands = cands.to(batch.label_vec.device)
+            cands = cands.to(batch.text_vec.device)
             scores, _ = self.model.decode_forced(enc, cands)
             score_view = scores.reshape(num_cands * cands.size(1), -1)
             cand_losses = F.cross_entropy(


### PR DESCRIPTION
**Patch description**
#3389 introduced a bug that required a label vec to exist to rank candidates. We only need text vec to exist so I swapped.
