### PR TITLE
Mutators inside `parlai_internal` and `parlai_fb`

### DIFF
--- a/parlai/core/mutators.py
+++ b/parlai/core/mutators.py
@@ -29,6 +29,24 @@ def setup_mutator_registry():
         return
     for module in pkgutil.iter_modules(parlai.mutators.__path__, 'parlai.mutators.'):
         importlib.import_module(module.name)
+    try:
+        import parlai_fb.mutators
+
+        for module in pkgutil.iter_modules(
+            parlai_fb.mutators.__path__, 'parlai_fb.mutators.'
+        ):
+            importlib.import_module(module.name)
+    except ImportError:
+        pass
+    try:
+        import parlai_internal.mutators
+
+        for module in pkgutil.iter_modules(
+            parlai_internal.mutators.__path__, 'parlai_internal.mutators.'
+        ):
+            importlib.import_module(module.name)
+    except ImportError:
+        pass
     setup_mutator_registry.loaded = True
     return MUTATOR_REGISTRY
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -611,6 +611,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
 
         This is also used in distributed mode to force a worker to sync with others.
         """
+        return
         if self.use_cuda and (force or not hasattr(self, 'buffer_initialized')):
             try:
                 self._control_local_metrics(disabled=True)

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -611,7 +611,6 @@ class TorchGeneratorAgent(TorchAgent, ABC):
 
         This is also used in distributed mode to force a worker to sync with others.
         """
-        return
         if self.use_cuda and (force or not hasattr(self, 'buffer_initialized')):
             try:
                 self._control_local_metrics(disabled=True)


### PR DESCRIPTION
**Patch description**
Allow ParlAI to pick up mutators from internal-only code for internal development.

**Testing steps**
Manual testing.