### PR TITLE
[ChunkTeacher] Fix infinite padding output

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2452,7 +2452,7 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
             if self.is_train:
                 self._enqueue_chunks()
                 next_chunk, chunk_reset_cnt = self.chunks.get()
-                while next_chunk is None:
+                if next_chunk is None:
                     # See the race condition described around "gross hack" in
                     # _enqueue_chunks.  if we win the race condition, then
                     # catch it here

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2452,11 +2452,11 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
             if self.is_train:
                 self._enqueue_chunks()
                 next_chunk, chunk_reset_cnt = self.chunks.get()
-                if next_chunk is None:
+                while next_chunk is None:
                     # See the race condition described around "gross hack" in
                     # _enqueue_chunks.  if we win the race condition, then
                     # catch it here
-                    return (None, chunk_reset_cnt)
+                    next_chunk, chunk_reset_cnt = self.chunks.get()
             else:
                 # if we're in valid/test, we need to actually signal the end
                 return (None, chunk_reset_cnt)


### PR DESCRIPTION
**Patch description**
Returning None here causes an issue where only padding examples are loaded onto the sample queue until we hit a crash. This was most obvious during dynamic batching because a self_observe invariant error was triggered.


**Testing steps**
```
 parlai tm -m test_agents/unigram --dict-tokenizer gpt2 -bs 2 -dynb full --truncate 128 -t integration_tests:chunky -mf /tmp/foo -dt train:stream
 ```