### PR TITLE
Parallelize detensorizing context over batch

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -1011,7 +1011,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         """
         if self.beam_context_block_ngram <= 0:
             # We aren't context blocking, return empty tensor of the correct size
-            return torch.LongTensor([[]] * batch.batchsize)
+            return torch.zeros(batch.batchsize, 0, dtype=torch.long)
 
         ctxt = batch.text_vec
         if self.beam_block_full_context:

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -1007,7 +1007,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
 
     def _get_batch_context(self, batch):
         """
-        TODO: write
+        Version of TGA._get_context() that operates on full batches for speed.
         """
         if self.beam_context_block_ngram <= 0:
             # We aren't context blocking, return empty tensor of the correct size
@@ -1302,12 +1302,14 @@ class TreeSearch(object):
         self: TSType, batch_context_list: List[List[int]], batch_idx: int
     ) -> TSType:
         """
+        Version of .set_context() that operates on a single element of a batch.
+
         Set the internal context representation and return self.
 
-        :param context:
-            a LongTensor representing the input context; used for context
-            ngram blocking, if supplied
-        # TODO: update docstring
+        :param batch_context_list:
+            a list of lists, each one containing the context for one member of the batch
+        :param batch_idx:
+            index of the batch
         """
         self.context = batch_context_list[batch_idx]
         return self


### PR DESCRIPTION
**Patch description**
Currently, when generating, we convert the context Tensor to a list one example at a time, which is expensive; this PR parallelizes this operation over the entire batch.

Performance on 1000 generations (`-mf zoo:blender/blender_90M/model -t blended_skill_talk -ne 1000`), on an otherwise unoccupied devfair:

- Original code, trial 1: median elapsed time 783 ms, mean 797 ms
- Original code, trial 2: median 770 ms, mean 785 ms
- This PR, trial 1: median 651 ms, mean 663 ms
- This PR, trial 2: median 665 ms, mean 677 ms

**Testing steps**
CI checks (which seem to cover context blocking)
