### PR TITLE
[RAG] Handle Special Toks

### DIFF
--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -33,6 +33,7 @@ from parlai.core.torch_generator_agent import PPLMetric, TorchGeneratorAgent, Tr
 from parlai.utils.distributed import sync_parameters
 from parlai.utils.io import PathManager
 import parlai.utils.logging as logging
+from parlai.utils.misc import recursive_getattr
 import parlai.utils.pickle
 from parlai.utils.torch import total_parameters, trainable_parameters, PipelineHelper
 from parlai.utils.typing import TShared
@@ -339,6 +340,36 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
             )
         return model
 
+    def _resize_token_embeddings(self, state_dict, msg=None):
+        """
+        Resize the token embeddings when are adding extra special tokens.
+
+        Modify TGA._resize_token_embeddings to access correct modules within RAG.
+        """
+        # map extra special tokens carefully
+        new_size = self.model.embeddings.weight.size()[0]
+        orig_size = state_dict['embeddings.weight'].size()[0]
+        logging.info(f'Resizing token embeddings from {orig_size} to {new_size}')
+        if new_size <= orig_size:
+            # new size should be greater than original size,
+            # as we are adding special tokens
+            raise RuntimeError(msg)
+
+        for emb_weights in [
+            'embeddings.weight',
+            'seq2seq_encoder.embeddings.weight',
+            'seq2seq_decoder.embeddings.weight',
+        ]:
+            # get new_embs
+            old_embs = state_dict[emb_weights]
+            new_embs = recursive_getattr(self.model, emb_weights).to(old_embs.device)
+            # copy over old weights
+            new_embs.data[:orig_size, :] = old_embs.data[:orig_size, :]
+            # reset in state dict
+            state_dict[emb_weights] = new_embs
+
+        return state_dict
+
     def build_dictionary(self) -> DictionaryAgent:
         """
         Build and return dictionary.
@@ -381,13 +412,16 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
             init_weight = (
                 model.seq2seq_encoder.position_embeddings.weight  # type: ignore
             )
-            state_dict[key] = torch.cat(
-                [
-                    state_dict[key].to(init_weight),  # type: ignore
-                    init_weight[-opt['n_extra_positions'] :, :],  # type: ignore
-                ],
-                dim=0,
-            )
+            if init_weight.size(0) <= opt['n_positions'] + opt['n_extra_positions']:
+                # Make sure we're not adding more positions to a model trained
+                # with extra positions
+                state_dict[key] = torch.cat(
+                    [
+                        state_dict[key].to(init_weight),  # type: ignore
+                        init_weight[-opt['n_extra_positions'] :, :],  # type: ignore
+                    ],
+                    dim=0,
+                )
         return state_dict
 
     def _should_override_dpr_model_weights(self, opt: Opt):
@@ -423,10 +457,24 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
                         for k, v in self.model.retriever.state_dict().items()  # type: ignore
                     }
                 )
-            super().load_state_dict(state_dict)
-        except RuntimeError:
+            self.model.load_state_dict(state_dict)
+        except RuntimeError as msg:
             state_dict = self.update_state_dict(self.opt, state_dict, self.model)
-            super().load_state_dict(state_dict)
+            msg_ = str(msg)
+            if 'size mismatch' in msg_ and 'embedding' in msg_:
+                if hasattr(self, 'special_toks') and len(self.special_toks) > 0:
+                    state_dict = self._resize_token_embeddings(state_dict, msg_)
+                    self.resized_embeddings = True  # make note that we resized here
+                else:
+                    raise RuntimeError(
+                        f'{msg_}\n'
+                        '-----------------\n'
+                        'Could not load the model due to a size mismatch in the '
+                        'embeddings. A common reason for this is trying to load '
+                        'a model trained with fp16 but loaded without fp16. Try '
+                        'adding --fp16 true or --force-fp16-tokens true.'
+                    )
+            self.model.load_state_dict(state_dict)
 
     def batchify(self, obs_batch: List[Message], sort: bool = False) -> Batch:
         """

--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -412,7 +412,7 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
             init_weight = (
                 model.seq2seq_encoder.position_embeddings.weight  # type: ignore
             )
-            if init_weight.size(0) <= opt['n_positions'] + opt['n_extra_positions']:
+            if state_dict[key].size(0) < opt['n_positions'] + opt['n_extra_positions']:
                 # Make sure we're not adding more positions to a model trained
                 # with extra positions
                 state_dict[key] = torch.cat(

--- a/tests/nightly/gpu/test_rag.py
+++ b/tests/nightly/gpu/test_rag.py
@@ -53,6 +53,7 @@ test_opt = {
     'n_heads': 2,
     'embedding_size': 32,
     'ffn_size': 128,
+    'n_positions': 1024,
     'dict_tokenizer': 're',
     'generation_model': 'transformer/generator',
 }
@@ -298,6 +299,12 @@ class TestOtherOptions(unittest.TestCase):
         opt = copy.deepcopy(test_opt)
         opt['rag_model_type'] = 'token'
         opt['n_extra_positions'] = 128
+        testing_utils.eval_model(opt, skip_test=True)
+
+    def test_resize_embs(self):
+        opt = copy.deepcopy(test_opt)
+        opt['rag_model_type'] = 'token'
+        opt['special_tok_lst'] = '__hello__,__goodbye__'
         testing_utils.eval_model(opt, skip_test=True)
 
 


### PR DESCRIPTION
**Patch description**
Handle specifying special tokens in a RAG setup by implementing `_resize_token_embeddings`

**Testing steps**
Updates `test_rag.py`, ran locally:

```
$ pytest -k TestOtherOptions
===== test session starts =====
platform linux -- Python 3.7.9, pytest-6.2.1, py-1.10.0, pluggy-1.0.0.dev0
rootdir: /private/home/kshuster/ParlAI, configfile: pytest.ini
plugins: hydra-core-1.0.7, requests-mock-1.8.0, regressions-2.1.1, datadir-1.3.1
collected 118 items / 116 deselected / 2 selected

test_rag.py ..                                                                                                                                                                                                                                                                                                                                                      [100%]
===== slowest 10 durations =====
12.15s call     tests/nightly/gpu/test_rag.py::TestOtherOptions::test_n_positions
8.56s call     tests/nightly/gpu/test_rag.py::TestOtherOptions::test_resize_embs
```