### PR TITLE
[bg] Catch exceptions in workers

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1282,8 +1282,18 @@ class BackgroundDriverWorld(World):
     def num_episodes(self):
         return self.world.num_episodes()
 
+    def _queue_get(self):
+        import queue
+
+        while True:
+            try:
+                return self._process_queue.get(timeout=10)
+            except queue.Empty:
+                # not getting anything, let's check for exceptions on the
+                self._process_pool.join(timeout=0.1)
+
     def parley(self):
-        index, batch = self._process_queue.get()
+        index, batch = self._queue_get()
         response_object = self.get_model_agent().batch_act(batch)
         # compute metrics
         for response in response_object:


### PR DESCRIPTION
**Patch description**
If exceptions happen in (all) background workers, currently training just hangs indefinitely while we wait for a batch from the queue. This patch adds a timeout, and checks background workers for exceptions when that timeout is hit. I had previously tested checking on these exceptions _before_ pulling from the queue, but it was devastating to speed. This patch seems to strike a good balance.

In manual testing, this patch displayed these properties:
- If _some_, but not all workers threw exceptions, then training continued with just fewer workers. _Sometimes_ there was a print of an exception, but not always. Speed was similar to launching with an equivalent smaller `--num-workers`.
- If _all_ workers threw exceptions, then there was a LOT of log spew and the program ended. But the log spew did contain the root exception in it and thus a hint for the developer.
- If _no_ workers threw exceptions, speed was the approximately same as before this patch (within random variation on an 8 gpu 8 worker 10 minute run)

**Testing steps**
Considerable manual testing.