### PR TITLE
[RAG] Handle Different DPR Model File with Pre-trained Model

### DIFF
--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -16,7 +16,7 @@ import os
 import torch
 import torch.nn
 import torch.cuda
-from typing import Any, Dict, List, Optional, Tuple, Union, Type, overload
+from typing import Any, Dict, List, Optional, Tuple, Union, Type
 
 from parlai.agents.bart.bart import BartAgent
 from parlai.agents.hugging_face.t5 import T5Agent
@@ -358,16 +358,12 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
         """
         return self._generation_agent.build_dictionary(self)
 
+    @staticmethod
     def update_state_dict(
-        self, opt: Opt, state_dict: Dict[str, torch.Tensor], model: torch.nn.Module
+        opt: Opt, state_dict: Dict[str, torch.Tensor], model: torch.nn.Module
     ):
         """
         Update the given state dict to be RAG-ified.
-
-        Under certain circumstances, one may wish to specify a different
-        `--dpr-model-file` for a pre-trained, RAG model. Thus, we additionally
-        check to make sure that the loaded DPR model weights are not overwritten
-        by the state loading.
 
         :param opt:
             options
@@ -410,6 +406,15 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
     def _should_override_dpr_model_weights(self, opt: Opt):
         """
         Determine if we need to override the DPR Model weights.
+
+        Under certain circumstances, one may wish to specify a different
+        `--dpr-model-file` for a pre-trained, RAG model. Thus, we additionally
+        check to make sure that the loaded DPR model weights are not overwritten
+        by the state loading.
+
+        NOTE: If `--model-file M` was trained with `--dpr-model-file D`, and
+        `--dpr-model-file D` is specified *after training* (i.e., in eval/interactive),
+        we cannot currently handle replacing those weights.
         """
         try:
             init_model, _ = self._get_init_model(opt, None)

--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -412,23 +412,16 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
         check to make sure that the loaded DPR model weights are not overwritten
         by the state loading.
 
-        NOTE: If `--model-file M` was trained with `--dpr-model-file D`, and
-        `--dpr-model-file D` is specified *after training* (i.e., in eval/interactive),
-        we cannot currently handle replacing those weights.
         """
-        try:
-            init_model, _ = self._get_init_model(opt, None)
-            init_model_opt = Opt.load(f'{init_model}.opt')
-            override_dpr = modelzoo_path(
-                opt['datapath'], opt['dpr_model_file']
-            ) != modelzoo_path(opt['datapath'], init_model_opt['dpr_model_file'])
-            if override_dpr:
-                logging.warning(
-                    f"Overriding DPR Model with {modelzoo_path(opt['datapath'], opt['dpr_model_file'])}"
-                )
-        except FileNotFoundError:
-            override_dpr = False
-
+        override_dpr = False
+        overrides = opt.get('override', {})
+        if overrides.get('dpr_model_file') and os.path.exists(
+            overrides['dpr_model_file']
+        ):
+            override_dpr = True
+            logging.warning(
+                f"Overriding DPR Model with {modelzoo_path(opt['datapath'], opt['dpr_model_file'])}"
+            )
         return override_dpr
 
     def load_state_dict(self, state_dict: Dict[str, torch.Tensor]):

--- a/tests/nightly/gpu/test_rag.py
+++ b/tests/nightly/gpu/test_rag.py
@@ -9,19 +9,13 @@ import torch.cuda
 from typing import Optional
 import unittest
 
-from parlai.agents.rag.args import (
-    DPR_ZOO_MODEL,
-    RAG_TOKEN_ZOO_MODEL,
-    RAG_SEQUENCE_ZOO_MODEL,
-)
-from parlai.agents.rag.dpr import DprQueryEncoder
 from parlai.core.build_data import modelzoo_path
 from parlai.core.agents import create_agent
 from parlai.core.params import ParlaiParser, Opt
 import parlai.utils.testing as testing_utils
 
 try:
-    import parlai.agents.rag.dpr  # noqa: F401
+    from parlai.agents.rag.dpr import DprQueryEncoder
 except ImportError:
     pass
 

--- a/tests/nightly/gpu/test_rag.py
+++ b/tests/nightly/gpu/test_rag.py
@@ -401,6 +401,10 @@ class TestFidZooModels(unittest.TestCase):
 class TestLoadDPRModel(unittest.TestCase):
     """
     Test loading different DPR models for RAG.
+
+    See RagAgent._should_override_dpr_model_weights for important note
+    regarding specifying the *same* dpr model file as was used to train
+    the model.
     """
 
     def test_load_dpr(self):


### PR DESCRIPTION
**Patch description**
This patch fixes a bug in which one would like to swap the `--dpr-model-file` for a *pre-trained* RAG or FiD model. The underlying issue is that the dpr model weights are loaded during model initialization, **PRIOR TO** loading the pre-trained model weights. This is fine when the pre-trained model is an underlying seq2seq model (BART, T5, BB), but it is not ok when the pre-trained model is a RAG or FiD model.

The solution is to overwrite the retriever weights in the `state_dict` with the _already loaded dpr model weights_.


**Testing steps**
Included CI testing:

```
$ pytest -k TestLoadDPRModel
===== test session starts =====
platform linux -- Python 3.7.9, pytest-6.2.1, py-1.10.0, pluggy-1.0.0.dev0
rootdir: /private/home/kshuster/ParlAI, configfile: pytest.ini
plugins: hydra-core-1.0.0, requests-mock-1.8.0, regressions-2.1.1, datadir-1.3.1
collected 96 items / 95 deselected / 1 selected

test_rag.py .                                                                                                                                                                      [100%]

=====slowest 10 durations =====
41.01s call     tests/nightly/gpu/test_rag.py::TestLoadDPRModel::test_load_dpr

(2 durations < 0.005s hidden.  Use -vv to show these durations.)
=====1 passed, 95 deselected, 4 warnings in 43.30s =====
```
