### PR TITLE
[WizInt, BB2] Remove docs mutators

### DIFF
--- a/parlai/tasks/wizard_of_internet/agents.py
+++ b/parlai/tasks/wizard_of_internet/agents.py
@@ -109,8 +109,9 @@ def parse_wizard_message(message_dict, doc_lines_delim):
 
         if not knowledge[CONST.SELECTED_DOCS]:
             knowledge[CONST.SELECTED_DOCS] = [CONST.NO_SELECTED_DOCS_TOKEN]
-            knowledge[CONST.SELECTED_SENTENCES] = [CONST.NO_SELECTED_SENTENCES_TOKEN]
+            knowledge[CONST.SELECTED_DOCS_URLS] = [CONST.NO_URLS]
             knowledge[CONST.SELECTED_DOCS_TITLES] = [CONST.NO_TITLE]
+            knowledge[CONST.SELECTED_SENTENCES] = [CONST.NO_SELECTED_SENTENCES_TOKEN]
 
         return knowledge
 
@@ -809,3 +810,21 @@ class WoiDropoutRetrievedDocs(MessageMutator):
 
         new_message.force_set(CONST.RETRIEVED_DOCS, new_docs)
         return new_message
+
+
+@register_mutator("woi_remove_retrieved_docs")
+class WoiRemoveRetrievedDocs(WoiDropoutRetrievedDocs):
+    def message_mutation(self, message: Message) -> Message:
+        if CONST.RETRIEVED_DOCS not in message:
+            return message
+
+        message.force_set(CONST.RETRIEVED_DOCS, [CONST.NO_RETRIEVED_DOCS_TOKEN])
+        message.force_set(CONST.RETRIEVED_DOCS, [CONST.NO_RETRIEVED_DOCS_TOKEN])
+        message.force_set(CONST.RETRIEVED_DOCS_URLS, [CONST.NO_URLS])
+        message.force_set(CONST.RETRIEVED_DOCS_TITLES, [CONST.NO_TITLE])
+
+        message.force_set(CONST.SELECTED_DOCS, [CONST.NO_SELECTED_DOCS_TOKEN])
+        message.force_set(CONST.SELECTED_SENTENCES, [CONST.NO_SELECTED_SENTENCES_TOKEN])
+        message.force_set(CONST.SELECTED_DOCS_URLS, [CONST.NO_URLS])
+        message.force_set(CONST.SELECTED_DOCS_TITLES, [CONST.NO_TITLE])
+        return message

--- a/parlai/tasks/wizard_of_internet/agents.py
+++ b/parlai/tasks/wizard_of_internet/agents.py
@@ -131,6 +131,19 @@ def parse_search_results(message_dict, delim='; '):
     return d
 
 
