### PR TITLE
Never load datatype from opt files

### DIFF
--- a/parlai/core/opt.py
+++ b/parlai/core/opt.py
@@ -33,6 +33,9 @@ __AUTOCLEAN_KEYS__: List[str] = [
     # we don't save interactive mode or load from checkpoint, it's only decided by scripts or CLI
     "interactive_mode",
     "load_from_checkpoint",
+    # added 2021-10-07
+    # internal discussion: https://fb.workplace.com/groups/770643789812374/permalink/1780621008814642/
+    "datatype",  
 ]
 
 

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -675,7 +675,9 @@ class TrainLoop:
 
     def _run_final_extra_eval(self, opt):
         final_valid_opt = copy.deepcopy(opt)
-        final_valid_opt_raw = Opt.load_init(opt['final_extra_opt'])
+        final_valid_opt_raw = Opt.load_init(
+            opt['final_extra_opt'], always_load_opts=["datatype"]
+        )
         final_datatype = final_valid_opt_raw["datatype"]
         for k, v in final_valid_opt_raw.items():
             final_valid_opt[k] = v

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -30,15 +30,15 @@ class TestTrainModel(unittest.TestCase):
         import parlai.scripts.train_model as tms
 
         def get_tl(tmpdir):
-            final_opt = Opt(
-                {
-                    'task': 'integration_tests',
-                    'datatype': 'valid',
-                    'validation_max_exs': 30,
-                    'short_final_eval': True,
-                }
-            )
-            final_opt.save(os.path.join(tmpdir, "final_opt.opt"))
+            final_opt = {
+                'task': 'integration_tests',
+                'datatype': 'valid',
+                'validation_max_exs': 30,
+                'short_final_eval': True,
+            }
+            opt_file = os.path.join(tmpdir, "final_opt.opt")
+            with open(opt_file, "w+") as f:
+                json.dump(final_opt, f)
 
             opt = Opt(
                 {
@@ -48,7 +48,7 @@ class TestTrainModel(unittest.TestCase):
                     'model_file': os.path.join(tmpdir, 'model'),
                     'short_final_eval': True,
                     'num_epochs': 1.0,
-                    'final_extra_opt': str(os.path.join(tmpdir, "final_opt.opt")),
+                    'final_extra_opt': str(opt_file),
                 }
             )
             parser = tms.setup_args()


### PR DESCRIPTION
**Patch description**
After internal discussion, datatypes are a nasty thing to be pulling from opts and can create some weirdness. Always use the root datatype.

**Testing steps**
CI