### PR TITLE
Fix `detect_offensive_language` script

### DIFF
--- a/parlai/scripts/detect_offensive_language.py
+++ b/parlai/scripts/detect_offensive_language.py
@@ -81,6 +81,8 @@ def detect(opt):
         return log
 
     def classify(text, stats):
+        if not text:
+            return
         offensive = False
         stats['total'] += 1
         if opt['safety'] == 'string_matcher' or opt['safety'] == 'all':


### PR DESCRIPTION
**Patch description**
The script would break if the `labels` or `text` fields within a task were empty strings; this fixes that.

I'm not really sure who to tag on this as a reviewer so lmk if someone else should review.

**Testing steps**
See #4049 for task that breaks the script. I've also added a new test to confirm this works.

