### PR TITLE
Repo-wide spelling corrections

### DIFF
--- a/docs/source/tutorial_basic.md
+++ b/docs/source/tutorial_basic.md
@@ -75,7 +75,7 @@ step.
 Messages are what we call the objects both observed by an agent
 (observations) and returned by an agent's act function (actions). These
 observations and actions are the primary way agents in ParlAI
-communicate with each other within their enviroment. The Message object
+communicate with each other within their environment. The Message object
 is a subclass of a python dict, whose key function is to prevent users
 from editing fields in an action or observation unintentionally.
 

--- a/docs/source/tutorial_crowdsourcing.md
+++ b/docs/source/tutorial_crowdsourcing.md
@@ -82,7 +82,7 @@ You may need to create your own `run.py` file with which to launch your script i
 
 You will also likely need to create the following helper files for your task:
 
-- `conf/example.yaml`: the file of Hydra parameter values that are set by your task by default when lauching `run.py`. The parameter values in this file should be set so as to easily demonstrate the basic functionality of your task without requiring additional configuration steps.
+- `conf/example.yaml`: the file of Hydra parameter values that are set by your task by default when launching `run.py`. The parameter values in this file should be set so as to easily demonstrate the basic functionality of your task without requiring additional configuration steps.
 - `task_config/`: the standard folder in which useful configuration files are stored, such as for specifying UI text, configuring models, providing sample onboarding parameters, etc.
 
 A few things to keep in mind:

