### PR TITLE
Update wizard_of_wikipedia agents.py

### DIFF
--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -262,7 +262,7 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
         d = self.data[ep]
         wizard_first = 'Wizard' in d['dialog'][0]['speaker']
         if wizard_first:
-            return (len(d['dialog']) - 1) // 2
+            return (len(d['dialog']) - 1) // 2 + 1
         return len(d['dialog']) // 2
 
     def num_examples(self):
@@ -471,7 +471,7 @@ class BasicdialogTeacher(WizardOfWikipediaTeacher):
         d = self.data[ep]
         first_speaker = d['dialog'][0]['speaker'].lower()
         if self.speaker_label != 'both' and self.speaker_label in first_speaker:
-            return (len(d['dialog']) - 1) // 2
+            return (len(d['dialog']) - 1) // 2 + 1
         return len(d['dialog']) // 2
 
     def get(self, episode_idx, entry_idx=0):

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -264,8 +264,8 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
             choices=['none', 'train', 'all'],
             default='none',
             help='For reproducibility, the default "none" is the previous version which misssing some data.'
-                 'When "train" is chosen, only the training set is supplemented.'
-                 'When "all" is chosen, all data are supplemented.',
+            'When "train" is chosen, only the training set is supplemented.'
+            'When "all" is chosen, all data are supplemented.',
         )
         return parser
 
@@ -491,8 +491,8 @@ class BasicdialogTeacher(WizardOfWikipediaTeacher):
             choices=['none', 'train', 'all'],
             default='none',
             help='For reproducibility, the default "none" is the previous version which misssing some data.'
-                 'When "train" is chosen, only the training set is supplemented.'
-                 'When "all" is chosen, all data are supplemented.',
+            'When "train" is chosen, only the training set is supplemented.'
+            'When "all" is chosen, all data are supplemented.',
         )
         return parser
 

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -490,8 +490,8 @@ class BasicdialogTeacher(WizardOfWikipediaTeacher):
             type=str,
             choices=['none', 'train', 'all'],
             default='none',
-            help='For reproducibility, the default "none" is the previous version which misssing some data.'
-            'When "train" is chosen, only the training set is supplemented.'
+            help='For reproducibility, the default "none" is the previous version which missing some data. '
+            'When "train" is chosen, only the training set is supplemented. '
             'When "all" is chosen, all data are supplemented.',
         )
         return parser

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -263,10 +263,9 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
             type=str,
             choices=['none', 'train', 'all'],
             default='none',
-            help='To add some previously missing data.'
-                 'For reproducibility, the default "none" is the previous version.'
+            help='For reproducibility, the default "none" is the previous version which misssing some data.'
                  'When "train" is chosen, only the training set is supplemented.'
-                 'When "all" is chosen, all data are supplemented',
+                 'When "all" is chosen, all data are supplemented.',
         )
         return parser
 
@@ -491,10 +490,9 @@ class BasicdialogTeacher(WizardOfWikipediaTeacher):
             type=str,
             choices=['none', 'train', 'all'],
             default='none',
-            help='To add some previously missing data.'
-                 'For reproducibility, the default "none" is the previous version.'
+            help='For reproducibility, the default "none" is the previous version which misssing some data.'
                  'When "train" is chosen, only the training set is supplemented.'
-                 'When "all" is chosen, all data are supplemented',
+                 'When "all" is chosen, all data are supplemented.',
         )
         return parser
 


### PR DESCRIPTION
**Patch description**
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->
When `wizard_first` is True, the `len_episode` is incorrectly determined, resulting in some data not being used.

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them. 
Also make sure you have connected your account to CircleCI and those tests run successfully. -->
I tested it using command 

> `parlai display_data --task wizard_of_wikipedia --num-examples 100000`

Before the change

> `loaded 18430 episodes with a total of 74092 examples`

After the change

> `loaded 18430 episodes with a total of 83247 examples`

**Other information**
<!-- Any other information or context you would like to provide. -->
