### PR TITLE
[WizInt] Mistake in the documentation 

### DIFF
--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1988,7 +1988,7 @@ model_list = [
         ),
         "example": (
             "parlai interactive -mf zoo:sea/bart_fid_sqse/model \\ \n"
-            "--search-query-generator-model-file zoo:sea/bart_fid_sqse/model \\ \n"
+            "--search-query-generator-model-file zoo:sea/bart_sq_gen/model \\ \n"
             "--search-server <your search server API address>"
         ),
         "result": (


### PR DESCRIPTION
**Patch description**
There was a mistake in documentation for the WizInt (SEA) models in zoo: the documentation was suggesting using wrong search query generator from the zoo. This patch fixes that.

**Testing steps**
Running the sample command used to crash because of incorrect opt values. Tested with the new command and it runs.