### PR TITLE
Minor: Print filename when missing in distributed.py

### DIFF
--- a/parlai/utils/distributed.py
+++ b/parlai/utils/distributed.py
@@ -358,7 +358,9 @@ def slurm_distributed_context(opt):
         raise e
     except FileNotFoundError as e:
         # Slurm is not installed
-        raise RuntimeError('SLURM does not appear to be installed. Missing file: ' + e.filename)
+        raise RuntimeError(
+            'SLURM does not appear to be installed. Missing file: ' + e.filename
+        )
 
 
 def find_free_port() -> int:

--- a/parlai/utils/distributed.py
+++ b/parlai/utils/distributed.py
@@ -356,9 +356,9 @@ def slurm_distributed_context(opt):
     except subprocess.CalledProcessError as e:
         # scontrol failed
         raise e
-    except FileNotFoundError:
+    except FileNotFoundError as e:
         # Slurm is not installed
-        raise RuntimeError('SLURM does not appear to be installed.')
+        raise RuntimeError('SLURM does not appear to be installed. Missing file: ' + e.filename)
 
 
 def find_free_port() -> int:


### PR DESCRIPTION
...when you have a script that potentially includes file operations (ex when opening a manually-passed-in json file to load data for a task), this piece of code will eat the filename if it's missing.

** Testing Steps **
Have hit this empirically a few times over the past few days, lol. 
