### PR TITLE
Allow redirects when downloading data

### DIFF
--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -168,7 +168,7 @@ def download(url, path, fname, redownload=False, num_retries=5):
 
         with requests.Session() as session:
             try:
-                response = session.get(url, stream=True, timeout=5)
+                response = session.get(url, stream=True, timeout=5, allow_redirects=True)
 
                 # negative reply could be 'none' or just missing
                 CHUNK_SIZE = 32768


### PR DESCRIPTION
**Patch description**
When I try to download http://parl.ai/downloads/blended_skill_talk/blended_skill_talk.tar.gz I get a redirect, which currently breaks `build.py`. After enabling redirect it works fine.

**Testing steps**
`parlai dd -t blended_skill_talk`

