### PR TITLE
[train] Fix bugs with loading validation impatience.

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -477,6 +477,7 @@ class TrainLoop:
                     'train_reports': self.train_reports,
                     'valid_reports': self.valid_reports,
                     'best_valid': self.best_valid,
+                    'impatience': self.impatience,
                 },
                 f,
                 indent=4,
@@ -515,15 +516,6 @@ class TrainLoop:
         if opt['wandb_log'] and is_primary_worker():
             valid_report['total_exs'] = self._total_exs
             self.wb_logger.log_metrics('valid', self.parleys, valid_report)
-
-        # saving
-        if (
-            opt.get('model_file')
-            and opt.get('save_after_valid')
-            and is_primary_worker()
-        ):
-            logging.info(f"saving model checkpoint: {opt['model_file']}.checkpoint")
-            self.save_model('.checkpoint')
 
         # send valid metrics to agent if the agent wants them
         if hasattr(self.agent, 'receive_metrics'):
@@ -572,6 +564,15 @@ class TrainLoop:
                 )
             )
         self.validate_time.reset()
+
+        # saving
+        if (
+            opt.get('model_file')
+            and opt.get('save_after_valid')
+            and is_primary_worker()
+        ):
+            logging.info(f"saving model checkpoint: {opt['model_file']}.checkpoint")
+            self.save_model('.checkpoint')
 
         # check if we are out of patience
         if (

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -9,9 +9,13 @@ Basic tests that ensure train_model.py behaves in predictable ways.
 """
 import os
 import unittest
+import json
 import parlai.utils.testing as testing_utils
+from parlai.core.metrics import AverageMetric
 from parlai.core.worlds import create_task
 from parlai.core.params import ParlaiParser
+from parlai.core.agents import register_agent, Agent
+from parlai.utils.data import DatatypeHelper
 
 
 class TestTrainModel(unittest.TestCase):
@@ -163,12 +167,84 @@ class TestTrainModel(unittest.TestCase):
         self._test_opt_step_opts(2)
 
 
+@register_agent("fake_report")
+class FakeReportAgent(Agent):
+    def __init__(self, opt, shared=None):
+        self.count = 0
+        super().__init__(opt, shared)
+
+    def report(self):
+        if self.count == 0:
+            # initial score
+            return {'loss': AverageMetric(3)}
+        elif self.count == 1:
+            # don't save the second validation
+            return {'loss': AverageMetric(4)}
+        else:
+            # do save the third validation
+            return {'loss': AverageMetric(2)}
+
+    def receive_metrics(self, report):
+        self.count += 1
+
+    def act(self):
+        return {}
+
+    def save(self, fname):
+        self.opt.save(fname + ".opt")
+        with open(fname, "w") as f:
+            f.write("Lol")
+
+    def load(self, fname):
+        pass
+
+
 class TestValidationImpatience(unittest.TestCase):
-    def test_impatience(self):
+    """
+    Tests to check we handle impatience correctly upon preemption.
+    """
+
+    def test_impatience(self, **kwargs):
         from parlai.scripts.train_model import TrainModel, TrainLoop
 
-    pass
+        # shallow copy to prevent overwrites
+        kwargs = kwargs.copy()
+        with testing_utils.tempdir() as tmpdir:
+            kwargs['model'] = 'fake_report'
+            kwargs['task'] = 'integration_tests'
+            kwargs['validation_metric'] = 'loss'
+            kwargs['model_file'] = os.path.join(tmpdir, 'model')
+            kwargs['dict_file'] = 'zoo:unittest/transformer_generator2/model.dict'
+            kwargs['log_every_n_steps'] = 1
+            kwargs['validation_every_n_steps'] = 10
+            kwargs['max_train_steps'] = 100
+            kwargs['save_after_valid'] = True
+            opt = TrainModel.setup_args().parse_kwargs(**kwargs)
 
+            logs_first = []
+            main_loop = TrainLoop(opt)
 
-if __name__ == '__main__':
-    unittest.main()
+            for i, train_step_log in enumerate(main_loop.train_steps()):
+                if i % 10 == 1:
+                    # simulate preemption
+                    # load from preempted and check variables are the same
+                    preempt_loop = TrainLoop(opt)
+                    # assert main_loop.impatience == preempt_loop.impatience
+                    # assert main_loop.last_valid_epoch == preempt_loop.last_valid_epoch
+                    # assert main_loop.best_valid == preempt_loop.best_valid
+                    print(i, preempt_loop.impatience, preempt_loop.best_valid)
+                    if i == 1:
+                        assert preempt_loop.impatience == 0
+                        assert preempt_loop.best_valid is None
+                    elif i == 11:
+                        assert preempt_loop.impatience == 0
+                        assert preempt_loop.best_valid == 3
+                    elif i == 21:
+                        assert preempt_loop.impatience == 1
+                        assert preempt_loop.best_valid == 3
+                    elif i == 31:
+                        assert preempt_loop.impatience == 0
+                        assert preempt_loop.best_valid == 2
+                    else:
+                        assert preempt_loop.impatience == (i - 31) // 10
+                        assert preempt_loop.best_valid == 2

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -163,5 +163,12 @@ class TestTrainModel(unittest.TestCase):
         self._test_opt_step_opts(2)
 
 
+class TestValidationImpatience(unittest.TestCase):
+    def test_impatience(self):
+        from parlai.scripts.train_model import TrainModel, TrainLoop
+
+    pass
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Patch description**
Validation impatience has been loading incorrectly upon preemption for a bit.

The following two bugs are observed and fixed:

- `.checkpoint` was saved BEFORE the validation report had happened, meaning it would always save epochs/progress/etc with the latest values, but the "best validation score" of the PREVIOUS validation.
- The `impatience` key was not being set, and therefore always being loaded with 0 (the default).

**Testing steps**
About to write unit tests.