### PR TITLE
skipping the padding

### DIFF
--- a/parlai/scripts/data_stats.py
+++ b/parlai/scripts/data_stats.py
@@ -108,6 +108,8 @@ def verify(opt):
     while not world.epoch_done() and world.total_exs < max_cnt:
         world.parley()
         act = world.get_acts()[opt.get('agent')]
+        if act.is_padding():
+            continue
         for itype in {'input', 'labels'}:
             if itype == 'input':
                 if opt.get('new_line_new_utt'):


### PR DESCRIPTION
**Patch description**
After looking into `parlai data_stats` crashes that I was running into, I noticed that it was happening when the script was trying to tokenize the non-existing text from a padding message. Added this to skip those messages.
Note: this was happening with chunk teachers, even with batch-size of 1. So the main problem might be from the teacher itself.

**Testing steps**
My `parlai data_stats` runs after this.