### PR TITLE
AUC metrics

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -52,6 +52,10 @@ class MetricDisplayData(NamedTuple):
 
 METRICS_DISPLAY_DATA = {
     "accuracy": MetricDisplayData("Accuracy", "Exact match text accuracy"),
+    'auc': MetricDisplayData(
+        'AUC',
+        "Area Under the Receiver Operating Characteristic Curve (true positive rate vs false positive rate curve)",
+    ),
     "bleu-4": MetricDisplayData(
         "BLEU-4",
         "BLEU-4 of the generation, under a standardized (model-independent) tokenizer",

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -267,7 +267,7 @@ class AUCMetrics(Metric):
             fp_tp.append((fp, tp))
         return fp_tp
 
-    def _calc_fpr_tpr(self) -> Tuple[List[int]]:
+    def _calc_fpr_tpr(self) -> Tuple[Union[List[int], int]]:
         _tot_pos = sum(self._pos_dict.values())
         _tot_neg = sum(self._neg_dict.values())
         fp_tp = self._calc_fp_tp()
@@ -282,16 +282,15 @@ class AUCMetrics(Metric):
         else:
             tpr = [tp / _tot_pos for tp in tps]
 
-        return (fpr, tpr, _tot_pos, _tot_neg)
+        return (list(zip(fpr, tpr)), _tot_pos, _tot_neg)
 
     def value(self) -> float:
-        fpr, tpr, _tot_pos, _tot_neg = self._calc_fpr_tpr()
+        fpr_tpr, _tot_pos, _tot_neg = self._calc_fpr_tpr()
 
         if _tot_pos == 0 and _tot_neg == 0:
             return 0
 
         # auc needs x-axis to be sorted
-        fpr_tpr = list(zip(fpr, tpr))
         fpr_tpr.sort()
         fpr, tpr = list(zip(*fpr_tpr))
         return auc(fpr, tpr)

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -286,7 +286,7 @@ class AUCMetrics(Metric):
 
             fp = self_false_p + other_false_p
             tp = self_true_p + other_true_p
-            all_vals[threshold] = (fp, tp)
+            all_vals[threshold] = [fp, tp]
 
         if len(all_thresholds) == 2:
             print('self_vals', self._values)

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -16,14 +16,13 @@ from parlai.core.torch_agent import TorchAgent, Output
 from parlai.utils.misc import round_sigfigs, warn_once
 from parlai.core.metrics import Metric, AverageMetric
 from typing import List, Optional, Tuple, Dict, Union
-from typing import Counter as Count
+from typing import Counter
 from parlai.utils.typing import TScalar
 from parlai.utils.io import PathManager
 from sklearn.metrics import auc
 
 import parlai.utils.logging as logging
 import torch.nn.functional as F
-from collections import Counter
 import torch
 import math
 
@@ -182,7 +181,7 @@ class AUCMetrics(Metric):
     metric, but may also use more space.
 
     NOTE: currently only used for classifiers in the `eval_model` script; to use,
-    add the argument `-auc <max_bucket_dec_places>` when running `eval_model` script
+    add the argument `-auc <max_bucket_dec_places>` when calling `eval_model` script
     """
 
     @property
@@ -210,12 +209,12 @@ class AUCMetrics(Metric):
         self,
         class_name: Union[int, str],
         max_bucket_dec_places: int = 3,
-        pos_dict: Optional[Count[float]] = None,
-        neg_dict: Optional[Count[float]] = None,
+        pos_dict: Optional[Counter[float]] = None,
+        neg_dict: Optional[Counter[float]] = None,
     ):
         # `_pos_dict` keeps track of the probabilities of the positive class
         self._pos_dict = pos_dict if pos_dict else Counter()
-        # `_neg_dict` keeps track of the probabilities of the positive class
+        # `_neg_dict` keeps track of the probabilities of the negative class
         self._neg_dict = neg_dict if neg_dict else Counter()
         self._class_name = class_name
         self._max_bucket_dec_places = max_bucket_dec_places

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -172,18 +172,14 @@ class ClassificationF1Metric(ConfusionMatrixMetric):
 
 class AUCMetrics(Metric):
     """
-    Class that calculates the area under the roc curve from list of labels and its true
-    probabilities; expecting values to be (false positives, true positives)
-    """
+    Computes Area Under ROC Curve (AUC) metrics.
 
-    __slots__ = (
-        '_pos_dict',
-        '_tot_pos',
-        '_neg_dict',
-        '_tot_neg',
-        '_class_name',
-        '_max_bucket_dec_places',
-    )
+    Does so by keeping track of positives' and negatives' probability score counts in Counters or dictionaries.
+    Note the introduction of `max_bucket_dec_places`;
+    this integer number determines the number of digits to save for the probability 
+    scores. A higher `max_bucket_dec_places` will a more accurate estimate of AUC metric, but may also use more 
+    space.
+    """
 
     @property
     def macro_average(self) -> bool:

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -58,6 +58,12 @@ class ConfusionMatrixMetric(Metric):
         self._true_negatives = self.as_number(true_negatives)
         self._false_positives = self.as_number(false_positives)
         self._false_negatives = self.as_number(false_negatives)
+        self._true_positive_rate = self._true_positives / (
+            self._true_positives + self._false_negatives
+        )
+        self._false_positive_rate = self._false_positives / (
+            self._true_negatives + self._false_positives
+        )
 
     def __add__(
         self, other: Optional['ConfusionMatrixMetric']

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -281,7 +281,7 @@ class AUCMetrics(Metric):
         fp, tp = list(zip(*(self._values.values())))
         fpr = np.array(fp) / self._neg_cnt
         tpr = np.array(tp) / self._pos_cnt
-        return auc(fpr, tpr)
+        return auc(tpr, fpr)
 
 
 class WeightedF1Metric(Metric):

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -177,7 +177,7 @@ class AUCMetrics(Metric):
     Does so by keeping track of positives' and negatives' probability score counts in Counters or dictionaries.
     Note the introduction of `max_bucket_dec_places`;
     this integer number determines the number of digits to save for the probability 
-    scores. A higher `max_bucket_dec_places` will a more accurate estimate of AUC metric, but may also use more 
+    scores. A higher `max_bucket_dec_places` will a more accurate estimate of the exact AUC metric, but may also use more 
     space.
     """
 
@@ -272,7 +272,7 @@ class AUCMetrics(Metric):
         if _tot_pos == 0 and _tot_neg == 0:
             return 0
         fp_tp = self._calc_fp_tp()
-        fp_tp.sort(key=lambda x: x[0])
+        fp_tp.sort()
         fps, tps = list(zip(*fp_tp))
         if _tot_neg == 0:
             fpr = [0] * len(fps)

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -192,7 +192,7 @@ class AUCMetrics(Metric):
     @classmethod
     def raw_data_to_auc(
         cls,
-        true_labels: List[int],
+        true_labels: List[Union[int, str]],
         pos_probs: List[float],
         class_name,
         max_bucket_dec_places: int = 3,
@@ -215,7 +215,9 @@ class AUCMetrics(Metric):
         self._class_name = class_name
         self._max_bucket_dec_places = max_bucket_dec_places
 
-    def update_raw(self, true_labels: List[int], pos_probs: List[float], class_name):
+    def update_raw(
+        self, true_labels: List[Union[int, str]], pos_probs: List[float], class_name
+    ):
         assert self._class_name == class_name
         assert len(true_labels) == len(pos_probs)
 

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -23,7 +23,7 @@ from sklearn.metrics import auc
 
 import parlai.utils.logging as logging
 import torch.nn.functional as F
-from collections import Counter as Counter
+from collections import Counter
 import torch
 import math
 

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -180,6 +180,9 @@ class AUCMetrics(Metric):
     integer number determines the number of digits to save for the probability scores. A
     higher `max_bucket_dec_places` will a more accurate estimate of the exact AUC
     metric, but may also use more space.
+
+    NOTE: currently only used for classifiers in the `eval_model` script; to use,
+    add the argument `-auc <max_bucket_dec_places>` when running `eval_model` script
     """
 
     @property

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -221,9 +221,10 @@ class AUCMetrics(Metric):
         self, true_labels: List[Union[int, str]], pos_probs: List[float], class_name
     ):
         """
-        given the true/golden labels and the probabilities of the positive class,
-        we will update our bucket dictionaries of positive and negatives (based on the class_name);
-        `max_bucket_dec_places` is also used here to round the probabilities and possibly
+        given the true/golden labels and the probabilities of the positive class, we
+        will update our bucket dictionaries of positive and negatives (based on the
+        class_name); `max_bucket_dec_places` is also used here to round the
+        probabilities and possibly.
         """
         assert self._class_name == class_name
         assert len(true_labels) == len(pos_probs)
@@ -256,8 +257,9 @@ class AUCMetrics(Metric):
 
     def _calc_fp_tp(self) -> List[Tuple[int]]:
         """
-        Calculates the False Positives and True positives;
-        returned as a list of pairs: `[(fp, tp)]`
+        Calculates the False Positives and True positives; returned as a list of pairs:
+
+        `[(fp, tp)]`
         """
         all_thresholds = sorted(
             set(list(self._pos_dict.keys()) + list(self._neg_dict.keys()))
@@ -282,12 +284,13 @@ class AUCMetrics(Metric):
 
     def _calc_fpr_tpr(self) -> Tuple[Union[List[int], int]]:
         """
-        Calculates the false positive rates and true positive rates
-        Also returns the total number of positives and negatives;
-        returned as a list of pairs and two integers:
-        `([(fpr, tpr)], positives, negatives)`;
-        note that if the total negatives/positives is 0, then
-        will return 0 for either fpr/tpr instead of raising an error
+        Calculates the false positive rates and true positive rates Also returns the
+        total number of positives and negatives; returned as a list of pairs and two
+        integers:
+
+        `([(fpr, tpr)], positives, negatives)`; note that if the total
+        negatives/positives is 0, then will return 0 for either fpr/tpr instead of
+        raising an error
         """
         _tot_pos = sum(self._pos_dict.values())
         _tot_neg = sum(self._neg_dict.values())

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -219,8 +219,10 @@ class AUCMetrics(Metric):
         neg_cnt = len(true_labels) - pos_cnt
 
         # first calculate thresholds, and include the default
-        # upper and lower bounds
-        all_thresholds = set([0, 1])
+        # upper bounds; don't need to include lower because
+        # we are doing greater and equal
+        # NOTE: assumes the probabilites are between 0 and 1
+        all_thresholds = set([1.5])
         CONST = 10 ** max_dec_places
         # add the upper and lower bound of the values
         for prob in class_probs:
@@ -243,7 +245,10 @@ class AUCMetrics(Metric):
             else:
                 effected_ind = 0
 
-            ind = np.searchsorted(sorted_thresholds, prob, side='right')
+            ind = np.searchsorted(sorted_thresholds, prob, side='left')
+            if ind < len(sorted_thresholds) and sorted_thresholds[ind] == prob:
+                ind += 1
+            # print('current prob', prob, '| found index:', ind)
             for thres in sorted_thresholds[:ind]:
                 values[thres][effected_ind] += 1
 

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -18,16 +18,13 @@ from parlai.core.metrics import Metric, AverageMetric
 from typing import List, Optional, Tuple, Dict, Union
 from parlai.utils.typing import TScalar
 from parlai.utils.io import PathManager
-import parlai.utils.logging as logging
-
-import torch
-import torch.nn.functional as F
-
-import numpy as np
-import math
-from collections import Counter
-
 from sklearn.metrics import auc
+
+import parlai.utils.logging as logging
+import torch.nn.functional as F
+from collections import Counter
+import torch
+import math
 
 
 class ConfusionMatrixMetric(Metric):
@@ -479,12 +476,6 @@ class TorchClassifierAgent(TorchAgent):
         if self.calc_auc:
             self.auc_class_ind = 0
             self.auc = AUCMetrics(class_name=self.class_list[self.auc_class_ind])
-            # self.auc_class_name = opt.get('area_under_curve_class_name')
-            # try:
-            #     self.auc_class_ind = self.class_list.index(self.auc_class_name)
-            # except ValueError:
-            #     self.auc_class_ind = 0
-            #     self.auc_class_name = self.class_list[self.auc_class_ind]
 
         # set up model and optimizers
         states = {}

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -185,8 +185,8 @@ class ClassificationF1Metric(ConfusionMatrixMetric):
 
 class AUCMetrics(Metric):
     """
-    Class that calculates the area under the curve from a list of
-    [(true positive rates, false positive rates)]
+    Class that calculates the area under the curve from a list of [(true positive rates,
+    false positive rates)]
     """
 
     __slots__ = ('_truth', '_max_probs')

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -174,11 +174,11 @@ class AUCMetrics(Metric):
     """
     Computes Area Under ROC Curve (AUC) metrics.
 
-    Does so by keeping track of positives' and negatives' probability score counts in Counters or dictionaries.
-    Note the introduction of `max_bucket_dec_places`;
-    this integer number determines the number of digits to save for the probability 
-    scores. A higher `max_bucket_dec_places` will a more accurate estimate of the exact AUC metric, but may also use more 
-    space.
+    Does so by keeping track of positives' and negatives' probability score counts in
+    Counters or dictionaries. Note the introduction of `max_bucket_dec_places`; this
+    integer number determines the number of digits to save for the probability scores. A
+    higher `max_bucket_dec_places` will a more accurate estimate of the exact AUC
+    metric, but may also use more space.
     """
 
     @property

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -194,7 +194,7 @@ class AUCMetrics(Metric):
         true_labels: List[int],
         pos_probs: List[float],
         class_name,
-        max_bucket_dec_places: float = 5,
+        max_bucket_dec_places: int = 3,
     ):
         auc_object = cls(class_name, max_bucket_dec_places=max_bucket_dec_places)
         auc_object.update_raw(
@@ -207,7 +207,7 @@ class AUCMetrics(Metric):
         class_name: Union[int, str],
         pos_dict: Dict[float, int] = None,
         neg_dict: Dict[float, int] = None,
-        max_bucket_dec_places: float = 3,
+        max_bucket_dec_places: int = 3,
     ):
         self._pos_dict = pos_dict if pos_dict else Counter()
         self._neg_dict = neg_dict if neg_dict else Counter()

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -244,7 +244,7 @@ class AUCMetrics(Metric):
                 effected_ind = 0
 
             ind = np.searchsorted(sorted_thresholds, prob, side='right')
-            for thres in sorted_thresholds[ind:]:
+            for thres in sorted_thresholds[:ind]:
                 values[thres][effected_ind] += 1
 
         return cls(values, pos_cnt, neg_cnt, sorted_thresholds, class_name)

--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -206,9 +206,9 @@ class AUCMetrics(Metric):
     def __init__(
         self,
         class_name: Union[int, str],
-        pos_dict: Optional[Count[float]],
-        neg_dict: Optional[Count[float]],
         max_bucket_dec_places: int = 3,
+        pos_dict: Optional[Count[float]] = None,
+        neg_dict: Optional[Count[float]] = None,
     ):
         # `_pos_dict` keeps track of the probabilities of the positive class
         self._pos_dict = pos_dict if pos_dict else Counter()

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -179,7 +179,7 @@ def _eval_single_world(opt, agent, task):
 
     report = aggregate_unnamed_reports(all_gather_list(world.report()))
 
-    if len(world.agents) > 1:
+    if isinstance(world.agents, list) and len(world.agents) > 1:
         classifier_agent = world.agents[CLASSIFIER_AGENT]
         if hasattr(classifier_agent, 'calc_auc') and classifier_agent.calc_auc:
             report['AUC'] = classifier_agent.auc

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -179,12 +179,13 @@ def _eval_single_world(opt, agent, task):
 
     report = aggregate_unnamed_reports(all_gather_list(world.report()))
 
-    classifier_agent = world.agents[CLASSIFIER_AGENT]
-    if hasattr(classifier_agent, 'calc_auc') and classifier_agent.calc_auc:
-        report['AUC'] = classifier_agent.auc
-        classifier_agent.reset_auc()
-        # for safety measures
-        agent.reset_auc()
+    if len(world.agents) > 1:
+        classifier_agent = world.agents[CLASSIFIER_AGENT]
+        if hasattr(classifier_agent, 'calc_auc') and classifier_agent.calc_auc:
+            report['AUC'] = classifier_agent.auc
+            classifier_agent.reset_auc()
+            # for safety measures
+            agent.reset_auc()
     world.reset()
     return report
 

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -72,11 +72,11 @@ def setup_args(parser=None):
         choices=['conversations', 'parlai'],
     )
     parser.add_argument(
-        '--area-under-curve',
+        '--area-under-curve-digits',
         '-auc',
         type=int,
         default=-1,
-        help='a positive number indicates to calculate the area under the roc curve and it also determines how many decimal digits of the predictions to keep (higher numbers->more accurate); ',
+        help='a positive number indicates to calculate the area under the roc curve and it also determines how many decimal digits of the predictions to keep (higher numbers->more accurate); also used to determine whether or not to calculate the AUC metric',
     )
     parser.add_argument(
         '--area-under-curve-class',

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -42,6 +42,7 @@ from parlai.utils.distributed import (
     get_rank,
 )
 
+# the index to access classifier agent's output in the world
 CLASSIFIER_AGENT = 1
 
 

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -77,7 +77,7 @@ def setup_args(parser=None):
         '-auc',
         type=int,
         default=-1,
-        help='a positive number indicates to calculate the area under the roc curve and it also determines how many decimal digits of the predictions to keep (higher numbers->more accurate); also used to determine whether or not to calculate the AUC metric',
+        help='a positive number indicates to calculate the area under the roc curve and it also determines how many decimal digits of the predictions to keep (higher numbers->more precise); also used to determine whether or not to calculate the AUC metric',
     )
     parser.add_argument(
         '--area-under-curve-class',

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -74,10 +74,17 @@ def setup_args(parser=None):
     parser.add_argument(
         '--area-under-curve',
         '-auc',
-        type='bool',
-        default=False,
-        help='whether to also calculate the area under the roc curve; '
-        'only for binary classification',
+        type=int,
+        default=-1,
+        help='a positive number indicates to calculate the area under the roc curve and it also determines how many decimal digits of the predictions to keep (higher numbers->more accurate); ',
+    )
+    parser.add_argument(
+        '--area-under-curve-class',
+        '-auclass',
+        type=str,
+        default=None,
+        nargs='*',
+        help='the name(s) of the class to calculate the auc for',
     )
     parser.add_argument('-ne', '--num-examples', type=int, default=-1)
     parser.add_argument('-d', '--display-examples', type='bool', default=False)
@@ -182,7 +189,10 @@ def _eval_single_world(opt, agent, task):
     if isinstance(world.agents, list) and len(world.agents) > 1:
         classifier_agent = world.agents[CLASSIFIER_AGENT]
         if hasattr(classifier_agent, 'calc_auc') and classifier_agent.calc_auc:
-            report['AUC'] = classifier_agent.auc
+            for class_indices, curr_auc in zip(
+                classifier_agent.auc_class_indices, classifier_agent.aucs
+            ):
+                report[f'AUC_{classifier_agent.class_list[class_indices]}'] = curr_auc
             classifier_agent.reset_auc()
             # for safety measures
             agent.reset_auc()

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -151,8 +151,6 @@ def _eval_single_world(opt, agent, task):
     if is_distributed():
         logging.warning('Progress bar is approximate in distributed mode.')
 
-    print('AUC BEFORE:', world.agents[CLASSIFIER_AGENT].auc)
-
     while not world.epoch_done() and cnt < max_cnt:
         cnt += opt.get('batchsize', 1)
         world.parley()
@@ -181,20 +179,8 @@ def _eval_single_world(opt, agent, task):
 
     report = aggregate_unnamed_reports(all_gather_list(world.report()))
 
-    print('AUC AFTER:', world.agents[CLASSIFIER_AGENT].auc)
-
     if world.agents[CLASSIFIER_AGENT].calc_auc:
-        # the second one should be the classifier agent for auc
-        from sklearn.metrics import roc_auc_score
-        from parlai.core.metrics import AverageMetric
-
         classifier_agent = world.agents[CLASSIFIER_AGENT]
-        auc = classifier_agent.auc
-        all_labels = ['not_okay'] * sum(auc._pos_dict.values()) + ['okay'] * sum(
-            auc._neg_dict.values()
-        )
-        all_probs = list(auc._pos_dict.elements()) + list(auc._neg_dict.elements())
-        report['AUC_sklearn_auc'] = AverageMetric(roc_auc_score(all_labels, all_probs))
         report['AUC'] = classifier_agent.auc
         classifier_agent.reset_auc()
         # for safety measures

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -179,8 +179,8 @@ def _eval_single_world(opt, agent, task):
 
     report = aggregate_unnamed_reports(all_gather_list(world.report()))
 
-    if world.agents[CLASSIFIER_AGENT].calc_auc:
-        classifier_agent = world.agents[CLASSIFIER_AGENT]
+    classifier_agent = world.agents[CLASSIFIER_AGENT]
+    if hasattr(classifier_agent, 'calc_auc') and classifier_agent.calc_auc:
         report['AUC'] = classifier_agent.auc
         classifier_agent.reset_auc()
         # for safety measures

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -322,57 +322,165 @@ class TestAggregators(unittest.TestCase):
         # task 1; borrowing example from scikit learn
         task1_probabilities = [0.1, 0.4, 0.35, 0.8]
         task1_gold_labels = ['class_ok', 'class_ok', 'class_notok', 'class_notok']
-        task1_exp_val = {
+        task1_pos_buckets = {0.35: 1, 0.8: 1}
+        task1_neg_buckets = {0.1: 1, 0.4: 1}
+        task1_exp_fp_tp = {
             # thres: (False positives, True positives)
-            0.1: [2, 2],
-            0.35: [1, 2],
-            0.4: [1, 1],
-            0.8: [0, 1],
-            1.5: [0, 0],
+            0.1: (2, 2),
+            0.35: (1, 2),
+            0.4: (1, 1),
+            0.8: (0, 1),
+            '_': (0, 0),
         }
 
         # task 2; checking with an odd number
         task2_probabilities = [0.05, 0.2, 0.6]
         task2_gold_labels = ['class_ok', 'class_ok', 'class_notok']
-
-        task2_exp_val = {0.05: [2, 1], 0.2: [1, 1], 0.6: [0, 1], 1.5: [0, 0]}
+        task2_pos_buckets = {0.6: 1}
+        task2_neg_buckets = {0.05: 1, 0.2: 1}
+        task2_exp_fp_tp = {0.05: (2, 1), 0.2: (1, 1), 0.6: (0, 1), 1.5: (0, 0)}
 
         # task 3: combining task 1 and task 2
         task3_probabilities = task1_probabilities + task2_probabilities
         task3_gold_labels = task1_gold_labels + task2_gold_labels
-
-        task3_exp_val = {
+        task3_pos_buckets = {0.35: 1, 0.8: 1, 0.6: 1}
+        task3_neg_buckets = {0.1: 1, 0.4: 1, 0.05: 1, 0.2: 1}
+        task3_exp_fp_tp = {
             # threshold: FP, TP
-            0.05: [4, 3],
-            0.1: [3, 3],
-            0.2: [2, 3],
-            0.35: [1, 3],
-            0.4: [1, 2],
-            0.6: [0, 2],
-            0.8: [0, 1],
-            1.5: [0, 0],
+            0.05: (4, 3),
+            0.1: (3, 3),
+            0.2: (2, 3),
+            0.35: (1, 3),
+            0.4: (1, 2),
+            0.6: (0, 2),
+            0.8: (0, 1),
+            '_': (0, 0),
+        }
+
+        # task 4: testing when there's ones in the same bucket
+        task4_probabilities = [0.1, 0.400001, 0.4, 0.359, 0.35, 0.900001, 0.9]
+        task4_gold_labels = [
+            'class_ok',
+            'class_ok',
+            'class_ok',
+            'class_notok',
+            'class_notok',
+            'class_notok',
+            'class_notok',
+        ]
+        task4_neg_buckets = {0.1: 1, 0.4: 2}
+        task4_pos_buckets = {0.35: 1, 0.359: 1, 0.9: 2}
+        task4_exp_fp_tp = {
+            # thres: (False positives, True positives)
+            0.1: (3, 4),
+            0.35: (2, 4),
+            0.359: (2, 3),
+            0.4: (2, 2),
+            0.9: (0, 2),
+            '_': (0, 0),
+        }
+
+        # task 5: testing when there's more difference in the bucket (similar to task 4),
+        # but testing to make sure the rounding/flooring is correct, and the edge cases 0.0, 1.0
+        task5_probabilities = [0, 0.8, 0.4009, 0.400, 0.359, 0.35, 0.9999, 0.999, 1]
+        # 4 okay, 5 not okay
+        task5_gold_labels = [
+            'class_ok',
+            'class_ok',
+            'class_ok',
+            'class_ok',
+            'class_notok',
+            'class_notok',
+            'class_notok',
+            'class_notok',
+            'class_notok',
+        ]
+        task5_neg_buckets = {0: 1, 0.8: 1, 0.4: 2}
+        task5_pos_buckets = {0.35: 1, 0.359: 1, 0.999: 2, 1: 1}
+        task5_exp_fp_tp = {
+            # thres: (False positives, True positives)
+            0: (4, 5),
+            0.35: (3, 5),
+            0.359: (3, 4),
+            0.4: (3, 3),
+            0.8: (1, 3),
+            0.9: (0, 3),
+            1.0: (0, 1),
+            '_': (0, 0),
+        }
+
+        # task 6: combining task 4 + task 5 (combining with same keys)
+        task6_probabilities = task4_probabilities + task5_probabilities
+        task6_gold_labels = task4_gold_labels + task5_gold_labels
+        task6_neg_buckets = {0: 1, 0.8: 1, 0.4: 4, 0.1: 1}
+        task6_pos_buckets = {0.35: 2, 0.359: 2, 0.9: 2, 0.999: 2, 1: 1}
+        task6_exp_fp_tp = {
+            # threshold: FP, TP
+            0: (7, 9),
+            0.1: (6, 9),
+            0.35: (5, 9),
+            0.359: (5, 7),
+            0.4: (5, 5),
+            0.8: (1, 5),
+            0.9: (0, 5),
+            0.999: (0, 3),
+            1: (0, 1),
+            '_': (0, 0),
         }
 
         # run and check the TPs and FPs
         task1_result = AUCMetrics.raw_data_to_auc(
-            task1_gold_labels, task1_probabilities, 'class_notok', max_dec_places=2
+            task1_gold_labels, task1_probabilities, 'class_notok'
         )
         task2_result = AUCMetrics.raw_data_to_auc(
-            task2_gold_labels, task2_probabilities, 'class_notok', max_dec_places=2
+            task2_gold_labels, task2_probabilities, 'class_notok'
         )
 
-        self.assertEqual(task1_result.key_vals, task1_exp_val)
-        self.assertEqual(task2_result.key_vals, task2_exp_val)
+        task4_result = AUCMetrics.raw_data_to_auc(
+            task4_gold_labels, task4_probabilities, 'class_notok'
+        )
 
-        # check that merging als produces the same results
+        task5_result = AUCMetrics.raw_data_to_auc(
+            task5_gold_labels, task5_probabilities, 'class_notok'
+        )
+
+        # check the buckets first
+        self.assertEqual(task1_result._pos_dict, task1_pos_buckets)
+        self.assertEqual(task1_result._neg_dict, task1_neg_buckets)
+        self.assertEqual(task2_result._pos_dict, task2_pos_buckets)
+        self.assertEqual(task2_result._neg_dict, task2_neg_buckets)
+        self.assertEqual(task4_result._pos_dict, task4_pos_buckets)
+        self.assertEqual(task4_result._neg_dict, task4_neg_buckets)
+        self.assertEqual(task5_result._pos_dict, task5_pos_buckets)
+        self.assertEqual(task5_result._neg_dict, task5_neg_buckets)
+
+        # then check fp, tp
+        self.assertEqual(set(task1_result._calc_fp_tp()), set(task1_exp_fp_tp.values()))
+        self.assertEqual(set(task2_result._calc_fp_tp()), set(task2_exp_fp_tp.values()))
+        self.assertEqual(set(task4_result._calc_fp_tp()), set(task4_exp_fp_tp.values()))
+        self.assertEqual(set(task5_result._calc_fp_tp()), set(task5_exp_fp_tp.values()))
+
+        # check that merging also produces the same results
         task3_result = task1_result + task2_result
-        self.assertEqual(task3_result.key_vals, task3_exp_val)
+        self.assertEqual(task3_result._pos_dict, task3_pos_buckets)
+        self.assertEqual(task3_result._neg_dict, task3_neg_buckets)
+        self.assertEqual(set(task3_result._calc_fp_tp()), set(task3_exp_fp_tp.values()))
+
+        task6_result = task4_result + task5_result
+        self.assertEqual(task6_result._pos_dict, task6_pos_buckets)
+        self.assertEqual(task6_result._neg_dict, task6_neg_buckets)
+        self.assertEqual(set(task6_result._calc_fp_tp()), set(task6_exp_fp_tp.values()))
 
         # then check from raw data again
         task3_result = AUCMetrics.raw_data_to_auc(
-            task3_gold_labels, task3_probabilities, 'class_notok', max_dec_places=2
+            task3_gold_labels, task3_probabilities, 'class_notok'
         )
-        self.assertEqual(task3_result.key_vals, task3_exp_val)
+        self.assertEqual(set(task3_result._calc_fp_tp()), set(task3_exp_fp_tp.values()))
+
+        task6_result = AUCMetrics.raw_data_to_auc(
+            task6_gold_labels, task6_probabilities, 'class_notok'
+        )
+        self.assertEqual(set(task6_result._calc_fp_tp()), set(task6_exp_fp_tp.values()))
 
         # now actually testing the area under curve
         from sklearn.metrics import roc_auc_score
@@ -385,6 +493,15 @@ class TestAggregators(unittest.TestCase):
         )
         self.assertAlmostEqual(
             roc_auc_score(task3_gold_labels, task3_probabilities), task3_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task4_gold_labels, task4_probabilities), task4_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task5_gold_labels, task5_probabilities), task5_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task6_gold_labels, task6_probabilities), task6_result.value()
         )
 
     def test_classifier_metrics(self):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -376,8 +376,12 @@ class TestAggregators(unittest.TestCase):
         self.assertAlmostEqual(
             roc_auc_score(task1_gold_labels, task1_probabilities), task1_result.value()
         )
