### PR TITLE
Fix "Warmup scheduler is loaded from the state dict, even when initializing fresh"

### DIFF
--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -51,14 +51,11 @@ class ParlAILRScheduler(object):
         self.hard_reset = hard_reset
         self.warmup_scheduler = None
 
-    def _init_warmup_scheduler(self, optimizer, states):
+    def _init_warmup_scheduler(self, optimizer):
         """
         :param optimizer optimizer:
             Optimizer being used for training. May be wrapped in
             fp16_optimizer_wrapper depending on whether fp16 is used.
-        :param state_dict states:
-            Possible state_dict provided by model checkpoint, for restoring
-            LR state.
         """
         if self.warmup_updates > 0:
             self.warmup_scheduler = optim.lr_scheduler.LambdaLR(

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -60,8 +60,9 @@ class ParlAILRScheduler(object):
         if self.warmup_updates > 0 and (
             updates_so_far < self.warmup_updates or hard_reset
         ):
+            last_epoch = -1 if updates_so_far == 0 else updates_so_far
             self.warmup_scheduler = optim.lr_scheduler.LambdaLR(
-                optimizer, self._warmup_lr, last_epoch=updates_so_far
+                optimizer, self._warmup_lr, last_epoch=last_epoch
             )
 
     def get_last_lr(self):

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -284,12 +284,12 @@ class ParlAILRScheduler(object):
             )
             hard_reset = True
 
+        # setup warmup scheduler after loading saved scheduler
+        scheduler._init_warmup_scheduler(optimizer)
+
         if not hard_reset:
             # do the actual loading (if possible)
             scheduler.load_state(states)
-
-        # setup warmup scheduler after loading saved scheduler
-        scheduler._init_warmup_scheduler(optimizer, states)
 
         return scheduler
 

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -38,12 +38,6 @@ class ParlAILRScheduler(object):
         Initialize warmup scheduler. Specific main schedulers should be initialized in
         the subclasses. Do not invoke this method diretly.
 
-        :param optimizer optimizer:
-            Optimizer being used for training. May be wrapped in
-            fp16_optimizer_wrapper depending on whether fp16 is used.
-        :param state_dict states:
-            Possible state_dict provided by model checkpoint, for restoring
-            LR state.
         :param bool hard_reset:
             If true, the LR scheduler should ignore the state dictionary.
         :param int warmup_updates:
@@ -57,6 +51,14 @@ class ParlAILRScheduler(object):
         self.hard_reset = hard_reset
 
     def _init_warmup_scheduler(self, optimizer, states):
