### PR TITLE
[Blenderbot2] Flush top_docs, search_queries from previous turns at the beginning of bot retrieval

### DIFF
--- a/projects/blenderbot2/agents/modules.py
+++ b/projects/blenderbot2/agents/modules.py
@@ -295,6 +295,14 @@ class BlenderBot2RagModel(RagModel):
             assert self.knowledge_access_method is KnowledgeAccessMethod.CLASSIFY
             return type_indices
 
+    def flush_previous_retriever_search_results(self):
+        if not hasattr(self, 'retriever'):
+            return
+        if hasattr(self.retriever, 'top_docs'):
+            delattr(self.retriever, 'top_docs')
+        if hasattr(self.retriever, 'search_queries'):
+            delattr(self.retriever, 'search_queries')
+
     def retrieve_and_concat(
         self,
         input: torch.LongTensor,
@@ -314,6 +322,7 @@ class BlenderBot2RagModel(RagModel):
         Override RagModel.retrieve_and_concat to perform different retrieval, depending
         on the RetrieverType.
         """
+        self.flush_previous_retriever_search_results()
         start = time.time()
         logging.debug(f'Begin encoder: {time.time() - start:.2f}')
         if input_turns_cnt is not None:


### PR DESCRIPTION
**Patch description**
https://github.com/facebookresearch/ParlAI/issues/4161
Flush the retrieval search from previous turn. Otherwise, the model output would include `top_docs`, `search_queries` from its last search if the model doesn't search in this turn but search in previous turns as in [here](https://github.com/facebookresearch/ParlAI/blob/main/projects/blenderbot2/agents/blenderbot2.py#L787-L790).

**Testing steps**
CI

**Other information**
<!-- Any other information or context you would like to provide. -->
