### PR TITLE
Fix LR scheduler cooldown

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -955,7 +955,13 @@ class TorchAgent(ABC, Agent):
         is_train = 'train' in datatype and 'evalmode' not in datatype
         return is_train
 
-    def init_optim(self, params, optim_states=None, saved_optim_type=None) -> bool:
+    def init_optim(
+        self,
+        params,
+        optim_states=None,
+        saved_optim_type=None,
+        is_finetune: bool = False,
+    ) -> bool:
         """
         Initialize optimizer with model parameters.
 
@@ -969,10 +975,14 @@ class TorchAgent(ABC, Agent):
             type of optimizer being loaded, if changed will skip loading
             optimizer states
 
+        :param is_finetune:
+            bool indicating whether this training run is a fine-tune or not
+
         :returns:
-            boolean indicating whether the optimizer was initialized with
+            boolean indicating whether the optimizer failed to initialize with
             optim_states.
         """
+
         if hasattr(self, 'resized_embeddings') and self.resized_embeddings:
             optim_states = None
             logging.warning('Not loading optimizer due to resize in token embeddings')
@@ -1055,14 +1065,15 @@ class TorchAgent(ABC, Agent):
                         f'list:\n{compatible_list}'
                     )
                 self.optimizer = MemoryEfficientFP16Optimizer(self.optimizer)
-        # TODO: we might want to hard reset optimizers here in the
-        # case of fine tuning. Some rudimentary experiments seemed to
-        # indicate that keeping adam weights around was desirable, so this
-        # will remain the behavior for the time being.
+
+        if is_finetune:
+            logging.warning('Detected a fine-tune run. Resetting the optimizer.')
+            return True
+
         if optim_states and saved_optim_type != opt['optimizer']:
             # we changed from adam to adamax, or sgd to adam, or similar
             logging.warning('Not loading optim state since optim class changed.')
-            return False
+            return True
         elif optim_states:
             # check for any fp16/fp32 conversions we need to do
             optimstate_fp16 = 'loss_scaler' in optim_states
@@ -1099,7 +1110,7 @@ class TorchAgent(ABC, Agent):
                 warn_once(
                     'WARNING: not loading optim state since model params changed.'
                 )
-                return False
+                return True
 
     def build_lr_scheduler(self, states=None, hard_reset=False):
         """

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1092,11 +1092,12 @@ class TorchAgent(ABC, Agent):
                 # this is a bit clunky, but alternatives are worse
                 try:
                     self.optimizer.load_state_dict(optim_states)
+                    return False
                 except ValueError:
                     warn_once(
                         'WARNING: not loading optim state since model params changed.'
                     )
-                return True
+                    return True
             else:
                 # previously trained in fp32, loading in fp32.
                 # no special treatment needed.

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -524,8 +524,9 @@ class TorchGeneratorAgent(TorchAgent, ABC):
                 [p for p in self.model.parameters() if p.requires_grad],
                 optim_states=states.get('optimizer'),
                 saved_optim_type=states.get('optimizer_type'),
+                is_finetune=is_finetune,
             )
-            if was_reset and not is_finetune:
+            if was_reset:
                 logging.warning("Optimizer was reset. Also resetting LR scheduler.")
             self.build_lr_scheduler(states, hard_reset=is_finetune or was_reset)
 

--- a/parlai/core/torch_ranker_agent.py
+++ b/parlai/core/torch_ranker_agent.py
@@ -241,10 +241,15 @@ class TorchRankerAgent(TorchAgent):
         elif self._should_initialize_optimizer():
             # only build an optimizer if we're training
             optim_params = [p for p in self.model.parameters() if p.requires_grad]
-            self.init_optim(
-                optim_params, states.get('optimizer'), states.get('optimizer_type')
+            was_reset = self.init_optim(
+                optim_params,
+                states.get('optimizer'),
+                states.get('optimizer_type'),
+                is_finetune=is_finetune,
             )
-            self.build_lr_scheduler(states, hard_reset=is_finetune)
+            if was_reset:
+                logging.warning("Optimizer was reset. Also resetting LR scheduler.")
+            self.build_lr_scheduler(states, hard_reset=is_finetune or was_reset)
 
         if shared is None and is_distributed():
             device_ids = None if self.model_parallel else [self.opt['gpu']]

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -86,7 +86,7 @@ class ParlAILRScheduler(object):
         return (
             hasattr(self, 'warmup_scheduler')
             and self.warmup_scheduler is not None
-            and self._number_training_updates <= self.warmup_updates
+            and self._number_training_updates < self.warmup_updates
         )
 
     def _warmup_lr(self, step):
@@ -414,7 +414,8 @@ class InvSqrtLRScheduler(ParlAILRScheduler):
         When steps taken == invsqrt_lr_decay_gamma, the lr multiplier is 1
         """
         super().__init__(hard_reset, warmup_updates, warmup_rate)
