### PR TITLE
skipping the padding message

### DIFF
--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -251,9 +251,9 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
         """
         Overrides TA.observe to tokenize the retriever query.
         """
+        observation = self._generation_agent.observe(self, observation)
         if observation.get('batch_padding', False):
             return observation
-        observation = self._generation_agent.observe(self, observation)
         if 'query_vec' not in observation:
             self._set_query_vec(observation)
         if 'input_turn_cnt_vec' not in observation:

--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -251,7 +251,7 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
         """
         Overrides TA.observe to tokenize the retriever query.
         """
-        if 'batch_padding' in observation and observation['batch_padding']:
+        if observation.get('batch_padding', False):
             return observation
         observation = self._generation_agent.observe(self, observation)
         if 'query_vec' not in observation:

--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -251,8 +251,9 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
         """
         Overrides TA.observe to tokenize the retriever query.
         """
+        observation = Message(observation)
         observation = self._generation_agent.observe(self, observation)
-        if observation.get('batch_padding', False):
+        if observation.is_padding():
             return observation
         if 'query_vec' not in observation:
             self._set_query_vec(observation)

--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -251,6 +251,8 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
         """
         Overrides TA.observe to tokenize the retriever query.
         """
+        if 'batch_padding' in observation and observation['batch_padding']:
+            return observation
         observation = self._generation_agent.observe(self, observation)
         if 'query_vec' not in observation:
             self._set_query_vec(observation)


### PR DESCRIPTION
**Patch description**
The rag agent may crash if there is batch padding message. These message do not contain the `text` data that it want to encode.

**Test**
It used to crash if it was receiving a batch padding message. It successfully finishes with this.