### PR TITLE
[RAG] pass the kwargs in building encoder

### DIFF
--- a/parlai/agents/rag/modules.py
+++ b/parlai/agents/rag/modules.py
@@ -106,7 +106,9 @@ class RagModel(TorchGeneratorModel):
                 opt=opt, dictionary=dictionary, embedding=embedding, **kwargs
             )
         else:
-            return encoder_class(opt, *args, **kwargs)
+            return encoder_class(
+                opt, *args, dictionary=dictionary, embedding=embedding, **kwargs
+            )
 
     @classmethod
     def build_decoder(


### PR DESCRIPTION
**Patch description**
- During `build_encoder` when `encoder_class` is not `RagEncoder`, some of the args are not passed (e.g. `embedding`, `dictionary`) if one calls `RagModel.build_encoder(opt, *args, **kwargs)`

TODO: seems to break the `ParlAIT5Encoder`
**Testing steps**
CI

**Other information**
<!-- Any other information or context you would like to provide. -->
