### PR TITLE
Dynamic Batching doesn't choke with really small datasets

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1133,8 +1133,14 @@ class DynamicBatchWorld(World):
                 indices.append(i)
 
         # quick invariant checks
-        assert len(indices) != 0, "DynamicBatchWorld ran out of data!"
+        assert (
+            len(indices) != 0 or self.world.num_examples() == 0
+        ), "DynamicBatchWorld ran out of data!"
         assert not any(self._scores[i] is None for i in indices)
+
+        if not indices:
+            assert self.world.num_examples() == 0
+            return
 
         # sort all the indices by their score, so that we can find similarly lengthed
         # items in O(1)

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1139,6 +1139,8 @@ class DynamicBatchWorld(World):
         assert not any(self._scores[i] is None for i in indices)
 
         if not indices:
+            # this worker got no examples. This can happen when there are fewer
+            # episodes than there are workers. "don't stress the small stuff."
             assert self.world.num_examples() == 0
             return
 

--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -27,6 +27,7 @@ import torch
 import random
 import os
 import signal
+import traceback
 import parlai.scripts.train_model as single_train
 import parlai.utils.distributed as distributed_utils
 from parlai.core.script import ParlaiScript, register_script
@@ -41,7 +42,13 @@ def multiprocess_train(
     ) as opt:
         # Run the actual training
         opt['multiprocessing'] = True
-        return single_train.TrainLoop(opt).train()
+        try:
+            return single_train.TrainLoop(opt).train()
+        except Exception as e:
+            import parlai.utils.logging as logging
+
+            logging.critical(traceback.format_exc())
+            raise
 
 
 def launch_and_train(opt, port):

--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -44,7 +44,7 @@ def multiprocess_train(
         opt['multiprocessing'] = True
         try:
             return single_train.TrainLoop(opt).train()
-        except Exception as e:
+        except Exception:
             import parlai.utils.logging as logging
 
             logging.critical(traceback.format_exc())

--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -48,6 +48,10 @@ def multiprocess_train(
             import parlai.utils.logging as logging
 
             logging.critical(traceback.format_exc())
+            logging.critical(
+                f"Got the above exception on worker {rank + rank_offset}. "
+                "This may cause hangs requiring manual killing of processes."
+            )
             raise
 
 

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -572,8 +572,8 @@ class DefaultTeacher(CandidateTeacher):
 
 class TinyTeacher(DialogTeacher):
     """
-    Teacher with a single example, to test data stratification with fewer
-    examples than GPUs.
+    Teacher with a single example, to test data stratification with fewer examples than
+    GPUs.
     """
 
     def __init__(self, opt, shared=None):

--- a/parlai/tasks/integration_tests/agents.py
+++ b/parlai/tasks/integration_tests/agents.py
@@ -568,3 +568,17 @@ class ShortFixedTeacher(FixedDialogCandidateTeacher):
 
 class DefaultTeacher(CandidateTeacher):
     pass
+
+
+class TinyTeacher(DialogTeacher):
+    """
+    Teacher with a single example, to test data stratification with fewer
+    examples than GPUs.
+    """
+
+    def __init__(self, opt, shared=None):
+        opt['datafile'] = 'tiny_data'
+        super().__init__(opt, shared)
+
+    def setup_data(self, _):
+        yield {'text': 'hi', 'label': 'there'}, True

--- a/tests/test_dynamicbatching.py
+++ b/tests/test_dynamicbatching.py
@@ -8,7 +8,6 @@ from parlai.core.opt import Opt
 from parlai.tasks.integration_tests.agents import NUM_TEST, EXAMPLE_SIZE
 from parlai.utils.conversations import Conversations
 import parlai.utils.testing as testing_utils
-from parlai.core.teachers import register_teacher, DialogTeacher
 
 import os
 from typing import Dict, Any
@@ -206,8 +205,8 @@ class TestBatchSort(unittest.TestCase):
 
 class TestTinyDataset(unittest.TestCase):
     """
-    Test Dyanmic batching when we have a world size fewer than the number
-    of available GPUs.
+    Test Dyanmic batching when we have a world size fewer than the number of available
+    GPUs.
     """
 
     @testing_utils.skipUnlessGPU


### PR DESCRIPTION
**Patch description**
Fixes a bug with dynamic batching where we would crash with an assertion error on later workers if the dataset was smaller than the number of GPUs.

**Testing steps**
New CI