### PR TITLE
Removed a simple consider-using-in pitfall case

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -89,7 +89,7 @@ def pytest_collection_modifyitems(config, items):
         else:
             assert "/" not in rel_path[6:], f"Couldn't categorize '{rel_path}'"
             item.add_marker("unit")
-            if marker_expr != 'unit' and marker_expr != '':
+            if marker_expr not in ['', 'unit']:
                 deselected.append(item)
 
     # kill everything that wasn't grabbed


### PR DESCRIPTION
**Problem**:
The code was incurring into the consider-using-in pitfall case, as described by Pylint documentation [here](https://github.com/vald-phoenix/pylint-errors/blob/master/plerr/errors/refactoring/R1714.md)

**Solution**:
Applied adequate refactoring. Only a single line of code was changed