### PR TITLE
Bump tqdm version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ tensorboardX==2.1
 tokenizers>=0.8.0
 torchtext>=0.5.0
 tornado==6.0.4
-tqdm~=4.42.0
+tqdm~=4.62.1
 typing-extensions==3.7.4.1
 Unidecode==1.1.1
 urllib3>=1.26.5


### PR DESCRIPTION
**Patch description**
Bump the version of `tqdm` to fix CI check errors such as https://app.circleci.com/pipelines/github/facebookresearch/ParlAI/10107/workflows/92b87406-a654-4575-95cc-7b6f8da31a34/jobs/83152 : `error: tqdm 4.42.1 is installed but tqdm>=4.62.1 is required by {'datasets'}`

**Testing steps**
cleaninstall_37 CI check