### PR TITLE
Model-chat model opt fixes

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/bot_agent.py
+++ b/parlai/crowdsourcing/tasks/model_chat/bot_agent.py
@@ -108,10 +108,10 @@ class TurkLikeAgent:
             )
 
         # Convert opt strings to Opt objects
-        parser = ParlaiParser(True, True)
-        parser.set_params(**model_overrides)
         processed_opts = {}
         for name, opt_string in model_opts.items():
+            parser = ParlaiParser(True, True)
+            parser.set_params(**model_overrides)
             processed_opts[name] = parser.parse_args(opt_string.split())
 
         # Load and share all model agents

--- a/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
+++ b/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
@@ -474,7 +474,7 @@ class ModelChatBlueprint(BaseModelChatBlueprint):
         active_model_opts = {
             model: opt
             for model, opt in all_model_opts.items()
-            if self.conversations_needed[model] > 0
+            if self.conversations_needed.get(model, 0) > 0
         }
         return TurkLikeAgent.get_bot_agents(args=args, model_opts=active_model_opts)
 


### PR DESCRIPTION
**Patch description**
For the model chat crowdsourcing task, when running human+model chat on multiple models at once, this PR prevents flags that are set for one model from being applied to other models, which happens for certain flags (generation flags for instance). It also removes the requirement that all models be specified by `mephisto.blueprint.conversations_needed_string`.

**Testing steps**
Tested this in the sandbox by setting `mephisto.blueprint.conversations_needed_string` to `"blender_3B_beam_min_length_1:10,blender_3B:10"` and the contents of `task_config/model_opts.yaml` to the following:
```
blender_90M: >
    --model-file zoo:blender/blender_90M/model

blender_3B_beam_min_length_1: >
    --model-file zoo:blender/blender_3B/model --beam_block_ngram 3 --beam_context_block_ngram 3 --beam_min_length 1 --beam_size 10 --inference beam

blender_3B: >
    --model-file zoo:blender/blender_3B/model --beam_block_ngram 3 --beam_context_block_ngram 3 --beam_min_length 20 --beam_size 10 --inference beam
```
Ideally we'd be able to rapidly build a test case for things like this. I'm adding a note to the feature tracker to have a test case for this in the future: I'm hoping that unit tests will be easier to modularize/maintain/extend after the Hydra 1.1 upgrade