### PR TITLE
Update exs in log by batchsize during eval_model

### DIFF
--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -184,7 +184,7 @@ def _eval_single_world(opt, agent, task):
         if log_time.time() > log_every_n_secs:
             report = world.report()
             text, report = log_time.log(
-                report.get('exs', 0), min(max_cnt, total_cnt), report
+                report.get('exs', cnt), min(max_cnt, total_cnt), report
             )
             logging.info(text)
 


### PR DESCRIPTION
Hello! 👋🏼
The `exs` in the log from `eval_model` is currently updated with `report.get('exs', 0)`.
The `exs` in the report is only computed when there are labels (by the `Metrics.evaluate_response()`).
Since `exs` is the cumulative number of completed examples, I believe it should be computed independently regardless of whether or not labels exist.

**Patch description**
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->
Update `exs` by batchsize whether labels exist or not

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

I ran `pytest tests/test_eval_model.py` and passed all the tests except for the key errors regarding rouge_L.

<img width="1338" alt="스크린샷 2021-08-13 오후 7 36 04" src="https://user-images.githubusercontent.com/22134963/129345324-9464fc92-1858-4162-9be1-868bbb8ed4a3.png">

**Other information**
<!-- Any other information or context you would like to provide. -->
