### PR TITLE
Update train_model.py

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -212,7 +212,7 @@ def setup_args(parser=None) -> ParlaiParser:
         '--validation-metric-mode',
         type=str,
         choices=['max', 'min'],
-        help='how to optimize validation metric (max or min)',
+        help='the direction in which to optimize the validation metric, i.e. maximize or minimize',
     )
     train.add_argument(
         '-vcut',


### PR DESCRIPTION
Updating validation-metric-mode help message

**Patch description**
Validation-metric-mode help message could be more clearly written.

**Testing steps**
`parlai -- train --help`

```
...
  --validation-metric-mode, --vmm {max,min}
        the direction in which to optimize the validation metric, i.e. maximize or minimize (default: None)

...
```

