### PR TITLE
[RareF1] Check for null inputs

### DIFF
--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -142,6 +142,8 @@ class RareWordF1Calculator:
         return " ".join([w for w in words if freq_dist.get(w, cutoff) < cutoff])
 
     def compute(self, guess: str, answers: List[str]) -> F1Metric:
+        if guess is None or answers is None:
+            return F1Metric(0, 0)
         guess = RareWordF1Calculator._filter(self._freq_dist, self._cutoff_count, guess)
         answers = [
             RareWordF1Calculator._filter(self._freq_dist, self._cutoff_count, a)

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -16,7 +16,7 @@ E.g. `wizard_of_wikipedia:WizardDialogKnowledgeTeacher:random_split`
 """
 
 from __future__ import annotations
-from typing import List, Optional, Tuple
+from typing import Iterable, Optional, Tuple
 from parlai.core.message import Message
 from parlai.core.metrics import AverageMetric, normalize_answer, F1Metric
 from parlai.core.params import ParlaiParser
@@ -141,7 +141,7 @@ class RareWordF1Calculator:
         words = normalize_answer(text).split()
         return " ".join([w for w in words if freq_dist.get(w, cutoff) < cutoff])
 
-    def compute(self, guess: str, answers: List[str]) -> F1Metric:
+    def compute(self, guess: str, answers: Iterable[str]) -> F1Metric:
         if guess is None or answers is None:
             return F1Metric(0, 0)
         guess = RareWordF1Calculator._filter(self._freq_dist, self._cutoff_count, guess)
@@ -464,10 +464,11 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
                     model_response['text'], [teacher_action['checked_sentence']]
                 ),
             )
-            self.metrics.add(
-                'rare_word_f1',
-                self.rare_word_f1.compute(model_response['text'], labels),
-            )
+            if labels:
+                self.metrics.add(
+                    'rare_word_f1',
+                    self.rare_word_f1.compute(model_response['text'], labels),
+                )
         elif (
             self.label_type == 'chosen_sent'
             and TOKEN_KNOWLEDGE in model_response['text']


### PR DESCRIPTION
**Patch description**
Didn't catch that `labels` can be `None`.

**Testing steps**
Circle CI
```
λ pytest -k test_end2end
=================================================== test session starts ====================================================
platform linux -- Python 3.7.9, pytest-6.2.2, py-1.10.0, pluggy-1.0.0.dev0
rootdir: /private/home/spoff/ParlAI, configfile: pytest.ini, testpaths: tests, parlai/tasks
plugins: hydra-core-1.0.6, anyio-2.2.0, requests-mock-1.8.0, regressions-2.2.0, datadir-1.3.1
collected 909 items / 905 deselected / 4 selected                                                                          

tests/test_lr_schedulers.py ...                                                                                      [ 75%]
tests/nightly/gpu/test_wizard.py .                                                                                   [100%]

=================================================== slowest 10 durations ===================================================
388.53s call     tests/nightly/gpu/test_wizard.py::TestWizardModel::test_end2end
28.53s setup    tests/nightly/gpu/test_wizard.py::TestWizardModel::test_end2end
3.72s call     tests/test_lr_schedulers.py::TestLRSchedulers::test_end2end_cosine
2.07s call     tests/test_lr_schedulers.py::TestLRSchedulers::test_end2end_linear
2.07s call     tests/test_lr_schedulers.py::TestLRSchedulers::test_end2end_invsqrt

(5 durations < 0.005s hidden.  Use -vv to show these durations.)
================================ 4 passed, 905 deselected, 8 warnings in 431.16s (0:07:11) =================================
```
