### PR TITLE
[Modular] Update Transformer Layer `__init__`s

### DIFF
--- a/parlai/agents/transformer/modules/decoder.py
+++ b/parlai/agents/transformer/modules/decoder.py
@@ -57,7 +57,7 @@ class TransformerDecoderLayer(nn.Module):
         variant: str = 'aiayn',
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__()
 
         def _default(val, default):
             """
@@ -215,7 +215,7 @@ class TransformerDecoder(nn.Module):
         n_positions: Optional[int] = None,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__()
         self.opt = opt
 
         def _default(val, default):

--- a/parlai/agents/transformer/modules/encoder.py
+++ b/parlai/agents/transformer/modules/encoder.py
@@ -48,7 +48,7 @@ class TransformerEncoderLayer(nn.Module):
         variant: Optional[str] = None,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__()
 
         def _default(val, default):
             """
@@ -141,7 +141,7 @@ class TransformerEncoder(nn.Module):
         output_scaling: Optional[float] = None,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__()
 
         def _default(val, default):
             return val if val is not None else default


### PR DESCRIPTION
**Patch description**
The `TransformerDecoder(Layer)` and `TransformerEncoder(Layer)` support passing `**kwargs` for maximum customizability; however, these `**kwargs` are unnecessarily (and, actually, incorrectly) being passed to the `nn.Module`'s `super().__init__()`, which doesn't accept arbitrary `**kwargs`. This patch removes these from the super call

**Testing steps**
Subclassed a `TransformerEncoder`, attempted to initialize with arbitrary parameters, confirmed it works after fix.
