### PR TITLE
Preserve the order of loaded openers in selfchat

### DIFF
--- a/parlai/tasks/self_chat/worlds.py
+++ b/parlai/tasks/self_chat/worlds.py
@@ -40,18 +40,21 @@ def load_openers(opt) -> Optional[List[str]]:
     task_world = create_task(task_opt, task_agent)
 
     # run through task data, collecting all first messages
-    openers = set()
+    openers = []
     is_first_turn = True
     while not task_world.epoch_done():
         task_world.parley()
         msg = task_world.get_acts()[0]
         # add only the first message in the episode
         if is_first_turn and msg.get('text'):
-            openers.add(msg['text'])
+            openers.append(msg['text'])
         is_first_turn = msg.get('episode_done', False)
 
+    # remove duplicates while preserving the ordering of the loaded openers
+    openers = list(dict.fromkeys(openers))
+
     print(f'[ loaded {len(openers)} openers ]')
-    return list(openers)
+    return openers
 
 
 def load_openers_from_file(filepath: str) -> List[str]:


### PR DESCRIPTION
Hello! 👋🏼
I found that we get non-deterministic order of openers even though we are loading them from fixed files or tasks.
So I fixed them to be deterministic.

**Patch description**
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->
`set()` results in non-deterministic order of openers for every run.
Use `dict.fromkeys()` instead to deduplicate openers and preserve order.

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
