### PR TITLE
Loudly warn about colliding world IDs, but allow it.

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -55,6 +55,7 @@ from parlai.core.teachers import Teacher, create_task_agent_from_taskname
 from parlai.utils.data import DatatypeHelper
 from parlai.utils.misc import Timer, display_messages
 from parlai.tasks.tasks import ids_to_tasks
+from parlai.utils.misc import error_once
 
 
 def validate(observation):
@@ -580,12 +581,12 @@ class MultiWorld(World):
         for each_world in self.worlds:
             world_id = each_world.getID()
             if world_id in task_ids:
-                raise AssertionError(
-                    '{} and {} teachers have overlap in id {}.'.format(
-                        task_ids[world_id],
-                        each_world.get_agents()[0].__class__,
-                        world_id,
-                    )
+                world_class = each_world.get_agents()[0].__class__
+                error_once(
+                    f"{task_ids[world_id]} and {world_class} teachers have overlap "
+                    f"in id '{world_id}'. This will cause their metrics to be "
+                    "intermingled. Change the id attribute of one to remove this "
+                    "message."
                 )
             else:
                 task_ids[world_id] = each_world.get_task_agent()

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -10,6 +10,7 @@ Basic tests that ensure train_model.py behaves in predictable ways.
 import os
 import unittest
 import json
+import parlai.utils.logging as logging
 import parlai.utils.testing as testing_utils
 from parlai.core.metrics import AverageMetric
 from parlai.core.worlds import create_task
@@ -164,13 +165,12 @@ class TestTrainModel(unittest.TestCase):
         )
 
     def test_multitasking_id_overlap(self):
-        with self.assertRaises(AssertionError) as context:
-            pp = ParlaiParser()
-            opt = pp.parse_args(['--task', 'integration_tests,integration_tests'])
+        pp = ParlaiParser()
+        opt = pp.parse_args(['--task', 'integration_tests,integration_tests'])
+        with self.assertLogs(logging.logger) as cm:
             self.world = create_task(opt, None)
-            self.assertTrue(
-                'teachers have overlap in id integration_tests.'
-                in str(context.exception)
+            self.assertIn(
+                "have overlap in id 'integration_tests'", "\n".join(cm.output)
             )
 
     def _test_opt_step_opts(self, update_freq: int):


### PR DESCRIPTION
**Patch description**
Several users have complained that, with mutators, they have to manually comment out this assertion because the ID doesn't change. I'm not fully convinced we want this behavior, but allow it to unblock research.

**Testing steps**
CI