### PR TITLE
[tests] Speed up test_chunkteacher

### DIFF
--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -82,10 +82,15 @@ def setup_args():
 class MultiProcessTrain(ParlaiScript):
     @classmethod
     def setup_args(cls):
-        return setup_args()
+        argparser = setup_args()
+        argparser.add_argument('--port', type=int, default=None)
+        return argparser
 
     def run(self):
-        port = random.randint(32000, 48000)
+        if self.opt['port'] is None:
+            port = random.randint(32000, 48000)
+        else:
+            port = self.opt['port']
         return launch_and_train(self.opt, port)
 
 

--- a/tests/test_chunkteacher.py
+++ b/tests/test_chunkteacher.py
@@ -8,7 +8,6 @@
 Test correctness of ChunkTeacher in a large number of settings.
 """
 
-import random
 from unittest import TestCase
 import os
 import parlai.utils.testing as testing_utils

--- a/tests/test_chunkteacher.py
+++ b/tests/test_chunkteacher.py
@@ -66,6 +66,10 @@ class TestNumExamples(_Abstract):
         )
 
     @testing_utils.skipUnlessGPU
+    def test_mp_normal_bs1(self):
+        self._run_mp(task='integration_tests:chunky', batchsize=1)
+
+    @testing_utils.skipUnlessGPU
     def test_mp_normal_bs3(self):
         self._run_mp(task='integration_tests:chunky', batchsize=3)
 

--- a/tests/test_chunkteacher.py
+++ b/tests/test_chunkteacher.py
@@ -8,6 +8,7 @@
 Test correctness of ChunkTeacher in a large number of settings.
 """
 
+import random
 from unittest import TestCase
 import os
 import parlai.utils.testing as testing_utils
@@ -15,13 +16,13 @@ from parlai.tasks.integration_tests.agents import NUM_TEST
 import parlai.scripts.multiprocessing_train as mp_train
 
 
-class TestNumExamples(TestCase):
+class _Abstract(TestCase):
     BASE_ARGS = {
         'model': 'test_agents/counter',
         'dict_file': 'zoo:unittest/transformer_generator2/model.dict',
         'dict_tokenizer': 'space',
         'truncate': 8,
-        'num_epochs': 2,
+        'max_train_steps': 10,
         'datatype': 'train:stream',
     }
 
@@ -47,13 +48,11 @@ class TestNumExamples(TestCase):
             assert test_report['times_seen'] == 1
             return valid_report, test_report
 
-    # Regular chunk teacher
 
+class TestNumExamples(_Abstract):
+    # Regular chunk teacher
     def test_normal_bs1(self):
         self._run(task='integration_tests:chunky')
-
-    def test_normal_bs2(self):
-        self._run(task='integration_tests:chunky', batchsize=2)
 
     def test_normal_bs3(self):
         self._run(task='integration_tests:chunky', batchsize=3)
@@ -67,14 +66,6 @@ class TestNumExamples(TestCase):
         )
 
     @testing_utils.skipUnlessGPU
-    def test_mp_normal_bs1(self):
-        self._run_mp(task='integration_tests:chunky')
-
-    @testing_utils.skipUnlessGPU
-    def test_mp_normal_bs2(self):
-        self._run_mp(task='integration_tests:chunky', batchsize=2)
-
-    @testing_utils.skipUnlessGPU
     def test_mp_normal_bs3(self):
         self._run_mp(task='integration_tests:chunky', batchsize=3)
 
@@ -84,19 +75,11 @@ class TestNumExamples(TestCase):
             task='integration_tests:chunky', batchsize=2, dynamic_batching='full'
         )
 
-    @testing_utils.skipUnlessGPU
-    def test_mp_normal_batchsort(self):
-        self._run_mp(
-            task='integration_tests:chunky', batchsize=2, dynamic_batching='batchsort'
-        )
 
+class TestSmallBuffer(_Abstract):
     # Small buffer
-
     def test_small_buffer_bs1(self):
         self._run(task='integration_tests:chunky_small_buffer')
-
-    def test_small_buffer_bs2(self):
-        self._run(task='integration_tests:chunky_small_buffer', batchsize=2)
 
     def test_small_buffer_bs3(self):
         self._run(task='integration_tests:chunky_small_buffer', batchsize=3)
@@ -120,10 +103,6 @@ class TestNumExamples(TestCase):
         self._run_mp(task='integration_tests:chunky_small_buffer')
 
     @testing_utils.skipUnlessGPU
-    def test_mp_small_buffer_bs2(self):
-        self._run_mp(task='integration_tests:chunky_small_buffer', batchsize=2)
-
-    @testing_utils.skipUnlessGPU
     def test_mp_small_buffer_bs3(self):
         self._run_mp(task='integration_tests:chunky_small_buffer', batchsize=3)
 
