### PR TITLE
Fix overloaded flag

### DIFF
--- a/parlai/scripts/torchscript.py
+++ b/parlai/scripts/torchscript.py
@@ -71,7 +71,7 @@ def setup_args() -> ParlaiParser:
         help='Where the scripted model checkpoint will be saved',
     )
     parser.add_argument(
-        "-i",
+        "-in",
         "--input",
         type=str,
         default='',


### PR DESCRIPTION
`-i` is already used as a short form for `--interactive-mode`, so prevent it from being used when TorchScripting a model