### PR TITLE
string preprocessing was not performed for 'labels:'

### DIFF
--- a/parlai/utils/misc.py
+++ b/parlai/utils/misc.py
@@ -645,8 +645,9 @@ def str_to_msg(txt, ignore_fields=''):
 
     def tolist(txt):
         vals = txt.split('|')
-        for v in vals:
+        for i, v in enumerate(vals):
             v = tostr(v)
+            vals[i] = v
         return vals
 
     def convert(key, value):


### PR DESCRIPTION
The current immplementation of tolist (used for 'labels:' and some others) calls tostr() on each label (separated by '|'), but does not store the result.

**Patch description**
One side effect of the bug: The (currently undocumented) ability to include multiple label fields by separating with a '|' character does not accept the '__PIPE__' replacement when a '|' character is required in the label.

**Testing steps**

```
> def tolist(txt):
      vals = txt.split('|')
      for v in vals:
          v = tostr(v)
      return vals
> def tostr(txt):
      txt = str(txt)
      txt = txt.replace('\\t', '\t')
      txt = txt.replace('\\n', '\n')
      txt = txt.replace('__PIPE__', '|')
      return txt
> tolist('this is one __PIPE__ two piece | string')
['this is one __PIPE__ two piece ', ' string']
> def tolist(txt):
      vals = txt.split('|')
      for i, v in enumerate(vals):
          v = tostr(v)
          vals[i] = v
      return vals
> tolist('this is one __PIPE__ two piece | string')
['this is one | two piece ', ' string']

```

**Other information**
<!-- Any other information or context you would like to provide. -->
