### PR TITLE
Written explanation for why tilde key cannot be used for $HOME

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
+++ b/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
@@ -194,7 +194,9 @@ class BaseModelChatBlueprint(ParlAIChatBlueprint, ABC):
             f'"~" can\'t currently be parsed in the chat data folder path '
             f'{args.blueprint.chat_data_folder}'
         )
-        # TODO: allow ~ to be parsed correctly
+        # Currently Hydra overrides the tilde key at lower levels as described here: https://hydra.cc/docs/next/advanced/override_grammar/basic/#grammar
+        # Thus the TILDE key cannot be used in replacement for $HOME variable
+        # Some hacky solution can probably be achieved but won't be good code so for now this assert is written as a placeholder
 
         if args.blueprint.get("annotations_config_path", "") != "":
             full_path = os.path.expanduser(args.blueprint.annotations_config_path)


### PR DESCRIPTION
**Patch description**
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->

Added an informative message in comments for why the TILDE key cannot be used in mephisto.blueprint.chat_data_folder argument.

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

Just comments in this PR.
CircleCI tests ran successfully.

**Other information**
<!-- Any other information or context you would like to provide. -->