-        # self.assertAlmostEqual(roc_auc_score(task2_gold_labels, task2_probabilities), task2_result.value())
-        # self.assertAlmostEqual(roc_auc_score(task3_gold_labels, task3_probabilities), task3_result.value())
+        self.assertAlmostEqual(
+            roc_auc_score(task2_gold_labels, task2_probabilities), task2_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task3_gold_labels, task3_probabilities), task3_result.value()
+        )
 
     def test_classifier_metrics(self):
         # We assume a batch of 16 samples, binary classification case, from 2 tasks.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -428,20 +428,24 @@ class TestAggregators(unittest.TestCase):
             '_': (0, 0),
         }
 
-        # run and check the TPs and FPs
+        # run and check the TPs and FPs for singles
         task1_result = AUCMetrics.raw_data_to_auc(
             task1_gold_labels, task1_probabilities, 'class_notok'
         )
         task2_result = AUCMetrics.raw_data_to_auc(
             task2_gold_labels, task2_probabilities, 'class_notok'
         )
-
+        task3_result = AUCMetrics.raw_data_to_auc(
+            task3_gold_labels, task3_probabilities, 'class_notok'
+        )
         task4_result = AUCMetrics.raw_data_to_auc(
             task4_gold_labels, task4_probabilities, 'class_notok'
         )
