### PR TITLE
Add --wandb-entity flag to the logger

### DIFF
--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -143,7 +143,7 @@ class WandbLogger(object):
             '--wandb-entity',
             type=str,
             default=None,
-            help='W&B enrity name.',
+            help='W&B entity name.',
             hidden=False,
         )
         return logger

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -139,6 +139,13 @@ class WandbLogger(object):
             help='W&B project name. Defaults to timestamp. Usually the name of the sweep.',
             hidden=False,
         )
+        logger.add_argument(
+            '--wandb-entity',
+            type=str,
+            default=None,
+            help='W&B enrity name.',
+            hidden=False,
+        )
         return logger
 
     def __init__(self, opt: Opt, model=None):
@@ -160,6 +167,7 @@ class WandbLogger(object):
             project=project,
             dir=os.path.dirname(opt['model_file']),
             notes=f"{opt['model_file']}",
+            entity=opt.get('wandb_entity'),
             reinit=True,  # in case of preemption
         )
         # suppress wandb's output


### PR DESCRIPTION
**Patch description**
Allows setting WandB's `entity=` parameter via command line flags.
See https://docs.wandb.ai/ref/run/init

**Testing steps**
Manual testing in a sweep
