### PR TITLE
Wizard of Wikipedia, knowledge source page title.

### DIFF
--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -758,7 +758,7 @@ class GeneratorTeacher(WizardDialogKnowledgeTeacher):
         return a
 
 
-class WikiTitlePageTeacher(WizardDialogKnowledgeTeacher):
+class WikiPageTitleTeacher(WizardDialogKnowledgeTeacher):
     def __init__(self, opt, shared=None):
         self.opt = copy.deepcopy(opt)
         self.opt['label_type'] = 'response'

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -759,6 +759,14 @@ class GeneratorTeacher(WizardDialogKnowledgeTeacher):
 
 
 class WikiPageTitleTeacher(WizardDialogKnowledgeTeacher):
+    """
+    Generates the title of Wikipedia page used as source of knowledge.
+
+    The context provided by this teacher (`text`) is the conversation history, with chosen topic removed.
+    The label is the title of the Wikipedia page of the passage that wizard selected for crafting
+    the next utterance; in other words, the source of knowledge for this utterance.
+    """
+
     def __init__(self, opt, shared=None):
         self.opt = copy.deepcopy(opt)
         self.opt['label_type'] = 'response'

--- a/parlai/tasks/wizard_of_wikipedia/test.py
+++ b/parlai/tasks/wizard_of_wikipedia/test.py
@@ -39,5 +39,9 @@ class TestGeneratorTeacher(AutoTeacherTest):
     task = "wizard_of_wikipedia:generator"
 
 
+class TestWikiPageTitleTeacher(AutoTeacherTest):
+    task = "wizard_of_wikipedia:wiki_page_title"
+
+
 class TestDocreaderTeacher(AutoTeacherTest):
     task = "wizard_of_wikipedia:docreader"

--- a/parlai/tasks/wizard_of_wikipedia/test/wizard_of_wikipedia_wiki_page_title_test.yml
+++ b/parlai/tasks/wizard_of_wikipedia/test/wizard_of_wikipedia_wiki_page_title_test.yml
@@ -2,14 +2,14 @@ acts:
 - - episode_done: true
     eval_labels:
     - Royal Blue (train)
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     text: 'Blue is my favorite primary color.
 
       Blue is always nice. I like royal blue.'
 - - episode_done: true
     eval_labels:
     - Blue Skies (1946 film)
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     text: 'Blue is my favorite primary color.
 
       Blue is always nice. I like royal blue.
@@ -20,12 +20,12 @@ acts:
 - - episode_done: true
     eval_labels:
     - Cinematography
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     text: Hi buddy, What you think about cinematography
 - - episode_done: true
     eval_labels:
     - Cinematography
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     text: "Hi buddy, What you think about cinematography\nCinematography,is a type\
       \ of motion picture , captured electronically by means of an image \nYes buddy,\
       \  Images captured with an electronic image-sensor, produces an electrical charge.The\
@@ -33,7 +33,7 @@ acts:
 - - episode_done: true
     eval_labels:
     - Photography
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     text: "Hi buddy, What you think about cinematography\nCinematography,is a type\
       \ of motion picture , captured electronically by means of an image \nYes buddy,\
       \  Images captured with an electronic image-sensor, produces an electrical charge.The\
@@ -42,5 +42,5 @@ acts:
       \ real images on the light-sensitive surface .\n Muybridge sequence of a horse\
       \ galloping In the 1830s, moving images were produced on revolving drums and\
       \ disks"
-num_episodes: 3374
-num_examples: 3374
+num_episodes: 3181
+num_examples: 3181

--- a/parlai/tasks/wizard_of_wikipedia/test/wizard_of_wikipedia_wiki_page_title_test.yml
+++ b/parlai/tasks/wizard_of_wikipedia/test/wizard_of_wikipedia_wiki_page_title_test.yml
@@ -1,0 +1,46 @@
+acts:
+- - episode_done: true
+    eval_labels:
+    - Royal Blue (train)
+    id: WikiTitleGenerationTeacher
+    text: 'Blue is my favorite primary color.
+
+      Blue is always nice. I like royal blue.'
+- - episode_done: true
+    eval_labels:
+    - Blue Skies (1946 film)
+    id: WikiTitleGenerationTeacher
+    text: 'Blue is my favorite primary color.
+
+      Blue is always nice. I like royal blue.
+
+      I once road on The Royal Blue train from New York to D.C
+
+      Oh that sounds really nice. I bet there was a lot of scenery and blue skies.'
+- - episode_done: true
+    eval_labels:
+    - Cinematography
+    id: WikiTitleGenerationTeacher
+    text: Hi buddy, What you think about cinematography
+- - episode_done: true
+    eval_labels:
+    - Cinematography
+    id: WikiTitleGenerationTeacher
+    text: "Hi buddy, What you think about cinematography\nCinematography,is a type\
+      \ of motion picture , captured electronically by means of an image \nYes buddy,\
+      \  Images captured with an electronic image-sensor, produces an electrical charge.The\
+      \ word \"cinematography\" is based on the Greek words  meaning movement, motion."
+- - episode_done: true
+    eval_labels:
+    - Photography
+    id: WikiTitleGenerationTeacher
+    text: "Hi buddy, What you think about cinematography\nCinematography,is a type\
+      \ of motion picture , captured electronically by means of an image \nYes buddy,\
+      \  Images captured with an electronic image-sensor, produces an electrical charge.The\
+      \ word \"cinematography\" is based on the Greek words  meaning movement, motion.\n\
+      It works by lens used to repeatedly focus the light reflected from objects into\
+      \ real images on the light-sensitive surface .\n Muybridge sequence of a horse\
+      \ galloping In the 1830s, moving images were produced on revolving drums and\
+      \ disks"
+num_episodes: 3374
+num_examples: 3374

