### PR TITLE
Handling the MTurkUnit with no message data

### DIFF
--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import os
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -185,5 +186,11 @@ class AbstractDataBrowserResultsCompiler(AbstractResultsCompiler):
         data_browser = self.get_mephisto_data_browser()
         task_data = []
         for unit in task_units:
-            task_data.append(data_browser.get_data_from_unit(unit))
+            try:
+                unit_data = data_browser.get_data_from_unit(unit)
+                task_data.append(unit_data)
+            except IndexError:
+                logging.warning(
+                    f"Skipping unit {unit.db_id}. No message found for this unit."
+                )
         return task_data

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -7,13 +7,14 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import os
 from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, Dict, List
 
 import pandas as pd
+
+import parlai.utils.logging as logging
 
 # Defining the class only if Mephisto is installed, since it relies on Mephisto
 try:


### PR DESCRIPTION
**Patch description**
After the recent changes to Mephisto, when I try to compile the data from the data collection task, there is the following error that indicates some of the `MTurkUnit`s have no messages. 

```
  File ".../Mephisto/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py", line 99, in get_parsed_data
    if "WORLD_DATA" in messages[-1]:
IndexError: list index out of range
```

**Testing steps**
My data compiler ran without any issue after these changes. It just produced a couple of warnings that indicated the units with missing data.