### PR TITLE
[tests] Make crowdsource tests whitespace-agnostic

### DIFF
--- a/parlai/crowdsourcing/tasks/acute_eval/util.py
+++ b/parlai/crowdsourcing/tasks/acute_eval/util.py
@@ -191,7 +191,7 @@ class AbstractFastAcuteTest(AbstractOneTurnCrowdsourcingTest):
             results_folder=results_folder, file_suffix=file_suffix
         )
         with open(file_path) as f:
-            contents = f.read()
+            contents = f.read().rstrip('\n') + '\n'
         file_regression.check(contents=contents)
 
     def _get_matching_file_path(self, results_folder: str, file_suffix: str) -> str:

--- a/parlai/crowdsourcing/tasks/acute_eval/util.py
+++ b/parlai/crowdsourcing/tasks/acute_eval/util.py
@@ -191,6 +191,8 @@ class AbstractFastAcuteTest(AbstractOneTurnCrowdsourcingTest):
             results_folder=results_folder, file_suffix=file_suffix
         )
         with open(file_path) as f:
+            # correct whitespace to deal with fbcode demanding disk files not
+            # have many trailing newlines
             contents = f.read().rstrip('\n') + '\n'
         file_regression.check(contents=contents)
 


### PR DESCRIPTION
**Patch description**
#3621 broke crowdsourcing tests by stripping a bunch of whitespace from our regression files. Annoying, but just correct for this in the test and strip the comparison point as well.

**Testing steps**
CI.