### PR TITLE
[Chunk Teacher] Remove exception for specifying non-streaming data

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2291,9 +2291,6 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
         super().__init__(opt, shared)
         self.buffersize = self.get_buffersize()
 
-        if 'stream' not in opt['datatype']:
-            raise ValueError('Chunk teacher should be used with streaming. ')
-
         self.set_datasettings(opt)
 
         self.dws = int(self.opt.get('distributed_world_size', 1))

--- a/tests/test_teachers.py
+++ b/tests/test_teachers.py
@@ -301,27 +301,25 @@ class TestChunkTeacher(unittest.TestCase):
         assert valid['exs'] == 100
         assert test['exs'] == 100
 
-    def test_stream_only(self):
-        with self.assertRaises(ValueError):
-            valid, test = testing_utils.eval_model(
-                dict(
-                    task='integration_tests:chunky',
-                    model='parlai.agents.test_agents.test_agents:MockTorchAgent',
-                    batchsize=32,
-                ),
-                valid_datatype='valid',
-            )
+    def test_non_stream_works(self):
+        testing_utils.eval_model(
+            dict(
+                task='integration_tests:chunky',
+                model='parlai.agents.test_agents.test_agents:MockTorchAgent',
+                batchsize=32,
+            ),
+            valid_datatype='valid',
+        )
 
-        with self.assertRaises(ValueError):
-            valid, test = testing_utils.eval_model(
-                dict(
-                    task='integration_tests:chunky',
-                    model='parlai.agents.test_agents.test_agents:MockTorchAgent',
-                    batchsize=32,
-                ),
-                valid_datatype='valid:stream',
-                test_datatype='test',
-            )
+        testing_utils.eval_model(
+            dict(
+                task='integration_tests:chunky',
+                model='parlai.agents.test_agents.test_agents:MockTorchAgent',
+                batchsize=32,
+            ),
+            valid_datatype='valid:stream',
+            test_datatype='test',
+        )
 
 
 class CustomEvaluationTeacher(DialogTeacher):


### PR DESCRIPTION
**Patch description**
Offline discussion has led me to believe that we can ignore the fact that "stream" is not in the datatype for chunk teacher.

**Testing steps**
Existing CI
