### PR TITLE
[BB2] Memory Only Fix

### DIFF
--- a/projects/blenderbot2/agents/modules.py
+++ b/projects/blenderbot2/agents/modules.py
@@ -107,6 +107,9 @@ class BlenderBot2RagModel(RagModel):
         self.should_generate_query = (
             self.knowledge_access_method is KnowledgeAccessMethod.CLASSIFY
             or self.search
+        ) and (
+            self.knowledge_access_method
+            not in [KnowledgeAccessMethod.MEMORY_ONLY, KnowledgeAccessMethod.NONE]
         )
 
     def has_query_generator(self) -> bool:
@@ -381,6 +384,7 @@ class BlenderBot2RagModel(RagModel):
                 memory_decoder_vec,
                 generated_memories,
             )
+            logging.debug(f'Memory Access Complete: {time.time() - start:.2f}')
             if memories is not None and memory_scores is not None:
                 self._fill_docs_and_scores(
                     top_docs, doc_scores, memory_indices, memories, memory_scores


### PR DESCRIPTION
**Patch description**
We don't need to classify retrieval when we're dealing with `--knowledge-access-method <memory_only>/<none>`. We do not set the `query_generator_vec` unless we're in the other three regimes (`search_only`, `classify`, or `all`), and thus we should only generate the queries in these regimes as well.

**Testing steps**
Verified that `parlai i -mf zoo:blenderbot2/blenderbot2_400M/model` works with `--knowledge-access-method memory_only` (this would lead to a bug before)
