### PR TITLE
[mutators] Prevent name collisions in mutators.

### DIFF
--- a/parlai/core/mutators.py
+++ b/parlai/core/mutators.py
@@ -58,6 +58,11 @@ def register_mutator(name: str) -> Callable[[Type], Type]:
 
     def _inner(cls_: Type) -> Type:
         global MUTATOR_REGISTRY
+        if name in MUTATOR_REGISTRY and cls_ is not MUTATOR_REGISTRY[name]:
+            raise NameError(
+                "Mutators must be uniquely named, but detected two mutators with "
+                f"the name '{name}'."
+            )
         MUTATOR_REGISTRY[name] = cls_
         return cls_
 

--- a/parlai/tasks/wizard_of_internet/agents.py
+++ b/parlai/tasks/wizard_of_internet/agents.py
@@ -581,13 +581,13 @@ class GoldDocTitlesTeacher(BaseKnowledgeTeacher):
         return CONST.SELECTED_DOCS_TITLES
 
 
-@register_mutator("add_checked_sentence_to_input")
+@register_mutator("add_checked_sentence_to_input_woi")
 class AddCheckedSentence(AddCheckedSentenceWizWiki):
     """
     Adds the checked sentence to the end of the text.
 
     E.g. run with: parlai display_data -t wizard_of_internet -n 100 -dt valid --mutators
-    flatten,add_checked_sentence_to_input
+    flatten,add_checked_sentence_to_input_woi
     """
 
     @property

--- a/parlai/tasks/wizard_of_internet/agents.py
+++ b/parlai/tasks/wizard_of_internet/agents.py
@@ -595,13 +595,13 @@ class AddCheckedSentence(AddCheckedSentenceWizWiki):
         return CONST.SELECTED_SENTENCES
 
 
-@register_mutator("checked_sentence_as_label")
+@register_mutator("checked_sentence_as_label_woi")
 class CheckedSentenceAsLabel(CheckedSentenceAsLabelWizWiki):
     """
     Uses the checked sentence (knowledge) as label.
 
     E.g. run with: parlai display_data -t wizard_of_internet -n 100 -dt valid --mutators
-    flatten,checked_sentence_as_label
+    flatten,checked_sentence_as_label_woi
     """
 
     @property
@@ -609,19 +609,19 @@ class CheckedSentenceAsLabel(CheckedSentenceAsLabelWizWiki):
         return CONST.SELECTED_SENTENCES
 
 
-@register_mutator("add_label_to_input")
+@register_mutator("add_label_to_input_woi")
 class AddLabel(AddLabelWizWiki):
     """
     Adds the dialogue sentence to the input.
 
     E.g. run with: parlai display_data -t wizard_of_internet -n 100 -dt valid --mutators
-    flatten,checked_sentence_as_label,add_label_to_input
+    flatten,checked_sentence_as_label_woi,add_label_to_input
     """
 
     pass
 
 
-@register_mutator("add_label_to_input_lm")
+@register_mutator("add_label_to_input_lm_woi")
 class AddLabelLM(AddLabelLMWizWiki):
     """
     Adds the dialogue sentence to the input (language modeling version).
@@ -630,11 +630,11 @@ class AddLabelLM(AddLabelLMWizWiki):
     the input. The rest is placed inside special tokens.
 
     E.g. run with: parlai display_data -t wizard_of_internet -n 100 -dt valid --mutators
-    flatten,add_label_to_input_lm
+    flatten,add_label_to_input_lm_woi
 
     To add the checked sentence as the label, use:
         parlai display_data -t wizard_of_internet -n 100 -dt valid --mutators
-        flatten,add_label_to_input_lm,checked_sentence_as_label
+        flatten,add_label_to_input_lm_woi,checked_sentence_as_label
     """
 
     pass

--- a/parlai/tasks/wizard_of_internet/agents.py
+++ b/parlai/tasks/wizard_of_internet/agents.py
@@ -615,7 +615,7 @@ class AddLabel(AddLabelWizWiki):
     Adds the dialogue sentence to the input.
 
     E.g. run with: parlai display_data -t wizard_of_internet -n 100 -dt valid --mutators
