### PR TITLE
[RAG] Fix ReGReT Cuda Issue

### DIFF
--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -756,7 +756,7 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
         for i in range(batch.batchsize):
             vec_i = pred_vecs[i]
             txt_i = self._v2t(vec_i)
-            query_i = torch.LongTensor(self.model.tokenize_query(txt_i))
+            query_i = torch.LongTensor(self.model.tokenize_query(txt_i)).to(query_vec)
             if self.retriever_query == 'one_turn':
                 new_queries.append(query_i)
             else:


### PR DESCRIPTION
**Patch description**
There was a small issue with tensors not being on appropriate devices; this did not show up in the RAG tests since the ReGReT tests are cpu-only (due to memory constraints...)

**Testing steps**
Tested a command from #3927 manually and confirmed this error 1) showed up before fix, and 2) does not show up after fix