### PR TITLE
[BB2] BlenderBot FiD agent that uses Wizard of Internet's original retrieved docs

### DIFF
--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -1283,6 +1283,7 @@ class ObservationEchoRetriever(RagRetriever):
 
     def __init__(self, opt: Opt, dictionary: DictionaryAgent, shared: TShared = None):
         self._delimiter = '\n'
+        self.n_docs = opt['n_docs']
         self._query_ids = dict()
         self._saved_docs = dict()
         super().__init__(opt, dictionary, shared=shared)
@@ -1290,7 +1291,9 @@ class ObservationEchoRetriever(RagRetriever):
     def add_retrieve_doc(self, query: str, retrieved_docs: List[Document]):
         new_idx = len(self._query_ids)
         self._query_ids[query] = new_idx
-        self._saved_docs[new_idx] = retrieved_docs or [BLANK_DOC]
+        self._saved_docs[new_idx] = retrieved_docs or [
+            BLANK_DOC for _ in range(self.n_docs)
+        ]
 
     def tokenize_query(self, query: str) -> List[int]:
         return [self._query_ids[query]]

--- a/parlai/tasks/wizard_of_internet/agents.py
+++ b/parlai/tasks/wizard_of_internet/agents.py
@@ -105,10 +105,12 @@ def parse_wizard_message(message_dict, doc_lines_delim):
         if not knowledge[CONST.RETRIEVED_DOCS]:
             knowledge[CONST.RETRIEVED_DOCS] = [CONST.NO_RETRIEVED_DOCS_TOKEN]
             knowledge[CONST.RETRIEVED_DOCS_URLS] = [CONST.NO_URLS]
+            knowledge[CONST.RETRIEVED_DOCS_TITLES] = [CONST.NO_TITLE]
 
         if not knowledge[CONST.SELECTED_DOCS]:
             knowledge[CONST.SELECTED_DOCS] = [CONST.NO_SELECTED_DOCS_TOKEN]
             knowledge[CONST.SELECTED_SENTENCES] = [CONST.NO_SELECTED_SENTENCES_TOKEN]
+            knowledge[CONST.SELECTED_DOCS_TITLES] = [CONST.NO_TITLE]
 
         return knowledge
 

--- a/parlai/tasks/wizard_of_internet/test/wizard_of_internet_WizardDialogGoldKnowledgeTeacher_test.yml
+++ b/parlai/tasks/wizard_of_internet/test/wizard_of_internet_WizardDialogGoldKnowledgeTeacher_test.yml
@@ -677,7 +677,8 @@ acts:
       Throwback video! When Salman Khan teased Katrina Kaif for missi...
 
       Pulwama terror attack: Ram Gopal Varma taunts Pakistan Prime Mi...'
-    __select-docs-titles__: []
+    __select-docs-titles__:
+    - __no_title__
     __selected-docs-urls__: []
     __selected-docs__:
     - __noselected-docs__

--- a/parlai/tasks/wizard_of_internet/test/wizard_of_internet_WizardDialogGoldKnowledgeTeacher_train.yml
+++ b/parlai/tasks/wizard_of_internet/test/wizard_of_internet_WizardDialogGoldKnowledgeTeacher_train.yml
@@ -3128,12 +3128,14 @@ acts:
       \ i forgot to mention there is also only a 20 or thirty minute time limit, depending\
       \ on the round. The cuisine is from around the world. Fine dining to street\
       \ style. "
-- - __retrieved-docs-titles__: []
+- - __retrieved-docs-titles__:
+    - __no_title__
     __retrieved-docs-urls__:
     - __no_urls__
     __retrieved-docs__:
     - __noretrieved-docs__
-    __select-docs-titles__: []
+    __select-docs-titles__:
+    - __no_title__
     __selected-docs-urls__: []
     __selected-docs__:
     - __noselected-docs__

--- a/parlai/tasks/wizard_of_internet/test/wizard_of_internet_WizardDialogGoldKnowledgeTeacher_valid.yml
+++ b/parlai/tasks/wizard_of_internet/test/wizard_of_internet_WizardDialogGoldKnowledgeTeacher_valid.yml
@@ -1,10 +1,12 @@
 acts:
