### PR TITLE
Allow more subclassing of self-chat world

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -256,13 +256,20 @@ class World(object):
         """
         Reset all agents in the world, and world statistics.
         """
-        for a in self.agents:
-            a.reset()
+        self.reset_agents()
         self.max_exs = None
         self.total_exs = 0
         self.total_epochs = 0
         self.total_parleys = 0
         self.time.reset()
+
+    def reset_agents(self):
+        """
+        Reset all agents in the world.
+        """
+        agents = self.get_agents()
+        for a in agents:
+            a.reset()
 
     def reset_metrics(self):
         """

--- a/parlai/tasks/self_chat/worlds.py
+++ b/parlai/tasks/self_chat/worlds.py
@@ -140,7 +140,7 @@ class SelfChatWorld(DialogPartnerWorld):
             for a in agents:
                 a.reset()
 
-        if self._use_seed_utterances():
+        if self.turn_cnt == 0:
             self.acts = [None, None]
             # get the beginning of the conversation, which can include contexts
             # and/or any number of starting messages
@@ -160,7 +160,7 @@ class SelfChatWorld(DialogPartnerWorld):
                 self.agents[i].observe(validate(context))
             # clear contexts so they are only added once per episode
             self.contexts = None
-        elif self.seed_utterances:
+        elif self.seed_utterances and self._use_seed_utterances():
             # pop the next two seed messages (there may be less or more than 2 total)
             utts = self.seed_utterances[:2]
             self.seed_utterances = self.seed_utterances[2:]
@@ -191,6 +191,7 @@ class SelfChatWorld(DialogPartnerWorld):
         """
         Logic to determine whether we should employ seed utterances.
 
-        Defaults to the beginning of the conversation, but can be overridden.
+        Defaults to always using seed utterances if they exist, but this can be
+        overridden.
         """
-        return self.turn_cnt == 0
+        return True

--- a/parlai/tasks/self_chat/worlds.py
+++ b/parlai/tasks/self_chat/worlds.py
@@ -140,7 +140,7 @@ class SelfChatWorld(DialogPartnerWorld):
             for a in agents:
                 a.reset()
 
-        if self.turn_cnt == 0:
+        if self._use_seed_utterances():
             self.acts = [None, None]
             # get the beginning of the conversation, which can include contexts
             # and/or any number of starting messages
@@ -186,3 +186,11 @@ class SelfChatWorld(DialogPartnerWorld):
 
         self.update_counters()
         self.turn_cnt += 1
+
+    def _use_seed_utterances(self) -> bool:
+        """
+        Logic to determine whether we should employ seed utterances.
+
+        Defaults to the beginning of the conversation, but can be overridden.
+        """
+        return self.turn_cnt == 0

--- a/parlai/tasks/self_chat/worlds.py
+++ b/parlai/tasks/self_chat/worlds.py
@@ -132,13 +132,7 @@ class SelfChatWorld(DialogPartnerWorld):
 
     def parley(self):
         if self.episode_done():
-            self.turn_cnt = 0
-            self.episode_cnt += 1
-            self.contexts = None
-            self.seed_utterances = None
-            agents = self.get_agents()
-            for a in agents:
-                a.reset()
+            self._end_episode()
 
         if self.turn_cnt == 0:
             self.acts = [None, None]
@@ -186,6 +180,18 @@ class SelfChatWorld(DialogPartnerWorld):
 
         self.update_counters()
         self.turn_cnt += 1
+
+    def _end_episode(self):
+        """
+        Apply logic to end the episode.
+        """
+        self.turn_cnt = 0
+        self.episode_cnt += 1
+        self.contexts = None
+        self.seed_utterances = None
+        agents = self.get_agents()
+        for a in agents:
+            a.reset()
 
     def _use_seed_utterances(self) -> bool:
         """

--- a/parlai/tasks/self_chat/worlds.py
+++ b/parlai/tasks/self_chat/worlds.py
@@ -189,9 +189,7 @@ class SelfChatWorld(DialogPartnerWorld):
         self.episode_cnt += 1
         self.contexts = None
         self.seed_utterances = None
-        agents = self.get_agents()
-        for a in agents:
-            a.reset()
+        self.reset_agents()
 
     def _use_seed_utterances(self) -> bool:
         """


### PR DESCRIPTION
Allow for more subclassing of `SelfChatWorld` to modify/extend its logic:
- Abstract out the logic applied at the end of every episode, in order to allow subclasses to supply custom logic (in my case, resetting a random turn-index variable per episode)
- Allow for specifying custom logic for when to use seed utterances (in my case, only when the current turn index equals the value of the random turn-index variable specified above)