--- a/docs/source/tutorial_metrics.md
+++ b/docs/source/tutorial_metrics.md
@@ -63,7 +63,7 @@ statements into your code.
 Some agents include their own metrics that are computed for them. For example,
 generative models automatically compute `ppl`
 ([perplexity](https://en.wikipedia.org/wiki/Perplexity)) and `token_acc`, both
-which measure the generative model's ability to predict indivdual tokens.  As
+which measure the generative model's ability to predict individual tokens.  As
 an example, let's evaluate the [BlenderBot](https://parl.ai/projects/recipes/)
 90M model on DailyDialog:
 

--- a/docs/source/tutorial_task.md
+++ b/docs/source/tutorial_task.md
@@ -490,7 +490,7 @@ your chunk data.
 
 In this case, one would inherit from the Teacher class. For this class,
 at least the `act()` method and probably the `observe()` method must be
-overriden. Quite a bit of functinoality will not be built in, such as a
+overridden. Quite a bit of functinoality will not be built in, such as a
 support for hogwild and batching, but metrics will be set up and can be
 used to track stats like the number of correctly answered examples.
 

--- a/parlai/agents/bart/convert_fairseq_to_parlai.py
+++ b/parlai/agents/bart/convert_fairseq_to_parlai.py
@@ -146,7 +146,7 @@ class ConversionScript(ParlaiScript):
         :return opt:
             opt parsed by ParlAI Parser
         """
-        # assume encoder/decoder symetrical except for number of layers
+        # assume encoder/decoder symmetrical except for number of layers
         state = self.state
         fairseq_args = state['args'].__dict__
 

--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -284,7 +284,7 @@ class SearchQuerySearchEngineFiDAgent(SearchQueryFiDAgent):
     def add_cmdline_args(cls, parser, partial_opt=None):
         super().add_cmdline_args(parser, partial_opt=partial_opt)
         group = parser.add_argument_group('Search Engine FiD Params')
-        group.add_argument('--search-server', type=str, help='A search server addrees.')
+        group.add_argument('--search-server', type=str, help='A search server address.')
         return parser
 
 

--- a/parlai/agents/hred/modules.py
+++ b/parlai/agents/hred/modules.py
@@ -293,7 +293,7 @@ class HredDecoder(nn.Module):
         seqlen = xs.size(1)
         xes = self.dropout(self.lt(xs))
 
-        # concatentate context lstm hidden state
+        # concatenate context lstm hidden state
         context_hidden_final_layer = context_hidden[:, -1, :].unsqueeze(1)
         resized_context_h = context_hidden_final_layer.expand(-1, seqlen, -1)
         xes = torch.cat((xes, resized_context_h), dim=-1).to(xes.device)

--- a/parlai/agents/hugging_face/dialogpt.py
+++ b/parlai/agents/hugging_face/dialogpt.py
@@ -117,7 +117,7 @@ class DialogptAgent(Gpt2Agent):
         """
         Return the dictionary class that this agent expects to use.
 
-        Can be overriden if a more complex dictionary is required.
+        Can be overridden if a more complex dictionary is required.
         """
         return DialoGPTDictionaryAgent
 

--- a/parlai/agents/hugging_face/dict.py
+++ b/parlai/agents/hugging_face/dict.py
@@ -172,7 +172,7 @@ class Gpt2DictionaryAgent(HuggingFaceDictionaryAgent):
 
     def _define_special_tokens(self, opt):
         if opt["add_special_tokens"]:
-            # Add addtional start/end/pad tokens
+            # Add additional start/end/pad tokens
             self.hf_tokenizer.add_special_tokens(SPECIAL_TOKENS)
             self.start_token = SPECIAL_TOKENS["bos_token"]
             self.end_token = SPECIAL_TOKENS["eos_token"]

--- a/parlai/agents/hugging_face/gpt2.py
+++ b/parlai/agents/hugging_face/gpt2.py
@@ -299,7 +299,7 @@ class Gpt2Agent(TorchGeneratorAgent):
         """
         Return the dictionary class that this agent expects to use.
 
-        Can be overriden if a more complex dictionary is required.
+        Can be overridden if a more complex dictionary is required.
         """
         return Gpt2DictionaryAgent
 

--- a/parlai/agents/ir_baseline/ir_baseline.py
+++ b/parlai/agents/ir_baseline/ir_baseline.py
@@ -16,7 +16,7 @@ Given an input message, either:
 
 Currently only (iii) is used.
 
-Additonally, TFIDF is either used (requires building a dictionary) or not,
+Additionally, TFIDF is either used (requires building a dictionary) or not,
 depending on whether you train on the train set first, or not.
 """
 

--- a/parlai/agents/rag/dpr.py
+++ b/parlai/agents/rag/dpr.py
@@ -98,7 +98,7 @@ class DprEncoder(TransformerEncoder):
         )  # type: ignore
         if not os.path.exists(pretrained_path):
             # when initializing from parlai rag models, the pretrained path
-            # may not longer exist. This is fine if we've alread trained
+            # may not longer exist. This is fine if we've already trained
             # the model.
             assert dpr_model == 'bert_from_parlai_rag'
             logging.error(f'Pretrained Path does not exist: {pretrained_path}')

--- a/parlai/agents/rag/indexers.py
+++ b/parlai/agents/rag/indexers.py
@@ -6,7 +6,7 @@
 """
 FAISS-based Indexers.
 
-Adapated from https://github.com/facebookresearch/DPR/blob/master/dpr/indexer/faiss_indexers.py
+Adapted from https://github.com/facebookresearch/DPR/blob/master/dpr/indexer/faiss_indexers.py
 """
 from parlai.core.build_data import modelzoo_path
 from parlai.core.opt import Opt

--- a/parlai/agents/rag/model_types.py
+++ b/parlai/agents/rag/model_types.py
@@ -267,7 +267,7 @@ class RagSequence(RagModelInterface):
 
     def get_initial_decoder_input(self, input: torch.LongTensor) -> torch.LongTensor:
         """
-        Don't repeat decoder input for rag seqeunce.
+        Don't repeat decoder input for rag sequence.
         """
         return input
 

--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -664,7 +664,7 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
         n_best_beam_preds_scores: List[List[Tuple[torch.LongTensor, torch.Tensor]]],
     ) -> List[List[Tuple[torch.LongTensor, torch.Tensor]]]:
         """
-        Optionall rerank beams, according to RAG Model type.
+        Optional rerank beams, according to RAG Model type.
 
         :param batch:
             current batch

--- a/parlai/agents/rag/retrieve_api.py
+++ b/parlai/agents/rag/retrieve_api.py
@@ -75,7 +75,7 @@ class SearchEngineRetriever(RetrieverAPI):
     Queries a server (eg, search engine) for a set of documents.
 
     This module relies on a running HTTP server. For each retrieval it sends the query
-    to this server and receieves a JSON; it parses the JSON to create the the response.
+    to this server and receives a JSON; it parses the JSON to create the the response.
     """
 
     def __init__(self, opt: Opt):

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -1136,7 +1136,7 @@ class SearchQuerySearchEngineRetriever(SearchQueryRetriever):
 
     def _empty_docs(self, num: int):
         """
-        Generates the requsted number of empty documents.
+        Generates the requested number of empty documents.
         """
         return [BLANK_SEARCH_DOC for _ in range(num)]
 
@@ -1230,9 +1230,9 @@ class SearchQueryFAISSIndexRetriever(SearchQueryRetriever, DPRRetriever):
         Retrieves from the FAISS index using a search query.
 
         This methods relies on the `retrieve_and_score` method in `RagRetriever`