-- - __retrieved-docs-titles__: []
+- - __retrieved-docs-titles__:
+    - __no_title__
     __retrieved-docs-urls__:
     - __no_urls__
     __retrieved-docs__:
     - __noretrieved-docs__
-    __select-docs-titles__: []
+    __select-docs-titles__:
+    - __no_title__
     __selected-docs-urls__: []
     __selected-docs__:
     - __noselected-docs__
@@ -17,12 +19,14 @@ acts:
     search_query: __no_search_used__
     text: "__knowledge__ __no_passages_used__ __endknowledge__ \n I work as a freelance\
       \ accountant.\nI enjoy reading books.   "
-- - __retrieved-docs-titles__: []
+- - __retrieved-docs-titles__:
+    - __no_title__
     __retrieved-docs-urls__:
     - __no_urls__
     __retrieved-docs__:
     - __noretrieved-docs__
-    __select-docs-titles__: []
+    __select-docs-titles__:
+    - __no_title__
     __selected-docs-urls__: []
     __selected-docs__:
     - __noselected-docs__
@@ -786,7 +790,8 @@ acts:
       Verification of Debentures | Guidelines for Auditors
 
       Tags:Auditing, Role of Auditor'
-    __select-docs-titles__: []
+    __select-docs-titles__:
+    - __no_title__
     __selected-docs-urls__: []
     __selected-docs__:
     - __noselected-docs__

--- a/parlai/tasks/wizard_of_internet/test/wizard_of_internet_test.yml
+++ b/parlai/tasks/wizard_of_internet/test/wizard_of_internet_test.yml
@@ -677,7 +677,8 @@ acts:
       Throwback video! When Salman Khan teased Katrina Kaif for missi...
 
       Pulwama terror attack: Ram Gopal Varma taunts Pakistan Prime Mi...'
-    __select-docs-titles__: []
+    __select-docs-titles__:
+    - __no_title__
     __selected-docs-urls__: []
     __selected-docs__:
     - __noselected-docs__

--- a/parlai/tasks/wizard_of_internet/test/wizard_of_internet_train.yml
+++ b/parlai/tasks/wizard_of_internet/test/wizard_of_internet_train.yml
@@ -3124,12 +3124,14 @@ acts:
     text: 'Yes, i forgot to mention there is also only a 20 or thirty minute time
       limit, depending on the round. The cuisine is from around the world. Fine dining
       to street style. '
-- - __retrieved-docs-titles__: []
+- - __retrieved-docs-titles__:
+    - __no_title__
     __retrieved-docs-urls__:
     - __no_urls__
     __retrieved-docs__:
     - __noretrieved-docs__
-    __select-docs-titles__: []
+    __select-docs-titles__:
+    - __no_title__
     __selected-docs-urls__: []
     __selected-docs__:
     - __noselected-docs__

--- a/parlai/tasks/wizard_of_internet/test/wizard_of_internet_valid.yml
+++ b/parlai/tasks/wizard_of_internet/test/wizard_of_internet_valid.yml
@@ -1,10 +1,12 @@
 acts:
-- - __retrieved-docs-titles__: []
+- - __retrieved-docs-titles__:
+    - __no_title__
     __retrieved-docs-urls__:
     - __no_urls__
     __retrieved-docs__:
     - __noretrieved-docs__
-    __select-docs-titles__: []
+    __select-docs-titles__:
+    - __no_title__
     __selected-docs-urls__: []
     __selected-docs__:
     - __noselected-docs__
@@ -18,12 +20,14 @@ acts:
     text: 'I work as a freelance accountant.
 
       I enjoy reading books.   '
-- - __retrieved-docs-titles__: []
+- - __retrieved-docs-titles__:
+    - __no_title__
     __retrieved-docs-urls__:
     - __no_urls__
     __retrieved-docs__:
     - __noretrieved-docs__
-    __select-docs-titles__: []
+    __select-docs-titles__:
+    - __no_title__
     __selected-docs-urls__: []
     __selected-docs__:
     - __noselected-docs__