+def remove_retrieved_docs_from_message(message: Message):
+    message.force_set(CONST.RETRIEVED_DOCS, [CONST.NO_RETRIEVED_DOCS_TOKEN])
+    message.force_set(CONST.RETRIEVED_DOCS_URLS, [CONST.NO_URLS])
+    message.force_set(CONST.RETRIEVED_DOCS_TITLES, [CONST.NO_TITLE])
+
+
+def remove_selected_docs_from_message(message: Message):
+    message.force_set(CONST.SELECTED_DOCS, [CONST.NO_SELECTED_DOCS_TOKEN])
+    message.force_set(CONST.SELECTED_SENTENCES, [CONST.NO_SELECTED_SENTENCES_TOKEN])
+    message.force_set(CONST.SELECTED_DOCS_URLS, [CONST.NO_URLS])
+    message.force_set(CONST.SELECTED_DOCS_TITLES, [CONST.NO_TITLE])
+
+
 class WizardOfInternetBaseTeacher(DialogTeacher):
     """
     Base Teacher for Wizard of Internet tasks.
@@ -433,6 +446,16 @@ class WizardDialogGoldKnowledgeTeacher(WizardDialogTeacher):
         super().add_cmdline_args(parser, partial_opt)
         parser.set_params(prepend_gold_knowledge=True)
         return parser
+
+
+class WizardDialogGoldKnowledgeNoDocsTeacher(WizardDialogGoldKnowledgeTeacher):
+    """
+    Prepends gold (selected knowledge) to the context, and removes the retrieved docs.
+    """
+
+    def additional_message_content(self, parlai_message: Message, action: Dict):
+        super().additional_message_content(parlai_message, action)
+        remove_retrieved_docs_from_message(parlai_message)
 
 
 class DefaultTeacher(WizardDialogTeacher):
@@ -812,19 +835,11 @@ class WoiDropoutRetrievedDocs(MessageMutator):
         return new_message
 
 
-@register_mutator("woi_remove_retrieved_docs")
-class WoiRemoveRetrievedDocs(WoiDropoutRetrievedDocs):
+@register_mutator("woi_remove_knowledge")
+class WoiRemoveKnowledge(MessageMutator):
     def message_mutation(self, message: Message) -> Message:
         if CONST.RETRIEVED_DOCS not in message:
             return message
-
-        message.force_set(CONST.RETRIEVED_DOCS, [CONST.NO_RETRIEVED_DOCS_TOKEN])
-        message.force_set(CONST.RETRIEVED_DOCS, [CONST.NO_RETRIEVED_DOCS_TOKEN])
-        message.force_set(CONST.RETRIEVED_DOCS_URLS, [CONST.NO_URLS])
-        message.force_set(CONST.RETRIEVED_DOCS_TITLES, [CONST.NO_TITLE])
-
-        message.force_set(CONST.SELECTED_DOCS, [CONST.NO_SELECTED_DOCS_TOKEN])
-        message.force_set(CONST.SELECTED_SENTENCES, [CONST.NO_SELECTED_SENTENCES_TOKEN])
-        message.force_set(CONST.SELECTED_DOCS_URLS, [CONST.NO_URLS])
-        message.force_set(CONST.SELECTED_DOCS_TITLES, [CONST.NO_TITLE])
+        remove_retrieved_docs_from_message(message)
+        remove_selected_docs_from_message(message)
         return message

--- a/parlai/tasks/wizard_of_internet/test/wizard_of_internet_WizardDialogGoldKnowledgeTeacher_test.yml
+++ b/parlai/tasks/wizard_of_internet/test/wizard_of_internet_WizardDialogGoldKnowledgeTeacher_test.yml
@@ -679,7 +679,8 @@ acts:
       Pulwama terror attack: Ram Gopal Varma taunts Pakistan Prime Mi...'
     __select-docs-titles__:
     - __no_title__
-    __selected-docs-urls__: []
+    __selected-docs-urls__:
+    - __no_urls__
     __selected-docs__:
     - __noselected-docs__
     __selected-sentences__:

--- a/parlai/tasks/wizard_of_internet/test/wizard_of_internet_WizardDialogGoldKnowledgeTeacher_train.yml
+++ b/parlai/tasks/wizard_of_internet/test/wizard_of_internet_WizardDialogGoldKnowledgeTeacher_train.yml
@@ -3136,7 +3136,8 @@ acts:
     - __noretrieved-docs__
     __select-docs-titles__:
     - __no_title__
-    __selected-docs-urls__: []
+    __selected-docs-urls__:
+    - __no_urls__
     __selected-docs__:
     - __noselected-docs__
     __selected-sentences__:

--- a/parlai/tasks/wizard_of_internet/test/wizard_of_internet_WizardDialogGoldKnowledgeTeacher_valid.yml
+++ b/parlai/tasks/wizard_of_internet/test/wizard_of_internet_WizardDialogGoldKnowledgeTeacher_valid.yml
@@ -7,7 +7,8 @@ acts:
     - __noretrieved-docs__
     __select-docs-titles__:
     - __no_title__
-    __selected-docs-urls__: []
+    __selected-docs-urls__:
+    - __no_urls__
     __selected-docs__:
     - __noselected-docs__
     __selected-sentences__:
@@ -27,7 +28,8 @@ acts:
     - __noretrieved-docs__
     __select-docs-titles__:
     - __no_title__
-    __selected-docs-urls__: []
+    __selected-docs-urls__:
+    - __no_urls__
     __selected-docs__:
     - __noselected-docs__
     __selected-sentences__:
@@ -792,7 +794,8 @@ acts:
       Tags:Auditing, Role of Auditor'
     __select-docs-titles__:
     - __no_title__
-    __selected-docs-urls__: []
+    __selected-docs-urls__:
+    - __no_urls__
     __selected-docs__:
     - __noselected-docs__
     __selected-sentences__:

--- a/parlai/tasks/wizard_of_internet/test/wizard_of_internet_test.yml
+++ b/parlai/tasks/wizard_of_internet/test/wizard_of_internet_test.yml
@@ -679,7 +679,8 @@ acts:
       Pulwama terror attack: Ram Gopal Varma taunts Pakistan Prime Mi...'
     __select-docs-titles__:
     - __no_title__
-    __selected-docs-urls__: []
+    __selected-docs-urls__:
+    - __no_urls__
     __selected-docs__:
     - __noselected-docs__
     __selected-sentences__:

--- a/parlai/tasks/wizard_of_internet/test/wizard_of_internet_train.yml
+++ b/parlai/tasks/wizard_of_internet/test/wizard_of_internet_train.yml
@@ -3132,7 +3132,8 @@ acts:
     - __noretrieved-docs__
     __select-docs-titles__:
     - __no_title__
-    __selected-docs-urls__: []
+    __selected-docs-urls__:
+    - __no_urls__
     __selected-docs__:
     - __noselected-docs__
     __selected-sentences__:

--- a/parlai/tasks/wizard_of_internet/test/wizard_of_internet_valid.yml
+++ b/parlai/tasks/wizard_of_internet/test/wizard_of_internet_valid.yml
@@ -7,7 +7,8 @@ acts:
     - __noretrieved-docs__
     __select-docs-titles__:
     - __no_title__
-    __selected-docs-urls__: []
+    __selected-docs-urls__:
+    - __no_urls__
     __selected-docs__:
     - __noselected-docs__
     __selected-sentences__:
@@ -28,7 +29,8 @@ acts:
     - __noretrieved-docs__
     __select-docs-titles__:
     - __no_title__
-    __selected-docs-urls__: []
+    __selected-docs-urls__:
+    - __no_urls__
     __selected-docs__:
     - __noselected-docs__
     __selected-sentences__:
@@ -792,7 +794,8 @@ acts:
       Tags:Auditing, Role of Auditor'
     __select-docs-titles__:
     - __no_title__
-    __selected-docs-urls__: []
+    __selected-docs-urls__:
+    - __no_urls__
     __selected-docs__:
     - __noselected-docs__
     __selected-sentences__:


### PR DESCRIPTION
**Patch description**
* Added `WizardOfInternetBaseTeacher` that is an extension to `WizardDialogGoldKnowledgeTeacher` with retrieved docs removed. 
* `woi_remove_knowledge` mutator that removes all knowledge (retrieved and selected) from the message.

Before

![Screen Shot 2021-11-12 at 1 24 20 PM](https://user-images.githubusercontent.com/11262163/141516285-dea1a373-6658-4606-b2d9-6dc853d80b2a.png)

After
![Screen Shot 2021-11-12 at 12 26 45 PM](https://user-images.githubusercontent.com/11262163/141516145-04c5932c-934f-4446-a4a1-05f2d2a3935f.png)



**Testing steps**
Teacher tests and visually checking with `parlai dd`