### PR TITLE
[gputests] Don't use temporary datapath in test_torchscript

### DIFF
--- a/tests/nightly/gpu/test_torchscript.py
+++ b/tests/nightly/gpu/test_torchscript.py
@@ -39,11 +39,9 @@ class TestTorchScript(unittest.TestCase):
         compiled_pattern = regex.compile(Gpt2BpeHelper.PATTERN)
 
         with testing_utils.tempdir() as tmpdir:
-            datapath = tmpdir
-
             for task in tasks:
                 opt = TorchScript.setup_args().parse_kwargs(
-                    task=task, datatype='train:ordered', datapath=datapath
+                    task=task, datatype='train:ordered'
                 )
                 agent = RepeatLabelAgent(opt)
                 # TODO(roller): make a proper create_teacher helper


### PR DESCRIPTION
**Patch description**
Use of a temporary datapath was preventing caching of data, and causing both data and models to be downloaded fresh every run.

**Testing steps**
Ran locally

Before:
```
275.22s call     tests/nightly/gpu/test_torchscript.py::TestTorchScript::test_torchscript_agent
82.70s call     tests/nightly/gpu/test_torchscript.py::TestTorchScript::test_token_splitter
```

After:
```
40.03s call     tests/nightly/gpu/test_torchscript.py::TestTorchScript::test_torchscript_agent
27.79s call     tests/nightly/gpu/test_torchscript.py::TestTorchScript::test_token_splitter
```

We'll need to bump the cache before we are likely to see this play out in CI but that will happen naturally eventually, or sooner for other speedups.