@@ -786,7 +790,8 @@ acts:
       Verification of Debentures | Guidelines for Auditors
 
       Tags:Auditing, Role of Auditor'
-    __select-docs-titles__: []
+    __select-docs-titles__:
+    - __no_title__
     __selected-docs-urls__: []
     __selected-docs__:
     - __noselected-docs__

--- a/projects/blenderbot2/agents/blenderbot2.py
+++ b/projects/blenderbot2/agents/blenderbot2.py
@@ -18,7 +18,7 @@ import torch.nn
 import torch.nn.functional as F
 from typing import Union, Dict, List, Tuple, Optional, Any
 
-from parlai.agents.fid.fid import FidAgent
+from parlai.agents.fid.fid import FidAgent, WizIntGoldDocRetrieverFiDAgent
 from parlai.agents.rag.args import DPR_ZOO_MODEL, QUERY_MODEL_TYPES
 from parlai.agents.rag.rag import RagAgent
 from parlai.agents.rag.model_types import (
@@ -892,3 +892,11 @@ class BlenderBot2FidAgent(FidAgent, BlenderBot2RagAgent):
                 model.encoder.embeddings.weight, self.opt['embedding_type']
             )
         return model
+
+
+class BlenderBot2WizIntGoldDocRetrieverFiDAgent(
+    WizIntGoldDocRetrieverFiDAgent, BlenderBot2FidAgent
+):
+    def _set_query_vec(self, observation: Message) -> Message:
+        self.show_observation_to_echo_retriever(observation)
+        super()._set_query_vec(observation)

--- a/projects/blenderbot2/agents/modules.py
+++ b/projects/blenderbot2/agents/modules.py
@@ -24,6 +24,7 @@ from parlai.agents.rag.retrievers import (
     RagRetrieverTokenizer,
     SearchQuerySearchEngineRetriever,
     SearchQueryFAISSIndexRetriever,
+    ObservationEchoRetriever,
 )
 from parlai.core.dict import DictionaryAgent
 from parlai.core.opt import Opt
@@ -64,6 +65,8 @@ def retriever_factory(
         return BB2SearchQuerySearchEngineRetriever(opt, dictionary, shared=shared)
     elif retriever is RetrieverType.SEARCH_TERM_FAISS:
         return BB2SearchQueryFaissIndexRetriever(opt, dictionary, shared=shared)
+    elif retriever is RetrieverType.OBSERVATION_ECHO_RETRIEVER:
+        return BB2ObservationEchoRetriever(opt, dictionary, shared=shared)
     else:
         return rag_retriever_factory(opt, dictionary, shared=shared)
 
@@ -907,4 +910,10 @@ class BB2SearchQueryFaissIndexRetriever(
 ):
     """
     Override Search Engine Retriever to accommodate SQ Generator from BB2 Setup.
+    """
+
+
+class BB2ObservationEchoRetriever(BB2SearchRetrieverMixin, ObservationEchoRetriever):
+    """
+    A retriever that reads retrieved docs as part of the observed example message.
     """


### PR DESCRIPTION
# Patch description
BlenderBot 2 FiD model with gold retrieved documents (documents that were shown to the crowdsourcing agents during data collection). It uses the `ObservationEchoRetriever` retriever for reading the observed messages from the content of the message from the Wizard of Internet teacher.

# Test
Running a few steps of training
```
parlai train -t wizard_of_internet \
--model projects.blenderbot2.agents.blenderbot2:BlenderBot2WizIntGoldDocRetrieverFiDAgent \
--batchsize 4 --dict-file zoo:blender/reddit_3B/model.dict -tr 32
```
![Screen Shot 2021-11-11 at 1 21 01 PM](https://user-images.githubusercontent.com/11262163/141349330-3f6356f3-e585-4b58-b241-64ffe3ea57e5.png)

## Note
* There was a nit change on the wizard of internet task for consistency.
* Training with this agent doesn't require using search engine.
* This knowledge retriever part of this agent only works with Wizard of Internet dataset, or any dataset that has similar messages (the content under knowledge component keys).

