### PR TITLE
[Mutators] Ensure mutations do not persist across epochs

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -465,8 +465,10 @@ class FixedDialogTeacher(Teacher):
                     break
                 buffer_entry_idx += 1
             # apply mutators
-            for mutator in self.mutators:
-                episode_buffer = mutator(episode_buffer)
+            if self.mutators:
+                episode_buffer = [m.copy() for m in episode_buffer]
+                for mutator in self.mutators:
+                    episode_buffer = mutator(episode_buffer)
             self.episode_buffer = list(episode_buffer)
 
             if not self.episode_buffer:
@@ -766,8 +768,10 @@ class DialogTeacher(FixedDialogTeacher):
                     self._saw_epoch_done = epoch_done
                     break
             # perform any mutations there are
-            for mutator in self.mutators:
-                episode_buffer = mutator(episode_buffer)
+            if self.mutators:
+                episode_buffer = [m.copy() for m in episode_buffer]
+                for mutator in self.mutators:
+                    episode_buffer = mutator(episode_buffer)
             # make sure mutations are fully realized (not generators)
             self.episode_buffer = list(episode_buffer)
             # The recursive call has dual purpose:

--- a/tests/test_mutators.py
+++ b/tests/test_mutators.py
@@ -226,3 +226,27 @@ class TestSpecificMutators(unittest.TestCase):
         assert set(ex2['text'].split()) == set(EXAMPLE2['text'].split())
         assert set(ex3['text'].split()) == set(EXAMPLE3['text'].split())
         assert set(ex4['text'].split()) == set(EXAMPLE4['text'].split())
+
+
+class TestMutatorStickiness(unittest.TestCase):
+    """
+    Test that mutations DO NOT stick with episode.
+    """
+
+    def test_not_sticky(self):
+        pp = ParlaiParser(True, False)
+        opt = pp.parse_kwargs(
+            task='integration_tests:multiturn',
+            mutators='flatten',
+            datatype='train:ordered',
+        )
+        teacher = create_task_agent_from_taskname(opt)[0]
+        first_epoch = []
+        second_epoch = []
+        for _ in range(teacher.num_examples()):
+            first_epoch.append(teacher.act())
+        teacher.reset()
+        for _ in range(teacher.num_examples()):
+            second_epoch.append(teacher.act())
+
+        assert all(f == s for f, s in zip(first_epoch, second_epoch))


### PR DESCRIPTION
**Patch description**
This patch makes sure that mutated episodes are not "re-mutated"; that is, mutations are applied exactly once, and then a fresh example is used for every following mutation.

**Testing steps**
New CI