### PR TITLE
Add AUC metrics 

### DIFF
--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -286,7 +286,7 @@ class AUCMetrics(Metric):
 
             fp = self_false_p + other_false_p
             tp = self_true_p + other_true_p
-            all_vals[threshold] = (fp, tp)
+            all_vals[threshold] = [fp, tp]
 
         if len(all_thresholds) == 2:
             print('self_vals', self._values)

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -58,6 +58,12 @@ class ConfusionMatrixMetric(Metric):
         self._true_negatives = self.as_number(true_negatives)
         self._false_positives = self.as_number(false_positives)
         self._false_negatives = self.as_number(false_negatives)
+        self._true_positive_rate = self._true_positives / (
+            self._true_positives + self._false_negatives
+        )
+        self._false_positive_rate = self._false_positives / (
+            self._true_negatives + self._false_positives
+        )
 
     def __add__(
         self, other: Optional['ConfusionMatrixMetric']

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -281,7 +281,7 @@ class AUCMetrics(Metric):
         fp, tp = list(zip(*(self._values.values())))
         fpr = np.array(fp) / self._neg_cnt
         tpr = np.array(tp) / self._pos_cnt
-        return auc(fpr, tpr)
+        return auc(tpr, fpr)
 
 
 class WeightedF1Metric(Metric):

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -219,8 +219,10 @@ class AUCMetrics(Metric):
         neg_cnt = len(true_labels) - pos_cnt
 
         # first calculate thresholds, and include the default
-        # upper and lower bounds
-        all_thresholds = set([0, 1])
+        # upper bounds; don't need to include lower because
+        # we are doing greater and equal
+        # NOTE: assumes the probabilites are between 0 and 1
+        all_thresholds = set([1.5])
         CONST = 10 ** max_dec_places
         # add the upper and lower bound of the values
         for prob in class_probs:
@@ -243,7 +245,10 @@ class AUCMetrics(Metric):
             else:
                 effected_ind = 0
 
-            ind = np.searchsorted(sorted_thresholds, prob, side='right')
+            ind = np.searchsorted(sorted_thresholds, prob, side='left')
+            if ind < len(sorted_thresholds) and sorted_thresholds[ind] == prob:
+                ind += 1
+            # print('current prob', prob, '| found index:', ind)
             for thres in sorted_thresholds[:ind]:
                 values[thres][effected_ind] += 1
 

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -18,16 +18,13 @@ from parlai.core.metrics import Metric, AverageMetric
 from typing import List, Optional, Tuple, Dict, Union
 from parlai.utils.typing import TScalar
 from parlai.utils.io import PathManager
-import parlai.utils.logging as logging
-
-import torch
-import torch.nn.functional as F
-
-import numpy as np
-import math
-from collections import Counter
-
 from sklearn.metrics import auc
+
+import parlai.utils.logging as logging
+import torch.nn.functional as F
+from collections import Counter
+import torch
+import math
 
 
 class ConfusionMatrixMetric(Metric):
@@ -479,12 +476,6 @@ class TorchClassifierAgent(TorchAgent):
         if self.calc_auc:
             self.auc_class_ind = 0
             self.auc = AUCMetrics(class_name=self.class_list[self.auc_class_ind])
-            # self.auc_class_name = opt.get('area_under_curve_class_name')
-            # try:
-            #     self.auc_class_ind = self.class_list.index(self.auc_class_name)
-            # except ValueError:
-            #     self.auc_class_ind = 0
-            #     self.auc_class_name = self.class_list[self.auc_class_ind]
 
         # set up model and optimizers
         states = {}

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -185,8 +185,8 @@ class ClassificationF1Metric(ConfusionMatrixMetric):
 
 class AUCMetrics(Metric):
     """
-    Class that calculates the area under the curve from a list of
-    [(true positive rates, false positive rates)]
+    Class that calculates the area under the curve from a list of [(true positive rates,
+    false positive rates)]
     """
 
     __slots__ = ('_truth', '_max_probs')

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -244,7 +244,7 @@ class AUCMetrics(Metric):
                 effected_ind = 0
 
             ind = np.searchsorted(sorted_thresholds, prob, side='right')
-            for thres in sorted_thresholds[ind:]:
+            for thres in sorted_thresholds[:ind]:
                 values[thres][effected_ind] += 1
 
         return cls(values, pos_cnt, neg_cnt, sorted_thresholds, class_name)

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -179,7 +179,7 @@ def _eval_single_world(opt, agent, task):
 
     report = aggregate_unnamed_reports(all_gather_list(world.report()))
 
-    if len(world.agents) > 1:
+    if isinstance(world.agents, list) and len(world.agents) > 1:
         classifier_agent = world.agents[CLASSIFIER_AGENT]
         if hasattr(classifier_agent, 'calc_auc') and classifier_agent.calc_auc:
             report['AUC'] = classifier_agent.auc

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -179,12 +179,13 @@ def _eval_single_world(opt, agent, task):
 
     report = aggregate_unnamed_reports(all_gather_list(world.report()))
 
-    classifier_agent = world.agents[CLASSIFIER_AGENT]
-    if hasattr(classifier_agent, 'calc_auc') and classifier_agent.calc_auc:
-        report['AUC'] = classifier_agent.auc
-        classifier_agent.reset_auc()
-        # for safety measures
-        agent.reset_auc()
+    if len(world.agents) > 1:
+        classifier_agent = world.agents[CLASSIFIER_AGENT]
+        if hasattr(classifier_agent, 'calc_auc') and classifier_agent.calc_auc:
+            report['AUC'] = classifier_agent.auc
+            classifier_agent.reset_auc()
+            # for safety measures
+            agent.reset_auc()
     world.reset()
     return report
 

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -151,8 +151,6 @@ def _eval_single_world(opt, agent, task):
     if is_distributed():
         logging.warning('Progress bar is approximate in distributed mode.')
 
-    print('AUC BEFORE:', world.agents[CLASSIFIER_AGENT].auc)
-
     while not world.epoch_done() and cnt < max_cnt:
         cnt += opt.get('batchsize', 1)
         world.parley()
@@ -181,20 +179,8 @@ def _eval_single_world(opt, agent, task):
 
     report = aggregate_unnamed_reports(all_gather_list(world.report()))
 
-    print('AUC AFTER:', world.agents[CLASSIFIER_AGENT].auc)
-
     if world.agents[CLASSIFIER_AGENT].calc_auc:
-        # the second one should be the classifier agent for auc
-        from sklearn.metrics import roc_auc_score
-        from parlai.core.metrics import AverageMetric
-
         classifier_agent = world.agents[CLASSIFIER_AGENT]
-        auc = classifier_agent.auc
-        all_labels = ['not_okay'] * sum(auc._pos_dict.values()) + ['okay'] * sum(
-            auc._neg_dict.values()
-        )
-        all_probs = list(auc._pos_dict.elements()) + list(auc._neg_dict.elements())
-        report['AUC_sklearn_auc'] = AverageMetric(roc_auc_score(all_labels, all_probs))
         report['AUC'] = classifier_agent.auc
         classifier_agent.reset_auc()
         # for safety measures

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -179,8 +179,8 @@ def _eval_single_world(opt, agent, task):
 
     report = aggregate_unnamed_reports(all_gather_list(world.report()))
 
-    if world.agents[CLASSIFIER_AGENT].calc_auc:
-        classifier_agent = world.agents[CLASSIFIER_AGENT]
+    classifier_agent = world.agents[CLASSIFIER_AGENT]
+    if hasattr(classifier_agent, 'calc_auc') and classifier_agent.calc_auc:
         report['AUC'] = classifier_agent.auc
         classifier_agent.reset_auc()
         # for safety measures

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -322,57 +322,165 @@ class TestAggregators(unittest.TestCase):
         # task 1; borrowing example from scikit learn
         task1_probabilities = [0.1, 0.4, 0.35, 0.8]
         task1_gold_labels = ['class_ok', 'class_ok', 'class_notok', 'class_notok']
-        task1_exp_val = {
+        task1_pos_buckets = {0.35: 1, 0.8: 1}
+        task1_neg_buckets = {0.1: 1, 0.4: 1}
+        task1_exp_fp_tp = {
             # thres: (False positives, True positives)
-            0.1: [2, 2],
-            0.35: [1, 2],
-            0.4: [1, 1],
-            0.8: [0, 1],
-            1.5: [0, 0],
+            0.1: (2, 2),
+            0.35: (1, 2),
+            0.4: (1, 1),
+            0.8: (0, 1),
+            '_': (0, 0),
         }
 
         # task 2; checking with an odd number
         task2_probabilities = [0.05, 0.2, 0.6]
         task2_gold_labels = ['class_ok', 'class_ok', 'class_notok']
-
-        task2_exp_val = {0.05: [2, 1], 0.2: [1, 1], 0.6: [0, 1], 1.5: [0, 0]}
+        task2_pos_buckets = {0.6: 1}
+        task2_neg_buckets = {0.05: 1, 0.2: 1}
+        task2_exp_fp_tp = {0.05: (2, 1), 0.2: (1, 1), 0.6: (0, 1), 1.5: (0, 0)}
 
         # task 3: combining task 1 and task 2
         task3_probabilities = task1_probabilities + task2_probabilities
         task3_gold_labels = task1_gold_labels + task2_gold_labels
-
-        task3_exp_val = {
+        task3_pos_buckets = {0.35: 1, 0.8: 1, 0.6: 1}
+        task3_neg_buckets = {0.1: 1, 0.4: 1, 0.05: 1, 0.2: 1}
+        task3_exp_fp_tp = {
             # threshold: FP, TP
-            0.05: [4, 3],
-            0.1: [3, 3],
-            0.2: [2, 3],
-            0.35: [1, 3],
-            0.4: [1, 2],
-            0.6: [0, 2],
-            0.8: [0, 1],
-            1.5: [0, 0],
+            0.05: (4, 3),
+            0.1: (3, 3),
+            0.2: (2, 3),
+            0.35: (1, 3),
+            0.4: (1, 2),
+            0.6: (0, 2),
+            0.8: (0, 1),
+            '_': (0, 0),
+        }
+
+        # task 4: testing when there's ones in the same bucket
+        task4_probabilities = [0.1, 0.400001, 0.4, 0.359, 0.35, 0.900001, 0.9]
+        task4_gold_labels = [
+            'class_ok',
+            'class_ok',
+            'class_ok',
+            'class_notok',
+            'class_notok',
+            'class_notok',
+            'class_notok',
+        ]
+        task4_neg_buckets = {0.1: 1, 0.4: 2}
+        task4_pos_buckets = {0.35: 1, 0.359: 1, 0.9: 2}
+        task4_exp_fp_tp = {
+            # thres: (False positives, True positives)
+            0.1: (3, 4),
+            0.35: (2, 4),
+            0.359: (2, 3),
+            0.4: (2, 2),
+            0.9: (0, 2),
+            '_': (0, 0),
+        }
+
+        # task 5: testing when there's more difference in the bucket (similar to task 4),
+        # but testing to make sure the rounding/flooring is correct, and the edge cases 0.0, 1.0
+        task5_probabilities = [0, 0.8, 0.4009, 0.400, 0.359, 0.35, 0.9999, 0.999, 1]
+        # 4 okay, 5 not okay
+        task5_gold_labels = [
+            'class_ok',
+            'class_ok',
+            'class_ok',
+            'class_ok',
+            'class_notok',
+            'class_notok',
+            'class_notok',
+            'class_notok',
+            'class_notok',
+        ]
+        task5_neg_buckets = {0: 1, 0.8: 1, 0.4: 2}
+        task5_pos_buckets = {0.35: 1, 0.359: 1, 0.999: 2, 1: 1}
+        task5_exp_fp_tp = {
+            # thres: (False positives, True positives)
+            0: (4, 5),
+            0.35: (3, 5),
+            0.359: (3, 4),
+            0.4: (3, 3),
+            0.8: (1, 3),
+            0.9: (0, 3),
+            1.0: (0, 1),
+            '_': (0, 0),
+        }
+
+        # task 6: combining task 4 + task 5 (combining with same keys)
+        task6_probabilities = task4_probabilities + task5_probabilities
+        task6_gold_labels = task4_gold_labels + task5_gold_labels
+        task6_neg_buckets = {0: 1, 0.8: 1, 0.4: 4, 0.1: 1}
+        task6_pos_buckets = {0.35: 2, 0.359: 2, 0.9: 2, 0.999: 2, 1: 1}
+        task6_exp_fp_tp = {
+            # threshold: FP, TP
+            0: (7, 9),
+            0.1: (6, 9),
+            0.35: (5, 9),
+            0.359: (5, 7),
+            0.4: (5, 5),
+            0.8: (1, 5),
+            0.9: (0, 5),
+            0.999: (0, 3),
+            1: (0, 1),
+            '_': (0, 0),
         }
 
         # run and check the TPs and FPs
         task1_result = AUCMetrics.raw_data_to_auc(
-            task1_gold_labels, task1_probabilities, 'class_notok', max_dec_places=2
+            task1_gold_labels, task1_probabilities, 'class_notok'
         )
         task2_result = AUCMetrics.raw_data_to_auc(
-            task2_gold_labels, task2_probabilities, 'class_notok', max_dec_places=2
+            task2_gold_labels, task2_probabilities, 'class_notok'
         )
 
-        self.assertEqual(task1_result.key_vals, task1_exp_val)
-        self.assertEqual(task2_result.key_vals, task2_exp_val)
+        task4_result = AUCMetrics.raw_data_to_auc(
+            task4_gold_labels, task4_probabilities, 'class_notok'
+        )
 
-        # check that merging als produces the same results
+        task5_result = AUCMetrics.raw_data_to_auc(
+            task5_gold_labels, task5_probabilities, 'class_notok'
+        )
+
+        # check the buckets first
+        self.assertEqual(task1_result._pos_dict, task1_pos_buckets)
+        self.assertEqual(task1_result._neg_dict, task1_neg_buckets)
+        self.assertEqual(task2_result._pos_dict, task2_pos_buckets)
+        self.assertEqual(task2_result._neg_dict, task2_neg_buckets)
+        self.assertEqual(task4_result._pos_dict, task4_pos_buckets)
+        self.assertEqual(task4_result._neg_dict, task4_neg_buckets)
+        self.assertEqual(task5_result._pos_dict, task5_pos_buckets)
+        self.assertEqual(task5_result._neg_dict, task5_neg_buckets)
+
+        # then check fp, tp
+        self.assertEqual(set(task1_result._calc_fp_tp()), set(task1_exp_fp_tp.values()))
+        self.assertEqual(set(task2_result._calc_fp_tp()), set(task2_exp_fp_tp.values()))
+        self.assertEqual(set(task4_result._calc_fp_tp()), set(task4_exp_fp_tp.values()))
+        self.assertEqual(set(task5_result._calc_fp_tp()), set(task5_exp_fp_tp.values()))
+
+        # check that merging also produces the same results
         task3_result = task1_result + task2_result
-        self.assertEqual(task3_result.key_vals, task3_exp_val)
+        self.assertEqual(task3_result._pos_dict, task3_pos_buckets)
+        self.assertEqual(task3_result._neg_dict, task3_neg_buckets)
+        self.assertEqual(set(task3_result._calc_fp_tp()), set(task3_exp_fp_tp.values()))
+
+        task6_result = task4_result + task5_result
+        self.assertEqual(task6_result._pos_dict, task6_pos_buckets)
+        self.assertEqual(task6_result._neg_dict, task6_neg_buckets)
+        self.assertEqual(set(task6_result._calc_fp_tp()), set(task6_exp_fp_tp.values()))
 
         # then check from raw data again
         task3_result = AUCMetrics.raw_data_to_auc(
-            task3_gold_labels, task3_probabilities, 'class_notok', max_dec_places=2
+            task3_gold_labels, task3_probabilities, 'class_notok'
         )
-        self.assertEqual(task3_result.key_vals, task3_exp_val)
+        self.assertEqual(set(task3_result._calc_fp_tp()), set(task3_exp_fp_tp.values()))
+
+        task6_result = AUCMetrics.raw_data_to_auc(
+            task6_gold_labels, task6_probabilities, 'class_notok'
+        )
+        self.assertEqual(set(task6_result._calc_fp_tp()), set(task6_exp_fp_tp.values()))
 
         # now actually testing the area under curve
         from sklearn.metrics import roc_auc_score
@@ -385,6 +493,15 @@ class TestAggregators(unittest.TestCase):
         )
         self.assertAlmostEqual(
             roc_auc_score(task3_gold_labels, task3_probabilities), task3_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task4_gold_labels, task4_probabilities), task4_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task5_gold_labels, task5_probabilities), task5_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task6_gold_labels, task6_probabilities), task6_result.value()
         )
 
     def test_classifier_metrics(self):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -376,8 +376,12 @@ class TestAggregators(unittest.TestCase):
         self.assertAlmostEqual(
             roc_auc_score(task1_gold_labels, task1_probabilities), task1_result.value()
         )
