### PR TITLE
[BlenderBot2] maximum num_agents for batch_generate

### DIFF
--- a/projects/blenderbot2/agents/sub_modules.py
+++ b/projects/blenderbot2/agents/sub_modules.py
@@ -181,7 +181,7 @@ class QueryGenerator(BB2SubmoduleMixin):
             )
             assert isinstance(base_agent, TorchAgent)
             self.agents = [base_agent]
-            bsz = opt.get('batchsize', 1)
+            bsz = max(opt.get('batchsize', 1), opt.get('eval_batchsize', 1))
             rag_turn_n_turns = opt.get('rag_turn_n_turns', 1)
             if bsz > 1 or rag_turn_n_turns > 1:
                 self.agents += [


### PR DESCRIPTION
**Patch description**
Training crashes where the doc_scores are `[]` during validation when finetuning BlenderBot 2. Trace back to `eval_batchsize > batch_size` when initializing the agents for `_batch_generate`.


**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
