### PR TITLE
[logging] Fix suppression of debug logs

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -1155,7 +1155,6 @@ class ParlaiParser(argparse.ArgumentParser):
 
         self._process_args_to_opts(args)
         print_announcements(self.opt)
-        logging.set_log_level(self.opt.get('loglevel', 'info').upper())
 
         assert '_subparser' not in self.opt
 

--- a/parlai/core/script.py
+++ b/parlai/core/script.py
@@ -102,6 +102,7 @@ class ParlaiScript(object):
 
     @classmethod
     def _run_from_parser_and_opt(cls, opt: Opt, parser: ParlaiParser):
+        logging.set_log_level(opt.get('loglevel', 'info').upper())
         script = cls(opt)
         script.parser = parser
         return script.run()

--- a/parlai/utils/logging.py
+++ b/parlai/utils/logging.py
@@ -133,7 +133,7 @@ class ParlaiLogger(logging.Logger):
 # -----------------------------------
 # Forming the logger                #
 # -----------------------------------
-logger = ParlaiLogger(name=__name__)
+logger = ParlaiLogger(name="parlai")
 
 
 def set_log_level(level):


### PR DESCRIPTION
**Patch description**
Fix an issue where usages of `create_agent_from_model_file` caused logging to bump back to INFO.

The reason is that we eventually call this line to try to fill in missing args with defaults:
https://github.com/facebookresearch/ParlAI/blob/91e883baf3352758fce6a48a075ce48e67d5caeb/parlai/core/agents.py#L368

Which would get the default args and accidentally call `set_log_level` here:
https://github.com/facebookresearch/ParlAI/blob/91e883baf3352758fce6a48a075ce48e67d5caeb/parlai/core/params.py#L1158

As a solution, I moved setting the log level to happen in the abstract ParlaiScript class.

**Testing steps**
Manual testing.