### PR TITLE
[crowdsourcing] Forcing mock to shutdown in test cleanup

### DIFF
--- a/parlai/crowdsourcing/utils/tests.py
+++ b/parlai/crowdsourcing/utils/tests.py
@@ -44,6 +44,7 @@ class AbstractCrowdsourcingTest:
         torch.manual_seed(0)
 
         self.operator = None
+        self.server = None
 
     def _teardown(self):
         """
@@ -54,6 +55,9 @@ class AbstractCrowdsourcingTest:
 
         if self.operator is not None:
             self.operator.force_shutdown()
+
+        if self.server is not None:
+            self.server.shutdown_mock()
 
     def _set_up_config(
         self,


### PR DESCRIPTION
**Patch description**
Adding a blocking forced shutdown for the Mephisto mock server to the cleanup of Mephisto-based testing. Attempts to ensure that the system doesn't hang indefinitely if a test fails and shutdown is unsuccessful.

**Testing steps**
Ran crowdsourcing tests locally 50 times. Ended up with a few failures, but none left pytest hanging.