### PR TITLE
Incomplete data

### DIFF
--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import os
 from abc import ABC, abstractmethod
 from datetime import datetime

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import os
 from abc import ABC, abstractmethod
 from datetime import datetime

--- a/parlai/crowdsourcing/utils/analysis.py
+++ b/parlai/crowdsourcing/utils/analysis.py
@@ -190,7 +190,7 @@ class AbstractDataBrowserResultsCompiler(AbstractResultsCompiler):
             try:
                 unit_data = data_browser.get_data_from_unit(unit)
                 task_data.append(unit_data)
-            except IndexError:
+            except (IndexError, AssertionError):
                 logging.warning(
                     f"Skipping unit {unit.db_id}. No message found for this unit."
                 )


### PR DESCRIPTION
**Patch description**
Skipping units that fail under internal assertions in Mephisto and generating a warning that tells user we are skipping them. This is one issue that one might run into while dealing with corrupted data in Mephisto. Skipping them avoids a potential crash in data compiler/

**Testing steps**
Using it to compile my dataset. It skipped the corrupted unit as expected.
