### PR TITLE
[StyleGen] Classifier on generator: BART bug

### DIFF
--- a/projects/style_gen/modules.py
+++ b/projects/style_gen/modules.py
@@ -160,6 +160,10 @@ class TransformerDecoderWithEmbeds(TransformerDecoder):
                 )
             )
         tensor = tensor + self.position_embeddings(positions).expand_as(tensor)
+
+        if self.variant == 'bart':
+            tensor = self.norm_embeddings(tensor)
+
         tensor = self.dropout(tensor)  # --dropout
 
         new_incr_state = {}


### PR DESCRIPTION
**Patch description**
Fix classifier on generator code to work for BART. The code overrides the TransformerDecoder, but does not include the forward through the norm_embeddings if `variant == 'bart'` 

This bug was caught when we do DDP -- DDP expects a grad for the norm_embeddings after forwarding but none is found