### PR TITLE
typing-extensions bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ tokenizers>=0.8.0
 torchtext>=0.5.0
 tornado==6.0.4
 tqdm~=4.62.1
-typing-extensions==3.7.4.1
+typing-extensions>=3.7.4.3
 Unidecode==1.1.1
 urllib3>=1.26.5
 websocket-client==0.56.0


### PR DESCRIPTION
update version requirement of typing-extensions

[main branch fails](https://app.circleci.com/pipelines/github/facebookresearch/ParlAI/10354/workflows/b2cc459e-c276-42ee-80c4-bf31e4e8b8bc/jobs/85428) due to this error `ImportError: cannot import name 'TypeAlias' from 'typing_extensions'`

copied the same fix here: https://github.com/huggingface/huggingface_hub/pull/453

Testing: CircleCI pass