### PR TITLE
Bump tqdm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ transformers==4.6.1
 tokenizers>=0.8.0
 torchtext>=0.5.0
 tornado==6.0.4
-tqdm~=4.38.0
+tqdm==4.42
 typing-extensions==3.7.4.1
 Unidecode==1.1.1
 urllib3>=1.26.5


### PR DESCRIPTION
**Patch description**
Bump tqdm to fix `error: tqdm 4.38.0 is installed but tqdm>=4.42 is required by {'datasets'}` error. CI run containing error: https://app.circleci.com/pipelines/github/facebookresearch/ParlAI/9712/workflows/c8e90210-39d0-4f6b-8412-d43e1eadcefb/jobs/79789

**Testing steps**
CI checks