### PR TITLE
[mp] Use free ports rather than random ports

### DIFF
--- a/parlai/scripts/multiprocessing_eval.py
+++ b/parlai/scripts/multiprocessing_eval.py
@@ -88,7 +88,7 @@ class MultiProcessEval(ParlaiScript):
         return setup_args()
 
     def run(self):
-        port = random.randint(32000, 48000)
+        port = distributed_utils.find_free_port()
         return launch_and_eval(self.opt, port)
 
 

--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -99,7 +99,7 @@ class MultiProcessTrain(ParlaiScript):
 
     def run(self):
         if self.opt['port'] is None:
-            port = random.randint(32000, 48000)
+            port = distributed_utils.find_free_port()
         else:
             port = self.opt['port']
         return launch_and_train(self.opt, port)

--- a/parlai/utils/distributed.py
+++ b/parlai/utils/distributed.py
@@ -346,3 +346,15 @@ def slurm_distributed_context(opt):
     except FileNotFoundError:
         # Slurm is not installed
         raise RuntimeError('SLURM does not appear to be installed.')
+
+
+def find_free_port() -> int:
+    """
+    Find a free port we can bind to locally.
+
+    Credit: https://stackoverflow.com/questions/1365265/on-localhost-how-do-i-pick-a-free-port-number
+    """
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(('', 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]


### PR DESCRIPTION
**Patch description**
I've noticed that sometimes tests will fail when using randomized ports, because the address is already in use. Resolve by always asking the OS for a free port.

Thanks stack overflow.

**Testing steps**
CI