### PR TITLE
Retry flaky crowdsourcing tests

### DIFF
--- a/tests/crowdsourcing/tasks/model_chat/test_model_chat.py
+++ b/tests/crowdsourcing/tasks/model_chat/test_model_chat.py
@@ -82,6 +82,7 @@ try:
         def tearDown(self) -> None:
             self._teardown()
 
+        @testing_utils.retry(ntries=3)
         def test_base_task(self):
 
             with testing_utils.tempdir() as tmpdir:

--- a/tests/crowdsourcing/tasks/model_chat/test_model_image_chat.py
+++ b/tests/crowdsourcing/tasks/model_chat/test_model_image_chat.py
@@ -64,6 +64,7 @@ try:
         def tearDown(self) -> None:
             self._teardown()
 
+        @testing_utils.retry(ntries=3)
         def test_base_task(self):
 
             with testing_utils.tempdir() as tmpdir:

--- a/tests/crowdsourcing/tasks/test_chat_demo.py
+++ b/tests/crowdsourcing/tasks/test_chat_demo.py
@@ -10,6 +10,8 @@ End-to-end testing for the chat demo crowdsourcing task.
 import os
 import unittest
 
+import parlai.utils.testing as testing_utils
+
 
 # Desired inputs/outputs
 EXPECTED_STATE_AGENT_0 = {
@@ -372,6 +374,7 @@ try:
         def tearDown(self) -> None:
             self._teardown()
 
+        @testing_utils.retry(ntries=3)
         def test_base_task(self):
 
             # # Setup


### PR DESCRIPTION
**Patch description**
Retry crowdsourcing tests that are flaky due to sockets closing without warning, occasional missing messages, etc.

**Testing steps**
CI checks