### PR TITLE
AcceptabilityChecker min words adjustable

### DIFF
--- a/parlai/crowdsourcing/utils/acceptability.py
+++ b/parlai/crowdsourcing/utils/acceptability.py
@@ -10,6 +10,9 @@ from typing import Iterable, List
 from parlai.utils.safety import OffensiveStringMatcher
 
 
+DEFAULT_MIN_WORDS_THRESHOLD = 3
+
+
 class AcceptabilityChecker:
 
     ALL_VIOLATION_TYPES = [
@@ -22,6 +25,7 @@ class AcceptabilityChecker:
 
     def __init__(self):
         self.offensive_lang_detector = OffensiveStringMatcher()
+        self.min_words_violation_threshold = DEFAULT_MIN_WORDS_THRESHOLD
 
     def check_messages(
         self,
@@ -57,7 +61,7 @@ class AcceptabilityChecker:
         # Do messages have the minimum acceptable average number of words?
         if 'min_words' in violation_types:
             total_num_words = sum([len(message.split()) for message in messages])
-            if total_num_words / len(messages) < 3:
+            if total_num_words / len(messages) < self.min_words_violation_threshold:
                 violations.append('under_min_length')
 
         # Does the first message start with a greeting, indicating that the Turker

--- a/parlai/crowdsourcing/utils/acceptability.py
+++ b/parlai/crowdsourcing/utils/acceptability.py
@@ -23,9 +23,9 @@ class AcceptabilityChecker:
         'safety',
     ]
 
-    def __init__(self):
+    def __init__(self, min_words=DEFAULT_MIN_WORDS_THRESHOLD):
         self.offensive_lang_detector = OffensiveStringMatcher()
-        self.min_words_violation_threshold = DEFAULT_MIN_WORDS_THRESHOLD
+        self.min_words_violation_threshold = min_words
 
     def check_messages(
         self,

--- a/parlai/crowdsourcing/utils/acceptability.py
+++ b/parlai/crowdsourcing/utils/acceptability.py
@@ -10,9 +10,6 @@ from typing import Iterable, List
 from parlai.utils.safety import OffensiveStringMatcher
 
 
-DEFAULT_MIN_WORDS_THRESHOLD = 3
-
-
 class AcceptabilityChecker:
 
     ALL_VIOLATION_TYPES = [
@@ -22,10 +19,13 @@ class AcceptabilityChecker:
         'exact_match',
         'safety',
     ]
+    DEFAULT_MIN_WORDS_THRESHOLD = 3
 
-    def __init__(self, min_words=DEFAULT_MIN_WORDS_THRESHOLD):
+    def __init__(self, min_words: int = None):
         self.offensive_lang_detector = OffensiveStringMatcher()
-        self.min_words_violation_threshold = min_words
+        self.min_words_violation_threshold = (
+            min_words or self.DEFAULT_MIN_WORDS_THRESHOLD
+        )
 
     def check_messages(
         self,


### PR DESCRIPTION
**Patch description**
The minimum number of words for `AcceptabilityChecker` is a hard-coded value (`3`). Needless to say this value may not work in all scenarios. This is a quick patch allowing user to adjust the minimum acceptable number of words in the `AcceptabilityChecker`.
