### PR TITLE
Fixed RAG sharding to include remainder of rows

### DIFF
--- a/parlai/agents/rag/scripts/generate_dense_embeddings.py
+++ b/parlai/agents/rag/scripts/generate_dense_embeddings.py
@@ -182,6 +182,9 @@ class Generator(ParlaiScript):
         )
         shard_id, num_shards = self.opt['shard_id'], self.opt['num_shards']
         shard_size = int(len(rows) / num_shards)
+        if shard_id > len(rows) % num_shards:
+            # don't forget the remainder!
+            shard_size += 1
         start_idx = shard_id * shard_size
         end_idx = start_idx + shard_size
         logging.info(

--- a/parlai/agents/rag/scripts/generate_dense_embeddings.py
+++ b/parlai/agents/rag/scripts/generate_dense_embeddings.py
@@ -182,7 +182,7 @@ class Generator(ParlaiScript):
         )
         shard_id, num_shards = self.opt['shard_id'], self.opt['num_shards']
         shard_size = int(len(rows) / num_shards)
-        if shard_id > len(rows) % num_shards:
+        if shard_id < len(rows) % num_shards:
             # don't forget the remainder!
             shard_size += 1
         start_idx = shard_id * shard_size


### PR DESCRIPTION
**Patch description**
This patch addresses a bug while generating embeddings. Previously, sharding skipped over the remainder of rows if the number of rows was not divisible by the number of shards. This patch simply distributes the remainder over the first few shards. For example,

```
# assume I want 3 shards out of 8 rows
rows: 1 2 3 4 5 6 7 8
previously: [1 2] [3 4] [5 6]
now: [1 2 3] [4 5 6] [7 8]
```

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

Just run `generate_dense_embeddings.py` with a `passages.tsv` file whose number of passages isn't divisible by the number of shards.

```bash
for i in `seq 0 49`; do /usr/bin/python generate_dense_embeddings.py \
-mf zoo:hallucination/bart_rag_turn_dtt/model \
--dpr-model True \
--passages-file passages.tsv \
--outfile test_embeddings/out \
--num-shards 50 \
--shard-id $i -bs 32; done
```

In my case I had 462356 passages which means for 50 shards the last 6 will be ignored.

```
23:59:50 | Shard 1 of 50 encoding psg index 9247 to 18494, out of 462356
23:59:50 | Encoded 320 out of 9247 passages
23:59:51 | Encoded 640 out of 9247 passages
23:59:52 | Encoded 960 out of 9247 passages
23:59:52 | Encoded 1280 out of 9247 passages
23:59:53 | Encoded 1600 out of 9247 passages
23:59:53 | Encoded 1920 out of 9247 passages
23:59:54 | Encoded 2240 out of 9247 passages
23:59:54 | Encoded 2560 out of 9247 passages
23:59:55 | Encoded 2880 out of 9247 passages
23:59:56 | Encoded 3200 out of 9247 passages
23:59:56 | Encoded 3520 out of 9247 passages
23:59:57 | Encoded 3840 out of 9247 passages
23:59:57 | Encoded 4160 out of 9247 passages
23:59:58 | Encoded 4480 out of 9247 passages
23:59:59 | Encoded 4800 out of 9247 passages
23:59:59 | Encoded 5120 out of 9247 passages
00:00:00 | Encoded 5440 out of 9247 passages
00:00:00 | Encoded 5760 out of 9247 passages
00:00:01 | Encoded 6080 out of 9247 passages
00:00:02 | Encoded 6400 out of 9247 passages
00:00:02 | Encoded 6720 out of 9247 passages
00:00:03 | Encoded 7040 out of 9247 passages
00:00:03 | Encoded 7360 out of 9247 passages
00:00:04 | Encoded 7680 out of 9247 passages
00:00:05 | Encoded 8000 out of 9247 passages
00:00:05 | Encoded 8320 out of 9247 passages
00:00:06 | Encoded 8640 out of 9247 passages
00:00:06 | Encoded 8960 out of 9247 passages
```
