### PR TITLE
[World Logs] Don't crash if a value can't be serialized

### DIFF
--- a/parlai/utils/conversations.py
+++ b/parlai/utils/conversations.py
@@ -336,7 +336,7 @@ class Conversations:
                             convo['context'].append(turn)
                     if new_pair:
                         convo['dialog'].append(new_pair)
-                json_convo = json.dumps(convo)
+                json_convo = json.dumps(convo, default=lambda v: '<not serializable>')
                 f.write(json_convo + '\n')
         logging.info(f'Conversations saved to file: {to_save}')
 


### PR DESCRIPTION
**Patch description**
`text_vec` and `full_text_vec` in the observations contain tensor and can't be json serialized in `eval_model --world-logs`. In this type of scenario, if we crash, we lose all of the logs and have to rerun. This fails more gracefully.

**Testing steps**
```
>>> d = {'a': tensor}
>>> json.dumps(d, default=lambda v: '<not serializable>')
'{"a": "<not serializable>"}'
```
