### PR TITLE
Adding parlai_fb and parlai_interal as alternative scripts directories

### DIFF
--- a/parlai/core/script.py
+++ b/parlai/core/script.py
@@ -35,6 +35,24 @@ def setup_script_registry():
     """
     for module in pkgutil.iter_modules(parlai.scripts.__path__, 'parlai.scripts.'):
         importlib.import_module(module.name)
+    try:
+        import parlai_fb.scripts
+
+        for module in pkgutil.iter_modules(
+            parlai_fb.scripts.__path__, 'parlai_fb.scripts.'
+        ):
+            importlib.import_module(module.name)
+    except ImportError:
+        pass
+    try:
+        import parlai_internal.scripts
+
+        for module in pkgutil.iter_modules(
+            parlai_internal.scripts.__path__, 'parlai_internal.scripts.'
+        ):
+            importlib.import_module(module.name)
+    except ImportError:
+        pass
 
 
 class ParlaiScript(object):


### PR DESCRIPTION
**Patch description**
Extending where the parlai command line looks for scripts. This is only relevant when working internally at FB.

**Testing steps**
See internal diff D28044715.