-        # self.assertAlmostEqual(roc_auc_score(task2_gold_labels, task2_probabilities), task2_result.value())
-        # self.assertAlmostEqual(roc_auc_score(task3_gold_labels, task3_probabilities), task3_result.value())
+        self.assertAlmostEqual(
+            roc_auc_score(task2_gold_labels, task2_probabilities), task2_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task3_gold_labels, task3_probabilities), task3_result.value()
+        )
 
     def test_classifier_metrics(self):
         # We assume a batch of 16 samples, binary classification case, from 2 tasks.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -428,20 +428,24 @@ class TestAggregators(unittest.TestCase):
             '_': (0, 0),
         }
 
-        # run and check the TPs and FPs
+        # run and check the TPs and FPs for singles
         task1_result = AUCMetrics.raw_data_to_auc(
             task1_gold_labels, task1_probabilities, 'class_notok'
         )
         task2_result = AUCMetrics.raw_data_to_auc(
             task2_gold_labels, task2_probabilities, 'class_notok'
         )
-
+        task3_result = AUCMetrics.raw_data_to_auc(
+            task3_gold_labels, task3_probabilities, 'class_notok'
+        )
         task4_result = AUCMetrics.raw_data_to_auc(
             task4_gold_labels, task4_probabilities, 'class_notok'
         )
