### PR TITLE
[RAG] Generate Dense Embeddings Fix

### DIFF
--- a/parlai/agents/rag/README.md
+++ b/parlai/agents/rag/README.md
@@ -98,7 +98,7 @@ The default RAG parameters use the `zoo:hallucination/wiki_passages/psgs_w100.ts
 
 ### 1a. [**Recommended**] Obtain/Choose a (Pre-trained) DPR Model
 
-The RAG model works **really well** with DPR models as the backbone retrievers; check out the [DPR repository](https://github.com/facebookresearch/DPR) for some pre-trained DPR models (or, train your own!).
+The RAG model works **really well** with DPR models as the backbone retrievers; check out the [DPR repository](https://github.com/facebookresearch/DPR) for some pre-trained DPR models (or, train your own!). Alternatively, you can specify a RAG or FiD model with DPR weights (perhaps, e.g., one from the ParlAI model zoo, such as `zoo:hallucination/bart_rag_token/model`).
 
 ### 1b. Train your own Dropout Poly-encoder
 
@@ -115,12 +115,12 @@ Check `/path/to/ParlAI/data/models/hallucination/wiki_passages/psgs_w100.tsv` fo
 Then, you can use the [`generate_dense_embeddings.py`](https://github.com/facebookresearch/ParlAI/blob/master/parlai/agents/rag/scripts/generate_dense_embeddings.py) script to run the following command:
 
 ```bash
-python generate_dense_embeddings.py -mf /path/to/dpr/model --dpr-model True \
+python generate_dense_embeddings.py --model-file /path/to/dpr/model --dpr-model True \
 --passages-file /path/to/passages --outfile /path/to/saved/embeddings \
 --shard-id <shard_id> --num-shards <num_shards> -bs <batchsize>
 ```
 
-The `--dpr-model True` flag signifies that the model file you are providing is a DPR model; if you use a Dropout Poly-encoder, set this to `False`. The script will generate embeddings with the DPR model for shard `<shard_id>` of the data, and save two files:
+If the provided `--model-file` is either a path to a DPR model or a path to a ParlAI RAG/FiD model, specify `--dpr-model True` so that the script can appropriately extract the DPR weights; if you use a Dropout Poly-encoder, set `--dpr-model` to `False`. The script will generate embeddings with the DPR model for shard `<shard_id>` of the data, and save two files:
 
 - `/path/to/saved/embeddings_<shard_id>`: The concatenated tensor of embeddings
 - `/path/to/saved/ids_<shard_id>`: The list of document ids that corresponds to these embeddings.

--- a/parlai/agents/rag/dpr.py
+++ b/parlai/agents/rag/dpr.py
@@ -203,13 +203,19 @@ class DPRModel(TransformerMemNetModel):
         try:
             # determine if loading a RAG model
             loaded_opt = Opt.load(f"{query_path}.opt")
-            if loaded_opt['model'] == 'rag' and loaded_opt['query_model'] in [
+            document_path = loaded_opt.get('dpr_model_file', document_path)
+            if loaded_opt['model'] in ['rag', 'fid'] and loaded_opt['query_model'] in [
                 'bert',
                 'bert_from_parlai_rag',
             ]:
                 query_model = 'bert_from_parlai_rag'
-            # document model is always frozen
-            document_path = loaded_opt.get('dpr_model_file', document_path)
+                if loaded_opt['model'] == 'fid':
+                    # document model is always frozen
+                    # but may be loading a FiD-RAG Model
+                    doc_loaded_opt = Opt.load(
+                        f"{modelzoo_path(opt['datapath'], document_path)}.opt"
+                    )
+                    document_path = doc_loaded_opt.get('dpr_model_file', document_path)
 
         except FileNotFoundError:
             pass


### PR DESCRIPTION
**Patch description**
#3868 pointed out a couple of current shortcomings in the custom embeddings generation process for RAG/FiD DPR Models.

1. If specifying a ParlAI RAG or FiD model, one needs to set `--dpr-model True`; this has been clarified in the README.
2. If specifying specifically a FiD-RAG model, we need to make sure that the document encoder is initialized appropriately (this was not correctly handled prior)


**Testing steps**
I tried running the provided command in #3868 with `--dpr-model True`, after the change, and it appears the script works correctly:

```
$ python parlai/agents/rag/scripts/generate_dense_embeddings.py -mf zoo:hallucination/bart_fid_rag/model --dpr-model true --passages-file data/models/hallucination/wow_passages/wow_articles.paragraphs.tsv --outfile /tmp/out --num-shards 1 --shard-id 0 -bs 32
17:12:05 | Overriding opt["model"] to dpr_agent (previously: fid)
17:12:05 | Overriding opt["interactive_candidates"] to inline (previously: fixed)
17:12:05 | Overriding opt["share_encoders"] to False (previously: True)
17:12:06 | Using CUDA
17:12:06 | DPR: full interactive mode on.
17:12:42 | Total parameters: 241,228,800 (240,442,368 trainable)
17:12:42 | Loading existing model parameters from /private/home/kshuster/ParlAI/data/models/hallucination/bart_fid_rag/model
17:12:49 | Loading data/models/hallucination/wow_passages/wow_articles.paragraphs.tsv
17:12:49 | Reading data from: data/models/hallucination/wow_passages/wow_articles.paragraphs.tsv
2863it [00:00, 105418.20it/s]
17:12:49 | Shard 0 of 1 encoding psg index 0 to 2862, out of 2862
17:12:51 | Encoded 320 out of 2862 passages
17:12:51 | Encoded 640 out of 2862 passages
17:12:52 | Encoded 960 out of 2862 passages
17:12:52 | Encoded 1280 out of 2862 passages
17:12:53 | Encoded 1600 out of 2862 passages
17:12:53 | Encoded 1920 out of 2862 passages
17:12:54 | Encoded 2240 out of 2862 passages
17:12:54 | Encoded 2560 out of 2862 passages
17:12:55 | Writing results to /tmp/out_0.pt
17:12:55 | Writing ids to /tmp/ids_0
```
