### PR TITLE
Change installation method of linkchecker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,8 +291,7 @@ commands:
           name: check for bad links
           working_directory: ~/ParlAI/
           command: |
-            sudo apt-get update
-            sudo apt-get install linkchecker
+            pip install linkchecker
             python -m http.server --directory website/build >/dev/null &
             linkchecker http://localhost:8000/
             kill %1


### PR DESCRIPTION
**Patch description**
Debian bumped versions, breaking our installation method of `linkchecker`, which is used to check for 404s in our docs. Fortunately, it's a python program so we can just switch to pip.

**Testing steps**
The `build_website` CI step should pass.