### PR TITLE
[bg] Fix exception with TCA/TRA.

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -1037,6 +1037,9 @@ class TeacherMetrics(Metrics):
         # Ranking metrics.
         self._update_ranking_metrics(observation, labels)
 
+        self._consume_user_metrics(observation)
+
+    def _consume_user_metrics(self, observation):
         # User-reported metrics
         if 'metrics' in observation:
             for uk, v in observation['metrics'].items():

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1297,7 +1297,7 @@ class BackgroundDriverWorld(World):
         response_object = self.get_model_agent().batch_act(batch)
         # compute metrics
         for response in response_object:
-            self.metrics.evaluate_response(response, [])
+            self.metrics._consume_user_metrics(response)
         self.total_parleys += 1
         self.total_exs += batch.batchsize
 


### PR DESCRIPTION
**Patch description**
TCA was producing text, which was causing most of evaluate_response to be executed, when we were lazily using it for metric accumulation. Refactor out the part we really need.

**Testing steps**
`parlai train -t integration_tests:classifier -m bert_classifier -mf /tmp/test_123 -bs 2 --num-workers 2 --classes one zero --truncate 128`