### PR TITLE
[ChunkTeacher] Re-enable shuffling on -dt train:stream.

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2292,19 +2292,13 @@ class ChunkTeacher(FixedDialogTeacher, ABC):
         self.buffersize = self.get_buffersize()
 
         self.set_datasettings(opt)
-        self.datatype = opt['datatype']
+        # chunk teacher makes shuffling decisions based on training, but
+        # train:stream turns off shuffling in other teachers.
+        self.datatype = DatatypeHelper.strip_stream(opt['datatype'])
 
         self.dws = int(self.opt.get('distributed_world_size', 1))
         self.rank = int(self.opt.get('rank', 0))
         self.bg_index = self.opt.get('background_index', None)
-        if (
-            shared is None
-            and self.is_train
-            and self.opt.get('distributed_world_size') is not None
-        ):
-            self.fold_chunks = [
-                c for c in self.fold_chunks if c % self.dws == self.rank
-            ]
 
         # If we're in training mode with --num-workers > 0, we will run the
         # chunk teacher in single threaded mode (self.threading is False). In

--- a/parlai/utils/data.py
+++ b/parlai/utils/data.py
@@ -31,6 +31,26 @@ class DatatypeHelper:
         return datatype.split(':')[0]
 
     @classmethod
+    def strip_stream(cls, datatype: str) -> str:
+        """
+        Remove :stream from the datatype.
+
+        Used by ChunkTeacher where behavior does not change based on streaming.
+
+        :param datatype:
+            parlai datatype
+
+        :return:
+            a non-streaming version of the datatype.
+
+        >>> DatatypeHelper.fold("train:stream")
+        "train"
+        >>> DatatypeHelper.fold("train")
+        "train"
+        """
+        return datatype.replace(":stream", "")
+
+    @classmethod
     def should_cycle(cls, datatype: str) -> bool:
         """
         Return whether we should cycle data based on the datatype.


### PR DESCRIPTION
**Patch description**
Experiments with @emilydinan showed:
- Since some of the refactors in #3681, CT has not been shuffling with `-dt train:stream`. This breaks backwards compatibility and causes significantly less generalization.
- Based on #3681, we no longer require every worker to shard up the chunks they are working on. As such, we can simply have every training worker load every chunk. This reduces the chance of oversampling when the number of workers does not evenly divide into the number of chunks.

**Testing steps**
CI. @emilydinan's experiments of generalization.