### PR TITLE
Fix model chat frame height

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
+++ b/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
@@ -287,7 +287,7 @@ class BaseModelChatBlueprint(ParlAIChatBlueprint, ABC):
             "annotation_buckets": annotation_buckets,
             "onboarding_data": getattr(self, 'onboard_task_data', None),
             "left_pane_text": self.left_pane_text,
-            "frame_height": '650px',
+            "frame_height": 650,
             "final_rating_question": self.args.blueprint.final_rating_question,
             "block_mobile": True,
         }


### PR DESCRIPTION
**Patch description**
Unlike ACUTE-Eval and `parlai_chat`, `model_chat` specifies the `frame_height` as a string with the suffix `'px'` added instead of as an integer, leading to a boto error when trying to create the HITs. This PR corrects this.

**Testing steps**
CI checks and test live HITs
