### PR TITLE
Add weighted version of TransformerUnlikelihoodAgent

### DIFF
--- a/projects/dialogue_unlikelihood/agents.py
+++ b/projects/dialogue_unlikelihood/agents.py
@@ -570,7 +570,6 @@ class RewardWeightedUnlikelihoodAgentTrait(object):
 
         notnull = targets.ne(self.NULL_IDX)
         if self.is_training:
-            # note it's >= because convai2 and other teachers all provide a 0 reward
             mle_notnull = notnull & (batch.rewards >= 0).unsqueeze(1).expand_as(notnull)
         else:
             mle_notnull = notnull


### PR DESCRIPTION
**Patch description**
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->
Added an agent for unlikelihood dialogue, `TransformerWeightedUnlikelihoodAgent` that allows rewards to be weighted as opposed to binary. This involved creating a new trait, `RewardWeightedUnlikelihoodAgentTrait`, that extends the functionality of `RewardUnlikelihoodAgent` such that the loss for each batch example is multiplied by `batch.rewards`.

This addition will allow parts of the training data to be selectively ignored or emphasized, thus allowing the model to be better tailored.

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them. 
Also make sure you have connected your account to CircleCI and those tests run successfully. -->
Not entirely sure how agents under `projects/dialogue_unlikelihood` are tested, but I ran these two test commands. 
```
pytest -k TestTorchAgent
pytest -k TestTransformer
```
The first ran successfully, but the second failed the tests for `test_wide_distillation_losses` and `test_narrow_distillation_losses` under `tests/nightly/gpu/anti_scaling/test_anti_scaling.py`. *However*, these tests also failed under the `master` branch, so I do not think it is related to my addition.

**Related Issues**

 - [#2966](https://github.com/facebookresearch/ParlAI/issues/2966)
 - [#3507](https://github.com/facebookresearch/ParlAI/issues/3507)