-        ancestor class. It recieve the query (conversation context) and generatess the
+        ancestor class. It receive the query (conversation context) and generatess the
         search term queries based on them. Then uses those search quries (instead of the
-        the query text itself) to retrive from the FAISS index.
+        the query text itself) to retrieve from the FAISS index.
         """
 
         search_queries = self.generate_search_query(query)
@@ -1250,7 +1250,7 @@ class SearchQueryFAISSIndexRetriever(SearchQueryRetriever, DPRRetriever):
 
 class DocumentChunkRanker:
     """
-    Base class for controling splitting long documents and selecting relevant chunks.
+    Base class for controlling splitting long documents and selecting relevant chunks.
     """
 
     def __init__(self, n_retrieved_chunks):

--- a/parlai/agents/seq2seq/seq2seq.py
+++ b/parlai/agents/seq2seq/seq2seq.py
@@ -215,7 +215,7 @@ class Seq2seqAgent(TorchGeneratorAgent):
         """
         Get the model states for saving.
 
-        Overriden to include longest_label
+        Overridden to include longest_label
         """
         states = super().state_dict()
         if hasattr(self.model, 'module'):

--- a/parlai/agents/starspace/starspace.py
+++ b/parlai/agents/starspace/starspace.py
@@ -285,7 +285,7 @@ class StarspaceAgent(Agent):
         """
         Set overridable opts from loaded opt file.
 
-        Print out each added key and each overriden key. Only override args specific to
+        Print out each added key and each overridden key. Only override args specific to
         the model.
         """
         model_args = {'embeddingsize', 'optimizer'}
@@ -432,7 +432,7 @@ class StarspaceAgent(Agent):
                     xe, ye = self.model(xs, ys, self.fixedCands)
                     self.fixedX = ye
                 else:
-                    # fixed candidate embed vectors are cached, dont't recompute
+                    # fixed candidate embed vectors are cached, don't recompute
                     blah = torch.LongTensor([1])
                     xe, ye = self.model(xs, ys, [blah])
                     ye = self.fixedX
@@ -440,7 +440,7 @@ class StarspaceAgent(Agent):
                 # test set prediction uses candidates
                 xe, ye = self.model(xs, ys, cands[0])
             pred = nn.CosineSimilarity().forward(xe, ye)
-            # This is somewhat costly which we could avoid if we do not evalute ranking.
+            # This is somewhat costly which we could avoid if we do not evaluate ranking.
             # i.e. by only doing: val,ind = pred.max(0)
             val, ind = pred.sort(descending=True)
             # predict the highest scoring candidate, and return it.

--- a/parlai/agents/tfidf_retriever/build_tfidf.py
+++ b/parlai/agents/tfidf_retriever/build_tfidf.py
@@ -82,7 +82,7 @@ def count_text(ngram, hash_size, doc_id, text=None):
     # Get ngrams from tokens, with stopword/punctuation filtering.
     ngrams = tokens.ngrams(n=ngram, uncased=True, filter_fn=utils.filter_ngram)
 
-    # Hash ngrams and count occurences
+    # Hash ngrams and count occurrences
     counts = Counter([utils.hash(gram, hash_size) for gram in ngrams])
 
     # Return in sparse matrix data format.
@@ -162,7 +162,7 @@ def get_tfidf_matrix(cnts):
     tfidf = log(tf + 1) * log((N - Nt + 0.5) / (Nt + 0.5))
     * tf = term frequency in document
     * N = number of documents
-    * Nt = number of occurences of term in all documents
+    * Nt = number of occurrences of term in all documents
     """
     Nt = get_doc_freqs(cnts)
     idfs = np.log((cnts.shape[1] - Nt + 0.5) / (Nt + 0.5))

--- a/parlai/agents/transformer/modules/decoder.py
+++ b/parlai/agents/transformer/modules/decoder.py
@@ -306,11 +306,11 @@ class TransformerDecoder(nn.Module):
             The target input IDs
         :param LongTensor[batch, seqlen] positions:
             Positions for input IDs. If None, computes defaults.
-        :param LongTensor[batch, seqlen] segements:
+        :param LongTensor[batch, seqlen] segments:
             Segment IDs for extra embedding features. If None, not used.
 
         :return (tensor, mask):
