### PR TITLE
Fully Sharded Data Parallel

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -772,6 +772,16 @@ class ParlaiParser(argparse.ArgumentParser):
         grp.add_argument(
             '--distributed-world-size', type=int, help='Number of workers.'
         )
+        grp.add_argument(
+            '--ddp-backend',
+            choices=['ddp', 'zero2', 'zero3'],
+            default='ddp',
+            help=(
+                'Distributed backend. Zero2 can be faster but is more experimental. '
+                'Zero3 uses radically less memory, but is slower. DDP is the most '
+                'tested.'
+            ),
+        )
         return grp
 
     def add_model_args(self):

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -774,12 +774,12 @@ class ParlaiParser(argparse.ArgumentParser):
         )
         grp.add_argument(
             '--ddp-backend',
-            choices=['ddp', 'zero2', 'zero3'],
+            # TODO: add in zero3. https://github.com/facebookresearch/ParlAI/issues/3753
+            choices=['ddp', 'zero2'],
             default='ddp',
             help=(
                 'Distributed backend. Zero2 can be faster but is more experimental. '
-                'Zero3 uses radically less memory, but is slower. DDP is the most '
-                'tested.'
+                'DDP is the most tested.'
             ),
         )
         return grp

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1117,9 +1117,6 @@ class TorchAgent(ABC, Agent):
                 )
                 return True
 
-    def _should_sync_overflows(self):
-        return self.fp16 and self.opt.get('ddp_backend', 'ddp') in ('zero2', 'zero3')
-
     def build_lr_scheduler(self, states=None, hard_reset=False):
         """
         Create the learning rate scheduler, and assign it to self.scheduler. This

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -2004,7 +2004,6 @@ class TorchAgent(ABC, Agent):
 
         For models or optimizers that shard parameters, this ensures we sync.
         """
-        logging.info("Saving non primary")
         if self.opt.get('ddp_backend', 'ddp') in ('zero2', 'zero3'):
             # make sure we call the state dict
             self.state_dict()

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1118,7 +1118,7 @@ class TorchAgent(ABC, Agent):
                 return True
 
     def _should_sync_overflows(self):
-        return self.fp16 and self.opt['ddp_backend'] in ('zero2', 'zero3')
+        return self.fp16 and self.opt.get('ddp_backend', 'ddp') in ('zero2', 'zero3')
 
     def build_lr_scheduler(self, states=None, hard_reset=False):
         """
@@ -1976,10 +1976,9 @@ class TorchAgent(ABC, Agent):
         """
         states = {}
         if hasattr(self, 'model'):  # save model params
-            if hasattr(self.model, 'module') and self.opt['ddp_backend'] not in (
-                'zero2',
-                'zero3',
-            ):
+            if hasattr(self.model, 'module') and self.opt.get(
+                'ddp_backend', 'ddp'
+            ) not in ('zero2', 'zero3'):
                 # did we wrap in a DistributedDataParallel
                 states['model'] = self.model.module.state_dict()
             else:
@@ -2009,7 +2008,7 @@ class TorchAgent(ABC, Agent):
         For models or optimizers that shard parameters, this ensures we sync.
         """
         logging.info("Saving non primary")
-        if self.opt['ddp_backend'] in ('zero2', 'zero3'):
+        if self.opt.get('ddp_backend', 'ddp') in ('zero2', 'zero3'):
             # make sure we call the state dict
             self.state_dict()
 

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -1983,13 +1983,7 @@ class TorchAgent(ABC, Agent):
                 # did we wrap in a DistributedDataParallel
                 states['model'] = self.model.module.state_dict()
             else:
-                logging.info("About to store state dict")
-                import traceback
-
-                logging.critical("".join(traceback.format_stack()))
                 states['model'] = self.model.state_dict()
-
-                logging.info("Out of here")
 
         if hasattr(self, 'optimizer'):
             # save optimizer params

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -36,7 +36,7 @@ from parlai.core.message import Message
 from parlai.utils.distributed import is_distributed
 from parlai.utils.misc import AttrDict, warn_once
 from parlai.utils.io import PathManager
-from parlai.utils.fsdp import should_sync_gradnorm, is_fsdp
+from parlai.utils.fsdp import should_sync_gradnorm, is_fsdp, DEFAULT_DDP_BACKEND
 from parlai.utils.fp16 import (
     SafeFP16Optimizer,
     MemoryEfficientFP16Optimizer,
@@ -2004,7 +2004,7 @@ class TorchAgent(ABC, Agent):
 
         For models or optimizers that shard parameters, this ensures we sync.
         """
