### PR TITLE
[RAG] Handle `nan` scores.

### DIFF
--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -640,6 +640,13 @@ class DPRRetriever(RagRetriever):
             vectors = vectors[:, :, :-1]
         # recompute exact FAISS scores
         scores = torch.bmm(query.unsqueeze(1), vectors.transpose(1, 2)).squeeze(1)
+        if torch.isnan(scores).sum().item():
+            logging.error(
+                '\n[ Document scores are NaN; please look into the built index. ]\n'
+                '[ If using a compressed index, try building an exact index: ]\n'
+                '[ $ python index_dense_embeddings --indexer-type exact... ]'
+            )
+            scores.fill_(1)
         ids = torch.tensor([[int(s) for s in ss] for ss in ids])
 
         return ids, scores


### PR DESCRIPTION
**Patch description**
Handles a bug caught in #3806; if the index building goes wrong, there's a possibility that the context/document scores are nan's; this seems to occur if there's an issue with the clustering of the vectors (see linked FAISS issue in #3806)

**Testing steps**
Reproduced the error with steps in #3806; verified that, with this fix, the error is no longer an issue.
