### PR TITLE
Handle some fbcode infra nuances.

### DIFF
--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -21,6 +21,7 @@ import hashlib
 import tqdm
 import gzip
 import math
+import contextlib
 import parlai.utils.logging as logging
 from parlai.utils.io import PathManager
 
@@ -28,6 +29,17 @@ try:
     from torch.multiprocessing import Pool
 except ImportError:
     from multiprocessing import Pool
+
+
+try:
+    # internal infra requires special attention to use http sessions
+    from parlai_fb import get_http_session
+except (ImportError, AttributeError):
+
+    @contextlib.contextmanager
+    def get_http_session():
+        with requests.Session() as session:
+            yield session
 
 
 class DownloadableFile:
@@ -95,17 +107,20 @@ class DownloadableFile:
         """
         Performs a HEAD request to check if the URL / Google Drive ID is live.
         """
-        session = requests.Session()
-        if self.from_google:
-            URL = 'https://docs.google.com/uc?export=download'
-            response = session.head(URL, params={'id': self.url}, stream=True)
-        else:
-            headers = {
-                'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36'
-            }
-            response = session.head(self.url, allow_redirects=True, headers=headers)
-        status = response.status_code
-        session.close()
+        with get_http_session() as session:
+            if self.from_google:
+                URL = 'https://docs.google.com/uc?export=download'
+                response = session.head(URL, params={'id': self.url}, stream=True)
+            else:
+                headers = {
+                    'User-Agent': (
+                        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) '
+                        'AppleWebKit/537.36 (KHTML, like Gecko) '
+                        'Chrome/77.0.3865.90 Safari/537.36'
+                    )
+                }
+                response = session.head(self.url, allow_redirects=True, headers=headers)
+            status = response.status_code
 
         assert status == 200
 
@@ -166,7 +181,7 @@ def download(url, path, fname, redownload=False, num_retries=5):
     while download and retry > 0:
         response = None
 
-        with requests.Session() as session:
+        with get_http_session() as session:
             try:
                 response = session.get(url, stream=True, timeout=5)
 
@@ -389,7 +404,7 @@ def download_from_google_drive(gd_id, destination):
     """
     URL = 'https://docs.google.com/uc?export=download'
 
-    with requests.Session() as session:
+    with get_http_session() as session:
         response = session.get(URL, params={'id': gd_id}, stream=True)
         token = _get_confirm_token(response)
 

--- a/parlai/utils/io.py
+++ b/parlai/utils/io.py
@@ -23,8 +23,7 @@ try:
     # register any internal file handlers
     import parlai_fb  # noqa: F401
 
-    parlai_fb.finalize_registration(PathManager)
     # internal file handlers can't handle atomic saving. see T71772714
-    USE_ATOMIC_TORCH_SAVE = False
+    USE_ATOMIC_TORCH_SAVE = not parlai_fb.finalize_registration(PathManager)
 except ModuleNotFoundError:
-    pass
+    USE_ATOMIC_TORCH_SAVE = True


### PR DESCRIPTION
**Patch description**
Downloading things in internal infrastructure can be a pain and requires setting things up carefully. This patch provides a stub that internal infra can easily override.

Additionally, fixes a long standing bug where some of our FAIR researchers would have atomic saving disabled due to import mismatches.

**Testing steps**
In progress.