-
         task5_result = AUCMetrics.raw_data_to_auc(
             task5_gold_labels, task5_probabilities, 'class_notok'
+        )
+        task6_result = AUCMetrics.raw_data_to_auc(
+            task6_gold_labels, task6_probabilities, 'class_notok'
         )
 
         # check the buckets first
@@ -449,16 +453,22 @@ class TestAggregators(unittest.TestCase):
         self.assertEqual(task1_result._neg_dict, task1_neg_buckets)
         self.assertEqual(task2_result._pos_dict, task2_pos_buckets)
         self.assertEqual(task2_result._neg_dict, task2_neg_buckets)
+        self.assertEqual(task3_result._pos_dict, task3_pos_buckets)
+        self.assertEqual(task3_result._neg_dict, task3_neg_buckets)
         self.assertEqual(task4_result._pos_dict, task4_pos_buckets)
         self.assertEqual(task4_result._neg_dict, task4_neg_buckets)
         self.assertEqual(task5_result._pos_dict, task5_pos_buckets)
         self.assertEqual(task5_result._neg_dict, task5_neg_buckets)
+        self.assertEqual(task6_result._pos_dict, task6_pos_buckets)
+        self.assertEqual(task6_result._neg_dict, task6_neg_buckets)
 
         # then check fp, tp
         self.assertEqual(set(task1_result._calc_fp_tp()), set(task1_exp_fp_tp.values()))
         self.assertEqual(set(task2_result._calc_fp_tp()), set(task2_exp_fp_tp.values()))
