### PR TITLE
BlenderBot2 interactive_web: Object of type AverageMetric is not JSON serializable  

### DIFF
--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -195,7 +195,9 @@ class MyHandler(BaseHTTPRequestHandler):
             model_response = self._interactive_running(
                 SHARED.get('opt'), body.decode('utf-8')
             )
-
+            int_metrics = {key: int(value) for key, value in model_response['metrics'].items()}
+            model_response.force_set('metrics', int_metrics)
+            logging.info(f'MODEL: {pformat(model_response)}')
             self.send_response(200)
             self.send_header('Content-type', 'application/json')
             self.end_headers()

--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -195,12 +195,10 @@ class MyHandler(BaseHTTPRequestHandler):
             model_response = self._interactive_running(
                 SHARED.get('opt'), body.decode('utf-8')
             )
-            int_metrics = {key: int(value) for key, value in model_response['metrics'].items()}
-            model_response.force_set('metrics', int_metrics)
             self.send_response(200)
             self.send_header('Content-type', 'application/json')
             self.end_headers()
-            json_str = json.dumps(model_response)
+            json_str = json.dumps(model_response.json_safe_payload())
             self.wfile.write(bytes(json_str, 'utf-8'))
         elif self.path == '/reset':
             self.send_response(200)

--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -197,7 +197,6 @@ class MyHandler(BaseHTTPRequestHandler):
             )
             int_metrics = {key: int(value) for key, value in model_response['metrics'].items()}
             model_response.force_set('metrics', int_metrics)
-            logging.info(f'MODEL: {pformat(model_response)}')
             self.send_response(200)
             self.send_header('Content-type', 'application/json')
             self.end_headers()


### PR DESCRIPTION


**Patch description**
Simply cast the `model_response['metrics']` values as plain ints instead of AverageMetric objects so `model_response` can be JSON serialized.

**Testing steps**
Running the following command

`$ parlai interactive_web --task blended_skill_talk:all -mf zoo:blenderbot2/blenderbot2_400M/model --search-server http://localhost:5000`

Open localhost:8080 when the interactive_web task comes online. Put in a message and post and backend gets this traceback:

```
Traceback (most recent call last):
  File "/Users/jquick/.pyenv/versions/3.8.7/lib/python3.8/socketserver.py", line 316, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/Users/jquick/.pyenv/versions/3.8.7/lib/python3.8/socketserver.py", line 347, in process_request
    self.finish_request(request, client_address)
  File "/Users/jquick/.pyenv/versions/3.8.7/lib/python3.8/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/Users/jquick/.pyenv/versions/3.8.7/lib/python3.8/socketserver.py", line 720, in __init__
    self.handle()
  File "/Users/jquick/.pyenv/versions/3.8.7/lib/python3.8/http/server.py", line 427, in handle
    self.handle_one_request()
  File "/Users/jquick/.pyenv/versions/3.8.7/lib/python3.8/http/server.py", line 415, in handle_one_request
    method()
  File "/Users/jquick/Projects/ParlAI/parlai/scripts/interactive_web.py", line 202, in do_POST
    json_str = json.dumps(model_response)
  File "/Users/jquick/.pyenv/versions/3.8.7/lib/python3.8/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/Users/jquick/.pyenv/versions/3.8.7/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Users/jquick/.pyenv/versions/3.8.7/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/Users/jquick/.pyenv/versions/3.8.7/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type Av
```


**Other information**
This is what the chunk of model_response looks like before the change

```
'metrics': {'clen': AverageMetric(5),
            'ctrunc': AverageMetric(0),
            'ctrunclen': AverageMetric(0)}
```

And after

```
'metrics': {'clen': 5,
            'ctrunc': 0,
            'ctrunclen': 0}
```

Now interactive_web page is working and can chat w/ bot