### PR TITLE
Fix interactive web

### DIFF
--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -25,6 +25,8 @@ import parlai.utils.logging as logging
 import json
 import time
 
+from parlai.agents.local_human.local_human import LocalHumanAgent
+
 HOST_NAME = 'localhost'
 PORT = 8080
 
@@ -266,14 +268,15 @@ def wait():
 def interactive_web(opt):
     global SHARED
 
-    opt['task'] = 'parlai.agents.local_human.local_human:LocalHumanAgent'
+    # opt['task'] = 'parlai.agents.local_human.local_human:LocalHumanAgent'
+    human_agent = LocalHumanAgent(opt)
 
     # Create model and assign it to the specified task
     agent = create_agent(opt, requireModelExists=True)
     agent.opt.log()
     SHARED['opt'] = agent.opt
     SHARED['agent'] = agent
-    SHARED['world'] = create_task(SHARED.get('opt'), SHARED['agent'])
+    SHARED['world'] = create_task(SHARED.get('opt'), [human_agent, SHARED['agent']])
 
     MyHandler.protocol_version = 'HTTP/1.0'
     httpd = HTTPServer((opt['host'], opt['port']), MyHandler)

--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -268,7 +268,6 @@ def wait():
 def interactive_web(opt):
     global SHARED
 
-    # opt['task'] = 'parlai.agents.local_human.local_human:LocalHumanAgent'
     human_agent = LocalHumanAgent(opt)
 
     # Create model and assign it to the specified task

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -85,7 +85,7 @@ class TestInteractiveLogging(unittest.TestCase):
 
 
 class TestInteractiveWeb(unittest.TestCase):
-    def test_iweb(self):
+    def test_iweb(self, task: str = None):
         import threading
         import random
         import requests
@@ -93,10 +93,11 @@ class TestInteractiveWeb(unittest.TestCase):
         import parlai.scripts.interactive_web as iweb
 
         port = random.randint(30000, 40000)
+        kwargs = {'model': 'repeat_query', 'port': port}
+        if task:
+            kwargs['task'] = task
         thread = threading.Thread(
-            target=iweb.InteractiveWeb.main,
-            kwargs={'model': 'repeat_query', 'port': port},
-            daemon=True,
+            target=iweb.InteractiveWeb.main, kwargs=kwargs, daemon=True
         )
         thread.start()
         iweb.wait()
@@ -122,6 +123,9 @@ class TestInteractiveWeb(unittest.TestCase):
         assert r.status_code == 500
 
         iweb.shutdown()
+
+    def test_iweb_task(self):
+        self.test_iweb(task='convai2')
 
 
 class TestProfileInteractive(unittest.TestCase):


### PR DESCRIPTION
**Patch description**
Interactive web script was broken if you tried to specify a `--task`; this fixes #4121. Functionality borrowed from `interactive.py`

**Testing steps**
Tested locally on laptop, ensured that command from #4121 works as expected post-fix.