+        self.assertEqual(set(task3_result._calc_fp_tp()), set(task3_exp_fp_tp.values()))
         self.assertEqual(set(task4_result._calc_fp_tp()), set(task4_exp_fp_tp.values()))
         self.assertEqual(set(task5_result._calc_fp_tp()), set(task5_exp_fp_tp.values()))
+        self.assertEqual(set(task6_result._calc_fp_tp()), set(task6_exp_fp_tp.values()))
 
         # check that merging also produces the same results
         task3_result = task1_result + task2_result
@@ -469,17 +479,6 @@ class TestAggregators(unittest.TestCase):
         task6_result = task4_result + task5_result
         self.assertEqual(task6_result._pos_dict, task6_pos_buckets)
         self.assertEqual(task6_result._neg_dict, task6_neg_buckets)
-        self.assertEqual(set(task6_result._calc_fp_tp()), set(task6_exp_fp_tp.values()))
-
-        # then check from raw data again
-        task3_result = AUCMetrics.raw_data_to_auc(
-            task3_gold_labels, task3_probabilities, 'class_notok'
-        )
-        self.assertEqual(set(task3_result._calc_fp_tp()), set(task3_exp_fp_tp.values()))
-
-        task6_result = AUCMetrics.raw_data_to_auc(
-            task6_gold_labels, task6_probabilities, 'class_notok'
-        )
         self.assertEqual(set(task6_result._calc_fp_tp()), set(task6_exp_fp_tp.values()))
 
         # now actually testing the area under curve
