### PR TITLE
reproducing the bug in Dialog teacher

### DIFF
--- a/parlai/tasks/dt_bug/__init__.py
+++ b/parlai/tasks/dt_bug/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/parlai/tasks/dt_bug/agents.py
+++ b/parlai/tasks/dt_bug/agents.py
@@ -17,4 +17,10 @@ class MyTeacher(DialogTeacher):
         for episode in self.mock_data:
             for ex in episode:
                 done = ex == episode[-1]
-                yield Message({"text": f"text_{ex}", "labels": [f"label {ex}"]}), done
+                yield Message(
+                    {
+                        "text": f"text_{ex}",
+                        "labels": [f"label {ex}"],
+                        "episode_done": done,
+                    }
+                ), done

--- a/parlai/tasks/dt_bug/agents.py
+++ b/parlai/tasks/dt_bug/agents.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from parlai.core.message import Message
 from parlai.core.teachers import DialogTeacher
 

--- a/parlai/tasks/dt_bug/agents.py
+++ b/parlai/tasks/dt_bug/agents.py
@@ -1,0 +1,15 @@
+from parlai.core.message import Message
+from parlai.core.teachers import DialogTeacher
+
+
+class MyTeacher(DialogTeacher):
+    def __init__(self, opt, shared=None):
+        self.mock_data = [[1, 2, 3], [1, 2, 3, 4]]
+        opt['datafile'] = "df"
+        super().__init__(opt, shared=shared)
+
+    def setup_data(self, datafile):
+        for episode in self.mock_data:
+            for ex in episode:
+                done = ex == episode[-1]
+                yield Message({"text": f"text_{ex}", "labels": [f"label {ex}"]}), done


### PR DESCRIPTION
**Patch description**
This is to discuss an issue that I ran into working with the `DialogTeacher`.
Using `parlai dd -t dt_bug:MyTeacher`, it is supposed to show me two episodes with 3 and 4 examples, but I see this.

<img width="341" alt="Screen Shot 2021-06-25 at 5 37 28 PM" src="https://user-images.githubusercontent.com/11262163/123487661-60e3df00-d5dc-11eb-9f23-9265a6b485b3.png">
 Looks like there is an off by 1 bug somewhere.