--- a/parlai/tasks/wizard_of_wikipedia/test/wizard_of_wikipedia_wiki_page_title_train.yml
+++ b/parlai/tasks/wizard_of_wikipedia/test/wizard_of_wikipedia_wiki_page_title_train.yml
@@ -1,0 +1,48 @@
+acts:
+- - episode_done: true
+    id: WikiTitleGenerationTeacher
+    labels:
+    - Science fiction film
+    text: 'I think science fiction is an amazing genre for anything. Future science,
+      technology, time travel, FTL travel, they''re all such interesting concepts.
+
+      I''m a huge fan of science fiction myself! '
+- - episode_done: true
+    id: WikiTitleGenerationTeacher
+    labels:
+    - Time travel in fiction
+    text: "I think science fiction is an amazing genre for anything. Future science,\
+      \ technology, time travel, FTL travel, they're all such interesting concepts.\n\
+      I'm a huge fan of science fiction myself! \nAwesome! I really love how sci-fi\
+      \ storytellers focus on political/social/philosophical issues that would still\
+      \ be around even in the future. Makes them relatable.\nI agree. One of my favorite\
+      \ forms of science fiction is anything related to time travel! I find it fascinating."
+- - episode_done: true
+    id: WikiTitleGenerationTeacher
+    labels:
+    - Science fiction
+    text: "I think science fiction is an amazing genre for anything. Future science,\
+      \ technology, time travel, FTL travel, they're all such interesting concepts.\n\
+      I'm a huge fan of science fiction myself! \nAwesome! I really love how sci-fi\
+      \ storytellers focus on political/social/philosophical issues that would still\
+      \ be around even in the future. Makes them relatable.\nI agree. One of my favorite\
+      \ forms of science fiction is anything related to time travel! I find it fascinating.\n\
+      It's not quite sci-fi, but my favorite version of time travel is in Harry Potter\
+      \ and the Prisoner of Azkaban. Breaks zero logical rules.\nAnd that's difficult\
+      \ to do when dealing with time travel. I actually haven't seen the latest Harry\
+      \ Potter movies. Guess it's time to check them out!"
+- - episode_done: true
+    id: WikiTitleGenerationTeacher
+    labels:
+    - Internet access
+    text: 'Can you imagine the world without internet access? '
+- - episode_done: true
+    id: WikiTitleGenerationTeacher
+    labels:
+    - Internet access
+    text: "Can you imagine the world without internet access? \nNo I could not! I\
+      \ couldn't imagine living when internet access was rare and very few people\
+      \ had it!\nOh me either! It seems like such a long time ago. I wonder when Internet\
+      \ was first created?"
+num_episodes: 64937
+num_examples: 64937

--- a/parlai/tasks/wizard_of_wikipedia/test/wizard_of_wikipedia_wiki_page_title_train.yml
+++ b/parlai/tasks/wizard_of_wikipedia/test/wizard_of_wikipedia_wiki_page_title_train.yml
@@ -1,6 +1,6 @@
 acts:
 - - episode_done: true
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     labels:
     - Science fiction film
     text: 'I think science fiction is an amazing genre for anything. Future science,
@@ -8,7 +8,7 @@ acts:
 
       I''m a huge fan of science fiction myself! '
 - - episode_done: true
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     labels:
     - Time travel in fiction
     text: "I think science fiction is an amazing genre for anything. Future science,\
@@ -18,7 +18,7 @@ acts:
       \ be around even in the future. Makes them relatable.\nI agree. One of my favorite\
       \ forms of science fiction is anything related to time travel! I find it fascinating."
 - - episode_done: true
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     labels:
     - Science fiction
     text: "I think science fiction is an amazing genre for anything. Future science,\
@@ -32,17 +32,17 @@ acts:
       \ to do when dealing with time travel. I actually haven't seen the latest Harry\
       \ Potter movies. Guess it's time to check them out!"
 - - episode_done: true
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     labels:
     - Internet access
     text: 'Can you imagine the world without internet access? '
 - - episode_done: true
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     labels:
     - Internet access
     text: "Can you imagine the world without internet access? \nNo I could not! I\
       \ couldn't imagine living when internet access was rare and very few people\
       \ had it!\nOh me either! It seems like such a long time ago. I wonder when Internet\
       \ was first created?"
