### PR TITLE
WikiToxic agents.py slight change 

### DIFF
--- a/parlai/tasks/dialogue_safety/agents.py
+++ b/parlai/tasks/dialogue_safety/agents.py
@@ -183,6 +183,7 @@ class WikiToxicCommentsTeacher(FixedDialogTeacher):
 
         self.use_test_set = opt['use_test_set']
         self.balance_data = opt['balance_data']
+        self.DATA_SOURCE = '<https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/data>'
 
         self.data_path = os.path.join(
             opt['datapath'], 'dialogue_safety', 'wiki-toxic-comments'
@@ -226,8 +227,7 @@ class WikiToxicCommentsTeacher(FixedDialogTeacher):
             PathManager.mkdirs(self.data_path)
         if not PathManager.exists(os.path.join(self.data_path, 'train.csv')):
             raise RuntimeError(
-                f'\n\n{stars}\nThis data must be downloaded from '
-                '<https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/data>. '
+                f'\n\n{stars}\nThis data must be downloaded from {self.DATA_SOURCE}'
                 '\nIt cannot be automatically downloaded, as one must agree to '
                 'the competition rules outlined on the website before '
                 'gaining access to the data.\n\n'


### PR DESCRIPTION
**Patch description**
Another dataset is using WikiToxic as its parent, but its _get_data() function's error message hardcodes WikiToxic's kaggle dataset source, so changing that to a variable instead. 

**Testing steps**
testing with test.py and also tried parlai display data
passed with 
```
parlai/tasks/dialogue_safety/test.py ...                    [100%]
```

----- 
update: I think I tried rebasing it, and then I had to force push it.... 
Also, the current checks that are failing are failing, I think, because of this:

*This build could not be run with the selected resource class. The default Medium resource class was used to run this build. To use the resource class to speed up your build or avoid an out-of-memory error, you can upgrade to a Performance Plan.*

Most of them are `Exited with code exit status 1` 