-        if self.opt.get('ddp_backend', 'ddp') in ('zero2', 'zero3'):
+        if self.opt.get('ddp_backend', DEFAULT_DDP_BACKEND) in ('zero2', 'zero3'):
             # make sure we call the state dict
             self.state_dict()
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -519,7 +519,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         if (
             shared is None
             and is_distributed()
-            and opt['ddp_backend'] in ('zero2', 'zero3')
+            and opt.get('ddp_backend', 'ddp') in ('zero2', 'zero3')
         ):
             from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
 
@@ -559,7 +559,11 @@ class TorchGeneratorAgent(TorchAgent, ABC):
                 logging.warning("Optimizer was reset. Also resetting LR scheduler.")
             self.build_lr_scheduler(states, hard_reset=is_finetune or was_reset)
 
-        if shared is None and is_distributed() and opt['ddp_backend'] == 'ddp':
+        if (
+            shared is None
+            and is_distributed()
+            and opt.get('ddp_backend', 'ddp') == 'ddp'
+        ):
             device_ids = None if self.model_parallel else [self.opt['gpu']]
             logging.debug("Wrapping in simple DDP")
             self.model = torch.nn.parallel.DistributedDataParallel(
@@ -579,7 +583,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
 
         return (
             self.fp16
-            and self.opt['ddp_backend'] in ('zero2', 'zero3')
+            and self.opt.get('ddp_backend', 'ddp') in ('zero2', 'zero3')
             and self.opt['fp16_impl'] == 'safe'
         )
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -28,7 +28,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from parlai.core.opt import Opt
-from parlai.utils.distributed import is_distributed, sync_parameters
+from parlai.utils.distributed import is_distributed, sync_parameters, get_dist_group
 from parlai.core.torch_agent import TorchAgent, Batch, Output, DictionaryAgent
 from parlai.utils.misc import warn_once
 from parlai.utils.io import PathManager
@@ -541,6 +541,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
                 compute_dtype=compute_dtype,
                 state_dict_device=torch.device('cpu'),
                 flatten_parameters=True,
+                process_group=get_dist_group(),
             )
 
         if shared is not None:

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -526,8 +526,6 @@ class TorchGeneratorAgent(TorchAgent, ABC):
             device_ids = None if self.model_parallel else [self.opt['gpu']]
             mixed_precision = opt['fp16']
             reshard_after_forward = opt['ddp_backend'] == 'zero3'