-    flatten,checked_sentence_as_label_woi,add_label_to_input
+    flatten,checked_sentence_as_label_woi,add_label_to_input_woi
     """
 
     pass
@@ -634,7 +634,7 @@ class AddLabelLM(AddLabelLMWizWiki):
 
     To add the checked sentence as the label, use:
         parlai display_data -t wizard_of_internet -n 100 -dt valid --mutators
-        flatten,add_label_to_input_lm_woi,checked_sentence_as_label
+        flatten,add_label_to_input_lm_woi,checked_sentence_as_label_woi
     """
 
     pass

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -1279,7 +1279,7 @@ class SelfchatTeacher(BasicBothDialogTeacher):
     pass
 
 
-@register_mutator("add_checked_sentence_to_input")
+@register_mutator("add_checked_sentence_to_input_wow")
 class AddCheckedSentence(MessageMutator):
     """
     Adds the checked sentence to the end of the text.

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -1306,7 +1306,7 @@ class AddCheckedSentence(MessageMutator):
         return new_message
 
 
-@register_mutator("checked_sentence_as_label")
+@register_mutator("checked_sentence_as_label_wow")
 class CheckedSentenceAsLabel(MessageMutator):
     """
     Uses the checked sentence (knowledge) as label.
@@ -1330,7 +1330,7 @@ class CheckedSentenceAsLabel(MessageMutator):
         return new_message
 
 
-@register_mutator("add_label_to_input")
+@register_mutator("add_label_to_input_wow")
 class AddLabel(MessageMutator):
     """
     Adds the dialogue sentence to the input.
@@ -1356,7 +1356,7 @@ class AddLabel(MessageMutator):
         return new_message
 
 
-@register_mutator("add_label_to_input_lm")
+@register_mutator("add_label_to_input_lm_wow")
 class AddLabelLM(MessageMutator):
     """
     Adds the dialogue sentence to the input (language modeling version).
@@ -1365,11 +1365,11 @@ class AddLabelLM(MessageMutator):
     the input. The rest is placed inside special tokens.
 
     E.g. run with: parlai display_data -t wizard_of_wikipedia -n 100 -dt valid --mutators
-    flatten,add_label_to_input_lm
+    flatten,add_label_to_input_lm_wow
 
     To add the checked sentence as the label, use:
         parlai display_data -t wizard_of_wikipedia -n 100 -dt valid --mutators
-        flatten,add_label_to_input_lm,checked_sentence_as_label
+        flatten,add_label_to_input_lm_wow,checked_sentence_as_label
     """
 
     def message_mutation(self, message: Message) -> Message:

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -1369,7 +1369,7 @@ class AddLabelLM(MessageMutator):
 
     To add the checked sentence as the label, use:
         parlai display_data -t wizard_of_wikipedia -n 100 -dt valid --mutators
-        flatten,add_label_to_input_lm_wow,checked_sentence_as_label
+        flatten,add_label_to_input_lm_wow,checked_sentence_as_label_wow
     """
 
     def message_mutation(self, message: Message) -> Message:

--- a/tests/test_mutators.py
+++ b/tests/test_mutators.py
@@ -250,3 +250,22 @@ class TestMutatorStickiness(unittest.TestCase):
             second_epoch.append(teacher.act())
 
         assert all(f == s for f, s in zip(first_epoch, second_epoch))
+
+
+class TestUniqueness(unittest.TestCase):
+    """
+    Test that mutators cannot have duplicate names.
+    """
+
+    def test_uniqueness(self):
+        from parlai.core.mutators import register_mutator, Mutator
+
+        @register_mutator("test_unique_mutator")
+        class Mutator1(Mutator):
+            pass
+
+        with self.assertRaises(NameError):
+
+            @register_mutator("test_unique_mutator")
+            class Mutator2(Mutator):
+                pass

--- a/tests/test_mutators.py
+++ b/tests/test_mutators.py
@@ -264,6 +264,10 @@ class TestUniqueness(unittest.TestCase):
         class Mutator1(Mutator):
             pass
 
+        # don't freak out if we accidentally register the exact same class twice
+        register_mutator("test_unique_mutator")(Mutator1)
+
+        # but do demand uniqueness
         with self.assertRaises(NameError):
 
             @register_mutator("test_unique_mutator")


### PR DESCRIPTION
**Patch description**
Recently @jaseweston had a spicy bug due to the global namespacing of mutators. This makes this failure case loud.

**Testing steps**
New CI.