-num_episodes: 64937
-num_examples: 64937
+num_episodes: 60797
+num_examples: 60797

--- a/parlai/tasks/wizard_of_wikipedia/test/wizard_of_wikipedia_wiki_page_title_valid.yml
+++ b/parlai/tasks/wizard_of_wikipedia/test/wizard_of_wikipedia_wiki_page_title_valid.yml
@@ -2,12 +2,12 @@ acts:
 - - episode_done: true
     eval_labels:
     - Gardening
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     text: I like Gardening, even when I've only been doing it for a short time.
 - - episode_done: true
     eval_labels:
     - Gardening
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     text: 'I like Gardening, even when I''ve only been doing it for a short time.
 
       I live on a farm, we garden all year long, it is very relaxing.
@@ -17,7 +17,7 @@ acts:
 - - episode_done: true
     eval_labels:
     - Gardening
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     text: 'I like Gardening, even when I''ve only been doing it for a short time.
 
       I live on a farm, we garden all year long, it is very relaxing.
@@ -33,7 +33,7 @@ acts:
 - - episode_done: true
     eval_labels:
     - Gardening
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     text: 'I like Gardening, even when I''ve only been doing it for a short time.
 
       I live on a farm, we garden all year long, it is very relaxing.
@@ -55,7 +55,7 @@ acts:
 - - episode_done: true
     eval_labels:
     - Bob Ross
-    id: WikiTitleGenerationTeacher
+    id: WikiPageTitleTeacher
     text: I would like to know more about bob ross
-num_episodes: 3434
-num_examples: 3434
+num_episodes: 3236
+num_examples: 3236

--- a/parlai/tasks/wizard_of_wikipedia/test/wizard_of_wikipedia_wiki_page_title_valid.yml
+++ b/parlai/tasks/wizard_of_wikipedia/test/wizard_of_wikipedia_wiki_page_title_valid.yml
@@ -1,0 +1,61 @@
+acts:
+- - episode_done: true
+    eval_labels:
+    - Gardening
+    id: WikiTitleGenerationTeacher
+    text: I like Gardening, even when I've only been doing it for a short time.
+- - episode_done: true
+    eval_labels:
+    - Gardening
+    id: WikiTitleGenerationTeacher
+    text: 'I like Gardening, even when I''ve only been doing it for a short time.
+
+      I live on a farm, we garden all year long, it is very relaxing.
+
+      That sounds great.  I''ve always thought that I would love living in a farm,
+      but I;ve always lived in the city.  What do you mostly plant?'
+- - episode_done: true
+    eval_labels:
+    - Gardening
+    id: WikiTitleGenerationTeacher
+    text: 'I like Gardening, even when I''ve only been doing it for a short time.
+
+      I live on a farm, we garden all year long, it is very relaxing.
+
+      That sounds great.  I''ve always thought that I would love living in a farm,
+      but I;ve always lived in the city.  What do you mostly plant?
+
+      I have planted several fruits trees, tomatoes, jalepenos, bell peppers, onions,
+      Garlic, and potatoes mostly.
+
+      Great, I love the idea of growing my own vegetables and fruits! Do you have
+      animals in the farm?'
+- - episode_done: true
+    eval_labels:
+    - Gardening
+    id: WikiTitleGenerationTeacher
+    text: 'I like Gardening, even when I''ve only been doing it for a short time.
+
+      I live on a farm, we garden all year long, it is very relaxing.
+
+      That sounds great.  I''ve always thought that I would love living in a farm,
+      but I;ve always lived in the city.  What do you mostly plant?
+
+      I have planted several fruits trees, tomatoes, jalepenos, bell peppers, onions,
+      Garlic, and potatoes mostly.
+
+      Great, I love the idea of growing my own vegetables and fruits! Do you have
+      animals in the farm?
+
+      yes i do. Cows, chickens, Micro pigs, Guinneas, We also do forest growing also.
+      we plants large pine trees.
+
+      Wow, it sounds amazing, the Micro-pigs are so cute! are they trainable to be
+      well behaved?'
+- - episode_done: true
+    eval_labels:
+    - Bob Ross
+    id: WikiTitleGenerationTeacher
+    text: I would like to know more about bob ross
+num_episodes: 3434
+num_examples: 3434


### PR DESCRIPTION
**Patch description**
Added `WikiPageTitleTeacher` to the Wizard of Internet task. It generates the title of the Wikipedia page of the passage that Wizard selected as their source of knowledge, or `no_passages_used` if there was no selection.

**Testing steps**
* Added `TestWikiPageTitleTeacher` to teacher tests.
* Running ``parlai dd -t wizard_of_wikipedia:wiki_page_title`

![Screen Shot 2021-07-22 at 3 25 41 PM](https://user-images.githubusercontent.com/11262163/126697921-63dc206b-2414-4c73-a11c-45355a5d25c5.png)