@@ -143,53 +122,15 @@ class TestNumExamples(TestCase):
             dynamic_batching='batchsort',
         )
 
+
+class TestSlowChunk(_Abstract):
     # Slow chunk
-
-    def test_slow_bs1(self):
-        self._run(task='integration_tests:chunky_slow')
-
-    def test_slow_bs2(self):
-        self._run(task='integration_tests:chunky_slow', batchsize=2)
-
     def test_slow_bs3(self):
         self._run(task='integration_tests:chunky_slow', batchsize=3)
 
     def test_slow_dynb(self):
         self._run(
             task='integration_tests:chunky_slow', batchsize=2, dynamic_batching='full'
-        )
-
-    def test_slow_batchsort(self):
-        self._run(
-            task='integration_tests:chunky_slow',
-            batchsize=2,
-            dynamic_batching='batchsort',
-        )
-
-    @testing_utils.skipUnlessGPU
-    def test_mp_slow_bs1(self):
-        self._run_mp(task='integration_tests:chunky_slow')
-
-    @testing_utils.skipUnlessGPU
-    def test_mp_slow_bs2(self):
-        self._run_mp(task='integration_tests:chunky_slow', batchsize=2)
-
-    @testing_utils.skipUnlessGPU
-    def test_mp_slow_bs3(self):
-        self._run_mp(task='integration_tests:chunky_slow', batchsize=3)
-
-    @testing_utils.skipUnlessGPU
-    def test_mp_slow_dynb(self):
-        self._run_mp(
-            task='integration_tests:chunky_slow', batchsize=2, dynamic_batching='full'
-        )
-
-    @testing_utils.skipUnlessGPU
-    def test_mp_slow_batchsort(self):
-        self._run_mp(
-            task='integration_tests:chunky_slow',
-            batchsize=2,
-            dynamic_batching='batchsort',
         )
 
 
@@ -199,7 +140,7 @@ class TestBackgroundPreprocessorNumExamples(TestNumExamples):
         'dict_file': 'zoo:unittest/transformer_generator2/model.dict',
         'dict_tokenizer': 'space',
         'truncate': 8,
-        'num_epochs': 2,
+        'max_train_steps': 10,
         'datatype': 'train:stream',
         'num_workers': 4,
     }


### PR DESCRIPTION
**Patch description**
Speed up some slower basic unit tests, mostly by removing a combinatorial explosion of options that isn't really necessary. These tests are also somewhat flaky but hopefully this also helps with that.

**Testing steps**
Before:
```
29.17s call     tests/test_chunkteacher.py::TestNumExamples::test_slow_batchsort
26.23s call     tests/test_chunkteacher.py::TestNumExamples::test_slow_dynb
25.44s call     tests/test_chunkteacher.py::TestNumExamples::test_mp_slow_batchsort
22.49s call     tests/test_chunkteacher.py::TestBackgroundPreprocessorNumExamples::test_mp_slow_dynb
22.28s call     tests/test_chunkteacher.py::TestBackgroundPreprocessorNumExamples::test_mp_slow_batchsort
18.69s call     tests/test_chunkteacher.py::TestBackgroundPreprocessorNumExamples::test_slow_dynb
18.63s call     tests/test_chunkteacher.py::TestBackgroundPreprocessorNumExamples::test_slow_batchsort
12.64s call     tests/test_chunkteacher.py::TestNumExamples::test_slow_bs3
12.55s call     tests/test_chunkteacher.py::TestNumExamples::test_slow_bs2
12.53s call     tests/test_chunkteacher.py::TestNumExamples::test_slow_bs1
======= 60 passed, 113 warnings in 477.21s (0:07:57) =======

```

After:
```
$ pytest tests/test_chunkteacher.py
15.95s call     tests/test_chunkteacher.py::TestSlowChunk::test_slow_dynb
10.15s call     tests/test_chunkteacher.py::TestSmallBuffer::test_mp_small_buffer_batchsort
9.12s call     tests/test_chunkteacher.py::TestNumExamples::test_mp_normal_dynb
8.19s call     tests/test_chunkteacher.py::TestNumExamples::test_normal_dynb
8.04s call     tests/test_chunkteacher.py::TestBackgroundPreprocessorNumExamples::test_mp_normal_dynb
7.80s call     tests/test_chunkteacher.py::TestSmallBuffer::test_mp_small_buffer_dynb
5.24s call     tests/test_chunkteacher.py::TestNumExamples::test_mp_normal_bs3
5.10s call     tests/test_chunkteacher.py::TestNumExamples::test_normal_batchsort
4.96s call     tests/test_chunkteacher.py::TestBackgroundPreprocessorNumExamples::test_mp_normal_bs3
4.77s call     tests/test_chunkteacher.py::TestSmallBuffer::test_mp_small_buffer_bs3
======= 22 passed, 113 warnings in 104.89s (0:01:44) =======
```