@@ -502,6 +501,26 @@ class TestAggregators(unittest.TestCase):
         )
         self.assertAlmostEqual(
             roc_auc_score(task6_gold_labels, task6_probabilities), task6_result.value()
+        )
+
+        # last task: adding everything together; uses task 3 & 6
+        # gonna just check roc scores
+        task_all_gold_labels = task3_gold_labels + task6_gold_labels
+        task_all_probabilities = task3_probabilities + task6_probabilities
+
+        task_all_result = task3_result + task6_result
+
+        self.assertAlmostEqual(
+            roc_auc_score(task_all_gold_labels, task_all_probabilities),
+            task_all_result.value(),
+        )
+
+        task_all_result2 = AUCMetrics.raw_data_to_auc(
+            task_all_gold_labels, task_all_probabilities, 'class_notok'
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task_all_gold_labels, task_all_probabilities),
+            task_all_result2.value(),
         )
 
     def test_classifier_metrics(self):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -319,6 +319,8 @@ class TestAggregators(unittest.TestCase):
         assert 'b/global_avg' not in agg
 
     def test_auc_metrics(self):
+        class_name = 'class_notok'
+        decimal_place = 3
         # task 1; borrowing example from scikit learn
         task1_probabilities = [0.1, 0.4, 0.35, 0.8]
         task1_gold_labels = ['class_ok', 'class_ok', 'class_notok', 'class_notok']