-            embeded input and mask
+            embedded input and mask
         """
         tensor = self.embeddings(input)
         if self.embeddings_scale:

--- a/parlai/agents/transformer/transformer.py
+++ b/parlai/agents/transformer/transformer.py
@@ -126,14 +126,14 @@ def add_common_cmdline_args(parser):
         '--n-encoder-layers',
         type=int,
         default=-1,
-        help='This will overide the n-layers for asymmetrical transformers',
+        help='This will overidde the n-layers for asymmetrical transformers',
     )
     parser.add_argument(
         '-ndl',
         '--n-decoder-layers',
         type=int,
         default=-1,
-        help='This will overide the n-layers for asymmetrical transformers',
+        help='This will overidde the n-layers for asymmetrical transformers',
     )
     parser.add_argument(
         '--model-parallel',

--- a/parlai/chat_service/services/messenger/messenger_manager.py
+++ b/parlai/chat_service/services/messenger/messenger_manager.py
@@ -94,7 +94,7 @@ class MessengerManager(ChatServiceManager):
         """
         Mark the agent as removed from the pool.
 
-        Can be overriden to change other metadata linked to agent removal.
+        Can be overridden to change other metadata linked to agent removal.
 
         :param agent_id:
             int agent psid
@@ -116,7 +116,7 @@ class MessengerManager(ChatServiceManager):
 
     def _handle_message_read(self, event):
         # If the message was sent by another user (as in during a conversation)
-        # then we need to propogate the read back to that user.
+        # then we need to propagate the read back to that user.
         self._log_debug('Messages {} marked as read.'.format(event['read']))
         super()._handle_message_read(event)
 
