### PR TITLE
Force model chats starting with "Hi!" to use BST-style context

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
+++ b/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
@@ -425,15 +425,22 @@ class ModelChatBlueprint(BaseModelChatBlueprint):
         run_statistics = {r: 0 for (r, v) in self.conversations_needed.items()}
         shared_state.run_statistics = run_statistics
 
-        context_generator: Optional[ContextGenerator] = None
         if (
             args.blueprint.include_persona
-            # 'hi' mode does not use a context generator and instead just displays "Hi!" at the start of the conversation
+            # 'hi' mode does not use a context generator and instead just displays "Hi!"
+            # at the start of the conversation
             or args.blueprint.conversation_start_mode != 'hi'
         ):
+            if args.blueprint.conversation_start_mode == 'hi':
+                # Default to using the context from BlendedSkillTalk
+                task = 'blended_skill_talk'
+            else:
+                task = args.blueprint.conversation_start_mode
             context_generator = get_context_generator(
-                args.blueprint.override_opt, args.blueprint.conversation_start_mode
+                override_opt=args.blueprint.override_opt, task=task
             )
+        else:
+            context_generator: Optional[ContextGenerator] = None
         shared_state.context_generator = context_generator
 
         # Lock for editing run statistics between threads

--- a/parlai/crowdsourcing/tasks/model_chat/utils.py
+++ b/parlai/crowdsourcing/tasks/model_chat/utils.py
@@ -413,7 +413,7 @@ class AbstractModelChatTest(AbstractParlAIChatTest, unittest.TestCase):
 
 def get_context_generator(
     override_opt: Optional[Dict[str, Any]] = None,
-    conversation_start_mode: Optional[str] = 'blended_skill_talk',
+    task: Optional[str] = 'blended_skill_talk',
     **kwargs,
 ) -> ContextGenerator:
     """
@@ -424,7 +424,7 @@ def get_context_generator(
     if override_opt is not None:
         argparser.set_params(**override_opt)
     opt = argparser.parse_args([])
-    task_module = load_task_module(conversation_start_mode)
+    task_module = load_task_module(task)
     context_generator_class = getattr(task_module, 'ContextGenerator', None)
     context_generator = context_generator_class(opt, datatype='test', seed=0, **kwargs)
     # We pull from the test set so that the model can't regurgitate


### PR DESCRIPTION
**Patch description**
A recent refactor caused model chat to throw an error when starting a conversation with "Hi!" (`args.blueprint.conversation_start_mode == 'hi'`) and using personas: in that case, the code to pull the context would try to look for a `parlai.tasks.hi` module, which doesn't exist. This PR adds logic to state that, if we are starting our conversation with "Hi!", we want to use BST-style context.

**Testing steps**
CI checks on the model chat task