-            # hack: fsdp expects things in fp32 if we're using mixed precision.
-            # lol! convert it back!
             compute_dtype = torch.float16 if self.fp16 else torch.float32
             mixed_precision = self.fp16 and opt['fp16_impl'] == 'safe'
             logging.debug(

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -535,7 +535,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         if (
             shared is None
             and is_distributed()
-            and opt.get('ddp_backend', 'ddp') == 'ddp'
+            and opt.get('ddp_backend', fsdp_utils.DEFAULT_DDP_BACKEND) == 'ddp'
         ):
             device_ids = None if self.model_parallel else [self.opt['gpu']]
             self.model = torch.nn.parallel.DistributedDataParallel(

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -1436,8 +1436,9 @@ class TreeSearch(object):
 
         self.outputs.append(tok_ids)
         self.bookkeep.append(hyp_ids)
+        tok_id_list = tok_ids.tolist()
         self.partial_hyps = [
-            self.partial_hyps[hyp_ids[i]] + [tok_ids[i].item()]
+            self.partial_hyps[hyp_ids[i]] + [tok_id_list[i]]
             for i in range(self.beam_size)
         ]
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -531,8 +531,8 @@ class TorchGeneratorAgent(TorchAgent, ABC):
             compute_dtype = torch.float16 if self.fp16 else torch.float32
             mixed_precision = self.fp16 and opt['fp16_impl'] == 'safe'
             logging.debug(
-                f"Wrapping in FSDP (reshard_after_forward = {reshard_after_forward}, "
-                f"compute_dtype = {compute_dtype} mixed_precision = {mixed_precision}"
+                f"Wrapping in FSDP(reshard_after_forward = {reshard_after_forward}, "
+                f"compute_dtype = {compute_dtype} mixed_precision = {mixed_precision})"
             )
             self.model = FSDP(
                 self.model,
@@ -540,6 +540,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
                 mixed_precision=mixed_precision,
                 compute_dtype=compute_dtype,
                 state_dict_device=torch.device('cpu'),
+                flatten_parameters=True,
             )
 
         if shared is not None:

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -482,7 +482,6 @@ class TorchGeneratorAgent(TorchAgent, ABC):
             self.criterion = self.build_criterion()
             with fsdp_utils.maybe_fsdp_wrap(opt):
                 self.model = fsdp_utils.fsdp_wrap(self.build_model())
-                logging.debug(f"Model arch:\n{self.model}")
                 if self.fp16 and not fsdp_utils.should_use_fsdp(opt):
                     self.model = self.model.half()
 

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -482,7 +482,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
             self.criterion = self.build_criterion()
             with fsdp_utils.maybe_fsdp_wrap(opt):
                 self.model = fsdp_utils.fsdp_wrap(self.build_model())
-                if self.fp16 and not fsdp_utils.should_use_fsdp(opt):
+                if self.fp16 and not fsdp_utils.delay_halving(opt):
                     self.model = self.model.half()
 
             # load the block_list for beam search

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -507,6 +507,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
 
             if self.fp16:
                 if not self._delay_halving:
+                    logging.debug("Halving the model")
                     self.model = self.model.half()
 
             if init_model is not None:
@@ -528,12 +529,11 @@ class TorchGeneratorAgent(TorchAgent, ABC):
             reshard_after_forward = opt['ddp_backend'] == 'zero3'
             # hack: fsdp expects things in fp32 if we're using mixed precision.
             # lol! convert it back!
-            if self.fp16 and mixed_precision:
-                self.model = self.model.float()
+            logging.debug("Wrapping in FSDP")
             self.model = FSDP(
                 self.model,
                 reshard_after_forward=reshard_after_forward,
-                mixed_precision=self.fp16 and opt['fp16_impl'] != 'mem_efficient',
+                mixed_precision=self.fp16 and opt['fp16_impl'] == 'safe',
                 compute_dtype=torch.float16 if self.fp16 else torch.float32,
                 state_dict_device=torch.device('cpu'),
             )
@@ -555,6 +555,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
 
         if shared is None and is_distributed() and opt['ddp_backend'] == 'ddp':
             device_ids = None if self.model_parallel else [self.opt['gpu']]
+            logging.debug("Wrapping in DDP")
             self.model = torch.nn.parallel.DistributedDataParallel(
                 self.model, device_ids=device_ids, broadcast_buffers=False
             )

--- a/parlai/scripts/multiprocessing_eval.py
+++ b/parlai/scripts/multiprocessing_eval.py
@@ -23,7 +23,6 @@ parlai multiprocessing_eval --model-file "zoo:tutorial_transformer_generator/mod
 """
 
 import torch
-import random
 import os
 import signal
 import parlai.utils.distributed as distributed_utils

--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -55,10 +55,12 @@ def multiprocess_train(
             raise
 
 
-def launch_and_train(opt, port):
+def launch_and_train(opt, port=None):
     """
     Perform a fork() to many processes.
     """
+    if port is None:
+        port = distributed_utils.find_free_port()
     # Launch multiple subprocesses
     spawncontext = torch.multiprocessing.start_processes(
         multiprocess_train,
@@ -99,7 +101,7 @@ class MultiProcessTrain(ParlaiScript):
 
     def run(self):
         if self.opt['port'] is None:
-            port = distributed_utils.find_free_port()
+            port = None
         else:
             port = self.opt['port']
         return launch_and_train(self.opt, port)

--- a/parlai/scripts/multiprocessing_train.py
+++ b/parlai/scripts/multiprocessing_train.py
@@ -24,7 +24,6 @@ parlai multiprocessing_train -m transformer/generator --batchsize 16 --task conv
 """
 
 import torch
-import random
 import os
 import signal
 import traceback

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -453,14 +453,12 @@ class TrainLoop:
         if not is_primary_worker():
             # never do IO as a non-primary worker
             if hasattr(self.agent, 'save_nonprimary'):
-                logging.debug("Saving on non-primary")
                 self.agent.save_nonprimary(fn)
             return
 
         while True:
             # don't ever let a ctrl-c interrupt saving
             try:
-                logging.debug("Saving on primary")
                 self.agent.save(fn)
                 self._save_train_stats(suffix)
                 break
@@ -593,12 +591,10 @@ class TrainLoop:
         max_cnt = max_exs if max_exs > 0 else float('inf')
         while not valid_world.epoch_done() and cnt < max_cnt:
             valid_world.parley()
-            logging.info(f"Ran cnt {cnt}")
             if cnt == 0 and opt['display_examples']:
                 print(valid_world.display() + '\n~~')
                 print(valid_world.report())
             cnt = valid_world.report().get('exs') or 0
-        logging.info(f"rank {is_primary_worker()} epoch_done")
 
         valid_report = valid_world.report()
         if opt.get('validation_share_agent', False):
@@ -637,9 +633,7 @@ class TrainLoop:
             named_reports, micro_average=self.opt.get('aggregate_micro', False)
         )
         # get the results from all workers
-        logging.debug("Syncing metrics")
         report = self._sync_metrics(report)
-        logging.debug("Done syncing metrics")
 
         metrics = f'{datatype}:\n{nice_report(report)}\n'
         logging.info(f'eval completed in {timer.time():.2f}s')

--- a/parlai/utils/distributed.py
+++ b/parlai/utils/distributed.py
@@ -296,6 +296,12 @@ def distributed_context(
             dist.destroy_process_group()
 
 
+def get_dist_group():
+    from torch.distributed.distributed_c10d import _get_default_group
+
+    return _get_default_group()
+
+
 @contextlib.contextmanager
 def slurm_distributed_context(opt):
     """

--- a/parlai/utils/distributed.py
+++ b/parlai/utils/distributed.py
@@ -300,9 +300,9 @@ def get_dist_group():
     """
     Find the default pytorch distributed group.
 
-    Used within FSDP to mark which workers are participating. Important to
-    manually call this because FSDP will cache old groups, but our test
-    suite will instantiate new groups per test.
+    Used within FSDP to mark which workers are participating. Important to manually call
+    this because FSDP will cache old groups, but our test suite will instantiate new
+    groups per test.
     """
     from torch.distributed.distributed_c10d import _get_default_group
 

--- a/parlai/utils/distributed.py
+++ b/parlai/utils/distributed.py
@@ -297,6 +297,13 @@ def distributed_context(
 
 
 def get_dist_group():
+    """
+    Find the default pytorch distributed group.
+
+    Used within FSDP to mark which workers are participating. Important to
+    manually call this because FSDP will cache old groups, but our test
+    suite will instantiate new groups per test.
+    """
     from torch.distributed.distributed_c10d import _get_default_group
 
     return _get_default_group()

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -104,11 +104,9 @@ class SafeFP16Optimizer(torch.optim.Optimizer):
         self.scaler = DynamicLossScaler(2.0 ** 15)
         self.min_loss_scale = 2 ** -5
         self._sync_overflows = sync_overflows
-        logging.debug(f"Sync overflows = {sync_overflows}")
 
     def _maybe_sync(self, value: bool) -> bool:
         if self._sync_overflows:
-            logging.debug(f"Syncing value {value}")
             import torch.distributed as dist
 
             value_tensor = torch.BoolTensor([value]).cuda()

--- a/parlai/utils/fp16.py
+++ b/parlai/utils/fp16.py
@@ -104,9 +104,11 @@ class SafeFP16Optimizer(torch.optim.Optimizer):
         self.scaler = DynamicLossScaler(2.0 ** 15)
         self.min_loss_scale = 2 ** -5
         self._sync_overflows = sync_overflows
+        logging.debug(f"Sync overflows = {sync_overflows}")
 
     def _maybe_sync(self, value: bool) -> bool:
         if self._sync_overflows:
+            logging.debug(f"Syncing value {value}")
             import torch.distributed as dist
 
             value_tensor = torch.BoolTensor([value]).cuda()

--- a/parlai/utils/fsdp.py
+++ b/parlai/utils/fsdp.py
@@ -75,7 +75,7 @@ def maybe_fsdp_wrap(opt):
         yield
 
 
-def delay_halving(self):
+def delay_halving(opt):
     """
     Check whether we should keep the model in fp32 before other setup.
 
@@ -86,7 +86,7 @@ def delay_halving(self):
     to call half() early.
     """
 
-    return self.fp16 and should_use_fsdp(opt) and self.opt['fp16_impl'] == 'safe'
+    return opt['fp16'] and should_use_fsdp(opt) and opt['fp16_impl'] == 'safe'
 
 
 def should_sync_gradnorm(opt):

--- a/parlai/utils/fsdp.py
+++ b/parlai/utils/fsdp.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Utility functions for FullyShardedDataParallel.
+"""
+
+import contextlib
+import torch.nn
+from parlai.utils.distributed import is_distributed, get_dist_group
+
+try:
+    from fairscale.nn.wrap.auto_wrap import wrap
+    from fairscale.nn.wrap.auto_wrap import enable_wrap as fairscale_enable_wrap
+    from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
+
+    FSDP_AVAILABLE = True
+except ImportError:
+    FSDP_AVAILABLE = False
+
+    def wrap(module, **kwargs):
+        return module
+
+
+DEFAULT_DDP_BACKEND = "ddp"
+
+
+def is_fsdp(module: torch.nn.Module):
+    """
+    Checks whether a module is fully sharded.
+    """
+    return FSDP_AVAILABLE and isinstance(module, FSDP)
+
+
+def should_use_fsdp(opt):
+    return (
+        FSDP_AVAILABLE
+        and is_distributed()
+        and opt.get('ddp_backend', DEFAULT_DDP_BACKEND) in ('zero2', 'zero3')
+    )
+
+
+@contextlib.contextmanager
+def maybe_fsdp_wrap(opt):
+    """
+    Context manager for enabling wrapping in FullyShardedDataParallel.
+    """
+    if not should_use_fsdp(opt):
+        # make a no-op
+        yield
+        return
+
+    # zero3 not supported at this time. Throw an exception
+    if opt['ddp_backend'] == 'zero3':
+        raise NotImplementedError(
+            '--ddp-backend zero3 is not supported at this time. For details, see '
+            'https://github.com/facebookresearch/ParlAI/issues/3753.'
+        )
+
+    reshard_after_forward = opt['ddp_backend'] == 'zero3'
+    compute_dtype = torch.float16 if opt['fp16'] else torch.float32
+    mixed_precision = opt['fp16'] and opt['fp16_impl'] == 'safe'
+    fsdp_args = dict(
+        reshard_after_forward=reshard_after_forward,
+        mixed_precision=mixed_precision,
+        compute_dtype=compute_dtype,
+        state_dict_device=torch.device('cpu'),
+        flatten_parameters=True,
+        process_group=get_dist_group(),
+    )
+    with fairscale_enable_wrap(wrapper_cls=FSDP, **fsdp_args):
+        yield
+
+
+def delay_halving(self):
+    """
+    Check whether we should keep the model in fp32 before other setup.
+
+    When using Zero2 or Zero3 backends with mixed precision, we need to
+    avoid converting the model to fp16, as the FSDP module does this for
+    us.
+    """
+
+    return (
+        self.fp16
+        and self.opt.get('ddp_backend', 'ddp') in ('zero2', 'zero3')
+        and self.opt['fp16_impl'] == 'safe'
+    )
+
+
+def should_sync_gradnorm(opt):
+    """
+    Indicates whether fp16 optimizer wrappers should cumulate over workers.
+
+    FP16 overflow detection and gradient clipping both require accumulating
+    gradients across all workers when using FSDP, as workers only store a
+    fraction of the gradients.
+    """
+    return (
+        FSDP_AVAILABLE
+        and opt['fp16']
+        and opt.get('ddp_backend', DEFAULT_DDP_BACKEND) in ('zero2', 'zero3')
+    )
+
+
+def fsdp_wrap(module):
+    """
+    Helper function for wrapping the outermost root module.
+    """
+    return wrap(module)

--- a/parlai/utils/fsdp.py
+++ b/parlai/utils/fsdp.py
@@ -81,13 +81,12 @@ def delay_halving(self):
 
     When using Zero2 or Zero3 backends with mixed precision, we need to avoid converting
     the model to fp16, as the FSDP module does this for us.
+
+    If we are using just plain DDP or MemoryEfficient optimizers, then we want
+    to call half() early.
     """
 
-    return (
-        self.fp16
-        and self.opt.get('ddp_backend', 'ddp') in ('zero2', 'zero3')
-        and self.opt['fp16_impl'] == 'safe'
-    )
+    return self.fp16 and should_use_fsdp(opt) and self.opt['fp16_impl'] == 'safe'
 
 
 def should_sync_gradnorm(opt):

--- a/parlai/utils/fsdp.py
+++ b/parlai/utils/fsdp.py
@@ -92,7 +92,7 @@ def delay_halving(self):
 
 def should_sync_gradnorm(opt):
     """
-    Indicates whether fp16 optimizer wrappers should cumulate over workers.
+    Indicates whether fp16 optimizer wrappers should accumulate over workers.
 
     FP16 overflow detection and gradient clipping both require accumulating gradients
     across all workers when using FSDP, as workers only store a fraction of the

--- a/parlai/utils/fsdp.py
+++ b/parlai/utils/fsdp.py
@@ -79,9 +79,8 @@ def delay_halving(self):
     """
     Check whether we should keep the model in fp32 before other setup.
 
-    When using Zero2 or Zero3 backends with mixed precision, we need to
-    avoid converting the model to fp16, as the FSDP module does this for
-    us.
+    When using Zero2 or Zero3 backends with mixed precision, we need to avoid converting
+    the model to fp16, as the FSDP module does this for us.
     """
 
     return (
@@ -95,9 +94,9 @@ def should_sync_gradnorm(opt):
     """
     Indicates whether fp16 optimizer wrappers should cumulate over workers.
 
-    FP16 overflow detection and gradient clipping both require accumulating
-    gradients across all workers when using FSDP, as workers only store a
-    fraction of the gradients.
+    FP16 overflow detection and gradient clipping both require accumulating gradients
+    across all workers when using FSDP, as workers only store a fraction of the
+    gradients.
     """
     return (
         FSDP_AVAILABLE

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -176,6 +176,7 @@ class TestZero3(TestDistributed):
     base_config = {**TestDistributed.base_config, 'ddp_backend': 'zero3'}
 
 
+@testing_utils.skipUnlessGPU
 class TestZero3NotImplemented(_AbstractTest):
     base_config = dict(
         task='integration_tests:overfit',

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -159,8 +159,8 @@ class TestDistributed(_AbstractTest):
         assert test['exs'].value() == inttests.NUM_TEST
 
 
-# class TestZero2(TestDistributed):
-#     pass
+class TestZero2(TestDistributed):
+    base_config = {**TestDistributed.base_config, 'ddp_backend': 'zero2'}
 
 
 class TestNoModelParallel(_AbstractTest):

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-import copy
 import unittest
 import parlai.utils.testing as testing_utils
 import parlai.scripts.build_dict as build_dict
@@ -13,18 +12,6 @@ import parlai.scripts.multiprocessing_train as mp_train
 import parlai.tasks.integration_tests.agents as inttests
 
 BATCHSIZE = 4
-
-
-def _forced_parse(parser, opt):
-    parser.set_params(**opt)
-    parser.set_params(log_every_n_sec=10)
-    popt = parser.parse_args([])
-    # in some rare cases, like for instance if the model class also
-    # overrides its default params, the params override will not
-    # be taken into account.
-    for k, v in opt.items():
-        popt[k] = v
-    return popt
 
 
 @testing_utils.skipUnlessGPU
@@ -49,7 +36,8 @@ class TestDistributed(unittest.TestCase):
     def setUp(self):
         print(f'[Setting up test {self._testMethodName}]')
 
-    def _distributed_train_model(self, opt):
+    def _distributed_train_model(self, **overrides):
+        opt = {**self._base_config, **overrides}
         with testing_utils.tempdir() as tmpdir:
             if 'model_file' not in opt:
                 opt['model_file'] = os.path.join(tmpdir, 'model')
@@ -57,7 +45,7 @@ class TestDistributed(unittest.TestCase):
                 opt['dict_file'] = os.path.join(tmpdir, 'model.dict')
 
             parser = mp_train.setup_args()
-            popt = _forced_parse(parser, opt)
+            popt = parser.parse_kwargs(**opt)
 
             # we need a prebuilt dictionary
             parser = build_dict.setup_args()
@@ -68,8 +56,7 @@ class TestDistributed(unittest.TestCase):
         return (valid, test)
 
     def test_generator_distributed(self):
-        config = copy.deepcopy(self._base_config)
-        valid, test = self._distributed_train_model(config)
+        valid, test = self._distributed_train_model()
 
         self.assertLessEqual(valid['ppl'], 1.60)
         self.assertLessEqual(test['ppl'], 1.60)
@@ -80,11 +67,11 @@ class TestDistributed(unittest.TestCase):
         self.assertEqual(test['exs'].value(), BATCHSIZE)
 
     def test_multitask_distributed(self):
-        config = copy.deepcopy(self._base_config)
-        config['num_epochs'] = 50
-        config['task'] = 'integration_tests:overfit,integration_tests:overfit_multiturn'
-        config['dynb'] = 'full'
-        valid, test = self._distributed_train_model(config)
+        valid, test = self._distributed_train_model(
+            num_epochs=50,
+            task='integration_tests:overfit,integration_tests:overfit_multiturn',
+            truncate=16,
+        )
 
         self.assertLessEqual(valid['ppl'], 1.20)
         self.assertLessEqual(test['ppl'], 1.20)
@@ -100,12 +87,12 @@ class TestDistributed(unittest.TestCase):
         )
 
     def test_distributed_eval_max_exs(self):
-        config = copy.deepcopy(self._base_config)
-        config['task'] = 'integration_tests'
-        config['num_epochs'] = 0.01
-        config['validation_max_exs'] = 90
-        config['short_final_eval'] = True
-        valid, test = self._distributed_train_model(config)
+        valid, test = self._distributed_train_model(
+            task='integration_tests',
+            num_epochs=0.01,
+            validation_max_exs=90,
+            short_final_eval=True,
+        )
 
         # Tests that DialogData.get() is doing the right thing
         # Ensure no duplication of examples among workers
@@ -120,11 +107,9 @@ class TestDistributed(unittest.TestCase):
         self.assertEqual(test['exs'].value(), 96)
 
     def test_distributed_eval_stream_mode(self):
-        config = copy.deepcopy(self._base_config)
-        config['task'] = 'integration_tests'
-        config['num_epochs'] = 0.01
-        config['datatype'] = 'train:stream'
-        valid, test = self._distributed_train_model(config)
+        valid, test = self._distributed_train_model(
+            task='integration_tests', num_epochs=0.01, datatype='train:stream'
+        )
 
         # Tests that StreamDialogData.get() is doing the right thing
         # Ensure no duplication of examples among workers
@@ -133,14 +118,13 @@ class TestDistributed(unittest.TestCase):
         self.assertEqual(test['exs'].value(), inttests.NUM_TEST)
 
     def test_distributed_eval_stream_mode_max_exs(self):
-        config = copy.deepcopy(self._base_config)
-        config['task'] = 'integration_tests'
-        config['num_epochs'] = 0.01
-        config['datatype'] = 'train:stream'
-        config['validation_max_exs'] = 90
-        config['short_final_eval'] = True
-
-        valid, test = self._distributed_train_model(config)
+        valid, test = self._distributed_train_model(
+            task='integration_tests',
+            num_epochs=0.01,
+            datatype='train:stream',
+            validation_max_exs=90,
+            short_final_eval=True,
+        )
 
         # Tests that StreamDialogData.get() is doing the right thing
         # Ensure no duplication of examples among workers
@@ -155,26 +139,23 @@ class TestDistributed(unittest.TestCase):
         self.assertEqual(test['exs'].value(), 96)
 
     def test_chunked_dynamic_teacher(self):
-        config = copy.deepcopy(self._base_config)
-        config['task'] = 'integration_tests'
-        config['num_epochs'] = 0.01
-        config['datatype'] = 'train:stream'
-        config['dynamic_batching'] = 'full'
-        config['truncate'] = 16
-
-        valid, test = self._distributed_train_model(config)
+        valid, test = self._distributed_train_model(
+            task='integration_tests',
+            num_epochs=0.01,
+            datatype='train:stream',
+            dynamic_batching='full',
+            truncate=16,
+        )
         assert valid['exs'].value() == inttests.NUM_TEST
         assert test['exs'].value() == inttests.NUM_TEST
 
     def test_chunked_teacher(self):
-        config = copy.deepcopy(self._base_config)
-        config['task'] = 'integration_tests'
-        config['num_epochs'] = 0.01
-        config['datatype'] = 'train:stream'
-        config['num_epochs'] = 5
-        config['dynamic_batching'] = None
-
-        valid, test = self._distributed_train_model(config)
+        valid, test = self._distributed_train_model(
+            task='integration_tests',
+            datatype='train:stream',
+            num_epochs=5,
+            dynamic_batching=None,
+        )
         assert valid['exs'].value() == inttests.NUM_TEST
         assert test['exs'].value() == inttests.NUM_TEST
 
@@ -184,16 +165,13 @@ class TestDistributed(unittest.TestCase):
 
         --model-parallel true.
         """
-        config = copy.deepcopy(self._base_config)
-        config['model_parallel'] = True
         for m in [
             'transformer/generator',
             'transformer/ranker',
             'transformer/classifier',
         ]:
-            config['model'] = m
             try:
-                _ = self._distributed_train_model(config)
+                _ = self._distributed_train_model(model=m, model_parallel=True)
             except RuntimeError:
                 pass
             else:

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -176,6 +176,31 @@ class TestZero3(TestDistributed):
     base_config = {**TestDistributed.base_config, 'ddp_backend': 'zero3'}
 
 
+class TestZero3NotImplemented(_AbstractTest):
+    base_config = dict(
+        task='integration_tests:overfit',
+        optimizer='sgd',
+        validation_metric='loss',
+        ddp_backend='zero3',
+        batchsize=BATCHSIZE,
+        model='transformer/generator',
+        validation_every_n_epochs=1,
+        num_epochs=1,
+        n_layers=1,
+        n_heads=1,
+        ffn_size=32,
+        embedding_size=8,
+        verbose=True,
+    )
+
+    def test_not_implemented(self):
+        """
+        Checks that using --ddp-backend zero3 throws an error
+        """
+        with self.assertRaises(NotImplementedError):
+            self._distributed_train_model()
+
+
 @testing_utils.skipUnlessGPU
 class TestNoModelParallel(_AbstractTest):
     base_config = dict(

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -159,10 +159,17 @@ class TestDistributed(_AbstractTest):
         assert test['exs'].value() == inttests.NUM_TEST
 
 
+@testing_utils.skipUnlessGPU
 class TestZero2(TestDistributed):
     base_config = {**TestDistributed.base_config, 'ddp_backend': 'zero2'}
 
 
+@testing_utils.skipUnlessGPU
+class TestZero3(TestDistributed):
+    base_config = {**TestDistributed.base_config, 'ddp_backend': 'zero3'}
+
+
+@testing_utils.skipUnlessGPU
 class TestNoModelParallel(_AbstractTest):
     base_config = dict(
         task='integration_tests:overfit',

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -168,7 +168,7 @@ class TestZero2(TestDistributed):
     base_config = {**TestDistributed.base_config, 'ddp_backend': 'zero2'}
 
 
-@testing_utils.skip
+@unittest.skip
 @testing_utils.skipUnlessGPU
 class TestZero3(TestDistributed):
     # Not supported at this time. See:

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -30,7 +30,7 @@ class _AbstractTest(unittest.TestCase):
             parser = build_dict.setup_args()
             build_dict.build_dict(popt)
 
-            valid, test = mp_train.launch_and_train(popt, 31338)
+            valid, test = mp_train.launch_and_train(popt)
 
         return (valid, test)
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -177,32 +177,6 @@ class TestZero3(TestDistributed):
 
 
 @testing_utils.skipUnlessGPU
-class TestZero3NotImplemented(_AbstractTest):
-    base_config = dict(
-        task='integration_tests:overfit',
-        optimizer='sgd',
-        validation_metric='loss',
-        ddp_backend='zero3',
-        batchsize=BATCHSIZE,
-        model='transformer/generator',
-        validation_every_n_epochs=1,
-        num_epochs=1,
-        n_layers=1,
-        n_heads=1,
-        ffn_size=32,
-        embedding_size=8,
-        verbose=True,
-    )
-
-    def test_not_implemented(self):
-        """
-        Checks that using --ddp-backend zero3 throws an error.
-        """
-        with self.assertRaises(NotImplementedError):
-            self._distributed_train_model()
-
-
-@testing_utils.skipUnlessGPU
 class TestNoModelParallel(_AbstractTest):
     base_config = dict(
         task='integration_tests:overfit',

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -161,11 +161,18 @@ class TestDistributed(_AbstractTest):
 
 @testing_utils.skipUnlessGPU
 class TestZero2(TestDistributed):
+    """
+    Integration tests for zero2 FSDP.
+    """
+
     base_config = {**TestDistributed.base_config, 'ddp_backend': 'zero2'}
 
 
+@testing_utils.skip
 @testing_utils.skipUnlessGPU
 class TestZero3(TestDistributed):
+    # Not supported at this time. See:
+    # https://github.com/facebookresearch/ParlAI/pull/3740
     base_config = {**TestDistributed.base_config, 'ddp_backend': 'zero3'}
 
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -196,7 +196,7 @@ class TestZero3NotImplemented(_AbstractTest):
 
     def test_not_implemented(self):
         """
-        Checks that using --ddp-backend zero3 throws an error
+        Checks that using --ddp-backend zero3 throws an error.
         """
         with self.assertRaises(NotImplementedError):
             self._distributed_train_model()


### PR DESCRIPTION
**Patch description**
Add support for Fairscale's FullyShardedDataParallel (FSDP). This is an implementation of DeepSpeed's Zero2 optimization, wherein optimizer state and gradients are sharded across different workers in order to reduce memory usage. Switching to `--ddp-backend zero2` results in about a 25% speedup in UPS (without bg workers, probably can be a bit higher), and about a 50% reduction in memory usage. It's recommended everyone switches to this for distributed training, and use the savings to increase batchsize or lower number of GPUs.

We also carve out support for Zero3, but cannot support it at this time due to high level design in ParlAI. See #3753 for a detailed description of why, and how we might overcome this in the future.

As a side change, this also makes our unit tests use OS-assigned free ports, instead of randomized ones, to slightly improve the reliability of running our test suites. I tried pulling this into another PR, but got tired of dealing with stacking.

**Testing steps**
Manual tests. New CI.

Here are some screenshots from a sweep that contained both `--ddp-backend ddp` and `--ddp-backend zero2`

![image](https://user-images.githubusercontent.com/31896/123813683-1b1c6480-d8c3-11eb-90b9-68805c810613.png)

![image](https://user-images.githubusercontent.com/31896/123813795-312a2500-d8c3-11eb-8e78-945396f909f2.png)

![image](https://user-images.githubusercontent.com/31896/123813859-3b4c2380-d8c3-11eb-83c5-7f891c8a2e41.png)

![image](https://user-images.githubusercontent.com/31896/123813900-43a45e80-d8c3-11eb-9aab-4440cb2e813a.png)
