### PR TITLE
[RAG] Fix Generate Dense Embeddings Script

### DIFF
--- a/parlai/agents/rag/scripts/generate_dense_embeddings.py
+++ b/parlai/agents/rag/scripts/generate_dense_embeddings.py
@@ -87,9 +87,11 @@ class Generator(ParlaiScript):
                 {
                     'model': 'dpr_agent',
                     'model_file': self.opt['model_file'],
+                    'share_encoders': False,
                     'override': {
                         'model': 'dpr_agent',
                         'interactive_candidates': 'inline',
+                        'share_encoders': False,
                     },
                 }
             )


### PR DESCRIPTION
**Patch description**
At some point, this script broke, in that the default flag for `--share-encoders` was forcing the document and query encoders to be shared; as we used the document encoder to generate embeddings, this is no good.

**Testing steps**
Confirmed that the total number of parameters printed when running the generation script is correct.
