### PR TITLE
[Per Turn Eval] Add task question to model chat blueprint

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
+++ b/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
@@ -467,6 +467,7 @@ class ModelChatBlueprint(BaseModelChatBlueprint):
                 'statistics_condition': statistics_condition,
                 'conversation_start_mode': args.blueprint.conversation_start_mode,
                 'include_persona': args.blueprint.include_persona,
+                'task_question': args.blueprint.task_question,
             }
         )
 


### PR DESCRIPTION
**Patch description**
Add task question to the model chat blueprint so that it can be accessed from the crowdsourcing task.

See related internal PR: https://github.com/fairinternal/ParlAI-Internal/pull/2472