### PR TITLE
[params] Fix parser in python 3.8

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -985,7 +985,7 @@ class ParlaiParser(argparse.ArgumentParser):
                     newargs.append(darg)
                 else:
                     newargs.append(arg)
-        args = newargs
+            args = newargs
 
         if nohelp:
             # ignore help

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -1318,6 +1318,8 @@ class ParlaiParser(argparse.ArgumentParser):
             # older python works fine
             return args
 
+        # need the long options specified first, or `dest` will get set to
+        # the short name on accident!
         out_long = []
         out_short = []
         for arg in args:

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -976,7 +976,7 @@ class ParlaiParser(argparse.ArgumentParser):
         # handle the single dash stuff. See _handle_single_dash_addarg for info
         actions = set()
         for action in self._actions:
-            actions = actions | set(action.option_strings)
+            actions.update(action.option_strings)
         if _sys.version_info >= (3, 8, 0):
             newargs = []
             for arg in args:


### PR DESCRIPTION
**Patch description**
ParlAI likes to use short options like `-hs 1024`. Since Python 3.8, this has been broken, and gets parsed as `-h s 1024`.

Although we've patched a few places previously ([example](https://github.com/facebookresearch/ParlAI/pull/3284)), there continue to be little bits and places left. This patch should fix all of them by changing everything to double dashes under the hood.

**Testing steps**
CI, manual testing.