### PR TITLE
Switched logging.warn to logging.warning

### DIFF
--- a/parlai/chat_service/services/websocket/sockets.py
+++ b/parlai/chat_service/services/websocket/sockets.py
@@ -23,7 +23,7 @@ class MessageSocketHandler(WebSocketHandler):
         self.subs: Dict[int, T] = kwargs.pop('subs')
 
         def _default_callback(message, socketID):
-            logging.warn(f"No callback defined for new WebSocket messages.")
+            logging.warning(f"No callback defined for new WebSocket messages.")
 
         self.message_callback = kwargs.pop('message_callback', _default_callback)
         self.sid = get_rand_id()

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -245,7 +245,7 @@ def compare_init_model_opts(opt: Opt, curr_opt: Opt):
     # print warnings
     extra_strs = ['{}: {}'.format(k, v) for k, v in extra_opts.items()]
     if extra_strs:
-        logging.warn(
+        logging.warning(
             'your model is being loaded with opts that do not '
             'exist in the model you are initializing the weights with: '
             '{}'.format(','.join(extra_strs))
@@ -255,7 +255,7 @@ def compare_init_model_opts(opt: Opt, curr_opt: Opt):
         '--{} {}'.format(k.replace('_', '-'), v) for k, v in different_opts.items()
     ]
     if different_strs:
-        logging.warn(
+        logging.warning(
             'your model is being loaded with opts that differ '
             'from the model you are initializing the weights with. Add the '
             'following args to your run command to change this: \n'
@@ -309,7 +309,7 @@ def create_agent_from_opt_file(opt: Opt):
     if opt.get('override'):
         for k, v in opt['override'].items():
             if k in opt_from_file and str(v) != str(opt_from_file.get(k)):
-                logging.warn(
+                logging.warning(
                     f'Overriding opt["{k}"] to {v} (previously: {opt_from_file.get(k)})'
                 )
             opt_from_file[k] = v
@@ -413,7 +413,7 @@ def create_agent(opt: Opt, requireModelExists=False):
         model = model_class(opt)
         if requireModelExists and hasattr(model, 'load') and not opt.get('model_file'):
             # double check that we didn't forget to set model_file on loadable model
-            logging.warn('model_file unset but model has a `load` function.')
+            logging.warning('model_file unset but model has a `load` function.')
         return model
     else:
         raise RuntimeError('Need to set `model` argument to use create_agent.')

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -997,7 +997,7 @@ class ParlaiParser(argparse.ArgumentParser):
             # existing command line parameters take priority.
             if key not in opt:
                 if opt.get('allow_missing_init_opts', False):
-                    logging.warn(
+                    logging.warning(
                         f'The "{key}" key in {optfile} will not be loaded, because it '
                         f'does not exist in the target opt.'
                     )

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -1975,7 +1975,7 @@ class AbstractImageTeacher(FixedDialogTeacher):
             with PathManager.open(image_mode_features_dict_path, 'rb') as f:
                 self.image_features_dict = torch.load(f, map_location='cpu')
         else:
-            logging.warn('No existing image features, attempting to build.')
+            logging.warning('No existing image features, attempting to build.')
             if self.is_image_mode_buildable(self.image_mode):
                 # TODO: Awkward to modify the input opt but needed to use
                 # TODO: ImageLoader functionality. Is from comment_battle,

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -966,7 +966,7 @@ class TorchAgent(ABC, Agent):
         """
         if hasattr(self, 'resized_embeddings') and self.resized_embeddings:
             optim_states = None
-            logging.warn('Not loading optimizer due to resize in token embeddings')
+            logging.warning('Not loading optimizer due to resize in token embeddings')
 
         opt = self.opt
 
@@ -1052,7 +1052,7 @@ class TorchAgent(ABC, Agent):
         # will remain the behavior for the time being.
         if optim_states and saved_optim_type != opt['optimizer']:
             # we changed from adam to adamax, or sgd to adam, or similar
-            logging.warn('Not loading optim state since optim class changed.')
+            logging.warning('Not loading optim state since optim class changed.')
             return False
         elif optim_states:
             # check for any fp16/fp32 conversions we need to do

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -317,7 +317,7 @@ class TorchRankerAgent(TorchAgent):
         path = self.opt['model_file'] + '.cands-' + self.opt['task'] + '.cands'
         if PathManager.exists(path) and self.opt['fixed_candidate_vecs'] == 'reuse':
             return path
-        logging.warn(f'Building candidates file as they do not exist: {path}')
+        logging.warning(f'Building candidates file as they do not exist: {path}')
         from parlai.scripts.build_candidates import build_cands
         from copy import deepcopy
 

--- a/parlai/crowdsourcing/tasks/model_chat/bot_agent.py
+++ b/parlai/crowdsourcing/tasks/model_chat/bot_agent.py
@@ -103,7 +103,7 @@ class TurkLikeAgent:
             # If we load many models at once, we have to keep it on CPU
             model_overrides['no_cuda'] = no_cuda
         else:
-            logging.warn(
+            logging.warning(
                 'WARNING: MTurk task has no_cuda FALSE. Models will run on GPU. Will '
                 'not work if loading many models at once.'
             )

--- a/parlai/scripts/data_stats.py
+++ b/parlai/scripts/data_stats.py
@@ -63,7 +63,7 @@ def _report(world, counts):
 
 def verify(opt):
     if opt['datatype'] == 'train':
-        logging.warn('changing datatype from train to train:ordered')
+        logging.warning('changing datatype from train to train:ordered')
         opt['datatype'] = 'train:ordered'
 
     # create repeat label agent and assign it to the specified task

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -139,7 +139,7 @@ def _eval_single_world(opt, agent, task):
     total_cnt = world.num_examples()
 
     if is_distributed():
-        logging.warn('Progress bar is approximate in distributed mode.')
+        logging.warning('Progress bar is approximate in distributed mode.')
 
     while not world.epoch_done() and cnt < max_cnt:
         cnt += opt.get('batchsize', 1)

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -60,7 +60,7 @@ def _num_else_inf(opt: Opt, key: str, distributed_warn=False):
     if opt[key] > 0:
         if distributed_warn and is_distributed():
             nicekey = '--' + key.replace('_', '-')
-            logging.warn(
+            logging.warning(
                 f'Using {nicekey} in distributed mode can lead to slowdowns. '
                 'See https://github.com/facebookresearch/ParlAI/pull/3379 for more info.'
             )

--- a/parlai/scripts/verify_data.py
+++ b/parlai/scripts/verify_data.py
@@ -57,7 +57,7 @@ def warn(txt, act, opt):
 
 def verify(opt):
     if opt['datatype'] == 'train':
-        logging.warn("changing datatype from train to train:ordered")
+        logging.warning("changing datatype from train to train:ordered")
         opt['datatype'] = 'train:ordered'
     opt.log()
     # create repeat label agent and assign it to the specified task

--- a/parlai/tasks/fromfile/agents.py
+++ b/parlai/tasks/fromfile/agents.py
@@ -100,7 +100,7 @@ class ParlaiformatTeacher(ParlAIDialogTeacher):
             if shared is None and (
                 'valid' in self.opt['datatype'] or 'test' in self.opt['datatype']
             ):
-                logging.warn(
+                logging.warning(
                     'You are using this fromfile data as a valid or test set without setting fromfile_datatype_extension to true. Please be aware this uses directly the file you indicated, make sure this is not the same as your training file.'
                 )
         if shared is None:

--- a/parlai/tasks/genderation_bias/agents.py
+++ b/parlai/tasks/genderation_bias/agents.py
@@ -257,7 +257,7 @@ class ControllableTaskTeacher(FixedDialogTeacher):
 
         if opt['invalidate_cache']:
             # invalidate the cache and remove the existing data
-            logging.warn(
+            logging.warning(
                 f' [ WARNING: invalidating cache at {self.save_path} and rebuilding the data. ]'
             )
             if self.save_path == most_recent:
@@ -285,7 +285,7 @@ class ControllableTaskTeacher(FixedDialogTeacher):
                 f.write(json_data)
             logging.info(f'[ Data successfully saved to path: {self.save_path} ]')
         except Exception:
-            logging.warn('Data is not json serializable; not saving')
+            logging.warning('Data is not json serializable; not saving')
 
     def get(self, episode_idx: int, entry_idx: int = 0) -> Message:
         """

--- a/parlai/utils/conversations.py
+++ b/parlai/utils/conversations.py
@@ -242,7 +242,7 @@ class Conversations:
         if self.metadata is not None:
             logging.info(self.metadata)
         else:
-            logging.warn('No metadata available.')
+            logging.warning('No metadata available.')
 
     def __getitem__(self, index):
         return self.conversations[index]

--- a/parlai/utils/logging.py
+++ b/parlai/utils/logging.py
@@ -180,10 +180,6 @@ def error(*args, **kwargs):
     return logger.error(*args, **kwargs)
 
 
-def warn(*args, **kwargs):
-    return logger.warn(*args, **kwargs)
-
-
 def warning(*args, **kwargs):
     return logger.warn(*args, **kwargs)
 

--- a/parlai/utils/logging.py
+++ b/parlai/utils/logging.py
@@ -180,8 +180,12 @@ def error(*args, **kwargs):
     return logger.error(*args, **kwargs)
 
 
+def warn(*args, **kwargs):
+    return logger.warning(*args, **kwargs)
+
+
 def warning(*args, **kwargs):
-    return logger.warn(*args, **kwargs)
+    return logger.warning(*args, **kwargs)
 
 
 def get_all_levels():

--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -770,7 +770,7 @@ def warn_once(msg: str) -> None:
     global _seen_logs
     if msg not in _seen_logs:
         _seen_logs.add(msg)
-        logging.warn(msg)
+        logging.warning(msg)
 
 
 def error_once(msg: str) -> None:


### PR DESCRIPTION
**Patch description**
Currently there are two ways to log warnings: logging.warn() and logging.warning().
This PR switches all logging.warn() usages to logging.warning() and removes logging.warn() implementation.
Besides removing ambiguity, this change is also inline with Python 3.3 warn vs warning naming.

**Testing steps**
Unit tests.
