### PR TITLE
Parallelize detensorizing token IDs during tree search

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -1406,8 +1406,9 @@ class TreeSearch(object):
 
         self.outputs.append(tok_ids)
         self.bookkeep.append(hyp_ids)
+        tok_id_list = tok_ids.tolist()
         self.partial_hyps = [
-            self.partial_hyps[hyp_ids[i]] + [tok_ids[i].item()]
+            self.partial_hyps[hyp_ids[i]] + [tok_id_list[i]]
             for i in range(self.beam_size)
         ]
 


### PR DESCRIPTION
**Patch description**
Currently, during any kind of tree search, the token ID tensor will be detensorized one item at a time, which is expensive. This PR rewrites that to detensorize the whole batch at once.

Performance on 1000 generations (`-mf zoo:blender/blender_90M/model -t blended_skill_talk -ne 1000`), on an otherwise unoccupied devfair:

- Original code, trial 1: median elapsed time 783 ms, mean 797 ms
- Original code, trial 2: median 770 ms, mean 785 ms
- This PR, trial 1: median 660 ms, mean 671 ms
- This PR, trial 2: median 656 ms, mean 667 ms

**Testing steps**
CI checks
