### PR TITLE
Point to examples in component swap tutorial

### DIFF
--- a/docs/source/tutorial_swap_components.md
+++ b/docs/source/tutorial_swap_components.md
@@ -34,7 +34,9 @@ layer = TransformerLayer.with_components(ffn=NewCustomFFN)(opt, ...)
 
 As long as `NewCustomFFN` has the same `__init__` and `forward` method signatures as `TransformerFFN`, everything should just work.
 
-For examples, see `parlai/agents/examples/transformer_variant.py`
+For examples, see:
+- `parlai/agents/examples/transformer_variant.py`
+- `projects/params_vs_compute/hash_ladder/hash_ladder.py`
 
 ## Composability
 

--- a/docs/source/tutorial_swap_components.md
+++ b/docs/source/tutorial_swap_components.md
@@ -34,6 +34,8 @@ layer = TransformerLayer.with_components(ffn=NewCustomFFN)(opt, ...)
 
 As long as `NewCustomFFN` has the same `__init__` and `forward` method signatures as `TransformerFFN`, everything should just work.
 
+For examples, see `parlai/agents/examples/transformer_variant.py`
+
 ## Composability
 
 Since the swapping happens before instantiation, decorated components can be transparently composed. For example:


### PR DESCRIPTION
Just pointing users of `@swappable` to the example code.
