### PR TITLE
Update retrievers and readme in RAG

### DIFF
--- a/parlai/agents/rag/README.md
+++ b/parlai/agents/rag/README.md
@@ -133,6 +133,8 @@ python generate_dense_embeddings.py -mf zoo:hallucination/multiset_dpr/hf_bert_b
 --outfile /tmp/wiki_passage_embeddings/wiki_passages --num-shards 50 --shard-id 0 -bs 32
 ```
 
+Note `--num-shards` should be a [small value](https://github.com/facebookresearch/ParlAI/blob/master/parlai/agents/rag/retrievers.py#L644) if the passages file only has a few entries; otherwise it may raise the `NaN` error when the number of retrieved passages, i.e., `--n-docs,` is a large value.
+
 ### 3. Index the Dense Embeddings
 
 The final step is to build the full FAISS index from these dense embeddings. You can use the [`index_dense_embeddings.py`](https://github.com/facebookresearch/ParlAI/blob/master/parlai/agents/rag/scripts/index_dense_embeddings.py) script to achieve this. You can choose one of the following options when indexing your embeddings for varying results, depending on the size of your dataset:

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -1135,7 +1135,7 @@ class SearchQuerySearchEngineRetriever(SearchQueryRetriever):
 
     def _empty_docs(self, num: int):
         """
-        Generates the requsted number of empty documents.
+        Generates the requested number of empty documents.
         """
         return [BLANK_SEARCH_DOC for _ in range(num)]
 
@@ -1229,9 +1229,9 @@ class SearchQueryFAISSIndexRetriever(SearchQueryRetriever, DPRRetriever):
         Retrieves from the FAISS index using a search query.
 
         This methods relies on the `retrieve_and_score` method in `RagRetriever`
-        ancestor class. It recieve the query (conversation context) and generatess the
+        ancestor class. It receive the query (conversation context) and generatess the
         search term queries based on them. Then uses those search quries (instead of the
-        the query text itself) to retrive from the FAISS index.
+        the query text itself) to retrieve from the FAISS index.
         """
 
         search_queries = self.generate_search_query(query)
@@ -1249,7 +1249,7 @@ class SearchQueryFAISSIndexRetriever(SearchQueryRetriever, DPRRetriever):
 
 class DocumentChunkRanker:
     """
-    Base class for controling splitting long documents and selecting relevant chunks.
+    Base class for controlling splitting long documents and selecting relevant chunks.
     """
 
     def __init__(self, n_retrieved_chunks):

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -641,12 +641,11 @@ class DPRRetriever(RagRetriever):
         # recompute exact FAISS scores
         scores = torch.bmm(query.unsqueeze(1), vectors.transpose(1, 2)).squeeze(1)
         if torch.isnan(scores).sum().item():
-            logging.error(
-                '\n[ Document scores are NaN; please look into the built index. ]\n'
-                '[ If using a compressed index, try building an exact index: ]\n'
-                '[ $ python index_dense_embeddings --indexer-type exact... ]'
+            raise AssertionError(
+                '\n[ Document scores are NaN; please make sure the passages file does not have repeated entries.]\n'
+                '[ Also set --num-shards to small values during generating dense embeddings: ]\n'
+                '[ e.g., when --shard-id is 0, --num-shards should be a value < int(len(rows of the passages file)/(num_of_maximum_passages_you_want_to_retrieve-1)).]'
             )
-            scores[scores != scores] = 1
         ids = torch.tensor([[int(s) for s in ss] for ss in ids])
 
         return ids, scores
@@ -1136,7 +1135,7 @@ class SearchQuerySearchEngineRetriever(SearchQueryRetriever):
 
     def _empty_docs(self, num: int):
         """
-        Generates the requested number of empty documents.
+        Generates the requsted number of empty documents.
         """
         return [BLANK_SEARCH_DOC for _ in range(num)]
 
@@ -1230,9 +1229,9 @@ class SearchQueryFAISSIndexRetriever(SearchQueryRetriever, DPRRetriever):
         Retrieves from the FAISS index using a search query.
 
         This methods relies on the `retrieve_and_score` method in `RagRetriever`
-        ancestor class. It receive the query (conversation context) and generatess the
+        ancestor class. It recieve the query (conversation context) and generatess the
         search term queries based on them. Then uses those search quries (instead of the
-        the query text itself) to retrieve from the FAISS index.
+        the query text itself) to retrive from the FAISS index.
         """
 
         search_queries = self.generate_search_query(query)
@@ -1250,7 +1249,7 @@ class SearchQueryFAISSIndexRetriever(SearchQueryRetriever, DPRRetriever):
 
 class DocumentChunkRanker:
     """
-    Base class for controlling splitting long documents and selecting relevant chunks.
+    Base class for controling splitting long documents and selecting relevant chunks.
     """
 
     def __init__(self, n_retrieved_chunks):


### PR DESCRIPTION
Update retriever to handle the NaN error and slightly add instructions to the readme 

**Patch description**
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->

Per #3881 and #3873. In #3881, the model should immediately raise an AssertionError when there are NaN instead of logging errors and/or replacing NaN with other values. Besides, after careful investigation, I found the NaN error is not caused by either --indexer-type exact or --indexer-type compressed. The error comes from num_shards if the passages file format meets requirements and there are no repeated entries. Where if end_idx<n_docs, it will raise NaN error. So it is better to set --num-shards to small values. For example, if --shard-id is 0, then --num-shards is a value < int(len(rows of the passages file)/(n_maximum_passages_you_want_to_retrieve-1)). I had also slightly updated the readme to give more instructions.

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
