### PR TITLE
[BB2] fixing the bug that crashed the BB2 runs for `bs > 1 `

### DIFF
--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -203,7 +203,7 @@ def argsort_scores_and_docs(
     scores_sorter = scores.sort(descending=True)
 
     ranked_docs = []
-    for idx in range(len(scores_sorter.indices[:n_docs])):
+    for idx in scores_sorter.indices[:n_docs]:
         doc_i = docs[idx] if idx < docs.size(0) else torch.zeros(docs.size(1))
         ranked_docs.append(doc_i.to(docs))
 

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -201,7 +201,12 @@ def argsort_scores_and_docs(
         (docs, scores) --> sorted documents, according to scores.
     """
     scores_sorter = scores.sort(descending=True)
-    ranked_docs = [docs[idx] for idx in scores_sorter.indices[:n_docs]]
+
+    ranked_docs = []
+    for idx in range(len(scores_sorter.indices[:n_docs])):
+        doc_i = docs[idx] if idx < docs.size(0) else torch.zeros(docs.size(1))
+        ranked_docs.append(doc_i.to(docs))
+
     ranked_scores = scores_sorter.values[:n_docs]
     return ranked_docs, ranked_scores
 


### PR DESCRIPTION
**Patch description**
While training BlenderBot2 models with `batchsize > 1` there were `IndexError` exceptions. Upon investigating I found cases like the screenshot below with mismatch between `docs` an `scores` (`scores_sorter`) tensor size. This patch adds dummy docs (with 0s) to the `docs` list to avoid this crash.

<img width="522" alt="Screen Shot 2021-11-08 at 8 59 50 PM" src="https://user-images.githubusercontent.com/11262163/140856912-a2446286-5db3-43ea-a79e-e8c667a8ed09.png">

**Testing steps**
Training after the changes, it doesn't crash anymore.

**Other information**
This resoles the issue with the crashed, but not sure if it causes any side-effects in the code.
