### PR TITLE
Fix cleaninstall test breakage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ ipython==7.19.0
 torch>=1.4.0
 joblib==0.14.1
 nltk==3.6.4
-numpy==1.17.5
 omegaconf~=2.1.1
 pandas==1.1.1
 pytest_regressions==2.1.1
@@ -52,3 +51,5 @@ urllib3>=1.26.5
 websocket-client==0.56.0
 websocket-server==0.4
 jsonlines==1.2.0
+numpy<=1.21 # Used to be `==1.17.5` before but tests -- pulling in latest at 1.22 not happy
+markdown<=3.3.2 # Pin to something that works so tests are happy


### PR DESCRIPTION
...gonna guess this might have to be done again at some point, but `python setup.py develop` runs cleanly in a new conda environment when I use this.

(Going to guess it'll involve changing all the `==` to `<=` or something. Guessing something changed `setuptools` under the hood at some point maybe... or the dependencies in the other requirements got upgraded enough where some of the documented undefined behavior about how it resolves versioning that setuptools has is biting us. Figuring that out is gonna take much longer than this brute force so w/e.)

**Testing steps**
Make a bunch of clean conda envs and finagle with requirements until everything installs cleanly lol. 