-
         task5_result = AUCMetrics.raw_data_to_auc(
             task5_gold_labels, task5_probabilities, 'class_notok'
+        )
+        task6_result = AUCMetrics.raw_data_to_auc(
+            task6_gold_labels, task6_probabilities, 'class_notok'
         )
 
         # check the buckets first
@@ -449,16 +453,22 @@ class TestAggregators(unittest.TestCase):
         self.assertEqual(task1_result._neg_dict, task1_neg_buckets)
         self.assertEqual(task2_result._pos_dict, task2_pos_buckets)
         self.assertEqual(task2_result._neg_dict, task2_neg_buckets)
+        self.assertEqual(task3_result._pos_dict, task3_pos_buckets)
+        self.assertEqual(task3_result._neg_dict, task3_neg_buckets)
         self.assertEqual(task4_result._pos_dict, task4_pos_buckets)
         self.assertEqual(task4_result._neg_dict, task4_neg_buckets)
         self.assertEqual(task5_result._pos_dict, task5_pos_buckets)
         self.assertEqual(task5_result._neg_dict, task5_neg_buckets)
+        self.assertEqual(task6_result._pos_dict, task6_pos_buckets)
+        self.assertEqual(task6_result._neg_dict, task6_neg_buckets)
 
         # then check fp, tp
         self.assertEqual(set(task1_result._calc_fp_tp()), set(task1_exp_fp_tp.values()))
         self.assertEqual(set(task2_result._calc_fp_tp()), set(task2_exp_fp_tp.values()))