@@ -157,7 +157,7 @@ class MessengerManager(ChatServiceManager):
 
     def _log_missing_agent(self, agent_id, assignment_id):
         """
-        Log the occurence of a missing agent.
+        Log the occurrence of a missing agent.
         """
         log_utils.print_and_log(
             logging.WARN,
@@ -190,7 +190,7 @@ class MessengerManager(ChatServiceManager):
                 logging.INFO,
                 'In order to run the server locally, you will need '
                 'to have a public HTTPS endpoint (SSL signed) running on '
-                'the server you are currently excecuting ParlAI on. Enter '
+                'the server you are currently executing ParlAI on. Enter '
                 'that public URL hostname when prompted and ensure that the '
                 'port being used by ParlAI (usually 3000) has external '
                 'traffic routed to it.',

--- a/parlai/core/agents.py
+++ b/parlai/core/agents.py
@@ -167,7 +167,7 @@ class Agent(object):
             A string for the 'text' field or a message which MUST
             comprise of the 'text' field apart from other fields.
         :param kwargs other_message_fields:
-            Provide fields for the message in the form of keyowrd arguments.
+            Provide fields for the message in the form of keyword arguments.
         :return:
             Agent's response to the message.
         :rtype:

--- a/parlai/core/mutators.py
+++ b/parlai/core/mutators.py
@@ -192,7 +192,7 @@ class EpisodeMutator(Mutator):
     @abc.abstractmethod
     def episode_mutation(self, episode: List[Message]) -> List[Message]:
         """
-        Abstract epsiode mutation.
+        Abstract episode mutation.
 
         The main method to implement when implementing an EpisodeMutator.
 

--- a/parlai/core/opt.py
+++ b/parlai/core/opt.py
@@ -23,7 +23,7 @@ from typing import List
 from parlai.utils.io import PathManager
 
 # these keys are automatically removed upon save. This is a rather blunt hammer.
-# It's preferred you indicate this at option definiton time.
+# It's preferred you indicate this at option definition time.
 __AUTOCLEAN_KEYS__: List[str] = [
     "override",
     "batchindex",

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -499,13 +499,13 @@ class FixedDialogTeacher(Teacher):
         """
         Get the number of episodes in this dataset.
         """
-        raise RuntimeError('"num_episodes" must be overriden by children.')
+        raise RuntimeError('"num_episodes" must be overridden by children.')
 
     def num_examples(self) -> int:
         """
         Get the total number of examples in this dataset.
         """
-        raise RuntimeError('"num_examples" must be overriden by children.')
+        raise RuntimeError('"num_examples" must be overridden by children.')
 
     def get(self, episode_idx, entry_idx=0):
         """
@@ -521,7 +521,7 @@ class FixedDialogTeacher(Teacher):
             single-entry episodes, so this defaults to zero.
         """
         # TODO: mark as abstract, get rid of runtime error.
-        raise RuntimeError('"Get" method must be overriden by children.')
+        raise RuntimeError('"Get" method must be overridden by children.')
 
     def observe(self, observation):
         """
@@ -680,7 +680,7 @@ class DialogTeacher(FixedDialogTeacher):
         new episodes.
 
         :param str datafile:
-            If the initializer set a 'datafile' field within the initalization,
+            If the initializer set a 'datafile' field within the initialization,
             this will be provided here. Otherwise, datafile will be the fold:
             either "train", "valid", or "test".
 
@@ -713,7 +713,7 @@ class DialogTeacher(FixedDialogTeacher):
         """
         Provide consistent label candidates for all examples.
 
-        Default implementation returns ``None`` always, but this may be overriden to
+        Default implementation returns ``None`` always, but this may be overridden to
         provide candidates in all areas. See ``FbDialogueTeacher``.
         """
         # TODO DEPRECATIONDAY: FbDialogueTeacher is being deprecated, should we
@@ -1271,7 +1271,7 @@ class FbDeprecatedDialogTeacher(DialogTeacher):
 
     def share(self):
         """
-        Share the data and canidates.
+        Share the data and candidates.
         """
         shared = super().share()
         shared['cands'] = self.cands
@@ -1784,7 +1784,7 @@ class AbstractImageTeacher(FixedDialogTeacher):
         # avoid calculating image features twice.
         self.image_mode = opt.get('image_mode')
 
-        # Not using default image_mode paramater b/c there is a normalization
+        # Not using default image_mode parameter b/c there is a normalization
         # (or bug) somewhere in build_dict that is setting it to none
         self.include_image = opt.get('image_mode') != 'no_image_model'
 
@@ -1923,7 +1923,7 @@ class AbstractImageTeacher(FixedDialogTeacher):
         """
         Image features for the dataset images are stored here.
 
-        Can be overriden in subclass to use custom paths. Image features can be manually
+        Can be overridden in subclass to use custom paths. Image features can be manually
         copied into this directory or in the case of ImageLoader eligible models, they
         will be built and stored here if not already there.
         """
@@ -1942,7 +1942,7 @@ class AbstractImageTeacher(FixedDialogTeacher):
 
         Users may wish to compute features for the dataset offline and use in the model,
         in which case, the image model should return False and get_image_features()
-        should be overriden in subclass.
+        should be overridden in subclass.
         """
         return model_name in ImageLoader.get_available_model_names()
 
@@ -1984,7 +1984,7 @@ class AbstractImageTeacher(FixedDialogTeacher):
         Load text and image data.
 
         The image features all live in dicts by default in <data_path>/
-        image_features/ but get_image_features_path() above can be overriden by
+        image_features/ but get_image_features_path() above can be overridden by
         subclass to put them elsewhere.
 
         In the (very odd) case that the resnet or resnext dicts (models
@@ -2079,7 +2079,7 @@ class AbstractImageTeacher(FixedDialogTeacher):
         """
         Get image features for example.
 
-        Can be overrided in subclass for different behavior. For large datasets, it may
+        Can be overridden in subclass for different behavior. For large datasets, it may
         be more appropriate to use the ImageLoader.load() method to load image features
         (as this is essentially streaming the features from disk, so that we do not have
         to load a large image feature dict in memory). #TODO Could be the default option

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -467,7 +467,7 @@ class TorchAgent(ABC, Agent):
         """
         Return the dictionary class that this agent expects to use.
 
-        Can be overriden if a more complex dictionary is required.
+        Can be overridden if a more complex dictionary is required.
         """
         return DictionaryAgent
 
@@ -476,7 +476,7 @@ class TorchAgent(ABC, Agent):
         """
         Return the history class that this agent expects to use.
 
-        Can be overriden if a more complex history is required.
+        Can be overridden if a more complex history is required.
         """
         return History
 
@@ -779,7 +779,7 @@ class TorchAgent(ABC, Agent):
             self.fp16_impl = self.opt.get('fp16_impl', 'safe')
 
         if shared is None:
-            # intitialize any important structures from scratch
+            # intialize any important structures from scratch
             self.dict = self.build_dictionary()
 
             if opt.get('fp16') or opt.get('force_fp16_tokens'):
@@ -1644,7 +1644,7 @@ class TorchAgent(ABC, Agent):
         Returns a namedtuple Batch. See original definition above for in-depth
         explanation of each field.
 
-        If you want to include additonal fields in the batch, you can subclass
+        If you want to include additional fields in the batch, you can subclass
         this function and return your own "Batch" namedtuple: copy the Batch
         namedtuple at the top of this class, and then add whatever additional
         fields that you want to be able to access. You can then call
@@ -1813,7 +1813,7 @@ class TorchAgent(ABC, Agent):
         between the original history and the temporary history. If you require
         such delimiter or spacing, you should include it in the temp history.
 
-        Intentionally overrideable so more complex models can insert temporary history
+        Intentionally overridable so more complex models can insert temporary history
         strings, i.e. strings that are removed from the history after a single turn.
         """
         return observation.get('temp_history')
@@ -2306,7 +2306,7 @@ class TorchAgent(ABC, Agent):
             self._number_grad_accum = (self._number_grad_accum + 1) % update_freq
 
             # we're doing gradient accumulation, so we don't need to sync gradients
-            # amoung GPUs
+            # among GPUs
             if self._number_grad_accum != 0 and is_distributed():
                 # accumulate without syncing
                 with self.model.no_sync():

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -593,7 +593,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
 
     def _fake_forward_backward_pass(self):
         """
-        Force a worker to syncronize with others in case of distributed mode.
+        Force a worker to synchronize with others in case of distributed mode.
 
         Necessary during recovery of OOMs to prevent hangs during the all-reduce of
         gradients.

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -29,7 +29,7 @@ All worlds are initialized with the following parameters:
     ``agents`` -- the set of agents that should be attached to the world,
         e.g. for DialogPartnerWorld this could be the teacher (that defines the
         task/dataset) and the learner agent. This is ignored in the case of
-        sharing, and the shared parameter is used instead to initalize agents.
+        sharing, and the shared parameter is used instead to initialize agents.
     ``shared`` (optional) -- if not None, contains any shared data used to construct
         this particular instantiation of the world. This data might have been
         initialized by another world, so that different agents can share the same

--- a/parlai/crowdsourcing/tasks/acute_eval/fast_eval.py
+++ b/parlai/crowdsourcing/tasks/acute_eval/fast_eval.py
@@ -123,7 +123,7 @@ class FastAcuteExecutor(object):
             and self.fast_acute_args.model_pairs is None
         ):
             raise RuntimeError(
-                'Either models or model-pairs should be set for comparision.'
+                'Either models or model-pairs should be set for comparison.'
             )
         if self.fast_acute_args.model_pairs is not None:
             model_pairs = self.fast_acute_args.model_pairs.split(',')

