### PR TITLE
Eliminate dummy batches and init_cuda_buffer.

### DIFF
--- a/parlai/agents/hred/hred.py
+++ b/parlai/agents/hred/hred.py
@@ -172,12 +172,3 @@ class HredAgent(TorchGeneratorAgent):
             truncated_vec = self._check_truncate(obs["text_vec"], truncate, True)
             obs.force_set("text_vec", torch.LongTensor(truncated_vec))
         return obs
-
-    def _dummy_batch(self, batchsize, maxlen):
-        """
-        Overridden to add dummy context vec and hist lens.
-        """
-        batch = super()._dummy_batch(batchsize, maxlen)
-        batch["context_vec"] = batch["text_vec"]
-        batch["hist_lens"] = torch.ones(batchsize, dtype=torch.long)
-        return batch

--- a/parlai/agents/image_seq2seq/image_seq2seq.py
+++ b/parlai/agents/image_seq2seq/image_seq2seq.py
@@ -102,23 +102,6 @@ class ImageSeq2seqAgent(TransformerGeneratorAgent, TorchImageAgent):
             )
         return obs
 
-    def _dummy_batch(self, batchsize: int, maxlen: int) -> Batch:
-        """
-        Override to include image feats.
-        """
-        b = super()._dummy_batch(batchsize, maxlen)
-        image = torch.ones(batchsize, self.image_features_dim).cuda()
-        if self.n_image_channels > 1:
-            image = image.unsqueeze(1).repeat(1, self.n_image_channels, 1)
-        if self.fp16:
-            image = image.half()
-        return Batch(
-            text_vec=b.text_vec,
-            label_vec=b.label_vec,
-            image=image,
-            personalities=torch.ones(batchsize, self.opt['embedding_size']).cuda(),
-        )
-
     def batchify_image_features(self, batch: Batch) -> Batch:
         """
         Format and return the batched image features.

--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -328,19 +328,6 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
         return self._model_input(batch)
 
     ##### 2. Standard TGA Function Overrides #####
-    def _dummy_batch(self, batchsize: int, maxlen: int) -> Batch:
-        """
-        Add query/input turn vecs.
-        """
-        batch = self._generation_agent._dummy_batch(self, batchsize, maxlen)
-        batch.query_vec = batch.text_vec.clone()
-        batch.input_turn_cnt_vec = (
-            None
-            if self.rag_model_type != 'turn'
-            else torch.ones(batch.query_vec.size(0)).to(batch.query_vec)
-        )
-        return batch
-
     def build_model(self) -> RagModel:
         """
         Build and return RagModel.
@@ -407,11 +394,9 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
         """
         Determine if we need to override the DPR Model weights.
 
-        Under certain circumstances, one may wish to specify a different
-        `--dpr-model-file` for a pre-trained, RAG model. Thus, we additionally
-        check to make sure that the loaded DPR model weights are not overwritten
-        by the state loading.
-
+        Under certain circumstances, one may wish to specify a different `--dpr-model-
+        file` for a pre-trained, RAG model. Thus, we additionally check to make sure
+        that the loaded DPR model weights are not overwritten by the state loading.
         """
         override_dpr = False
         overrides = opt.get('override', {})

--- a/projects/dialogue_unlikelihood/agents.py
+++ b/projects/dialogue_unlikelihood/agents.py
@@ -66,11 +66,6 @@ class RewardUnlikelihoodAgentTrait(object):
         grp.add_argument('--alpha', default=1.0, type=float)
         return parser
 
-    def _dummy_batch(self, batchsize, maxlen):
-        batch = super()._dummy_batch(batchsize, maxlen)
-        batch['rewards'] = torch.ones(batchsize, dtype=torch.long).cuda()
-        return batch
-
     def compute_loss(self, batch, return_output=False):
         if batch.label_vec is None:
             raise ValueError('Cannot compute loss without a label.')

--- a/projects/wizard_of_wikipedia/generator/agents.py
+++ b/projects/wizard_of_wikipedia/generator/agents.py
@@ -114,16 +114,6 @@ class EndToEndAgent(_GenericWizardAgent):
         self.max_knowledge = opt.get('max_knowledge')
         self.knowledge_alpha = opt['knowledge_alpha']
 
-    def _dummy_batch(self, bsz, maxlen):
-        batch = super()._dummy_batch(bsz, maxlen)
-        batch['know_vec'] = th.zeros(bsz, 2, 2).long().cuda()
-        # bool/uint8 backwards for pytorch 1.0/1.2 compatibility
-        ck_mask = (th.ones(bsz, 2, dtype=th.uint8) != 0).cuda()
-        batch['ck_mask'] = ck_mask
-        batch['cs_ids'] = th.zeros(bsz).long().cuda()
-        batch['use_cs_ids'] = True
-        return batch
-
     def compute_loss(self, batch, return_output=False):
         # first compute our regular forced decoding loss
         token_loss, model_output = super().compute_loss(batch, return_output=True)


### PR DESCRIPTION
**Patch description**
Eliminate the dreaded `_dummy_batch` and `_init_cuda_buffer`.

Users have complained about the presence of these methods. When debugging, the first batch being a dummy causes some confusion (why am I getting gibberish data?) and the manual implementation of a `_dummy_batch` is annoying (why is my model breaking on the first pass?)

Adopt Fairseq's newer approach:
- Cache the very first batch we ever seen. If it's invalid, we should be raising an exception anyway. If it's valid, it will be good enough
- Do NOT initialize the cuda buffer. Just keep that batch around
- If we need to recover from an OOM, used the cached dummy batch as the data.

**Testing steps**
CI.