### PR TITLE
[fbcode] Add support for PathManager in vacuum

### DIFF
--- a/parlai/scripts/vacuum.py
+++ b/parlai/scripts/vacuum.py
@@ -10,7 +10,6 @@ Reduces the size of a model file by stripping the optimizer.
 Assumes we are working with a TorchAgent
 """
 
-import os
 import torch
 
 from parlai.core.params import ParlaiParser
@@ -46,7 +45,7 @@ class Vacuum(ParlaiScript):
         model_file = self.opt['path']
         if not model_file:
             raise RuntimeError('--model-file argument is required')
-        if not os.path.isfile(model_file):
+        if not PathManager.isfile(model_file):
             raise RuntimeError(f"'{model_file}' does not exist")
         logging.info(f"Loading {model_file}")
         with PathManager.open(model_file, 'rb') as f:
@@ -55,7 +54,7 @@ class Vacuum(ParlaiScript):
             )
         if not self.opt['no_backup']:
             logging.info(f"Backing up {model_file} to {model_file}.unvacuumed")
-            os.rename(model_file, model_file + ".unvacuumed")
+            PathManager.mv(model_file, model_file + ".unvacuumed")
         for key in [
             'optimizer',
             'optimizer_type',

--- a/parlai/utils/io.py
+++ b/parlai/utils/io.py
@@ -11,8 +11,8 @@ except ImportError:
         from fvcore.common.file_io import PathManagerBase as _PathManager
     except ImportError:
         raise ImportError(
-            "parlai now requires fvcore for some I/O operations. Please run "
-            "`pip install fvcore==0.1.1.post20200716`"
+            "parlai now requires iopath for some I/O operations. Please run "
+            "`pip install iopath`"
         )
 
 USE_ATOMIC_TORCH_SAVE = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ emoji==0.5.4
 docformatter==1.3.0
 flake8-bugbear==19.8.0
 flake8==3.7.8
-fvcore==0.1.1.post20200716
+iopath~=0.1.8
 gitdb2==2.0.5
 GitPython==3.0.3
 hydra-core~=1.0.6


### PR DESCRIPTION
**Patch description**
Hit some internal bugs in fbcode without this patch. Just use PathManager instead of os operations to support internal storage systems.

**Testing steps**
Internal testing, CI