### PR TITLE
Model chat id clarification

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/worlds.py
+++ b/parlai/crowdsourcing/tasks/model_chat/worlds.py
@@ -297,9 +297,9 @@ class BaseModelChatWorld(CrowdTaskWorld, ABC):
                     'agent_idx': idx,
                     # Get rid of annotations HTML if it's the bot response
                     'text': acts[idx]['text'].split('<br>')[0],
-                    'id': acts[idx]['id']
-                    if 'id' in acts[idx]
-                    else 'NULL_ID',  # Person1 or Polyencoder
+                    'id': acts[idx].get(
+                        'id', 'NULL_ID'
+                    ),  # In case model doesn't set id
                 }
                 self.dialog.append(utterance_data)
                 if idx == 0:


### PR DESCRIPTION
**Patch description**
Clarify a comment the model_chat crowdsourcing task to no longer imply that the worker may not have an `id` set, because we manually always set the worker's `id` to `'Worker'`

**Testing steps**
CI checks