+        """
+        :param optimizer optimizer:
+            Optimizer being used for training. May be wrapped in
+            fp16_optimizer_wrapper depending on whether fp16 is used.
+        :param state_dict states:
+            Possible state_dict provided by model checkpoint, for restoring
+            LR state.
+        """
         updates_so_far = states.get('number_training_updates', 0)
         if self.warmup_updates > 0 and (
             updates_so_far < self.warmup_updates or self.hard_reset

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -60,6 +60,8 @@ class ParlAILRScheduler(object):
         if self.warmup_updates > 0 and (
             updates_so_far < self.warmup_updates or hard_reset
         ):
+            # initializing LambdaLR scheduler can mess up learning rates,
+            # so try to avoid it, when warmup is already done
             last_epoch = -1 if updates_so_far == 0 else updates_so_far
             self.warmup_scheduler = optim.lr_scheduler.LambdaLR(
                 optimizer, self._warmup_lr, last_epoch=last_epoch

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -62,7 +62,7 @@ class ParlAILRScheduler(object):
         ):
             # initializing LambdaLR scheduler can mess up learning rates,
             # so try to avoid it, when warmup is already done
-            last_epoch = -1 if updates_so_far == 0 else updates_so_far
+            last_epoch = -1 if updates_so_far == 0 or hard_reset else updates_so_far
             self.warmup_scheduler = optim.lr_scheduler.LambdaLR(
                 optimizer, self._warmup_lr, last_epoch=last_epoch
             )

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -251,21 +251,11 @@ class ParlAILRScheduler(object):
             )
         elif opt.get('lr_scheduler') == 'cosine':
             scheduler = CosineLRScheduler(
-                optimizer,
-                patience,
-                decay,
-                warmup_updates,
-                warmup_rate,
-                max_lr_steps,
+                optimizer, patience, decay, warmup_updates, warmup_rate, max_lr_steps
             )
         elif opt.get('lr_scheduler') == 'linear':
             scheduler = LinearLRScheduler(
-                optimizer,
-                patience,
-                decay,
-                warmup_updates,
-                warmup_rate,
-                max_lr_steps,
+                optimizer, patience, decay, warmup_updates, warmup_rate, max_lr_steps
             )
         else:
             raise ValueError(
@@ -343,9 +333,7 @@ class ReduceOnPlateauLRScheduler(ParlAILRScheduler):
     Scheduler that decays by a multiplicative rate when valid loss plateaus.
     """
 
-    def __init__(
-        self, optimizer, patience, decay, warmup_updates, warmup_rate
-    ):
+    def __init__(self, optimizer, patience, decay, warmup_updates, warmup_rate):
         super().__init__(warmup_updates, warmup_rate)
         self.scheduler = optim.lr_scheduler.ReduceLROnPlateau(
             optimizer, 'min', factor=decay, patience=patience, verbose=True
@@ -371,9 +359,7 @@ class FixedLRScheduler(ParlAILRScheduler):
     Scheduler that decays by a fixed multiplicative rate at each valid step.
     """
 
-    def __init__(
-        self, optimizer, patience, decay, warmup_updates, warmup_rate
-    ):
+    def __init__(self, optimizer, patience, decay, warmup_updates, warmup_rate):
         super().__init__(warmup_updates, warmup_rate)
         self.scheduler = optim.lr_scheduler.StepLR(optimizer, patience, gamma=decay)
 
@@ -443,13 +429,7 @@ class CosineLRScheduler(ParlAILRScheduler):
     """
 
     def __init__(
-        self,
-        optimizer,
-        patience,
-        decay,
-        warmup_updates,
-        warmup_rate,
-        max_lr_steps,
+        self, optimizer, patience, decay, warmup_updates, warmup_rate, max_lr_steps
     ):
         """
         max_lr_steps determines the cycle length of the cosine annealing.
@@ -482,13 +462,7 @@ class LinearLRScheduler(ParlAILRScheduler):
     """
 
     def __init__(
-        self,
-        optimizer,
-        patience,
-        decay,
-        warmup_updates,
-        warmup_rate,
-        max_lr_steps,
+        self, optimizer, patience, decay, warmup_updates, warmup_rate, max_lr_steps
     ):
         """
         max_lr_steps determines the cycle length of the linear annealing.

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -60,10 +60,7 @@ class ParlAILRScheduler(object):
             Possible state_dict provided by model checkpoint, for restoring
             LR state.
         """
-        updates_so_far = states.get('number_training_updates', 0)
-        if self.warmup_updates > 0 and (
-            updates_so_far < self.warmup_updates or self.hard_reset
-        ):
+        if self.warmup_updates > 0:
             self.warmup_scheduler = optim.lr_scheduler.LambdaLR(
                 optimizer, self._warmup_lr
             )

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -66,8 +66,6 @@ class ParlAILRScheduler(object):
             self.warmup_scheduler = optim.lr_scheduler.LambdaLR(
                 optimizer, self._warmup_lr
             )
-            if states.get('warmup_scheduler'):
-                self.warmup_scheduler.load_state_dict(states['warmup_scheduler'])
         else:
             self.warmup_scheduler = None
 

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -48,15 +48,18 @@ class ParlAILRScheduler(object):
         self.warmup_rate = warmup_rate
         self.warmup_scheduler = None
 
-    def _init_warmup_scheduler(self, optimizer):
+    def _init_warmup_scheduler(self, optimizer, states):
         """
         :param optimizer optimizer:
             Optimizer being used for training. May be wrapped in
             fp16_optimizer_wrapper depending on whether fp16 is used.
+        :param states:
+            A dict containing loaded states
         """
+        updates_so_far = states.get('number_training_updates', 0)
         if self.warmup_updates > 0:
             self.warmup_scheduler = optim.lr_scheduler.LambdaLR(
-                optimizer, self._warmup_lr
+                optimizer, self._warmup_lr, last_epoch=updates_so_far
             )
 
     def get_last_lr(self):
@@ -285,7 +288,7 @@ class ParlAILRScheduler(object):
             hard_reset = True
 
         # setup warmup scheduler after loading saved scheduler
-        scheduler._init_warmup_scheduler(optimizer)
+        scheduler._init_warmup_scheduler(optimizer, states)
 
         if not hard_reset:
             # do the actual loading (if possible)

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -49,6 +49,7 @@ class ParlAILRScheduler(object):
         self.warmup_updates = max(0, warmup_updates)
         self.warmup_rate = warmup_rate
         self.hard_reset = hard_reset
+        self.warmup_scheduler = None
 
     def _init_warmup_scheduler(self, optimizer, states):
         """
@@ -66,8 +67,6 @@ class ParlAILRScheduler(object):
             self.warmup_scheduler = optim.lr_scheduler.LambdaLR(
                 optimizer, self._warmup_lr
             )
-        else:
-            self.warmup_scheduler = None
 
     def get_last_lr(self):
         s = self.warmup_scheduler if self._is_lr_warming_up() else self.scheduler
@@ -84,8 +83,7 @@ class ParlAILRScheduler(object):
         Check if we're warming up the learning rate.
         """
         return (
-            hasattr(self, 'warmup_scheduler')
-            and self.warmup_scheduler is not None
+            self.warmup_scheduler is not None
             and self.warmup_scheduler.get_last_lr()[0] < 1.0
         )
 


### PR DESCRIPTION
**Patch description**
This patch fixes the bug described in the issue: https://github.com/facebookresearch/ParlAI/issues/4195

**Testing steps**
I don't know much about testing, but probably we should have a test that checks the bug described in the issue above.

**Other information**
lr_scheduler.py needs a huge refactoring
