### PR TITLE
Self chat from messages in file

### DIFF
--- a/parlai/scripts/self_chat.py
+++ b/parlai/scripts/self_chat.py
@@ -54,6 +54,11 @@ def setup_args(parser=None):
         help='Automatically seed conversation with messages from task dataset.',
     )
     parser.add_argument(
+        '--seed-messages-from-file',
+        default=None,
+        help='If specified, loads newline-separated strings from the file as conversation starters.',
+    )
+    parser.add_argument(
         '--outfile', type=str, default=None, help='File to save self chat logs'
     )
     parser.add_argument(

--- a/parlai/tasks/self_chat/worlds.py
+++ b/parlai/tasks/self_chat/worlds.py
@@ -50,6 +50,13 @@ def load_openers(opt) -> Optional[List[str]]:
     return list(openers)
 
 
+def load_openers_from_file(filepath: str) -> List[str]:
+    openers = []
+    with open(filepath, 'r') as f:
+        openers = [l.strip() for l in f]
+    return openers
+
+
 class SelfChatWorld(DialogPartnerWorld):
     def __init__(self, opt, agents, shared=None):
         super().__init__(opt, agents, shared)
@@ -81,6 +88,8 @@ class SelfChatWorld(DialogPartnerWorld):
         """
         if self.opt.get('seed_messages_from_task'):
             self._openers = load_openers(self.opt)
+        elif self.opt.get('seed_messages_from_file'):
+            self._openers = load_openers_from_file(self.opt['seed_messages_from_file'])
 
     def get_openers(self, episode_num: int) -> Optional[List[str]]:
         """

--- a/tests/tasks/self_chat/test_worlds.py
+++ b/tests/tasks/self_chat/test_worlds.py
@@ -6,8 +6,12 @@
 from parlai.agents.repeat_label.repeat_label import RepeatLabelAgent
 from parlai.core.worlds import create_task
 from parlai.scripts.display_data import setup_args
-from parlai.tasks.self_chat.worlds import SelfChatWorld as SelfChatBaseWorld
+from parlai.tasks.self_chat.worlds import (
+    load_openers_from_file,
+    SelfChatWorld as SelfChatBaseWorld,
+)
 
+from tempfile import NamedTemporaryFile
 import unittest
 from unittest.mock import MagicMock
 
@@ -60,6 +64,13 @@ class TestSelfChat(unittest.TestCase):
 
         assert_contexts_match(['you are a seal', 'you are an ostrich'])
         assert_contexts_match([])
+
+    def test_load_openers_from_file(self):
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(b'hey\nhowdy')
+            tmpfile.seek(0)
+            op = load_openers_from_file(tmpfile.name)
+        self.assertListEqual(op, ['hey', 'howdy'])
 
 
 if __name__ == '__main__':

--- a/tests/test_self_chat.py
+++ b/tests/test_self_chat.py
@@ -4,8 +4,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from tempfile import NamedTemporaryFile
 import unittest
+
 from parlai.scripts.self_chat import SelfChat
+import parlai.utils.testing as testing_utils
 
 
 class TestSelfChat(unittest.TestCase):
@@ -30,3 +33,19 @@ class TestSelfChat(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             DisplayData.main(task='self_chat')
+
+    def test_seed_messages_from_file(self):
+        with testing_utils.capture_output() as output:
+            with NamedTemporaryFile() as tmpfile:
+                tmpfile.write(b'howdy\nunique message')
+                tmpfile.seek(0)
+                SelfChat.main(
+                    model='fixed_response',
+                    fixed_response='hi',
+                    seed_messages_from_file=tmpfile.name,
+                    num_self_chats=10,
+                    selfchat_max_turns=2,
+                )
+            output = output.getvalue()
+        assert 'howdy' in output
+        assert 'unique message' in output


### PR DESCRIPTION
**Patch description**
I found myself wanting to generate responses for long list of initial messages. To do this, I extended the self chat to allow for starting the chats with messages from a supplied file.

**Testing steps**
```
λ printf "hello\nhowdy" > ~/tmp/openers.txt
λ parlai self_chat -mf zoo:blender/blender_90M/model --seed-messages-from-file ~/tmp/openers.txt --selfchat-max-turns 2 --num-self-chats 2
15:53:34 | creating task(s): self_chat
[context]: Hi!
[TransformerGenerator_1]: howdy
   [TransformerGenerator_2]: hi , how are you doing today ? i just got back from a long day at the office .
-- end of episode --
15:53:35 | 50.0% complete (1 / 2), 0:00:00 elapsed, 0:00:01 eta
    exs  gpu_mem
      1   .01193
[context]: Hi!
[TransformerGenerator_1]: hello
   [TransformerGenerator_2]: hello , how are you today ? i just got back from a long day at work , so i ' m nervous .
-- end of episode --
```


