### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/source/core/messages.md
+++ b/docs/source/core/messages.md
@@ -53,7 +53,7 @@ should be an `iterable` (e.g. a list, a tuple).
 ## eval_labels
 
 During validation and testing, the "labels" field is moved to "eval_labels" in
-order to help prevent accidentaly training on evaluation data.
+order to help prevent accidentally training on evaluation data.
 
 However, by providing this field, models can still compute model-side metrics
 such as perplexity.
@@ -85,7 +85,7 @@ to compute metrics like `hits@10` or `MRR`.
 ## episode_done
 
 The "episode_done" flag is used to mark the end of an episode.
-Conversations in ParlAI don't necesarily have more than one exchange, but
+Conversations in ParlAI don't necessarily have more than one exchange, but
 many datasets do.
 
 For example, the WikiMovies dataset only has one:

--- a/parlai/tasks/wizard_of_internet/README.md
+++ b/parlai/tasks/wizard_of_internet/README.md
@@ -2,7 +2,7 @@ Task: Wizard of Internet
 ==========================
 This task involves a dialogue dataset between two crowdsource workers.
 One of the agents (called hereafter the *apprentice*) has some interests that wants to talk about them.
-The other agent (*wizard*) has access to internet search and provides knowledgeble responses to the apprentice.
+The other agent (*wizard*) has access to internet search and provides knowledgeable responses to the apprentice.
 
 See the [project page](https://parl.ai/projects/sea) for more information.
 

--- a/projects/wizard_of_wikipedia/README.md
+++ b/projects/wizard_of_wikipedia/README.md
@@ -130,7 +130,7 @@ Each `<train/val/test>.json` file is a list of all dialogues in that split. An e
 - `dialog`: the list of dialogue turns
 - `chosen_topic_passage`: a list of sentences from the wiki passage corresponding to the chosen topic
 
-The entries of `dialog` (may) have the following keys; some are ommitted for the apprentice:
+The entries of `dialog` (may) have the following keys; some are omitted for the apprentice:
 
 - `speaker`: either `"wizard"` or `"apprentice"`
 - `text`: what the speaker wrote


### PR DESCRIPTION
**Patch description**
made corrections to the typos i have found in the documentations.