### PR TITLE
[bug-fix] fixed is_ prebuilt function name typo in BertDictionaryAgent

### DIFF
--- a/parlai/agents/bert_ranker/bert_dictionary.py
+++ b/parlai/agents/bert_ranker/bert_dictionary.py
@@ -25,7 +25,7 @@ class BertDictionaryAgent(DictionaryAgent):
     Allow to use the Torch Agent with the wordpiece dictionary of Hugging Face.
     """
 
-    def is_prebuit(self):
+    def is_prebuilt(self):
         return True
 
     def __init__(self, opt):


### PR DESCRIPTION
**Patch description**
Fixed  a typo in function name `is_prebuit` -> `is_ prebuilt`.