### PR TITLE
[World logging] Fix world logging for dynamic batching

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1198,6 +1198,8 @@ class DynamicBatchWorld(World):
         self.acts = [[self._task_acts[i] for i in batch], acts]
         # broadcast the results back to all the models
         for i, act in zip(batch, acts):
+            # broadcast to the subworld
+            self.worlds[i].acts = [self._task_acts[i], act]
             # we need to make sure that the teachers saw the result
             self.worlds[i].get_task_agent().observe(act)
             # and that the agent copies saw their own voice

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -1198,8 +1198,6 @@ class DynamicBatchWorld(World):
         self.acts = [[self._task_acts[i] for i in batch], acts]
         # broadcast the results back to all the models
         for i, act in zip(batch, acts):
-            # broadcast to the subworld
-            self.worlds[i].acts = [self._task_acts[i], act]
             # we need to make sure that the teachers saw the result
             self.worlds[i].get_task_agent().observe(act)
             # and that the agent copies saw their own voice

--- a/parlai/utils/world_logging.py
+++ b/parlai/utils/world_logging.py
@@ -97,6 +97,14 @@ class WorldLogger:
         """
         self._logs.append(episode)
 
+    def _check_episode_done(self, parley) -> bool:
+        """
+        Check whether an episode is done for a given parley.
+        """
+        if parley[0]:
+            return parley[0].get('episode_done', False)
+        return False
+
     def _is_batch_world(self, world):
         return (
             isinstance(world, BatchWorld) or isinstance(world, DynamicBatchWorld)
@@ -111,7 +119,7 @@ class WorldLogger:
             # in the buffer
             idx = parley[0]['dyn_batch_idx'] if 'dyn_batch_idx' in parley[0] else i
             self._add_msgs(parley, idx=idx)
-            if world.worlds[idx].episode_done():
+            if self._check_episode_done(parley):
                 self.reset_world(idx=idx)
 
     def log(self, world):

--- a/parlai/utils/world_logging.py
+++ b/parlai/utils/world_logging.py
@@ -79,7 +79,7 @@ class WorldLogger:
             if not isinstance(act, Message):
                 act = Message(act)
             if act.is_padding():
-                break
+                continue
             if not self.keep_all:
                 msg = {f: act[f] for f in self.keep_fields if f in act}
             else:

--- a/parlai/utils/world_logging.py
+++ b/parlai/utils/world_logging.py
@@ -79,7 +79,7 @@ class WorldLogger:
             if not isinstance(act, Message):
                 act = Message(act)
             if act.is_padding():
-                continue
+                break
             if not self.keep_all:
                 msg = {f: act[f] for f in self.keep_fields if f in act}
             else:

--- a/tests/test_dynamicbatching.py
+++ b/tests/test_dynamicbatching.py
@@ -126,8 +126,9 @@ class TestDynamicBatching(unittest.TestCase):
 
     def test_world_logging_buffersize(self):
         """
-        Test world logging with dynamic batching when the number of
-        examples exceeds the buffersize.
+        Test world logging with dynamic batching.
+        
+        Checks when the number of examples exceeds the buffersize.
         """
         with testing_utils.tempdir() as tmpdir:
             save_report = os.path.join(tmpdir, 'report')

--- a/tests/test_dynamicbatching.py
+++ b/tests/test_dynamicbatching.py
@@ -135,7 +135,7 @@ class TestDynamicBatching(unittest.TestCase):
                 dict(
                     model_file='zoo:unittest/transformer_generator2/model',
                     task='integration_tests:RepeatTeacher:2000',
-                    world_logs=save_report,
+                    world_logs=save_report + '.jsonl',
                     report_filename=save_report,
                     truncate=1024,
                     dynamic_batching='full',

--- a/tests/test_dynamicbatching.py
+++ b/tests/test_dynamicbatching.py
@@ -124,6 +124,31 @@ class TestDynamicBatching(unittest.TestCase):
                         # we log the batch index in the teacher acts only
                         self.assertEquals(dyn_batch_idx, turn['dyn_batch_idx'])
 
+    def test_world_logging_buffersize(self):
+        """
+        Test world logging with dynamic batching when the number of
+        examples exceeds the buffersize.
+        """
+        with testing_utils.tempdir() as tmpdir:
+            save_report = os.path.join(tmpdir, 'report')
+            testing_utils.eval_model(
+                dict(
+                    model_file='zoo:unittest/transformer_generator2/model',
+                    task='integration_tests:RepeatTeacher:2000',
+                    world_logs=save_report,
+                    report_filename=save_report,
+                    truncate=1024,
+                    dynamic_batching='full',
+                    batchsize=4,
+                ),
+                valid_datatype='train:evalmode',
+                skip_test=True,
+            )
+            convo_fle = str(save_report) + '.jsonl'
+            convos = Conversations(convo_fle)
+            # we expect there to be 2000 episodes logged in the convos
+            self.assertEquals(len(convos), 2000)
+
     def test_weird_batchsize(self):
         # intentionally a difficult number
         self._test_correct_processed(NUM_TEST, batchsize=7)


### PR DESCRIPTION
**Patch description**
Episodes were not properly being flushed during world logging since world.acts always returns `[None, None]` -- acts are only tracked at the DynamicBatchWorld level. Added a manual check in world logging for a parley to see if the episode is done.

**Testing steps**
Added a test that broke before the change and passes after.