+        self.assertEqual(set(task3_result._calc_fp_tp()), set(task3_exp_fp_tp.values()))
         self.assertEqual(set(task4_result._calc_fp_tp()), set(task4_exp_fp_tp.values()))
         self.assertEqual(set(task5_result._calc_fp_tp()), set(task5_exp_fp_tp.values()))
+        self.assertEqual(set(task6_result._calc_fp_tp()), set(task6_exp_fp_tp.values()))
 
         # check that merging also produces the same results
         task3_result = task1_result + task2_result
@@ -469,17 +479,6 @@ class TestAggregators(unittest.TestCase):
         task6_result = task4_result + task5_result
         self.assertEqual(task6_result._pos_dict, task6_pos_buckets)
         self.assertEqual(task6_result._neg_dict, task6_neg_buckets)
-        self.assertEqual(set(task6_result._calc_fp_tp()), set(task6_exp_fp_tp.values()))
-
-        # then check from raw data again
-        task3_result = AUCMetrics.raw_data_to_auc(
-            task3_gold_labels, task3_probabilities, 'class_notok'
-        )
-        self.assertEqual(set(task3_result._calc_fp_tp()), set(task3_exp_fp_tp.values()))
-
-        task6_result = AUCMetrics.raw_data_to_auc(
-            task6_gold_labels, task6_probabilities, 'class_notok'
-        )
         self.assertEqual(set(task6_result._calc_fp_tp()), set(task6_exp_fp_tp.values()))
 
         # now actually testing the area under curve
