### PR TITLE
[RAG] Fix RAG Passage Loading

### DIFF
--- a/parlai/agents/rag/README.md
+++ b/parlai/agents/rag/README.md
@@ -106,6 +106,8 @@ To utilize the PolyFAISS method, you can train your own [`DropoutPolyencoder`](h
 
 ### 2. Generate Dense Embeddings (~1-2 hours minutes if sharded appropriately - 50 x 1 GPU).
 
+**WARNING**: If you generated passage embeddings prior to 11/19/2021, you *may* have corrupted embeddings, especially if you were using a relatively small set of passages (anything under ~50k), and found that indexing took excessively long (anything over a couple minutes); see [#4199](https://github.com/facebookresearch/ParlAI/pull/4199) for more details.
+
 After obtaining a DPR model, you'll need to generate dense embeddings on a dataset. The data should be in a tab-separated (tsv) file with the following format:
 
       integer document id starting at zero<tab>document text<tab>document title

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -109,9 +109,9 @@ def load_passage_reader(
                     assert line[0] == 'id'
                 if line[0] != 'id':
                     if return_dict:
-                        passages[row[0]] = (row[1], row[2])  # type: ignore
+                        passages[line[0]] = (line[1], line[2])  # type: ignore
                     else:
-                        passages.append((row[0], row[1], row[2]))  # type: ignore
+                        passages.append((line[0], line[1], line[2]))  # type: ignore
     return passages
 
 


### PR DESCRIPTION
**Patch description**
Previously, if we errored out attempting to read a `.csv` file, we switched to reading passages and splitting by `\t` manually. However, we were still referencing an old variable from the prior loop, which references an old row. I've updated to point to the new variable.

**Testing steps**
I discovered this because someone pointed out that their retriever was retrieving the same document for every turn. I looked at the logs and saw that the indexing for 5k documents was taking over 5 minutes; this is *way* too slow, and usually means that the passage embeddings are too close to eachother. After reproducing the error locally, the passages are correctly loaded and indexing takes around 2 seconds.

Relying on CI for the rest.