### PR TITLE
[RAG] Fail Informatively if Transformers not Installed

### DIFF
--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -19,6 +19,7 @@ import torch.cuda
 from typing import Any, Dict, List, Optional, Tuple, Union, Type
 
 from parlai.agents.bart.bart import BartAgent
+import parlai.agents.hugging_face.hugging_face  # noqa: F401
 from parlai.agents.hugging_face.t5 import T5Agent
 from parlai.agents.transformer.polyencoder import PolyencoderAgent
 from parlai.agents.transformer.transformer import TransformerGeneratorAgent


### PR DESCRIPTION
**Patch description**
Provide a more informative message if the user does not have `transformers` installed when attempting to run a RAG model

Addresses concerns in #3774

**Testing steps**
Verified that the error message is more informative than that in #3774:
```
$ parlai interactive -mf zoo:hallucination/bart_rag_token/model
Traceback (most recent call last):
  File "/private/home/kshuster/ParlAI/parlai/agents/hugging_face/hugging_face.py", line 15, in <module>
    import transformers
ModuleNotFoundError: No module named 'transformers'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/home/kshuster/.conda/envs/raw_conda_parlai_7_21_21/bin/parlai", line 33, in <module>
    sys.exit(load_entry_point('parlai', 'console_scripts', 'parlai')())
  File "/private/home/kshuster/ParlAI/parlai/__main__.py", line 14, in main
    superscript_main()
  File "/private/home/kshuster/ParlAI/parlai/core/script.py", line 316, in superscript_main
    opt = parser.parse_args(args)
  File "/private/home/kshuster/ParlAI/parlai/core/params.py", line 1163, in parse_args
    self.add_extra_args(args)
  File "/private/home/kshuster/ParlAI/parlai/core/script.py", line 175, in add_extra_args
    sa.choices[args[0]].add_extra_args(args)
  File "/private/home/kshuster/ParlAI/parlai/core/params.py", line 948, in add_extra_args
    self.add_model_subargs(model, partial)
  File "/private/home/kshuster/ParlAI/parlai/core/params.py", line 822, in add_model_subargs
    agent = load_agent_module(model)
  File "/private/home/kshuster/ParlAI/parlai/core/loader.py", line 188, in load_agent_module
    my_module = importlib.import_module(module_name)
  File "/private/home/kshuster/.conda/envs/raw_conda_parlai_7_21_21/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/private/home/kshuster/ParlAI/parlai/agents/rag/rag.py", line 22, in <module>
    import parlai.agents.hugging_face.hugging_face  # noqa: F401
  File "/private/home/kshuster/ParlAI/parlai/agents/hugging_face/hugging_face.py", line 17, in <module>
    raise ImportError('Please run `pip install transformers`.')
ImportError: Please run `pip install transformers`.
```

