### PR TITLE
Fix Hydra 1.1 upgrade issue for Fast ACUTEs

### DIFF
--- a/parlai/crowdsourcing/tasks/acute_eval/fast_eval.py
+++ b/parlai/crowdsourcing/tasks/acute_eval/fast_eval.py
@@ -21,7 +21,7 @@ import torch
 from mephisto.operations.hydra_config import register_script_config
 from mephisto.operations.operator import Operator
 from mephisto.tools.scripts import load_db_and_process_config
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from parlai.crowdsourcing.tasks.acute_eval.analysis import (
     AcuteAnalyzer,
@@ -478,6 +478,7 @@ class FastAcuteExecutor(object):
         self.set_up_acute_eval()
         db, cfg = load_db_and_process_config(self.args)
         print(f'*** RUN ID: {cfg.mephisto.task.task_name} ***')
+        print(f'\nHydra config:\n{OmegaConf.to_yaml(cfg)}')
         operator = Operator(db)
         operator.validate_and_run_config(run_config=cfg.mephisto, shared_state=None)
         operator.wait_for_runs_then_shutdown(
@@ -547,6 +548,7 @@ class FastAcuteExecutor(object):
 
 
 defaults = [
+    '_self_',
     {"mephisto/blueprint": FAST_ACUTE_BLUEPRINT_TYPE},
     {"mephisto/architect": "local"},
     {"mephisto/provider": "mock"},


### PR DESCRIPTION
**Patch description**
When running Fast ACUTEs, the Hydra flags in `base_fast_acute.yaml` (such as `mephisto.task.maximum_units_per_worker`) were not being applied. This PR fixes this issue, and also prints out all actual values of Hydra flags for easier debugging of this kind of issue in the future.

**Testing steps**
- CI checks
- Running Fast ACUTEs to check, before and after, that the flags are now respected:
```
python parlai/crowdsourcing/tasks/acute_eval/fast_eval.py \
mephisto.blueprint.acute_eval_type=engaging \
mephisto.blueprint.config_path=${CONFIG_PATH} \
mephisto.blueprint.model_pairs=${MODEL_PAIRS} \
mephisto.blueprint.onboarding_path=${REPO_FOLDER}/parlai/crowdsourcing/tasks/acute_eval/task_config/onboarding.json \
mephisto.blueprint.root_dir=${ROOT_DIR} \
mephisto.blueprint.matchups_per_pair=500 \
mephisto.task.task_name=${TASK_NAME}
```