@@ -502,6 +501,26 @@ class TestAggregators(unittest.TestCase):
         )
         self.assertAlmostEqual(
             roc_auc_score(task6_gold_labels, task6_probabilities), task6_result.value()
+        )
+
+        # last task: adding everything together; uses task 3 & 6
+        # gonna just check roc scores
+        task_all_gold_labels = task3_gold_labels + task6_gold_labels
+        task_all_probabilities = task3_probabilities + task6_probabilities
+
+        task_all_result = task3_result + task6_result
+
+        self.assertAlmostEqual(
+            roc_auc_score(task_all_gold_labels, task_all_probabilities),
+            task_all_result.value(),
+        )
+
+        task_all_result2 = AUCMetrics.raw_data_to_auc(
+            task_all_gold_labels, task_all_probabilities, 'class_notok'
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task_all_gold_labels, task_all_probabilities),
+            task_all_result2.value(),
         )
 
     def test_classifier_metrics(self):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -319,6 +319,8 @@ class TestAggregators(unittest.TestCase):
         assert 'b/global_avg' not in agg
 
     def test_auc_metrics(self):
+        class_name = 'class_notok'
+        decimal_place = 3
         # task 1; borrowing example from scikit learn
         task1_probabilities = [0.1, 0.4, 0.35, 0.8]
         task1_gold_labels = ['class_ok', 'class_ok', 'class_notok', 'class_notok']
@@ -430,22 +432,40 @@ class TestAggregators(unittest.TestCase):
 
         # run and check the TPs and FPs for singles
         task1_result = AUCMetrics.raw_data_to_auc(
-            task1_gold_labels, task1_probabilities, 'class_notok'
+            task1_gold_labels,
+            task1_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
         )
         task2_result = AUCMetrics.raw_data_to_auc(
-            task2_gold_labels, task2_probabilities, 'class_notok'
+            task2_gold_labels,
+            task2_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
         )
         task3_result = AUCMetrics.raw_data_to_auc(
-            task3_gold_labels, task3_probabilities, 'class_notok'
+            task3_gold_labels,
+            task3_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
         )
         task4_result = AUCMetrics.raw_data_to_auc(
-            task4_gold_labels, task4_probabilities, 'class_notok'
+            task4_gold_labels,
+            task4_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
         )
         task5_result = AUCMetrics.raw_data_to_auc(
-            task5_gold_labels, task5_probabilities, 'class_notok'
+            task5_gold_labels,
+            task5_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
         )
         task6_result = AUCMetrics.raw_data_to_auc(
-            task6_gold_labels, task6_probabilities, 'class_notok'
+            task6_gold_labels,
+            task6_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
         )
 
         # check the buckets first
@@ -516,7 +536,7 @@ class TestAggregators(unittest.TestCase):
         )
 
         task_all_result2 = AUCMetrics.raw_data_to_auc(
-            task_all_gold_labels, task_all_probabilities, 'class_notok'
+            task_all_gold_labels, task_all_probabilities, class_name
         )
         self.assertAlmostEqual(
             roc_auc_score(task_all_gold_labels, task_all_probabilities),

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -363,12 +363,21 @@ class TestAggregators(unittest.TestCase):
         task3_result = AUCMetrics.raw_data_to_auc(
             task3_gold_labels, task3_probabilities, 'class_notok', max_dec_places=2
         )
-        self.assertEqual(task1_result._values, task1_exp_val)
-        self.assertEqual(task2_result._values, task2_exp_val)
-        self.assertEqual(task3_result._values, task3_exp_val)
+        self.assertEqual(task1_result.key_vals, task1_exp_val)
+        self.assertEqual(task2_result.key_vals, task2_exp_val)
+        self.assertEqual(task3_result.key_vals, task3_exp_val)
 
         task3_result = task1_result + task2_result
-        self.assertEqual(task3_result._values, task3_exp_val)
+        self.assertEqual(task3_result.key_vals, task3_exp_val)
+
+        # now actually testing the area under curve
+        from sklearn.metrics import roc_auc_score
+
+        self.assertAlmostEqual(
+            roc_auc_score(task1_gold_labels, task1_probabilities), task1_result.value()
+        )
+        # self.assertAlmostEqual(roc_auc_score(task2_gold_labels, task2_probabilities), task2_result.value())
+        # self.assertAlmostEqual(roc_auc_score(task3_gold_labels, task3_probabilities), task3_result.value())
 
     def test_classifier_metrics(self):
         # We assume a batch of 16 samples, binary classification case, from 2 tasks.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -360,8 +360,15 @@ class TestAggregators(unittest.TestCase):
             task2_gold_labels, task2_probabilities, 'class_notok', max_dec_places=2
         )
 
