### PR TITLE
Modify dictionary load to only rstrip to handle space prefixed tokens

### DIFF
--- a/parlai/core/dict.py
+++ b/parlai/core/dict.py
@@ -628,7 +628,7 @@ class DictionaryAgent(Agent):
         SPECIAL_TOKENS = {'__UNK__', '__NULL__', '__END__', '__START__'}
         with PathManager.open(filename, 'r', encoding='utf-8', errors='ignore') as read:
             for line in read:
-                split = line.strip().split('\t')
+                split = line.rstrip("\n\r").split('\t')
                 token = unescape(split[0])
                 if lower_special and token in SPECIAL_TOKENS:
                     token = token.lower()


### PR DESCRIPTION
**Patch description**
If special tokens are prefixed by space, while loading them from the dict for eval, the space was being stripped out. Modifying the strip to be rstrip and strip only line breaks

**Testing steps**
Will wait for CI tests to pass 