@@ -430,22 +432,40 @@ class TestAggregators(unittest.TestCase):
 
         # run and check the TPs and FPs for singles
         task1_result = AUCMetrics.raw_data_to_auc(
-            task1_gold_labels, task1_probabilities, 'class_notok'
+            task1_gold_labels,
+            task1_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
         )
         task2_result = AUCMetrics.raw_data_to_auc(
-            task2_gold_labels, task2_probabilities, 'class_notok'
+            task2_gold_labels,
+            task2_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
         )
         task3_result = AUCMetrics.raw_data_to_auc(
-            task3_gold_labels, task3_probabilities, 'class_notok'
+            task3_gold_labels,
+            task3_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
         )
         task4_result = AUCMetrics.raw_data_to_auc(
-            task4_gold_labels, task4_probabilities, 'class_notok'
+            task4_gold_labels,
+            task4_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
         )
         task5_result = AUCMetrics.raw_data_to_auc(
-            task5_gold_labels, task5_probabilities, 'class_notok'
+            task5_gold_labels,
+            task5_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
         )
         task6_result = AUCMetrics.raw_data_to_auc(
-            task6_gold_labels, task6_probabilities, 'class_notok'
+            task6_gold_labels,
+            task6_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
         )
 
         # check the buckets first
@@ -516,7 +536,7 @@ class TestAggregators(unittest.TestCase):
         )
 
         task_all_result2 = AUCMetrics.raw_data_to_auc(
-            task_all_gold_labels, task_all_probabilities, 'class_notok'
+            task_all_gold_labels, task_all_probabilities, class_name
         )
         self.assertAlmostEqual(
             roc_auc_score(task_all_gold_labels, task_all_probabilities),

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -363,12 +363,21 @@ class TestAggregators(unittest.TestCase):
         task3_result = AUCMetrics.raw_data_to_auc(
             task3_gold_labels, task3_probabilities, 'class_notok', max_dec_places=2
         )
-        self.assertEqual(task1_result._values, task1_exp_val)
-        self.assertEqual(task2_result._values, task2_exp_val)
-        self.assertEqual(task3_result._values, task3_exp_val)
+        self.assertEqual(task1_result.key_vals, task1_exp_val)
+        self.assertEqual(task2_result.key_vals, task2_exp_val)
+        self.assertEqual(task3_result.key_vals, task3_exp_val)
 
         task3_result = task1_result + task2_result
-        self.assertEqual(task3_result._values, task3_exp_val)
+        self.assertEqual(task3_result.key_vals, task3_exp_val)
+
+        # now actually testing the area under curve
+        from sklearn.metrics import roc_auc_score
+
+        self.assertAlmostEqual(
+            roc_auc_score(task1_gold_labels, task1_probabilities), task1_result.value()
+        )
+        # self.assertAlmostEqual(roc_auc_score(task2_gold_labels, task2_probabilities), task2_result.value())
+        # self.assertAlmostEqual(roc_auc_score(task3_gold_labels, task3_probabilities), task3_result.value())
 
     def test_classifier_metrics(self):
         # We assume a batch of 16 samples, binary classification case, from 2 tasks.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -360,8 +360,15 @@ class TestAggregators(unittest.TestCase):
             task2_gold_labels, task2_probabilities, 'class_notok', max_dec_places=2
         )
 
-        assert task1_result._values == task1_exp_val
-        assert task2_result._values == task2_exp_val
+        task3_result = AUCMetrics.raw_data_to_auc(
+            task3_gold_labels, task3_probabilities, 'class_notok', max_dec_places=2
+        )
+        self.assertEqual(task1_result._values, task1_exp_val)
+        self.assertEqual(task2_result._values, task2_exp_val)
+        self.assertEqual(task3_result._values, task3_exp_val)
+
+        task3_result = task1_result + task2_result
+        self.assertEqual(task3_result._values, task3_exp_val)
 
     def test_classifier_metrics(self):
         # We assume a batch of 16 samples, binary classification case, from 2 tasks.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -353,6 +353,7 @@ class TestAggregators(unittest.TestCase):
             1.5: [0, 0],
         }
 
+        # run and check the TPs and FPs
         task1_result = AUCMetrics.raw_data_to_auc(
             task1_gold_labels, task1_probabilities, 'class_notok', max_dec_places=2
         )
@@ -360,14 +361,17 @@ class TestAggregators(unittest.TestCase):
             task2_gold_labels, task2_probabilities, 'class_notok', max_dec_places=2
         )
 
+        self.assertEqual(task1_result.key_vals, task1_exp_val)
+        self.assertEqual(task2_result.key_vals, task2_exp_val)
+
+        # check that merging als produces the same results
+        task3_result = task1_result + task2_result
+        self.assertEqual(task3_result.key_vals, task3_exp_val)
+
+        # then check from raw data again
         task3_result = AUCMetrics.raw_data_to_auc(
             task3_gold_labels, task3_probabilities, 'class_notok', max_dec_places=2
         )
-        self.assertEqual(task1_result.key_vals, task1_exp_val)
-        self.assertEqual(task2_result.key_vals, task2_exp_val)
-        self.assertEqual(task3_result.key_vals, task3_exp_val)
-
-        task3_result = task1_result + task2_result
         self.assertEqual(task3_result.key_vals, task3_exp_val)
 
         # now actually testing the area under curve

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -320,6 +320,7 @@ class TestAggregators(unittest.TestCase):
 
     def test_auc_metrics(self):
         class_name = 'class_notok'
+        class_to_int = {'class_notok': 1, 'class_ok': 0}
         decimal_place = 3
         # task 1; borrowing example from scikit learn
         task1_probabilities = [0.1, 0.4, 0.35, 0.8]
@@ -504,34 +505,54 @@ class TestAggregators(unittest.TestCase):
         # now actually testing the area under curve
         from sklearn.metrics import roc_auc_score
 
