### PR TITLE
Change `--inference` to `--ranker-inference` in torch_ranker_agent

### DIFF
--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -162,7 +162,7 @@ class TorchRankerAgent(TorchAgent):
             'single candidate according to the ranking.',
         )
         agent.add_argument(
-            '--inference',
+            '--ranker-inference',
             choices={'max', 'topk'},
             default='max',
             help='Final response output algorithm',


### PR DESCRIPTION
There's a name collision between this and torch_generator_agent. For models that make use of both, the name collision makes for weird behavior.

Since torch_ranker_agent is the one that is less used (and generally has less changes in this variable), let's shift the name collision here.


**Testing steps**
Been using this a bunch in various sweeps and it's fine.

