### PR TITLE
FiD gold retrieved docs agent n-docs debug

### DIFF
--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -356,9 +356,10 @@ class GoldDocRetrieverFiDAgent(SearchQueryFiDAgent):
         if len(retrieved_docs) > self._n_docs:
             logging.warning(
                 f'Your `get_retrieved_knowledge` method returned {len(retrieved_docs)} Documents, '
-                f'instead of the expected {self._n_docs}. '
+                f'instead of the expected {self._n_docs} (set by `--n-docs`). '
                 f'This agent will only use the first {self._n_docs} Documents. '
-                'Consider modifying your implementation of `get_retrieved_knowledge` to avoid unexpected results.'
+                'Consider modifying your implementation of `get_retrieved_knowledge` to avoid unexpected results. '
+                '(or alternatively you may increase `--n-docs` parameter)'
             )
             retrieved_docs = retrieved_docs[: self._n_docs]
         self.model_api.retriever.add_retrieve_doc(

--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -412,6 +412,11 @@ class WizIntGoldDocRetrieverFiDAgent(GoldDocRetrieverFiDAgent):
             if len(retrieved_docs) == self._n_docs:
                 break
 
+        if n_docs_in_message > len(retrieved_docs):
+            logging.debug(
+                f'Trimmed retrieved docs from {n_docs_in_message} to {len(retrieved_docs)}'
+            )
+
         return retrieved_docs
 
 

--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -10,8 +10,8 @@ See https://arxiv.org/abs/2007.01282
 """
 from abc import abstractmethod
 from copy import deepcopy
-from enum import unique
 import torch
+import random
 from typing import Tuple, Union, Optional, List, Dict, Any
 
 from parlai.core.dict import DictionaryAgent
@@ -416,7 +416,7 @@ class WizIntGoldDocRetrieverFiDAgent(GoldDocRetrieverFiDAgent):
             logging.debug(
                 f'Trimmed retrieved docs from {n_docs_in_message} to {len(retrieved_docs)}'
             )
-
+        random.shuffle(retrieved_docs)
         return retrieved_docs
 
 


### PR DESCRIPTION
**Patch description**
Working with `WizIntGoldDocRetrieverFiDAgent`, I noticed it OOMing more often that it should. Looking into it, I realized that the agent was including all the retrieved docs. WoI doc chunk mutators split a document into 100 chunks or more and `ObservationEchoRetriever` returns these all docs---ignoring the `n_docs` parameter.

This patch fixed this issue by picking `n_docs` number of docs from the list of docs and then adding some filler docs.

NOTE: this problem could be fixed in the upstream by setting `--woi-doc-max-chunks` from `woi_dropout_retrieved_docs` as well. But this makes sure that it is safe to run it with other mutators, teachers as well.

**Testing it**
Ran 100 steps of training with a debug level message that shows the number of docs before and after trimming.

![Screen Shot 2021-11-05 at 6 09 34 PM](https://user-images.githubusercontent.com/11262163/140585382-58a7a26b-4f1f-41af-a6e9-cef663fd8348.png)