+        task1_labels_int = [
+            class_to_int[gold_label] for gold_label in task1_gold_labels
+        ]
+        task2_labels_int = [
+            class_to_int[gold_label] for gold_label in task2_gold_labels
+        ]
+        task3_labels_int = [
+            class_to_int[gold_label] for gold_label in task3_gold_labels
+        ]
+        task4_labels_int = [
+            class_to_int[gold_label] for gold_label in task4_gold_labels
+        ]
+        task5_labels_int = [
+            class_to_int[gold_label] for gold_label in task5_gold_labels
+        ]
+        task6_labels_int = [
+            class_to_int[gold_label] for gold_label in task6_gold_labels
+        ]
+
         self.assertAlmostEqual(
-            roc_auc_score(task1_gold_labels, task1_probabilities), task1_result.value()
+            roc_auc_score(task1_labels_int, task1_probabilities), task1_result.value()
         )
         self.assertAlmostEqual(
-            roc_auc_score(task2_gold_labels, task2_probabilities), task2_result.value()
+            roc_auc_score(task2_labels_int, task2_probabilities), task2_result.value()
         )
         self.assertAlmostEqual(
-            roc_auc_score(task3_gold_labels, task3_probabilities), task3_result.value()
+            roc_auc_score(task3_labels_int, task3_probabilities), task3_result.value()
         )
         self.assertAlmostEqual(
-            roc_auc_score(task4_gold_labels, task4_probabilities), task4_result.value()
+            roc_auc_score(task4_labels_int, task4_probabilities), task4_result.value()
         )
         self.assertAlmostEqual(
-            roc_auc_score(task5_gold_labels, task5_probabilities), task5_result.value()
+            roc_auc_score(task5_labels_int, task5_probabilities), task5_result.value()
         )
         self.assertAlmostEqual(
-            roc_auc_score(task6_gold_labels, task6_probabilities), task6_result.value()
+            roc_auc_score(task6_labels_int, task6_probabilities), task6_result.value()
         )
 
         # last task: adding everything together; uses task 3 & 6
         # gonna just check roc scores
         task_all_gold_labels = task3_gold_labels + task6_gold_labels
+        task_all_labels_int = task3_labels_int + task6_labels_int
         task_all_probabilities = task3_probabilities + task6_probabilities
 
         task_all_result = task3_result + task6_result
 
         self.assertAlmostEqual(
-            roc_auc_score(task_all_gold_labels, task_all_probabilities),
+            roc_auc_score(task_all_labels_int, task_all_probabilities),
             task_all_result.value(),
         )
 
@@ -539,8 +560,83 @@ class TestAggregators(unittest.TestCase):
             task_all_gold_labels, task_all_probabilities, class_name
         )
         self.assertAlmostEqual(
-            roc_auc_score(task_all_gold_labels, task_all_probabilities),
+            roc_auc_score(task_all_labels_int, task_all_probabilities),
             task_all_result2.value(),
+        )
+
+        ### now reusing the tests for the other class, just checking rocs
+        ## for binary classes, they should be the same?
+        class_name = 'class_ok'
+        task1_probabilities = [1 - curr_prob for curr_prob in task1_probabilities]
+        task2_probabilities = [1 - curr_prob for curr_prob in task2_probabilities]
+        task3_probabilities = [1 - curr_prob for curr_prob in task3_probabilities]
+        task4_probabilities = [1 - curr_prob for curr_prob in task4_probabilities]
+        task5_probabilities = [1 - curr_prob for curr_prob in task5_probabilities]
+        task6_probabilities = [1 - curr_prob for curr_prob in task6_probabilities]
+
+        task1_labels_int = [1 - curr for curr in task1_labels_int]
+        task2_labels_int = [1 - curr for curr in task2_labels_int]
+        task3_labels_int = [1 - curr for curr in task3_labels_int]
+        task4_labels_int = [1 - curr for curr in task4_labels_int]
+        task5_labels_int = [1 - curr for curr in task5_labels_int]
+        task6_labels_int = [1 - curr for curr in task6_labels_int]
+
+        # get the results
+        task1_result = AUCMetrics.raw_data_to_auc(
+            task1_gold_labels,
+            task1_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
+        )
+        task2_result = AUCMetrics.raw_data_to_auc(
+            task2_gold_labels,
+            task2_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
+        )
+        task3_result = AUCMetrics.raw_data_to_auc(
+            task3_gold_labels,
+            task3_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
+        )
+        task4_result = AUCMetrics.raw_data_to_auc(
+            task4_gold_labels,
+            task4_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
+        )
+        task5_result = AUCMetrics.raw_data_to_auc(
+            task5_gold_labels,
+            task5_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
+        )
+        task6_result = AUCMetrics.raw_data_to_auc(
+            task6_gold_labels,
+            task6_probabilities,
+            class_name,
+            max_bucket_dec_places=decimal_place,
+        )
+
+        # check against roc_auc_score
+        self.assertAlmostEqual(
+            roc_auc_score(task1_labels_int, task1_probabilities), task1_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task2_labels_int, task2_probabilities), task2_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task3_labels_int, task3_probabilities), task3_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task4_labels_int, task4_probabilities), task4_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task5_labels_int, task5_probabilities), task5_result.value()
+        )
+        self.assertAlmostEqual(
+            roc_auc_score(task6_labels_int, task6_probabilities), task6_result.value()
         )
 
     def test_classifier_metrics(self):


### PR DESCRIPTION
## Patch description
Adding AUC (Area under ROC curve) metrics as an option for eval_model

## Testing steps
0. Check the other metric tests r okay (` pytest -v -k TestMetrics/ pytest -v -k TestMetric`)
1. Check via test to make sure AUC added up correctly..... (`pytest -v -k TestAggregators`) 
2. Check it works via `eval_model` for both classes with micro aggregation --> checking to make sure the agents' auc resetted.  (`parlai em -mf zoo:dialogue_safety/multi_turn/model -t internal:civil_bias_toxic_comment:civil_bias_toxicity,dialogue_safety -auc 4 -rf parlai_internal/reports/auc_multi_safety_civil_multi.json -ne 3000 -micro True`)

## Logs
<img width="602" alt="Screen Shot 2021-06-30 at 1 36 01 PM" src="https://user-images.githubusercontent.com/14303605/124027805-1e3d5080-d9a8-11eb-8001-0bdceea5de79.png">

<img width="615" alt="Screen Shot 2021-06-30 at 1 36 17 PM" src="https://user-images.githubusercontent.com/14303605/124027836-272e2200-d9a8-11eb-8ce8-63bcb45aea4b.png">


metric|dialogue_safety|internal:civil_bias_toxic_comment:civil_bias_toxicity|all
---|---|---|---
class___notok___f1|0.82453|0.55437|0.68945
AUC___notok__|0.98469|0.92527|0.96373

### Testing Step 2
```
parlai em -mf zoo:dialogue_safety/multi_turn/model -t internal:civil_bias_toxic_comment:civil_bias_toxicity -auc True -rf parlai_internal/reports/auc_multi_safety_civil_single.json -ne 3000
```
Results:


