### PR TITLE
dicts to messasges

### DIFF
--- a/parlai/tasks/blended_skill_talk/agents.py
+++ b/parlai/tasks/blended_skill_talk/agents.py
@@ -159,7 +159,7 @@ class WoWPersonaTopicifierTeacher(WizardDialogKnowledgeTeacher):
         gotten = super().get(episode_idx, entry_idx=entry_idx)
         if entry_idx == 0:
             modified_text = self.persona_topicifier.get_modified_text(gotten['text'])
-            gotten['text'] = modified_text
+            gotten.force_set('text', modified_text)
         return gotten
 
 

--- a/parlai/tasks/wizard_of_wikipedia/agents.py
+++ b/parlai/tasks/wizard_of_wikipedia/agents.py
@@ -227,17 +227,19 @@ class WizardOfWikipediaTeacher(FixedDialogTeacher):
         d = self.data[episode_idx]
         dialog_entry = d['dialog'][entry_idx]
         episode_done = entry_idx == len(d['dialog']) - 1
-        action = {
-            'wizard_eval': d['wizard_eval'],
-            'chosen_topic': d['chosen_topic'],
-            'chosen_topic_passage': d['chosen_topic_passage'],
-            'text': dialog_entry['text'],
-            'retrieved_topics': dialog_entry['retrieved_topics'],
-            'retrieved_passages': dialog_entry['retrieved_passages'],
-            'checked_sentence': dialog_entry.get('checked_sentence', None),
-            'checked_passage': dialog_entry.get('checked_passage', None),
-            'episode_done': episode_done,
-        }
+        action = Message(
+            {
+                'wizard_eval': d['wizard_eval'],
+                'chosen_topic': d['chosen_topic'],
+                'chosen_topic_passage': d['chosen_topic_passage'],
+                'text': dialog_entry['text'],
+                'retrieved_topics': dialog_entry['retrieved_topics'],
+                'retrieved_passages': dialog_entry['retrieved_passages'],
+                'checked_sentence': dialog_entry.get('checked_sentence', None),
+                'checked_passage': dialog_entry.get('checked_passage', None),
+                'episode_done': episode_done,
+            }
+        )
 
         return action
 
@@ -444,14 +446,16 @@ class WizardDialogKnowledgeTeacher(WizardOfWikipediaTeacher):
             else:
                 label_cands = wizard_entry.get('candidate_responses', [])
 
-        action = {
-            'id': 'WizardDialogKnowledgeTeacher',
-            'text': text,
-            'labels': labels,
-            'chosen_topic': chosen_topic,
-            'episode_done': episode_done,
-            'label_candidates': label_cands,
-        }
+        action = Message(
+            {
+                'id': 'WizardDialogKnowledgeTeacher',
+                'text': text,
+                'labels': labels,
+                'chosen_topic': chosen_topic,
+                'episode_done': episode_done,
+                'label_candidates': label_cands,
+            }
+        )
         if self.include_knowledge:
             action['knowledge'] = knowledge_str
         if self.include_checked_sentence:
@@ -623,12 +627,14 @@ class BasicdialogTeacher(WizardOfWikipediaTeacher):
         if self.add_topic and entry_idx == 0:
             text = d.get('chosen_topic', '') + '\n' + text
 
-        action = {
-            'id': 'WizardBasicDialog',
-            'text': text,
-            'labels': labels,
-            'episode_done': episode_done,
-        }
+        action = Message(
+            {
+                'id': 'WizardBasicDialog',
+                'text': text,
+                'labels': labels,
+                'episode_done': episode_done,
+            }
+        )
         if 'label_candidates' in d:
             action['label_candidates'] = d['label_candidates']
 
@@ -728,36 +734,42 @@ class GeneratorTeacher(WizardDialogKnowledgeTeacher):
             # just a batch padding item
             return a
         # save some memory, we don't need label_candidates
-        a['label_candidates'] = []
+        a.force_set('label_candidates', [])
         if not a['knowledge'].startswith(TOKEN_NOCHOSEN):
             # make sure the token is appearing
-            a['knowledge'] = (
-                TOKEN_NOCHOSEN
-                + ' '
-                + TOKEN_KNOWLEDGE
-                + ' '
-                + TOKEN_NOCHOSEN
-                + '\n'
-                + a['knowledge']
+            a.force_set(
+                'knowledge',
+                (
+                    TOKEN_NOCHOSEN
+                    + ' '
+                    + TOKEN_KNOWLEDGE
+                    + ' '
+                    + TOKEN_NOCHOSEN
+                    + '\n'
+                    + a['knowledge']
+                ),
             )
         if self.only_checked_knowledge:
             # useful for test time evaluation, where it's only ever trained on true
             # knowledge
-            a['knowledge'] = (
-                a['title'] + ' ' + TOKEN_KNOWLEDGE + ' ' + a['checked_sentence']
+            a.force_set(
+                'knowledge',
+                (a['title'] + ' ' + TOKEN_KNOWLEDGE + ' ' + a['checked_sentence']),
             )
 
         if random.random() < self.dropout:
             # Drop the knowledge with some probability
-            a['title'] = TOKEN_NOCHOSEN
-            a['checked_sentence'] = TOKEN_NOCHOSEN
-            a['knowledge'] = (
-                TOKEN_NOCHOSEN + ' ' + TOKEN_KNOWLEDGE + ' ' + TOKEN_NOCHOSEN
+            a.force_set('title', TOKEN_NOCHOSEN)
+            a.force_set('checked_sentence', TOKEN_NOCHOSEN)
+            a.force_set(
+                'knowledge',
+                TOKEN_NOCHOSEN + ' ' + TOKEN_KNOWLEDGE + ' ' + TOKEN_NOCHOSEN,
             )
         elif self.prepend_gold_knowledge:
-            a[
-                'text'
-            ] = f"{TOKEN_KNOWLEDGE} {a['checked_sentence']} {TOKEN_END_KNOWLEDGE}{self.gold_knowledge_delimiter}{a['text']}"
+            a.force_set(
+                'text',
+                f"{TOKEN_KNOWLEDGE} {a['checked_sentence']} {TOKEN_END_KNOWLEDGE}{self.gold_knowledge_delimiter}{a['text']}",
+            )
         return a
 
 
@@ -1153,11 +1165,13 @@ class DocreaderTeacher(WizardOfWikipediaTeacher):
         # get sentence span
         span_label = self.get_span_label(d, idx)
 
-        action = {
-            'id': 'WizardDocReader:{}'.format(self.teacher_type),
-            'labels': [sentence],
-            'episode_done': episode_done,
-        }
+        action = Message(
+            {
+                'id': 'WizardDocReader:{}'.format(self.teacher_type),
+                'labels': [sentence],
+                'episode_done': episode_done,
+            }
+        )
 
         if self.teacher_type == 'docs':
             action['text'] = '{}\n{}'.format(passage, text)


### PR DESCRIPTION
**Patch description**
Changed the Wizard of Wikipedia examples from `dict` to `Message`. Running WoW with `parlai dd` used to show the following warning about the teacher examples being `dict` instead of `Message`. 

![Screen Shot 2021-11-05 at 1 47 13 PM](https://user-images.githubusercontent.com/11262163/140575963-c2e28c8e-91b7-41fd-bedd-36cd4d9e6dba.png)

**Testing steps**
1. The existing teacher tests.
2. Checking that warning doesn't appear anymore.
