### PR TITLE
Fix variable name in model chat test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ transformers==4.6.1
 tokenizers>=0.8.0
 torchtext>=0.5.0
 tornado==6.0.4
-tqdm~=4.38.0
+tqdm==4.42
 typing-extensions==3.7.4.1
 Unidecode==1.1.1
 urllib3>=1.26.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ transformers==4.6.1
 tokenizers>=0.8.0
 torchtext>=0.5.0
 tornado==6.0.4
-tqdm==4.42
+tqdm~=4.38.0
 typing-extensions==3.7.4.1
 Unidecode==1.1.1
 urllib3>=1.26.5

--- a/tests/crowdsourcing/tasks/model_chat/test_model_chat.py
+++ b/tests/crowdsourcing/tasks/model_chat/test_model_chat.py
@@ -107,7 +107,7 @@ fixed_response: >
                     f.write(model_opt_contents)
 
                 # Set up the config and database
-                num_blender_convos = 10
+                num_convos = 10
                 args = ModelChatBlueprintArgs()
                 overrides = [
                     f'+mephisto.blueprint.{key}={val}'
@@ -122,12 +122,12 @@ fixed_response: >
                     ]
                 ] + [
                     'mephisto.blueprint.annotations_config_path=${task_dir}/task_config/annotations_config.json',
-                    f'mephisto.blueprint.conversations_needed_string=\"fixed_response:{num_blender_convos:d}\"',
+                    f'mephisto.blueprint.conversations_needed_string=\"fixed_response:{num_convos:d}\"',
                     f'mephisto.blueprint.chat_data_folder={chat_data_folder}',
                     '+mephisto.blueprint.left_pane_text_path=${task_dir}/task_config/left_pane_text.html',
                     '+mephisto.blueprint.max_concurrent_responses=1',
                     f'mephisto.blueprint.model_opt_path={model_opt_path}',
-                    f'+mephisto.blueprint.num_conversations={num_blender_convos:d}',
+                    f'+mephisto.blueprint.num_conversations={num_convos:d}',
                     '+mephisto.blueprint.onboard_task_data_path=${task_dir}/task_config/onboard_task_data.json',
                     '+mephisto.blueprint.task_description_file=${task_dir}/task_config/task_description.html',
                 ]


### PR DESCRIPTION
**Patch description**
Fix a misleading variable name in a model chat test: we're running conversations with the fixed response agent, not BlenderBot

**Testing steps**
CI checks
