### PR TITLE
ChunkTeacher no longer requires num_examples/num_episodes to be correct

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2535,7 +2535,15 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
             if DatatypeHelper.should_cycle(self.datatype):
                 # start putting chunks back onto the queue
                 self._enqueue_chunks()
-            return (None, chunk_reset_cnt)
+                next_chunk, chunk_reset_cnt = self.chunks.get()
+                if next_chunk is None:
+                    # See the race condition described around "gross hack" in
+                    # _enqueue_chunks.  if we win the race condition, then
+                    # catch it here
+                    next_chunk, chunk_reset_cnt = self.chunks.get()
+            else:
+                # if we're in valid/test, we need to actually signal the end
+                return (None, chunk_reset_cnt)
         # abstract method `load_from_chunk` returns a list of tuples
         output = self.load_from_chunk(next_chunk)
 

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2354,7 +2354,6 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
 
         self._episode_done = True
         self.last_queue_output = None
-        self._ct_epoch_done = False
 
     def _get_data_folder(self):
         if not self.opt.get('datafile'):
@@ -2555,7 +2554,6 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
         # never "epochs").
         retval, fake_epoch_done = super().next_example()
         real_epoch_done = retval.is_padding()
-        self._ct_epoch_done = False
         return retval, real_epoch_done
 
     def get(self, episode_idx, entry_idx=0):
@@ -2574,7 +2572,6 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
                 logging.debug(f"Removed {stale_exs} stale examples from the queue.")
             if queue_output is None:
                 self.samples.put((None, reset_cnt))
-                self._ct_epoch_done = True
                 return Message.padding_example()
 
             # Update the last queue output in the case
@@ -2596,7 +2593,6 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
 
     def reset(self):
         super().reset()