-        assert task1_result._values == task1_exp_val
-        assert task2_result._values == task2_exp_val
+        task3_result = AUCMetrics.raw_data_to_auc(
+            task3_gold_labels, task3_probabilities, 'class_notok', max_dec_places=2
+        )
+        self.assertEqual(task1_result._values, task1_exp_val)
+        self.assertEqual(task2_result._values, task2_exp_val)
+        self.assertEqual(task3_result._values, task3_exp_val)
+
+        task3_result = task1_result + task2_result
+        self.assertEqual(task3_result._values, task3_exp_val)
 
     def test_classifier_metrics(self):
         # We assume a batch of 16 samples, binary classification case, from 2 tasks.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -353,6 +353,7 @@ class TestAggregators(unittest.TestCase):
             1.5: [0, 0],
         }
 
+        # run and check the TPs and FPs
         task1_result = AUCMetrics.raw_data_to_auc(
             task1_gold_labels, task1_probabilities, 'class_notok', max_dec_places=2
         )
@@ -360,14 +361,17 @@ class TestAggregators(unittest.TestCase):
             task2_gold_labels, task2_probabilities, 'class_notok', max_dec_places=2
         )
 
+        self.assertEqual(task1_result.key_vals, task1_exp_val)
+        self.assertEqual(task2_result.key_vals, task2_exp_val)
+
+        # check that merging als produces the same results
+        task3_result = task1_result + task2_result
+        self.assertEqual(task3_result.key_vals, task3_exp_val)
+
+        # then check from raw data again
         task3_result = AUCMetrics.raw_data_to_auc(
             task3_gold_labels, task3_probabilities, 'class_notok', max_dec_places=2
         )
-        self.assertEqual(task1_result.key_vals, task1_exp_val)
-        self.assertEqual(task2_result.key_vals, task2_exp_val)
-        self.assertEqual(task3_result.key_vals, task3_exp_val)
-
-        task3_result = task1_result + task2_result
         self.assertEqual(task3_result.key_vals, task3_exp_val)
 
         # now actually testing the area under curve


### PR DESCRIPTION
## Patch description
Adding AUC (Area under ROC curve) metrics as an option for eval_model

## Testing steps
1. Check via test to make sure AUC added up correctly..... (checked)
2. Check it works via `eval_model` for both classes
3. Check it works via `eval_model` for both classes with micro aggregation --> checking to make sure the agents' auc resetted. 

## Logs
**Other information**
*For Testing Steps 2-3, I used the numbers stored in AUCmetric and then calculated it with `sklearn.metrics.roc_auc_score` to check for the accuracy (only done for testing... non-existant in the final version); the numbers were then recorded in the report under the key `AUC_sklearn_auc`. See below for code snippet:
```
        from sklearn.metrics import roc_auc_score
        from parlai.core.metrics import AverageMetric
        classifier_agent = world.agents[CLASSIFIER_AGENT]
        auc = classifier_agent.auc
        all_labels = ['not_okay']*sum(auc._pos_dict.values()) + ['okay']*sum(auc._neg_dict.values())
        all_probs = list(auc._pos_dict.elements()) + list(auc._neg_dict.elements())
        report['AUC_sklearn_auc'] = AverageMetric(roc_auc_score(all_labels, all_probs))
        report['AUC'] = classifier_agent.auc
        classifier_agent.reset_auc()
```
### Testing Step 3:
```
parlai em -mf zoo:dialogue_safety/multi_turn/model -t internal:civil_bias_toxic_comment:civil_bias_toxicity,dialogue_safety -auc True -rf parlai_internal/reports/auc_multi_safety_civil_multi.json -ne 3000
```

