### PR TITLE
[version] Bump to v1.3.0.

### DIFF
--- a/parlai/__init__.py
+++ b/parlai/__init__.py
@@ -4,4 +4,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 
 from setuptools import setup, find_packages
 
-VERSION = '1.2.0'  # if you update, update parlai/__init__.py too!
+VERSION = '1.3.0'  # if you update, update parlai/__init__.py too!
 
 if sys.version_info < (3, 7):
     sys.exit('Sorry, Python >=3.7 is required for ParlAI.')


### PR DESCRIPTION
**Patch description**
Bump version to v1.3.0.

Will wait for #3720 and #3718 before landing.

**Testing steps**
CI.