### PR TITLE
See if I can fix crowdsourcing jslint pre-commit hook error

### DIFF
--- a/parlai/crowdsourcing/package.json
+++ b/parlai/crowdsourcing/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "mturk",
+  "scripts": {
+    "lint": "eslint . --ext jsx,js"
+  },
+  "devDependencies": {
+    "babel-eslint": "^10.0.1",
+    "eslint": "^5.14.1",
+    "eslint-config-prettier": "^4.1.0",
+    "eslint-plugin-ignore-generated-and-nolint": "^1.0.0",
+    "eslint-plugin-jsx-a11y": "^6.2.1",
+    "eslint-plugin-react": "^7.12.4",
+    "husky": "^1.3.1",
+    "lint-staged": "^8.1.4",
+    "prettier": "^1.16.4"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{js,jsx,json,css}": [
+      "prettier --write",
+      "git add"
+    ]
+  }
+}


### PR DESCRIPTION
Not sure why this is suddenly causing the jslint to fail when it didn't prior, but seems like a reasonable thing to fix.

Copypasting from `parlai/mturk/package.json` file of https://github.com/facebookresearch/ParlAI/pull/3362/files

------

Using this change to see if it fixes the stuff. Indeed, the jslint test no longer fails (though there's one in cleaninstall that I'm currently yak shaving...)
