### PR TITLE
fix update_freq when initializing CUDA buffer

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -2255,7 +2255,7 @@ class TorchAgent(ABC, Agent):
             # Only print in the non-shared version.
             logging.info(f'{self.id}: full interactive mode on.')
 
-    def backward(self, loss):
+    def backward(self, loss, is_init_buffer=False):
         """
         Perform a backward pass.
 
@@ -2264,7 +2264,7 @@ class TorchAgent(ABC, Agent):
         """
         update_freq = self.opt.get('update_freq', 1)
 
-        if update_freq > 1:
+        if update_freq > 1 and not is_init_buffer:
             # gradient accumulation, but still need to average across the minibatches
             loss = loss / update_freq
             self._number_grad_accum = (self._number_grad_accum + 1) % update_freq

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -838,7 +838,7 @@ class TorchAgent(ABC, Agent):
         # set interactive mode or not according to options.
         self.set_interactive_mode(opt.get('interactive_mode', False), shared)
 
-        self.buffer_initialized = True
+        self.buffer_initialized = False
 
     def build_history(self):
         """

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -840,7 +840,6 @@ class TorchAgent(ABC, Agent):
 
         self.buffer_initialized = True
 
-
     def build_history(self):
         """
         Return the constructed history object.

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -838,6 +838,9 @@ class TorchAgent(ABC, Agent):
         # set interactive mode or not according to options.
         self.set_interactive_mode(opt.get('interactive_mode', False), shared)
 
+        self.buffer_initialized = True
+
+
     def build_history(self):
         """
         Return the constructed history object.
@@ -2255,7 +2258,7 @@ class TorchAgent(ABC, Agent):
             # Only print in the non-shared version.
             logging.info(f'{self.id}: full interactive mode on.')
 
-    def backward(self, loss, is_init_buffer=False):
+    def backward(self, loss):
         """
         Perform a backward pass.
 
@@ -2264,7 +2267,7 @@ class TorchAgent(ABC, Agent):
         """
         update_freq = self.opt.get('update_freq', 1)
 
-        if update_freq > 1 and not is_init_buffer:
+        if update_freq > 1 and self.buffer_initialized:
             # gradient accumulation, but still need to average across the minibatches
             loss = loss / update_freq
             self._number_grad_accum = (self._number_grad_accum + 1) % update_freq

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -617,7 +617,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
                 loss = 0 * self.compute_loss(self._dummy_batch(batchsize, maxlen))
                 self._control_local_metrics(enabled=True)
                 self._temporarily_disable_local_metrics = False
-                self.backward(loss)
+                self.backward(loss, is_init_buffer=True)
                 self.buffer_initialized = True
             except RuntimeError as e:
                 if 'out of memory' in str(e):

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -617,7 +617,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
                 loss = 0 * self.compute_loss(self._dummy_batch(batchsize, maxlen))
                 self._control_local_metrics(enabled=True)
                 self._temporarily_disable_local_metrics = False
-                self.backward(loss, is_init_buffer=True)
+                self.backward(loss)
                 self.buffer_initialized = True
             except RuntimeError as e:
                 if 'out of memory' in str(e):


### PR DESCRIPTION
**Patch description**
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->

This fixes an issue of initializing  CUDA buffer when using  the accumulated gradients·


**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them. 
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

Tested with [projects.wizard_of_wikipedia.generator.agents:EndToEndAgent](https://github.com/facebookresearch/ParlAI/blob/master/projects/wizard_of_wikipedia/generator/agents.py) agent with train_model.

Before the change
```
20:14:55 | time:50s total_exs:6400 total_steps:100 epochs:0.09
    clen  clip  ctpb  ctps  ctrunc  ctrunclen  exps  exs  gpu_mem  know_acc  know_chance  llen        lr  ltpb  ltps   ltrunc  ltrunclen  token_acc  token_em  total_train_updates  tpb   tps   ups
   75.89     0  2146  9167   .1884      8.831 136.7 3200    .3320         1       .03965 23.46 1.005e-05 746.9  3191 .0003125      .1209          0         0                  100 2893 12357 2.148
```

After the change
```
20:23:45 | time:92s total_exs:12800 total_steps:100 epochs:0.17
    clen  clip  ctpb  ctps  ctrunc  ctrunclen  exps  exs  gnorm  gpu_mem  know_acc  know_chance  know_loss  llen  loss        lr  ltpb  ltps  ltrunc  ltrunclen   ppl  token_acc  token_em  \
   75.48 .1000  2151 10052   .1866      8.264 149.5 6400 .08706    .2992    .04063       .03927       6.19 23.02 10.21 1.005e-05 736.5  3442       0          0 27192  1.358e-05         0
    total_train_updates  tpb   tps   ups
                    100 2888 13493 1.168
```

**Other information**
<!-- Any other information or context you would like to provide. -->
The reason for this issue is that initializing the buffer also updates the parameter `self._number_grad_accum`, causing the loss to become `nan`.
