### PR TITLE
Make paths attributes of AcuteEvalBuilder

### DIFF
--- a/parlai/crowdsourcing/tasks/acute_eval/acute_eval_builder.py
+++ b/parlai/crowdsourcing/tasks/acute_eval/acute_eval_builder.py
@@ -10,16 +10,16 @@ import os
 import shutil
 import subprocess
 
-ACUTE_TASK_DIR = os.path.dirname(__file__)
-FRONTEND_SOURCE_DIR = os.path.join(ACUTE_TASK_DIR, "webapp")
-FRONTEND_BUILD_DIR = os.path.join(FRONTEND_SOURCE_DIR, "build")
-
 
 class AcuteEvalBuilder(TaskBuilder):
     """
     Builder for a static task, pulls the appropriate html, builds the frontend (if a
     build doesn't already exist), then puts the file into the server directory.
     """
+
+    ACUTE_TASK_DIR = os.path.dirname(__file__)
+    FRONTEND_SOURCE_DIR = os.path.join(ACUTE_TASK_DIR, "webapp")
+    FRONTEND_BUILD_DIR = os.path.join(FRONTEND_SOURCE_DIR, "build")
 
     BUILT_FILE = "done.built"
     BUILT_MESSAGE = "built!"
@@ -29,9 +29,9 @@ class AcuteEvalBuilder(TaskBuilder):
         Rebuild the frontend for this task.
         """
         return_dir = os.getcwd()
-        os.chdir(FRONTEND_SOURCE_DIR)
-        if os.path.exists(FRONTEND_BUILD_DIR):
-            shutil.rmtree(FRONTEND_BUILD_DIR)
+        os.chdir(self.FRONTEND_SOURCE_DIR)
+        if os.path.exists(self.FRONTEND_BUILD_DIR):
+            shutil.rmtree(self.FRONTEND_BUILD_DIR)
         packages_installed = subprocess.call(["npm", "install"])
         if packages_installed != 0:
             raise Exception(
@@ -55,13 +55,13 @@ class AcuteEvalBuilder(TaskBuilder):
             self.rebuild_core()
 
         # Copy the built core and the given task file to the target path
-        bundle_js_file = os.path.join(FRONTEND_BUILD_DIR, "bundle.js")
+        bundle_js_file = os.path.join(self.FRONTEND_BUILD_DIR, "bundle.js")
         target_resource_dir = os.path.join(build_dir, "static")
         target_path = os.path.join(target_resource_dir, "bundle.js")
         shutil.copy2(bundle_js_file, target_path)
 
         copied_static_file = os.path.join(
-            FRONTEND_SOURCE_DIR, "src", "static", "index.html"
+            self.FRONTEND_SOURCE_DIR, "src", "static", "index.html"
         )
         target_path = os.path.join(target_resource_dir, "index.html")
         shutil.copy2(copied_static_file, target_path)


### PR DESCRIPTION
**Patch description**
Make the ACUTE-Eval task folder an attribute of `AcuteEvalBuilder` in order to allow subclasses to overwrite this

**Testing steps**
CI checks, test ACUTEs