### PR TITLE
updated weighted_f1 to not assume binary classification

### DIFF
--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -199,11 +199,8 @@ class WeightedF1Metric(Metric):
         values = list(self._values.values())
         if len(values) == 0:
             return weighted_f1
-        total_examples = (
-            values[0]._true_positives
-            + values[0]._true_negatives
-            + values[0]._false_positives
-            + values[0]._false_negatives
+        total_examples = sum(
+            [each._true_positives + each._false_negatives for each in values]
         )
         for each in values:
             actual_positive = each._true_positives + each._false_negatives


### PR DESCRIPTION
**Patch description**
weighted f1 was calculated was broken -- it assumes there are only 2 classes. Specifically `total_examples` calculation was corrected for multiclass.

**Testing steps**

**Other information**

