### PR TITLE
Specify left pane in model chat

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/frontend/main.js
+++ b/parlai/crowdsourcing/tasks/model_chat/frontend/main.js
@@ -31,7 +31,7 @@ function MainApp() {
       renderSidePane={({ mephistoContext: { taskConfig }, appContext: { taskContext } }) => (
         <DefaultTaskDescription
           chatTitle={taskConfig.chat_title}
-          taskDescriptionHtml={taskConfig.task_description}
+          taskDescriptionHtml={taskConfig.left_pane_text}
         >
           {(taskContext.hasOwnProperty('image_src') && taskContext['image_src']) ? (
             <div>


### PR DESCRIPTION
**Patch description**
For some reason, in the model chat crowdsourcing task, the `task_description.html` file was being used to render both the front page (correctly) and the left pane (incorrectly); this remedies that problem by using `left_pane_text.html` to render the left pane.

**Testing steps**
Sandbox HIT
