### PR TITLE
[TGA] Beam context block bug

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -996,7 +996,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         Intentionally overridable for more complex model histories.
         """
         ctxt = batch.text_vec[batch_idx]
-        if self.beam_block_full_context:
+        if self.beam_context_block_n_gram > 0 and self.beam_block_full_context:
             ctxt = batch.full_text_vec[batch_idx]
         return ctxt
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -995,8 +995,12 @@ class TorchGeneratorAgent(TorchAgent, ABC):
 
         Intentionally overridable for more complex model histories.
         """
+        if self.beam_context_block_n_gram <= 0:
+            # We aren't context blocking, return empty tensor
+            return torch.LongTensor()
+
         ctxt = batch.text_vec[batch_idx]
-        if self.beam_context_block_n_gram > 0 and self.beam_block_full_context:
+        if self.beam_block_full_context:
             ctxt = batch.full_text_vec[batch_idx]
         return ctxt
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -995,7 +995,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
 
         Intentionally overridable for more complex model histories.
         """
-        if self.beam_context_block_n_gram <= 0:
+        if self.beam_context_block_ngram <= 0:
             # We aren't context blocking, return empty tensor
             return torch.LongTensor()
 

--- a/tests/test_tga.py
+++ b/tests/test_tga.py
@@ -112,6 +112,8 @@ class TestTreeSearch(unittest.TestCase):
             'beam',
             '--truncate',
             '1024',
+            '--beam-context-block-ngram',
+            '1',
         ]
         pp = ParlaiParser(True, True)
         agent = create_agent(pp.parse_args(args), True)


### PR DESCRIPTION
**Patch description**
Hit a bug with beam blocking in TGA. TGA has beam_block_full_context set to True by default, which requires the batch to have a `full_text_vec`. I have beam context blocking off, and am passing a cached text vec in the observation to avoid re-tokenization (which means `full_text_vec` never gets set) and hit this error. To remedy, I return an empty tensor when beam_context_blocking is turned off.