-        self.max_lr_steps = max_lr_steps
+        assert self.warmup_updates >= 0
+        self.max_lr_steps = max_lr_steps - self.warmup_updates
         self.invsqrt_lr_decay_gamma = invsqrt_lr_decay_gamma
         if invsqrt_lr_decay_gamma <= 0:
             warn_once(
@@ -464,7 +465,8 @@ class CosineLRScheduler(ParlAILRScheduler):
         super().__init__(hard_reset, warmup_updates, warmup_rate)
         if max_lr_steps <= 0:
             raise ValueError('--lr-scheduler cosine requires setting --max-train-steps')
-        self.max_lr_steps = max_lr_steps
+        assert self.warmup_updates >= 0
+        self.max_lr_steps = max_lr_steps - self.warmup_updates
         self.scheduler = optim.lr_scheduler.LambdaLR(optimizer, self._cosine_lr)
 
     def _cosine_lr(self, step):
@@ -502,13 +504,13 @@ class LinearLRScheduler(ParlAILRScheduler):
         super().__init__(hard_reset, warmup_updates, warmup_rate)
         if max_lr_steps <= 0:
             raise ValueError('--lr-scheduler linear requires setting --max-train-steps')
-        self.max_lr_steps = max_lr_steps
+        assert self.warmup_updates >= 0
+        self.max_lr_steps = max_lr_steps - self.warmup_updates
         self.scheduler = optim.lr_scheduler.LambdaLR(optimizer, self._linear_lr)
 
     def _linear_lr(self, step):
         # this multiplicative factor ensures linear decay rate
-        # lr_mult = float(self.max_lr_steps - step - 1) / float(self.max_lr_steps - step)
-        lr_mult = max(0.0, 1e-6 + (1.0 - step / self.max_lr_steps) * (1 - 1e-6))
+        lr_mult = max(0.0, 1.0 - step / self.max_lr_steps)
         return lr_mult
 
     def train_step(self, scheduler_steps):

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -59,7 +59,7 @@ class ParlAILRScheduler(object):
     def _init_warmup_scheduler(self, optimizer, states):
         updates_so_far = states.get('number_training_updates', 0)
         if self.warmup_updates > 0 and (
-            updates_so_far <= self.warmup_updates or self.hard_reset
+            updates_so_far < self.warmup_updates or self.hard_reset
         ):
             self.warmup_scheduler = optim.lr_scheduler.LambdaLR(
                 optimizer, self._warmup_lr
@@ -110,7 +110,10 @@ class ParlAILRScheduler(object):
         self._number_training_updates = states.get('number_training_updates', 0)
 
         try:
-            self.scheduler.get_last_lr()
+            if self._is_lr_warming_up():
+                self.warmup_scheduler.get_last_lr()
+            else:
+                self.scheduler.get_last_lr()
         except AttributeError:
             # on older pytorches
             self.step(self._number_training_updates)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -131,7 +131,7 @@ class TestTransformerRanker(unittest.TestCase):
                     n_heads=1,
                     ffn_size=4,
                     embedding_size=4,
-                    warmup_updates=1,
+                    warmup_updates=0,
                     lr_scheduler='invsqrt',
                 )
             )
@@ -176,7 +176,7 @@ class TestTransformerRanker(unittest.TestCase):
                     n_heads=1,
                     ffn_size=32,
                     embedding_size=32,
-                    warmup_updates=1,
+                    warmup_updates=0,
                     lr_scheduler='reduceonplateau',
                 )
             )
@@ -724,7 +724,7 @@ class TestLearningRateScheduler(unittest.TestCase):
         Test generators resume correctly.
         """
         GENERATOR_ARGS = dict(
-            model='transformer/generator', skip_generation=True, warmup_updates=1
+            model='transformer/generator', skip_generation=True, warmup_updates=0
         )
         self._test_learning_rate_resuming(GENERATOR_ARGS)
 
@@ -732,7 +732,7 @@ class TestLearningRateScheduler(unittest.TestCase):
         """
         Test resuming learning rate for the ranker.
         """
-        RANKER_ARGS = dict(model='transformer/ranker', warmup_updates=1)
+        RANKER_ARGS = dict(model='transformer/ranker', warmup_updates=0)
         self._test_learning_rate_resuming(RANKER_ARGS)
 
     def test_invsqrt_learning_rate(self):
@@ -741,7 +741,7 @@ class TestLearningRateScheduler(unittest.TestCase):
             model='transformer/generator',
             learningrate=1,
             batchsize=1,
-            warmup_updates=1,
+            warmup_updates=0,
             lr_scheduler='invsqrt',
             n_layers=1,
             n_heads=1,
@@ -752,11 +752,9 @@ class TestLearningRateScheduler(unittest.TestCase):
             short_final_eval=True,
         )
 
-        args['num_epochs'] = 9 / 500
-        args['validation_every_n_epochs'] = 9 / 500
+        args['num_epochs'] = args['validation_every_n_epochs'] = 9 / 500
         valid1, test1 = testing_utils.train_model(args)
-        args['num_epochs'] = 16 / 500
-        args['validation_every_n_epochs'] = 16 / 500
+        args['num_epochs'] = args['validation_every_n_epochs'] = 16 / 500
         valid2, test2 = testing_utils.train_model(args)
 
         self.assertAlmostEqual(


### PR DESCRIPTION
**Patch description**
Context:
- Originally in ParlAI, fixed LR schedulers like cosine/linear would consume (warmup_updates + max_lr_steps) updates, cooling down to 0 eventually
- #3379 changed this behavior such that only max_lr_steps would be consumed, but did not change the cooldown to be faster
- This PR changes it so the full cooldown is completed by the end of max_lr_steps.

**Testing steps**
Adjusted CI, new assertions.