### PR TITLE
[eval model] store world logs per task

### DIFF
--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -159,12 +159,12 @@ def _eval_single_world(opt, agent, task):
     if world_logger is not None:
         # dump world acts to file
         world_logger.reset()  # add final acts to logs
+        base_outfile, extension = os.path.splitext(opt['world_logs'])
         if is_distributed():
             rank = get_rank()
-            base_outfile, extension = os.path.splitext(opt['world_logs'])
-            outfile = base_outfile + f'_{rank}' + extension
+            outfile = base_outfile + f'_{task}_{rank}' + extension
         else:
-            outfile = opt['world_logs']
+            outfile = base_outfile + f'_{task}' + extension
         world_logger.write(outfile, world, file_format=opt['save_format'])
 
     report = aggregate_unnamed_reports(all_gather_list(world.report()))

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -134,7 +134,7 @@ def _eval_single_world(opt, agent, task):
     # add task suffix in case of multi-tasking
     if opt['world_logs']:
         task_opt['world_logs'] = get_task_world_logs(
-            task, task_opt['world_logs'], is_multitask=True
+            task, task_opt['world_logs'], is_multitask=len(opt['task'].split(',')) > 1
         )
 
     world_logger = WorldLogger(task_opt) if task_opt['world_logs'] else None

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -228,9 +228,9 @@ class TestEvalModel(unittest.TestCase):
                 json_lines = f.readlines()
             assert len(json_lines) == 100
 
-    def test_save_multiple_reports(self):
+    def test_save_multiple_logs(self):
         """
-        Test that we can save report from eval model.
+        Test that we can save multiple world_logs from eval model on multiple tasks.
         """
         with testing_utils.tempdir() as tmpdir:
             log_report = os.path.join(tmpdir, 'world_logs.jsonl')

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -8,6 +8,7 @@ from parlai.utils.io import PathManager
 import pytest
 import unittest
 import parlai.utils.testing as testing_utils
+from parlai.scripts.eval_model import get_task_world_logs
 
 
 class TestEvalModel(unittest.TestCase):
@@ -226,6 +227,34 @@ class TestEvalModel(unittest.TestCase):
             with PathManager.open(log_report) as f:
                 json_lines = f.readlines()
             assert len(json_lines) == 100
+
+    def test_save_multiple_reports(self):
+        """
+        Test that we can save report from eval model.
+        """
+        with testing_utils.tempdir() as tmpdir:
+            log_report = os.path.join(tmpdir, 'world_logs.jsonl')
+            save_report = os.path.join(tmpdir, 'report')
+            multitask = 'integration_tests,blended_skill_talk'
+            opt = dict(
+                task=multitask,
+                model='repeat_label',
+                datatype='valid',
+                batchsize=97,
+                num_examples=100,
+                display_examples=False,
+                world_logs=log_report,
+                report_filename=save_report,
+            )
+            valid, test = testing_utils.eval_model(opt)
+
+            for task in multitask.split(','):
+                task_log_report = get_task_world_logs(
+                    task, log_report, is_multitask=True
+                )
+                with PathManager.open(task_log_report) as f:
+                    json_lines = f.readlines()
+                assert len(json_lines) == 100
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Patch description**
Currently when running `parlai em --world-logs .....` it only stores the world logs for the very last task if multitasking. 
This pr would fix this issue by adding the task name as suffix to the world log file path if it's multitasking.

Fixes #3648

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

```
.(conda_parlai) jingxu23@devfair0173:~/ParlAI$ python /private/home/jingxu23/ParlAI/tests/test_transformers.py

.....
----------------------------------------------------------------------
Ran 34 tests in 149.635s

OK
```

**Other information**
<!-- Any other information or context you would like to provide. -->