--- a/parlai/crowdsourcing/utils/worlds.py
+++ b/parlai/crowdsourcing/utils/worlds.py
@@ -20,7 +20,7 @@ class CrowdDataWorld(World):
     def get_custom_task_data(self):
         """
         This function should take the contents of whatever was collected during this
-        task that should be saved and return it in some format, preferrably a dict
+        task that should be saved and return it in some format, preferably a dict
         containing acts.
 
         If you need some extraordinary data storage that this doesn't cover, you can

--- a/parlai/mutators/flatten.py
+++ b/parlai/mutators/flatten.py
@@ -15,7 +15,7 @@ class FlattenMutator(ManyEpisodeMutator):
     """
     Flattens the entire conversation history.
 
-    Simply concatentates all turns in the conversation with a newline. Frequently useful
+    Simply concatenates all turns in the conversation with a newline. Frequently useful
     when composed with other mutators.
     """
 

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -243,7 +243,7 @@ def eval_model(opt):
         dict(zip(tasks, reports)), micro_average=opt.get('aggregate_micro', False)
     )
 
-    # print announcments and report
+    # print announcements and report
     print_announcements(opt)
     logging.info(
         f'Finished evaluating tasks {tasks} using datatype {opt.get("datatype")}'

--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -463,7 +463,7 @@ class ContextGenerator:
 
     def __init__(self, opt, datatype: str = 'train', seed: Optional[int] = None):
         """
-        Initalize the context generator.
+        Initialize the context generator.
 
         opt: only a 'datapath' key is required, to specify the ParlAI data folder
         """

--- a/parlai/tasks/commonsenseqa/agents.py
+++ b/parlai/tasks/commonsenseqa/agents.py
@@ -13,7 +13,7 @@ import json
 
 class CommonSenseQATeacher(FixedDialogTeacher):
     """
-    CommonSenseQA is a multiple-choice Q-A dataset that relies on commonsense knowlegde
+    CommonSenseQA is a multiple-choice Q-A dataset that relies on commonsense knowledge
     to predict correct answers. More information found at:
 
     <https://www.tau-nlp.org/commonsenseqa>.

--- a/parlai/tasks/dialogue_safety/agents.py
+++ b/parlai/tasks/dialogue_safety/agents.py
@@ -296,7 +296,7 @@ class WikiToxicCommentsTeacher(FixedDialogTeacher):
             total_data.loc[total_data['sensitive'] < 1, 'is_sensitive'] = 0
             total_data.loc[total_data['sensitive'] >= 1, 'is_sensitive'] = 1
 
-            # Drop unecessary column
+            # Drop unnecessary column
             total_data = total_data.drop(columns=['id'])
 
             self.data_to_json(total_data, 'wiki-toxic-comments-default.json')

