### PR TITLE
[Opt Presets] Fix BB Gen Opt

### DIFF
--- a/parlai/opt_presets/gen/blenderbot.opt
+++ b/parlai/opt_presets/gen/blenderbot.opt
@@ -1,5 +1,5 @@
 {
-  "beam_block_context_ngram": 3,
+  "beam_context_block_ngram": 3,
   "beam_block_ngram": 3,
   "beam_size": 10,
   "inference": "beam",


### PR DESCRIPTION
**Patch description**
Fixing context blocking key in blenderbot gen opt preset.

**Testing steps**
before: 
```
$ parlai i -mf zoo:blender/blender_3B/model -o gen/blenderbot
Traceback (most recent call last):
  File "/private/home/kshuster/.conda/envs/conda_parlai/bin/parlai", line 33, in <module>
    sys.exit(load_entry_point('parlai', 'console_scripts', 'parlai')())
  File "/private/home/kshuster/ParlAI/parlai/__main__.py", line 14, in main
    superscript_main()
  File "/private/home/kshuster/ParlAI/parlai/core/script.py", line 315, in superscript_main
    opt = parser.parse_args(args)
  File "/private/home/kshuster/ParlAI/parlai/core/params.py", line 1156, in parse_args
    self._process_args_to_opts(args)
  File "/private/home/kshuster/ParlAI/parlai/core/params.py", line 1110, in _process_args_to_opts
    self._load_opts(self.opt)
  File "/private/home/kshuster/ParlAI/parlai/core/params.py", line 1025, in _load_opts
    'Trying to set opt from file that does not exist: ' + str(key)
RuntimeError: Trying to set opt from file that does not exist: beam_block_context_ngram
```
After:

```
$ parlai i -mf zoo:blender/blender_3B/model -o gen/blenderbot
...
Enter Your Message: what's up
[TransformerGenerator]: Not much, just got back from the gym. How about you? What are you up to?
```