-        self._ct_epoch_done = False
         if self.is_root_teacher:
             self.reset_counter.increment()
             # drain the queues and refill the chunk queue with a new epoch.

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1774,7 +1774,7 @@ class TorchAgent(ABC, Agent):
             from model. May be None (default) if model chooses not to answer.
             This method will check for ``text`` and ``text_candidates`` fields.
         """
-        if output is None:
+        if output is None or valid_inds is None:
             return batch_reply
         for k, v in output.items():
             if v is None:

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -490,6 +490,38 @@ class ChunkyTeacher(ChunkTeacher):
         return Message({'text': text, 'labels': [label], 'episode_done': True})
 
 
+class WrongExamplesChunkyTeacher(ChunkyTeacher):
+    """
+    Chunk teacher with an incorrect number of examples.
+
+    Useful for testing we don't get a deadlock from a common user error.
+    """
+
+    def num_examples(self):
+        return 10
+
+
+class WrongEpisodesChunkyTeacher(ChunkyTeacher):
+    """
+    Chunk teacher with an incorrect number of episodes.
+    """
+
+    def num_episodes(self):
+        return 10
+
+
+class WrongExamplesEpisodesChunkyTeacher(ChunkyTeacher):
+    """
+    Chunk teacher with an incorrect number of episodes and examples.
+    """
+
+    def num_examples(self):
+        return 10
+
+    def num_episodes(self):
+        return 10
+
+
 class ChunkySmallBufferTeacher(ChunkyTeacher):
     def get_buffersize(self):
         return NUM_TEST // 2

--- a/tests/test_chunkteacher.py
+++ b/tests/test_chunkteacher.py
@@ -84,8 +84,9 @@ class TestNumExamples(_Abstract):
 
 
 class TestSmallBuffer(_Abstract):
-    TASK = 'integration_tests:chunky_small_buffer'
     # Small buffer
+    TASK = 'integration_tests:chunky_small_buffer'
+
     def test_small_buffer_bs1(self):
         self._run()
 

--- a/tests/test_chunkteacher.py
+++ b/tests/test_chunkteacher.py
@@ -25,8 +25,11 @@ class _Abstract(TestCase):
         'datatype': 'train:stream',
     }
 
+    TASK = None
+
     def _run(self, **kwargs):
         opt = {**self.BASE_ARGS, **kwargs}
+        opt['task'] = self.TASK
         valid_report, test_report = testing_utils.train_model(opt)
         assert valid_report['unique'] == NUM_TEST
         assert valid_report['times_seen'] == 1
@@ -36,6 +39,7 @@ class _Abstract(TestCase):
 
     def _run_mp(self, **kwargs):
         opt = {**self.BASE_ARGS, **kwargs}
+        opt['task'] = self.TASK
         with testing_utils.tempdir() as tmpdir:
             if 'model_file' not in opt:
                 opt['model_file'] = os.path.join(tmpdir, 'model')
@@ -49,20 +53,20 @@ class _Abstract(TestCase):
 
 
 class TestNumExamples(_Abstract):
+    TASK = 'integration_tests:chunky'
+
     # Regular chunk teacher
     def test_normal_bs1(self):
-        self._run(task='integration_tests:chunky')
+        self._run()
 
     def test_normal_bs3(self):
-        self._run(task='integration_tests:chunky', batchsize=3)
+        self._run(batchsize=3)
 
     def test_normal_dynb(self):
-        self._run(task='integration_tests:chunky', batchsize=2, dynamic_batching='full')
+        self._run(batchsize=2, dynamic_batching='full')
 
     def test_normal_batchsort(self):
-        self._run(
-            task='integration_tests:chunky', batchsize=2, dynamic_batching='batchsort'
-        )
+        self._run(batchsize=2, dynamic_batching='batchsort')
 
     @testing_utils.skipUnlessGPU
     def test_mp_normal_bs1(self):
@@ -80,61 +84,46 @@ class TestNumExamples(_Abstract):
 
 
 class TestSmallBuffer(_Abstract):
+    TASK = 'integration_tests:chunky_small_buffer'
     # Small buffer
     def test_small_buffer_bs1(self):
-        self._run(task='integration_tests:chunky_small_buffer')
+        self._run()
 
     def test_small_buffer_bs3(self):
-        self._run(task='integration_tests:chunky_small_buffer', batchsize=3)
+        self._run(batchsize=3)
 
     def test_small_buffer_dynb(self):
-        self._run(
-            task='integration_tests:chunky_small_buffer',
-            batchsize=2,
-            dynamic_batching='full',
-        )
+        self._run(batchsize=2, dynamic_batching='full')
 
     def test_small_buffer_batchsort(self):
-        self._run(
-            task='integration_tests:chunky_small_buffer',
-            batchsize=2,
-            dynamic_batching='batchsort',
-        )
+        self._run(batchsize=2, dynamic_batching='batchsort')
 
     @testing_utils.skipUnlessGPU
     def test_mp_small_buffer_bs1(self):
-        self._run_mp(task='integration_tests:chunky_small_buffer')
+        self._run_mp()
 
     @testing_utils.skipUnlessGPU
     def test_mp_small_buffer_bs3(self):
-        self._run_mp(task='integration_tests:chunky_small_buffer', batchsize=3)
+        self._run_mp(batchsize=3)
 
     @testing_utils.skipUnlessGPU
     def test_mp_small_buffer_dynb(self):
-        self._run_mp(
-            task='integration_tests:chunky_small_buffer',
-            batchsize=2,
-            dynamic_batching='full',
-        )
+        self._run_mp(batchsize=2, dynamic_batching='full')
 
     @testing_utils.skipUnlessGPU
     def test_mp_small_buffer_batchsort(self):
-        self._run_mp(
-            task='integration_tests:chunky_small_buffer',
-            batchsize=2,
-            dynamic_batching='batchsort',
-        )
+        self._run_mp(batchsize=2, dynamic_batching='batchsort')
 
 
 class TestSlowChunk(_Abstract):
+    TASK = 'integration_tests:chunky_slow'
+
     # Slow chunk
     def test_slow_bs3(self):
-        self._run(task='integration_tests:chunky_slow', batchsize=3)
+        self._run(batchsize=3)
 
     def test_slow_dynb(self):
-        self._run(
-            task='integration_tests:chunky_slow', batchsize=2, dynamic_batching='full'
-        )
+        self._run(batchsize=2, dynamic_batching='full')
 
 
 class TestBackgroundPreprocessorNumExamples(TestNumExamples):
@@ -147,3 +136,15 @@ class TestBackgroundPreprocessorNumExamples(TestNumExamples):
         'datatype': 'train:stream',
         'num_workers': 4,
     }
+
+
+class TestWrongExamples(TestNumExamples):
+    TASK = 'integration_tests:wrong_examples_chunky'
+
+
+class TestWrongEpisodes(TestNumExamples):
+    TASK = 'integration_tests:wrong_episodes_chunky'
+
+
+class TestWrongExamplesEpisodes(TestNumExamples):
+    TASK = 'integration_tests:wrong_examples_episodes_chunky'


### PR DESCRIPTION
**Patch description**
For as long as we've had ChunkTeacher, it's required that the number of episodes and examples be exactly reported correctly, or else it would cause a hang. With this patch, we loosen that requirement.

Methodology:
- Upgrade some of ChunkTeacher's internal logic to use DatatypeHelper to check about shuffling/cycling. Some of this is equivalent but more explicit and makes a bit more sense. The one logical change here is `train:ordered` was previously cycling, when it shouldn't.
- FixedDialogTeacher keeps track of the current episode and sees if we'll go over our limit, and starts emitting padding. Modify ChunkTeacher to always lie about its "next episode" so that check never triggers.
- Epoch done was previously computed in FixedDialogTeacher.next_example, checking the counts. Override this behavior in ChunkTeacher to have it simply test whether it's seeing a pad or not. This means we'll go one batch further than we need to, but that's okay -- everything filters the pads correctly and it doesn't affect counts or examples seen.

**Testing steps**
Manual testing.

New CI tests that stand up chunk teachers that lie about their number examples/episodes, and check that the number of unique messages seen is exactly correct.