### PR TITLE
[parser] Support nargs=+ in parse_kwargs

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -1223,7 +1223,7 @@ class ParlaiParser(argparse.ArgumentParser):
                     string_args.append(self._value2argstr(value))
                 elif isinstance(action, argparse._StoreAction) and action.nargs in '*+':
                     string_args.append(last_option_string)
-                    string_args.extend([self._value2argstr(value) for v in value])
+                    string_args.extend([self._value2argstr(v) for v in value])
                 else:
                     raise TypeError(f"Don't know what to do with {action}")
 
@@ -1262,7 +1262,7 @@ class ParlaiParser(argparse.ArgumentParser):
                 elif isinstance(action, argparse._StoreAction) and action.nargs in '*+':
                     string_args.append(last_option_string)
                     # Special case: Labels
-                    string_args.extend([str(v) for v in value])
+                    string_args.extend([self._value2argstr(v) for v in value])
                 else:
                     raise TypeError(f"Don't know what to do with {action}")
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -190,6 +190,25 @@ class TestParlaiParser(unittest.TestCase):
         with self.assertRaises(KeyError):
             parser.parse_kwargs(task='integration_tests', fake_option=False)
 
+    def test_parse_kwargs_nargsplus(self):
+        """
+        Test parse_kwargs when provided an argument with >1 item
+        """
+        parser = ParlaiParser(False, False)
+        parser.add_argument('--example', nargs='+', choices=['a', 'b', 'c'])
+        opt = parser.parse_args(['--example', 'a', 'b'])
+        assert opt['example'] == ['a', 'b']
+
+        parser = ParlaiParser(False, False)
+        parser.add_argument('--example', nargs='+', choices=['a', 'b', 'c'])
+        opt = parser.parse_kwargs(example=['a', 'b'])
+        assert opt['example'] == ['a', 'b']
+
+        parser = ParlaiParser(False, False)
+        parser.add_argument('--example', nargs='+')
+        opt = parser.parse_kwargs(example=['x', 'y'])
+        assert opt['example'] == ['x', 'y']
+
     def test_bool(self):
         """
         test add_argument(type=bool)


### PR DESCRIPTION
**Patch description**
@ankitade discovered that parse_kwargs doesn't work with `choices` and `nargs='+'`. This bug has actually been around a surprising amount of time. Patch and test.

**Testing steps**
New CI