### PR TITLE
[swappable] Annotate decorator with original type

### DIFF
--- a/parlai/agents/transformer/modules/modular.py
+++ b/parlai/agents/transformer/modules/modular.py
@@ -96,7 +96,7 @@ class ModularComponentBuilder(Generic[MC]):
             setattr(self._subcomponents, name, value)
 
 
-def swappable(**kwargs) -> Callable[[Type[C]], Type[ModularComponent[C]]]:
+def swappable(**kwargs) -> Callable[[Type[C]], Type[C]]:
     """
     Decorator that adds swappable subcomponents to a class.
 
@@ -109,13 +109,13 @@ def swappable(**kwargs) -> Callable[[Type[C]], Type[ModularComponent[C]]]:
 
     # Decorators need to return callables that accept only the decorated object.
     # To comply, bundle kwargs into a function that accepts only one argument.
-    def wrap(cls: Type[C]) -> Type[ModularComponent[C]]:
+    def wrap(cls: Type[C]) -> Type[C]:
         return _make_class_swappable(cls, **kwargs)
 
     return wrap
 
 
-def _make_class_swappable(cls: Type[C], **kwargs) -> Type[ModularComponent[C]]:
+def _make_class_swappable(cls: Type[C], **kwargs) -> Type[C]:
     """
     Creates a new class that subclasses ModularComponent.
 


### PR DESCRIPTION
**Patch description**
Unfortunately Python doesn't support an `Intersection` type hint (though they've been talking about it since 2014: https://www.python.org/dev/peps/pep-0483/).

So we have to choose whether we tell static type checkers that the class returned by `@swappable` is the original class or a class that conforms to `ModularComponent`, we can't communicate both.

I think it makes more sense to type check agains the original class, since it's much more likely that people will be accessing properties and methods of the original class rather than `swappables` and `ModularSubcomponents`, which are meant to be somewhat invisible in most cases.

**Testing steps**
Open up IDE and verify that calls to properties of `@swappable` classes don't throw static type checking errors.
CircleCI

