### PR TITLE
tqdm version changed to 4.38.0 due to spacey req

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ tensorboardX==2.1
 tokenizers>=0.8.0
 torchtext>=0.5.0
 tornado==6.0.4
-tqdm~=4.36.1
+tqdm~=4.38.0
 typing-extensions==3.7.4.1
 Unidecode==1.1.1
 urllib3~=1.25.9


### PR DESCRIPTION
**Patch description**
tqdm version changed to 4.38.0 due to spacey req, which is required by task/model @ https://parl.ai/docs/zoo.html#md-gender-models
