### PR TITLE
[BB2] Handle no-memories in `memory_only` case

### DIFF
--- a/projects/blenderbot2/agents/modules.py
+++ b/projects/blenderbot2/agents/modules.py
@@ -566,9 +566,11 @@ class BlenderBot2RagModel(RagModel):
         indices = memory_indices.tolist()
 
         if memory_vec is not None:
+            # Only look in memory_vec for batch elements with memories
+            memory_ids = [m for m in indices if num_memories[m] > 0]
             memory_dict = {
                 batch_id: memory_vec[batch_id, : num_memories[mem_id]]
-                for batch_id, mem_id in enumerate(indices)
+                for batch_id, mem_id in enumerate(memory_ids)
             }
         if memory_decoder_vec is not None:
             for batch_id in indices:


### PR DESCRIPTION
**Patch description**
When training with `--knowledge-access-method memory_only`, we send every example to access the long-term memory. If some examples within that batch do not have any `memory` vectors, the current access errors out.

This fix bars access to the `memory_vec` to be only those examples with tokenized memories; other examples are handled by adding "fake" memories, as is done in the `--knowledge-access-method classify` scenario.

**Testing steps**
Ran `test_bb2.py` locally:

```
$ pytest -k TestBB2Fid
================================================================================ test session starts ================================================================================
platform linux -- Python 3.7.9, pytest-5.3.2, py-1.10.0, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini
plugins: hydra-core-1.1.0, requests-mock-1.8.0, regressions-2.1.1, datadir-1.3.1
collected 120 items / 115 deselected / 5 selected

test_bb2.py .....                                                                                                                                                             [100%]

============================================================================= slowest 10 test durations =============================================================================
105.39s call     tests/nightly/gpu/test_bb2.py::TestBB2Fid::test_retrieval_all
79.66s call     tests/nightly/gpu/test_bb2.py::TestBB2Fid::test_retrieval_classify
77.69s call     tests/nightly/gpu/test_bb2.py::TestBB2Fid::test_retrieval_search_only
74.57s call     tests/nightly/gpu/test_bb2.py::TestBB2Fid::test_retrieval_memory_only
69.27s call     tests/nightly/gpu/test_bb2.py::TestBB2Fid::test_retrieval_none

(0.00 durations hidden.  Use -vv to show these durations.)
============================================================= 5 passed, 115 deselected, 7 warnings in 420.48s (0:07:00) =============================================================
```
