### PR TITLE
Enable self_chat to seed messages from tasks in parlai_internal

### DIFF
--- a/parlai/tasks/self_chat/worlds.py
+++ b/parlai/tasks/self_chat/worlds.py
@@ -15,7 +15,7 @@ from parlai.core.message import Message
 
 
 def load_openers(opt) -> Optional[List[str]]:
-    if opt['task'].startswith('internal:'):
+    if opt['task'].startswith('internal:') or opt['task'].startswith('fb:'):
         base_task = opt['task']
     else:
         base_task = opt['task'].split(':')[0]

--- a/parlai/tasks/self_chat/worlds.py
+++ b/parlai/tasks/self_chat/worlds.py
@@ -15,7 +15,11 @@ from parlai.core.message import Message
 
 
 def load_openers(opt) -> Optional[List[str]]:
-    base_task = opt['task'].split(':')[0]
+    if opt['task'].startswith('internal:'):
+        base_task = opt['task']
+    else:
+        base_task = opt['task'].split(':')[0]
+
     if base_task == 'self_chat':
         # TODO(#2284): Load default openers from s3
         return None


### PR DESCRIPTION
**Patch description**
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->
A fix for enabling self_chat to seed messages from tasks in parlai_internal.

Currently, when we give `--task internal:xxx --seed-messages-from-task true` for self_chat, 
the `load_openers()` function will try to create a dummy task from `parlai.tasks.internal.agents` 
instead of `parlai_internal.tasks.xxx.agents` and fails.

This is because the first line of `load_openers()` parses the `basetask` according to `:`.
As a result, when we try to seed from tasks in parlai_internal by prepending `internal:`, it will parse the "internal" as `basetask`.
So, I fixed `load_openers()` to pass the task as is when it starts with "internal:".
Then the `create_task()` will handle it seamlessly as in other circumstances.


**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
