### PR TITLE
[TA] Support temp history via special field in observation

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1786,7 +1786,11 @@ class TorchAgent(ABC, Agent):
 
     def get_temp_history(self, observation) -> Optional[str]:
         """
-        Return a string to temporarily insert into history.
+        Return a string to temporarily insert into history for a single turn.
+
+        *NOTE*: This does NOT attempt to provide any sort of delimiter or spacing
+        between the original history and the temporary history. If you require
+        such delimiter or spacing, you should include it in the temp history.
 
         Intentionally overrideable so more complex models can insert temporary history
         strings, i.e. strings that are removed from the history after a single turn.

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1791,7 +1791,7 @@ class TorchAgent(ABC, Agent):
         Intentionally overrideable so more complex models can insert temporary history
         strings, i.e. strings that are removed from the history after a single turn.
         """
-        return None
+        return observation.get('temp_history')
 
     def observe(self, observation):
         """


### PR DESCRIPTION
**Patch description**
Add a default implementation of `get_temp_history` in the root TorchAgent, which uses the observation's `temp_history` field. This makes it possible to provide temp history to any of our standard models via a teacher, in settings like self-chat.

**Testing steps**
New CI