### PR TITLE
Fix WandB requeueing

### DIFF
--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -180,7 +180,7 @@ class WandbLogger(object):
             notes=f"{opt['model_file']}",
             entity=opt.get('wandb_entity'),
             reinit=True,  # in case of preemption
-            resume=True, # requeued runs should be treated as single run
+            resume=True,  # requeued runs should be treated as single run
         )
         # suppress wandb's output
         logging.getLogger("wandb").setLevel(logging.ERROR)

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -184,9 +184,12 @@ class WandbLogger(object):
         )
         # suppress wandb's output
         logging.getLogger("wandb").setLevel(logging.ERROR)
-        for key, value in opt.items():
-            if value is None or isinstance(value, (str, numbers.Number, tuple)):
-                setattr(self.run.config, key, value)
+
+        print("RESUMED?", self.run.resumed)
+        if not self.run.resumed:
+            for key, value in opt.items():
+                if value is None or isinstance(value, (str, numbers.Number, tuple)):
+                    setattr(self.run.config, key, value)
         if model is not None:
             self.run.watch(model)
 

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -180,6 +180,7 @@ class WandbLogger(object):
             notes=f"{opt['model_file']}",
             entity=opt.get('wandb_entity'),
             reinit=True,  # in case of preemption
+            resume=True, # requeued runs should be treated as single run
         )
         # suppress wandb's output
         logging.getLogger("wandb").setLevel(logging.ERROR)

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -185,7 +185,6 @@ class WandbLogger(object):
         # suppress wandb's output
         logging.getLogger("wandb").setLevel(logging.ERROR)
 
-        print("RESUMED?", self.run.resumed)
         if not self.run.resumed:
             for key, value in opt.items():
                 if value is None or isinstance(value, (str, numbers.Number, tuple)):


### PR DESCRIPTION
**Patch description**

If a job is pre-empted and then re-queued, the current logic produces multiple runs in WandB, each corresponding a respective execution of the job. We should tell WandB to automatically group runs of the same job into a single run if a process exited unsuccessfully (i.e. was pre-empted). 

For more detail, see: https://docs.wandb.ai/guides/track/advanced/resuming.

**Testing steps**

I ran the following command twice, Ctrl+C'ing after the first one, using my WandB account to verify that it did not produce two runs, but instead joined the logs from both runs. If you want to run this yourself, you need to login to your WandB account and update ` --wandb-entity` arg to your username below.

```
parlai train_model -t personachat -m transformer/ranker --n-layers 1 --embedding-size 300 --ffn-size 600 --n-heads 4 --num-epochs 10 -veps 0.25 -bs 64 -lr 0.001 --dropout 0.1 --embedding-type fasttext_cc --candidates batch -wblog True --wandb-name a_test --wandb-project test2 --wandb-entity colinflaherty --model-file './tmp/model'
```

This is what things look like if for the code currently on `main`:
<img width="570" alt="Screen Shot 2021-11-16 at 3 49 10 PM" src="https://user-images.githubusercontent.com/37087066/142063390-e3f82bc2-def2-4419-aea9-465e6e1a07fc.png">

<img width="574" alt="Screen Shot 2021-11-16 at 3 49 35 PM" src="https://user-images.githubusercontent.com/37087066/142063454-89f2bc6b-09f0-4889-b9d7-52ccaf590406.png">

<img width="583" alt="Screen Shot 2021-11-16 at 3 49 26 PM" src="https://user-images.githubusercontent.com/37087066/142063418-faa99845-f31c-4bd6-9c60-62d66179b62d.png">


This is what things look like with this PR's changes added:

<img width="511" alt="Screen Shot 2021-11-16 at 3 52 55 PM" src="https://user-images.githubusercontent.com/37087066/142063919-a12ff8d1-9062-40ec-892d-bc57d82d109a.png">

<img width="498" alt="Screen Shot 2021-11-16 at 3 53 16 PM" src="https://user-images.githubusercontent.com/37087066/142063962-e621b7f9-5b00-4152-8c46-c94f3db20e41.png">