Report:
```
"report": {
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/exs": 3000,
        "exs": 6000,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/accuracy": 0.9303333333333333,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/f1": 0.9303333333333333,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/bleu-4": 9.30333333333376e-10,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/clen": 67.913,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/ctrunc": 0.0,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/ctrunclen": 0.0,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/llen": 7.065666666666667,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/ltrunc": 0.0,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/ltrunclen": 0.0,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/loss": 0.22661039933852226,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/class___notok___prec": 0.47794117647058826,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/class___notok___recall": 0.6598984771573604,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/class___notok___f1": 0.5543710021321961,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/class___ok___prec": 0.9754398826979472,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/class___ok___recall": 0.9493399928647878,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/class___ok___f1": 0.9622129813776894,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/weighted_f1": 0.9354313580739021,
        "exps": 15.050285570909473,
        "ltpb": 7.065666666666667,
        "ltps": 106.3404888186349,
        "ctpb": 68.913,
        "ctps": 1037.1623590694487,
        "tpb": 75.97866666666667,
        "tps": 1143.5028203682646,
        "lr": 5e-05,
        "total_train_updates": 5469,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/AUC_sklearn_auc": 0.08654432976995277,
        "internal:civil_bias_toxic_comment:civil_bias_toxicity/AUC": 0.08654432976995277,
        "AUC": 0.04401976369269863,
        "dialogue_safety/exs": 3000,
        "dialogue_safety/accuracy": 0.9656666666666667,
        "dialogue_safety/f1": 0.9656666666666667,
        "dialogue_safety/bleu-4": 9.65666666666712e-10,
        "dialogue_safety/clen": 81.26066666666667,
        "dialogue_safety/ctrunc": 0.0023333333333333335,
        "dialogue_safety/ctrunclen": 0.345,
        "dialogue_safety/llen": 7.095666666666666,
        "dialogue_safety/ltrunc": 0.0,
        "dialogue_safety/ltrunclen": 0.0,
        "dialogue_safety/loss": 0.12102492743211345,
        "dialogue_safety/class___notok___prec": 0.8066666666666666,
        "dialogue_safety/class___notok___recall": 0.8432055749128919,
        "dialogue_safety/class___notok___f1": 0.8245315161839863,
        "dialogue_safety/class___ok___prec": 0.9833333333333333,
        "dialogue_safety/class___ok___recall": 0.9786214522668633,
        "dialogue_safety/class___ok___f1": 0.9809717347127286,
        "dialogue_safety/weighted_f1": 0.9660056204734789,
        "dialogue_safety/AUC_sklearn_auc": 0.018068892710410962,
        "dialogue_safety/AUC": 0.018068892710410962,
        "accuracy": 0.948,
        "f1": 0.948,
        "bleu-4": 9.48000000000044e-10,
        "clen": 74.58683333333333,
        "ctrunc": 0.0011666666666666668,
        "ctrunclen": 0.1725,
        "llen": 7.080666666666667,
        "ltrunc": 0.0,
        "ltrunclen": 0.0,
        "loss": 0.17381766338531784,
        "class___notok___prec": 0.6423039215686275,
        "class___notok___recall": 0.7515520260351262,
        "class___notok___f1": 0.6894512591580912,
        "class___ok___prec": 0.9793866080156403,
        "class___ok___recall": 0.9639807225658255,
        "class___ok___f1": 0.971592358045209,
        "weighted_f1": 0.9507184892736905,
        "AUC_sklearn_auc": 0.05230661124018186
    }
```

### Testing Step 2
```
parlai em -mf zoo:dialogue_safety/multi_turn/model -t internal:civil_bias_toxic_comment:civil_bias_toxicity -auc True -rf parlai_internal/reports/auc_multi_safety_civil_single.json -ne 3000
```
Results:
```
"report": {
        "exs": 3000,
        "accuracy": 0.9303333333333333,
        "f1": 0.9303333333333333,
        "bleu-4": 9.30333333333376e-10,
        "clen": 67.913,
        "ctrunc": 0.0,
        "ctrunclen": 0.0,
        "llen": 7.065666666666667,
        "ltrunc": 0.0,
        "ltrunclen": 0.0,
        "loss": 0.22661039933852226,
        "class___notok___prec": 0.47794117647058826,
        "class___notok___recall": 0.6598984771573604,
        "class___notok___f1": 0.5543710021321961,
        "class___ok___prec": 0.9754398826979472,
        "class___ok___recall": 0.9493399928647878,
        "class___ok___f1": 0.9622129813776894,
        "weighted_f1": 0.9354313580739021,
        "exps": 12.01698139414844,
        "ltpb": 7.065666666666667,
        "ltps": 84.90810796410062,
        "ctpb": 68.913,
        "ctps": 828.1275848954622,
        "tpb": 75.97866666666667,
        "tps": 913.0357008042344,
        "lr": 5e-05,
        "total_train_updates": 5469,
        "AUC": 0.08654432976995277,
        "AUC_sklearn_auc": 0.08654432976995277
    }
```

### Testing Step 1

```
(conda_parlai) wzhang4343@devfair0173:~/ParlAI$ pytest -v -k TestAggregators
===================================================== test session starts =====================================================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-1.0.0.dev0 -- /private/home/wzhang4343/.conda/envs/conda_parlai/bin/python
cachedir: .pytest_cache
rootdir: /private/home/wzhang4343/ParlAI, configfile: pytest.ini, testpaths: tests, parlai/tasks
plugins: requests-mock-1.9.2, regressions-2.2.0, hydra-core-1.0.6, datadir-1.3.1
collected 997 items / 990 deselected / 7 selected                                                                             

tests/test_metrics.py::TestAggregators::test_auc_metrics PASSED                                                         [ 14%]
tests/test_metrics.py::TestAggregators::test_classifier_metrics PASSED                                                  [ 28%]
tests/test_metrics.py::TestAggregators::test_macro_aggregation PASSED                                                   [ 42%]
tests/test_metrics.py::TestAggregators::test_micro_aggregation PASSED                                                   [ 57%]
tests/test_metrics.py::TestAggregators::test_time_metric PASSED                                                         [ 71%]
tests/test_metrics.py::TestAggregators::test_uneven_macro_aggrevation PASSED                                            [ 85%]
tests/test_metrics.py::TestAggregators::test_unnamed_aggregation PASSED                                                 [100%]

==================================================== slowest 10 durations =====================================================
0.01s call     tests/test_metrics.py::TestAggregators::test_auc_metrics

(9 durations < 0.005s hidden.  Use -vv to show these durations.)
======================================== 7 passed, 990 deselected, 2 warnings in 5.77s ========================================
```

### Testing Step 2

```
parlai em -mf zoo:dialogue_safety/multi_turn/model -t internal:civil_bias_toxic_comment:civil_bias_toxicity -auc True -ne 3000 -rf parlai_internal/reports/auc_multi_safety_civil.json
```

