### PR TITLE
added text to the history

### DIFF
--- a/parlai/mutators/flatten.py
+++ b/parlai/mutators/flatten.py
@@ -23,4 +23,5 @@ class FlattenMutator(ManyEpisodeMutator):
         for message in episode:
             history.append(message.pop('text'))
             message['text'] = '\n'.join(history)
+            history.extend(message["labels"])
             yield [message]


### PR DESCRIPTION
**Patch description**
flatten mutator was only keeping one side of the conversations in its history and there was losing the context of the conversation after flattening. Keeping the previous labels in the history for having for conversation context.

**Testing steps**
Used `parlai display_data` to compare before and after. See images below:

Before:
<img width="341" alt="Screen Shot 2021-04-09 at 4 50 16 PM" src="https://user-images.githubusercontent.com/11262163/114240413-75a5c480-9955-11eb-8318-9ee7849c2664.png">

After:
<img width="451" alt="Screen Shot 2021-04-09 at 4 59 43 PM" src="https://user-images.githubusercontent.com/11262163/114240423-79d1e200-9955-11eb-879c-b9246d902be0.png">
