### PR TITLE
Patch on world logging

### DIFF
--- a/parlai/utils/world_logging.py
+++ b/parlai/utils/world_logging.py
@@ -76,7 +76,9 @@ class WorldLogger:
         msgs = []
         for act in acts:
             # padding examples in the episode[0]
-            if isinstance(act, Message) and act.is_padding():
+            if not isinstance(act, Message):
+                act = Message(act)
+            if act.is_padding():
                 break
             if not self.keep_all:
                 msg = {f: act[f] for f in self.keep_fields if f in act}

--- a/parlai/utils/world_logging.py
+++ b/parlai/utils/world_logging.py
@@ -16,6 +16,7 @@ from parlai.utils.misc import msg_to_str
 from parlai.utils.conversations import Conversations
 from parlai.utils.io import PathManager
 import parlai.utils.logging as logging
+from parlai.core.message import Message
 
 import copy
 from tqdm import tqdm
@@ -74,12 +75,17 @@ class WorldLogger:
         """
         msgs = []
         for act in acts:
+            # padding examples in the episode[0]
+            if isinstance(act, Message) and act.is_padding():
+                break
             if not self.keep_all:
                 msg = {f: act[f] for f in self.keep_fields if f in act}
             else:
                 msg = act
             msgs.append(msg)
 
+        if len(msgs) == 0:
+            return
         self._current_episodes.setdefault(idx, [])
         self._current_episodes[idx].append(msgs)
 

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import os
+from parlai.utils.io import PathManager
 import pytest
 import unittest
 import parlai.utils.testing as testing_utils
@@ -209,17 +210,22 @@ class TestEvalModel(unittest.TestCase):
         Test that we can save report from eval model.
         """
         with testing_utils.tempdir() as tmpdir:
+            log_report = os.path.join(tmpdir, 'world_logs.jsonl')
             save_report = os.path.join(tmpdir, 'report')
             opt = dict(
                 task='integration_tests',
                 model='repeat_label',
                 datatype='valid',
-                num_examples=5,
+                batchsize=97,
                 display_examples=False,
-                world_logs=save_report,
+                world_logs=log_report,
                 report_filename=save_report,
             )
             valid, test = testing_utils.eval_model(opt)
+
+            with PathManager.open(log_report) as f:
+                json_lines = f.readlines()
+            assert len(json_lines) == 100
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Patch on world logging
- filter by `message.is_padding()` when writing episodes to `self._current_episodes`.
- modify the test tests/test_eval_model.py on test_save_report to verify the no dummy world logs are stored (those with `batch_padding`  `True`)

before this patch:
the world logs saved will contain the following dummy episode:
```
{"dialog": [[{"batch_padding": true, "episode_done": true, "id": "bot_adversarial_dialogue:HumanSafetyEvaluation.persona_False_flatten_False"}, {"id": "TransformerGenerator", "episode_done": false}]], "context": [], "metadata_path": "random/world_logs.metadata"}
```

After this patch, no such padding examples will be saved to the world logs

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