Generated Report: 
```
"report": {
        "exs": 3000,
        "accuracy": 0.9303333333333333,
        "f1": 0.9303333333333333,
        "bleu-4": 9.30333333333376e-10,
        "clen": 67.913,
        "ctrunc": 0.0,
        "ctrunclen": 0.0,
        "llen": 7.065666666666667,
        "ltrunc": 0.0,
        "ltrunclen": 0.0,
        "loss": 0.22661039933852226,
        "class___notok___prec": 0.47794117647058826,
        "class___notok___recall": 0.6598984771573604,
        "class___notok___f1": 0.5543710021321961,
        "class___ok___prec": 0.9754398826979472,
        "class___ok___recall": 0.9493399928647878,
        "class___ok___f1": 0.9622129813776894,
        "weighted_f1": 0.9354313580739021,
        "exps": 12.01698139414844,
        "ltpb": 7.065666666666667,
        "ltps": 84.90810796410062,
        "ctpb": 68.913,
        "ctps": 828.1275848954622,
        "tpb": 75.97866666666667,
        "tps": 913.0357008042344,
        "lr": 5e-05,
        "total_train_updates": 5469,
        "AUC": 0.08654432976995277,
        "AUC_sklearn_auc": 0.08654432976995277
    }
```

### Testing Step 1
```
(conda_parlai) wzhang4343@devfair0173:~/ParlAI$ pytest -v -k TestMetric
===================================================== test session starts =====================================================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-1.0.0.dev0 -- /private/home/wzhang4343/.conda/envs/conda_parlai/bin/python
cachedir: .pytest_cache
rootdir: /private/home/wzhang4343/ParlAI, configfile: pytest.ini, testpaths: tests, parlai/tasks
plugins: requests-mock-1.9.2, regressions-2.2.0, hydra-core-1.0.6, datadir-1.3.1
collected 996 items / 984 deselected / 12 selected                                                                            

tests/test_metrics.py::TestMetric::test_average_metric_additions PASSED                                                 [  8%]
tests/test_metrics.py::TestMetric::test_average_metric_inputs PASSED                                                    [ 16%]
tests/test_metrics.py::TestMetric::test_fixedmetric PASSED                                                              [ 25%]
tests/test_metrics.py::TestMetric::test_macroaverage_additions PASSED                                                   [ 33%]
tests/test_metrics.py::TestMetric::test_sum_metric_additions PASSED                                                     [ 41%]
tests/test_metrics.py::TestMetric::test_sum_metric_inputs PASSED                                                        [ 50%]
tests/test_metrics.py::TestMetrics::test_largebuffer PASSED                                                             [ 58%]
tests/test_metrics.py::TestMetrics::test_multithreaded PASSED                                                           [ 66%]
tests/test_metrics.py::TestMetrics::test_recent PASSED                                                                  [ 75%]
tests/test_metrics.py::TestMetrics::test_shared PASSED                                                                  [ 83%]
tests/test_metrics.py::TestMetrics::test_simpleadd PASSED                                                               [ 91%]
tests/test_metrics.py::TestMetrics::test_verymultithreaded PASSED                                                       [100%]

==================================================== slowest 10 durations =====================================================
0.13s call     tests/test_metrics.py::TestMetrics::test_verymultithreaded
0.09s call     tests/test_metrics.py::TestMetrics::test_largebuffer

(8 durations < 0.005s hidden.  Use -vv to show these durations.)
======================================= 12 passed, 984 deselected, 2 warnings in 7.61s ========================================
(conda_parlai) wzhang4343@devfair0173:~/ParlAI$ pytest -v -k TestMetrics
===================================================== test session starts =====================================================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-1.0.0.dev0 -- /private/home/wzhang4343/.conda/envs/conda_parlai/bin/python
cachedir: .pytest_cache
rootdir: /private/home/wzhang4343/ParlAI, configfile: pytest.ini, testpaths: tests, parlai/tasks
plugins: requests-mock-1.9.2, regressions-2.2.0, hydra-core-1.0.6, datadir-1.3.1
collected 996 items / 990 deselected / 6 selected                                                                             

tests/test_metrics.py::TestMetrics::test_largebuffer PASSED                                                             [ 16%]
tests/test_metrics.py::TestMetrics::test_multithreaded PASSED                                                           [ 33%]
tests/test_metrics.py::TestMetrics::test_recent PASSED                                                                  [ 50%]
tests/test_metrics.py::TestMetrics::test_shared PASSED                                                                  [ 66%]
tests/test_metrics.py::TestMetrics::test_simpleadd PASSED                                                               [ 83%]
tests/test_metrics.py::TestMetrics::test_verymultithreaded PASSED                                                       [100%]

==================================================== slowest 10 durations =====================================================
0.13s call     tests/test_metrics.py::TestMetrics::test_verymultithreaded
0.09s call     tests/test_metrics.py::TestMetrics::test_largebuffer

(8 durations < 0.005s hidden.  Use -vv to show these durations.)
======================================== 6 passed, 990 deselected, 2 warnings in 5.16s ========================================
```

** Other Info **
- I chose to store the AUCmetric in the classifier because if we ever wanna do it during training.... it should be relatively easy to modify the code and do it there :) (maybe?)
- Also, added 6 tests and know that it might be a lot less code if I just did a for loop with some of the commands, but then I noticed that if I did do that, it would be less easy to read exactly which test it was. 