### Testing Step 1

```
(conda_parlai) wzhang4343@devfair0173:~/ParlAI$ pytest -v -k TestAggregators
===================================================== test session starts =====================================================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-1.0.0.dev0 -- /private/home/wzhang4343/.conda/envs/conda_parlai/bin/python
cachedir: .pytest_cache
rootdir: /private/home/wzhang4343/ParlAI, configfile: pytest.ini, testpaths: tests, parlai/tasks
plugins: requests-mock-1.9.2, regressions-2.2.0, hydra-core-1.0.6, datadir-1.3.1
collected 997 items / 990 deselected / 7 selected                                                                             

tests/test_metrics.py::TestAggregators::test_auc_metrics PASSED                                                         [ 14%]
tests/test_metrics.py::TestAggregators::test_classifier_metrics PASSED                                                  [ 28%]
tests/test_metrics.py::TestAggregators::test_macro_aggregation PASSED                                                   [ 42%]
tests/test_metrics.py::TestAggregators::test_micro_aggregation PASSED                                                   [ 57%]
tests/test_metrics.py::TestAggregators::test_time_metric PASSED                                                         [ 71%]
tests/test_metrics.py::TestAggregators::test_uneven_macro_aggrevation PASSED                                            [ 85%]
tests/test_metrics.py::TestAggregators::test_unnamed_aggregation PASSED                                                 [100%]

==================================================== slowest 10 durations =====================================================
0.01s call     tests/test_metrics.py::TestAggregators::test_auc_metrics

(9 durations < 0.005s hidden.  Use -vv to show these durations.)
======================================== 7 passed, 990 deselected, 2 warnings in 5.77s ========================================
```

### Testing Step 0
```
(conda_parlai) wzhang4343@devfair0173:~/ParlAI$ pytest -v -k TestMetric
===================================================== test session starts =====================================================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-1.0.0.dev0 -- /private/home/wzhang4343/.conda/envs/conda_parlai/bin/python
cachedir: .pytest_cache
rootdir: /private/home/wzhang4343/ParlAI, configfile: pytest.ini, testpaths: tests, parlai/tasks
plugins: requests-mock-1.9.2, regressions-2.2.0, hydra-core-1.0.6, datadir-1.3.1
collected 996 items / 984 deselected / 12 selected                                                                            

tests/test_metrics.py::TestMetric::test_average_metric_additions PASSED                                                 [  8%]
tests/test_metrics.py::TestMetric::test_average_metric_inputs PASSED                                                    [ 16%]
tests/test_metrics.py::TestMetric::test_fixedmetric PASSED                                                              [ 25%]
tests/test_metrics.py::TestMetric::test_macroaverage_additions PASSED                                                   [ 33%]
tests/test_metrics.py::TestMetric::test_sum_metric_additions PASSED                                                     [ 41%]
tests/test_metrics.py::TestMetric::test_sum_metric_inputs PASSED                                                        [ 50%]
tests/test_metrics.py::TestMetrics::test_largebuffer PASSED                                                             [ 58%]
tests/test_metrics.py::TestMetrics::test_multithreaded PASSED                                                           [ 66%]
tests/test_metrics.py::TestMetrics::test_recent PASSED                                                                  [ 75%]
tests/test_metrics.py::TestMetrics::test_shared PASSED                                                                  [ 83%]
tests/test_metrics.py::TestMetrics::test_simpleadd PASSED                                                               [ 91%]
tests/test_metrics.py::TestMetrics::test_verymultithreaded PASSED                                                       [100%]

==================================================== slowest 10 durations =====================================================
0.13s call     tests/test_metrics.py::TestMetrics::test_verymultithreaded
0.09s call     tests/test_metrics.py::TestMetrics::test_largebuffer

(8 durations < 0.005s hidden.  Use -vv to show these durations.)
======================================= 12 passed, 984 deselected, 2 warnings in 7.61s ========================================
(conda_parlai) wzhang4343@devfair0173:~/ParlAI$ pytest -v -k TestMetrics
===================================================== test session starts =====================================================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-1.0.0.dev0 -- /private/home/wzhang4343/.conda/envs/conda_parlai/bin/python
cachedir: .pytest_cache
rootdir: /private/home/wzhang4343/ParlAI, configfile: pytest.ini, testpaths: tests, parlai/tasks
plugins: requests-mock-1.9.2, regressions-2.2.0, hydra-core-1.0.6, datadir-1.3.1
collected 996 items / 990 deselected / 6 selected                                                                             

tests/test_metrics.py::TestMetrics::test_largebuffer PASSED                                                             [ 16%]
tests/test_metrics.py::TestMetrics::test_multithreaded PASSED                                                           [ 33%]
tests/test_metrics.py::TestMetrics::test_recent PASSED                                                                  [ 50%]
tests/test_metrics.py::TestMetrics::test_shared PASSED                                                                  [ 66%]
tests/test_metrics.py::TestMetrics::test_simpleadd PASSED                                                               [ 83%]
tests/test_metrics.py::TestMetrics::test_verymultithreaded PASSED                                                       [100%]

==================================================== slowest 10 durations =====================================================
0.13s call     tests/test_metrics.py::TestMetrics::test_verymultithreaded
0.09s call     tests/test_metrics.py::TestMetrics::test_largebuffer

(8 durations < 0.005s hidden.  Use -vv to show these durations.)
======================================== 6 passed, 990 deselected, 2 warnings in 5.16s ========================================
```

** Other Info **
- I chose to store the AUCmetric in the classifier because if we ever wanna do it during training.... it should be relatively easy to modify the code and do it there :) (maybe?)
- Also, added 6 tests and know that it might be a lot less code if I just did a for loop with some of the commands, but then I noticed that if I did do that, it would be less easy to read exactly which test it was. 
- Please don't get scared by the lines...... ~300 are in the tests. 
- Code used to generate the graphs (not in the final version) 
```
                # for fun...
                import matplotlib.pyplot as plt
                from sklearn import metrics
                fpr, tpr, _, _ = curr_auc._calc_fpr_tpr()
                display = metrics.RocCurveDisplay(fpr=fpr, tpr=tpr, roc_auc=curr_auc.value())
                display.plot()
                folder = '/'.join(opt['report_filename'].split('/')[:-1])
                plt.savefig(folder+f"/AUC_graph_{task}_{classifier_agent.class_list[class_indices]}.png")
                plt.clf()
                print(f"graphed {folder}/AUC_graph_{task}_{classifier_agent.class_list[class_indices]}.png")
```
- Code used to generate table from report file:

```
interested_metrics = {'AUC___notok__', 'class___notok___f1'}

fields = ['dialogue_safety', 'internal:civil_bias_toxic_comment:civil_bias_toxicity']
rows = []

for metric in interested_metrics:  
 row = [metric]
 for field in fields:
   key = field + '/' + metric 
   row.append(str(round(report[key], 5)))
 row.append(str(round(report[metric], 5)))
 rows.append('|'.join(row))

print('|'.join(['metric'] + fields + ['all']))
print('|'.join(['---']*(len(fields) + 2)))
print('\n'.join(rows))
```
