### PR TITLE
Improve error message in Teachers

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -430,8 +430,9 @@ class FixedDialogTeacher(Teacher):
                     self.index.value %= num_eps
                 except ZeroDivisionError:
                     raise ZeroDivisionError(
-                        "Your setup_data is providing zero items. Teachers can not "
-                        "be empty."
+                        "The teacher has either empty data (e.g. setup_data yielded "
+                        "no items, or self.num_episodes() == 0). We do not support "
+                        "empty datasets (or folds) at this time."
                     )
             new_idx = self.index.value
         return new_idx

--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -426,7 +426,13 @@ class FixedDialogTeacher(Teacher):
         else:
             self.index.value += 1
             if loop:
-                self.index.value %= num_eps
+                try:
+                    self.index.value %= num_eps
+                except ZeroDivisionError:
+                    raise ZeroDivisionError(
+                        "Your setup_data is providing zero items. Teachers can not "
+                        "be empty."
+                    )
             new_idx = self.index.value
         return new_idx
 


### PR DESCRIPTION
**Patch description**
This is a fairly common mistake, but the old error message is quite obtuse and far away from the actual solution. Provide a better error message that gives more hints about where the issue actually is.

**Testing steps**
CI, reading.