--- a/parlai/tasks/light_dialog_wild/agents.py
+++ b/parlai/tasks/light_dialog_wild/agents.py
@@ -392,7 +392,7 @@ class ReversedTeacher(DefaultTeacher):
             '--light-hard-max-length-cap',
             type='bool',
             default=False,
-            help="if specificed, conversation max length is a hard cap - that is, "
+            help="if specified, conversation max length is a hard cap - that is, "
             "any conversations greater than --light-max-conv-length will be "
             "removed completely",
         )

--- a/parlai/tasks/msc/agents.py
+++ b/parlai/tasks/msc/agents.py
@@ -199,7 +199,7 @@ class SessionBaseMscTeacher(DialogTeacher):
             '--session-openning',
             type=bool,
             default=False,
-            help="whether to only include session openning or not",
+            help="whether to only include session opening or not",
         )
         agent.add_argument(
             '--label-speaker-id',

--- a/parlai/tasks/natural_questions/utils/text_utils.py
+++ b/parlai/tasks/natural_questions/utils/text_utils.py
@@ -7,7 +7,7 @@
 ##########################################################################
 #
 #  Note:  this file is mostly copied from the utility functions provided
-#         with the the datatset itself. For more information check
+#         with the the dataset itself. For more information check
 #         the original repository, linked blow:
 #   https://github.com/google-research-datasets/natural-questions
 #
@@ -94,7 +94,7 @@ def simplify_nq_example(nq_example):
     r"""Returns dictionary with blank separated tokens in `document_text` field.
 
     Removes byte offsets from annotations, and removes `document_html` and
-    `document_tokens` fields. All annotations in the ouput are represented as
+    `document_tokens` fields. All annotations in the output are represented as
     [start_token, end_token) offsets into the blank separated tokens in the
     `document_text` field.
 

--- a/parlai/tasks/wizard_of_internet/agents.py
+++ b/parlai/tasks/wizard_of_internet/agents.py
@@ -176,7 +176,7 @@ class WizardOfInternetBaseTeacher(DialogTeacher):
             d = {CONST.PERSONA: persona, CONST.TOTAL_CONVERSATION_INDEX: msg_ind}
             action = message[CONST.ACTION]
 
-            # Seperating the actions
+            # Separating the actions
             if action == CONST.ACTION_APPRENTICE_TO_WIZARD:
                 d.update(parse_apprentice_message(message))
             elif action == CONST.ACTION_WIZARD_TO_APPRENTICE:

--- a/parlai/tasks/woz/README.md
+++ b/parlai/tasks/woz/README.md
@@ -1,6 +1,6 @@
-Task: WOZ restuarant reservation (Goal-Oriented Dialogue)
+Task: WOZ restaurant reservation (Goal-Oriented Dialogue)
 ==========================================================
-Description: Dataset containing dialogues dengotiating a resturant reservation. Implemented as part of the DecaNLP task, focused on the change in the dialogue state. Original paper: https://arxiv.org/abs/1604.04562
+Description: Dataset containing dialogues dengotiating a restaurant reservation. Implemented as part of the DecaNLP task, focused on the change in the dialogue state. Original paper: https://arxiv.org/abs/1604.04562
 
 Tags: #woz, #All, #decanlp
 

--- a/parlai/utils/bpe.py
+++ b/parlai/utils/bpe.py
@@ -222,7 +222,7 @@ class BPEHelper(ABC):
                 left = self.helper_decode(tokens[:i], token_ids[:i], delimiter)
                 # token itself is easy to map to a string
                 center = token
-                # to the right, there may stil be special tokens
+                # to the right, there may still be special tokens
                 right = self.decode(
                     tokens[min(len(token_ids), i + 1) :],
                     token_ids[min(len(token_ids), i + 1) :],
@@ -597,7 +597,7 @@ class Gpt2BpeHelper(BPEHelper):
         The reversible bpe codes work on unicode strings. This means you need a large #
         of unicode characters in your vocab if you want to avoid UNKs. When you're at
         something like a 10B token dataset you end up needing around 5K for decent
-        coverage. This is a signficant percentage of your normal, say, 32K bpe vocab. To
+        coverage. This is a significant percentage of your normal, say, 32K bpe vocab. To
         avoid that, we want lookup tables between utf-8 bytes and unicode strings. And
         avoids mapping to whitespace/control characters the bpe code barfs on.
         """

--- a/parlai/utils/pickle.py
+++ b/parlai/utils/pickle.py
@@ -8,7 +8,7 @@
 ParlAI's custom unpickler.
 
 As modules move around or are renamed, it old torch model files become invalid,
-since they look for modules in all the wrong places. Furthermore, we occassionally
+since they look for modules in all the wrong places. Furthermore, we occasionally
 use APEX for performance reasons, but we don't want to outright die if the user
 has not installed it.
 

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1014,7 +1014,7 @@ model_list = [
         "path": "zoo:tutorial_transformer_generator/model",
         "task": "pushshift.io",
         "description": (
-            "Small (87M paramter) generative transformer, pretrained on pushshift.io Reddit."
+            "Small (87M parameter) generative transformer, pretrained on pushshift.io Reddit."
         ),
         "example": "parlai interactive -mf zoo:tutorial_transformer_generator/model",
         "external_website": '',

--- a/projects/blenderbot2/README.md
+++ b/projects/blenderbot2/README.md
@@ -65,7 +65,7 @@ BART     | 400M        | WizInt search engine FiD (Bing)         | 76.1 | 5.3 | 
 
 ### Safety 
 
-We add extra safety into our models, by a baked-in method: during generation, we train the model such that a generated unsafe reponse has the special token _\_POTENTIALLY_UNSAFE\__ appended to the end of the generation. In that case, several mitigation strategies can be pursued if that case arises, e.g. a safe response. See our [safety recipes paper](https://parl.ai/projects/safety_recipes) for an in depth discussion and analysis.
+We add extra safety into our models, by a baked-in method: during generation, we train the model such that a generated unsafe response has the special token _\_POTENTIALLY_UNSAFE\__ appended to the end of the generation. In that case, several mitigation strategies can be pursued if that case arises, e.g. a safe response. See our [safety recipes paper](https://parl.ai/projects/safety_recipes) for an in depth discussion and analysis.
 
 We also follow the recent paper on [Anticipating Safety Issues in E2E Conversational AI: Framework and Tooling](https://parl.ai/projects/safety_bench) and use 
 their safety evaluation framework to evaluate our models.

--- a/projects/blenderbot2/agents/modules.py
+++ b/projects/blenderbot2/agents/modules.py
@@ -856,7 +856,7 @@ class BB2SearchQuerySearchEngineRetriever(
     BB2SearchRetrieverMixin, SearchQuerySearchEngineRetriever
 ):
     """
-    Override Search Engine Retriever to accomodate SQ Generator from BB2 Setup.
+    Override Search Engine Retriever to accommodate SQ Generator from BB2 Setup.
     """
 
 
@@ -864,5 +864,5 @@ class BB2SearchQueryFaissIndexRetriever(
     BB2SearchRetrieverMixin, SearchQueryFAISSIndexRetriever
 ):
     """
-    Override Search Engine Retriever to accomodate SQ Generator from BB2 Setup.
+    Override Search Engine Retriever to accommodate SQ Generator from BB2 Setup.
     """

--- a/projects/image_chat/transresnet_multimodal/transresnet_multimodal.py
+++ b/projects/image_chat/transresnet_multimodal/transresnet_multimodal.py
@@ -56,7 +56,7 @@ class TransresnetMultimodalAgent(TransresnetAgent):
             default=None,
             help="for use in other tasks where no personality "
             "is given. This will give the model a personality "
-            "(whichever is specifed).",
+            "(whichever is specified).",
         )
         parser.add_argument(
             "--personalities-path",
@@ -349,7 +349,7 @@ class TransresnetMultimodalAgent(TransresnetAgent):
         """
         Update Metrics.
 
-        Overriden to include dialogue round
+        Overridden to include dialogue round
 
         :param loss:
             float loss

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -289,7 +289,7 @@ class TestByteLevelBPE(unittest.TestCase):
             [agent.tok2ind[w] for w in BYTELEVEL_BPE_RESULT],
         )
         # Test special token ids are mapped correctly:
-        # 4 special tokens are added in ParlAI dict in the begining and at the
+        # 4 special tokens are added in ParlAI dict in the beginning and at the
         # end for Hugging Face null token would be 0 in ParlAI dict and
         # original_vocab in Hugging Face
         assert agent.txt2vec("__null__") == [0]

--- a/tests/test_ta_inheritence.py
+++ b/tests/test_ta_inheritence.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-Inheritence around add_cmdline_args can be tricky.
+Inheritance around add_cmdline_args can be tricky.
 
 This serves as an example, and verifies inheritence is behaving correctly.
 """


### PR DESCRIPTION
**Patch description**
fix typo spelling grammar, and replace word with reference from [Merriam webster](https://www.merriam-webster.com/) and [Wiktionary](https://www.wiktionary.org/)

**Testing steps**
testing not include because just replace the typo with the correct one

**Other information**
testing on local testing