### PR TITLE
[FiD] Add specialized chunking to search engine retrievers

### DIFF
--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -294,7 +294,7 @@ class SearchQueryFiDAgent(FidAgent):
         group.add_argument(
             '--doc-chunks-ranker',
             type=str,
-            choices=['tfidf', 'head'],
+            choices=['tfidf', 'head', 'woi_chunk_retrieved_docs'],
             default='head',
             help='How to rank doc chunks.',
         )

--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -298,6 +298,12 @@ class SearchQueryFiDAgent(FidAgent):
             default='head',
             help='How to rank doc chunks.',
         )
+        parser.add_argument(
+            '--woi-doc-chunk-size',
+            default=500,
+            type=int,
+            help='Document chunk size (in characters).',
+        )
 
         return parser
 

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -1046,10 +1046,10 @@ class SearchQueryRetriever(RagRetriever):
         self.len_chunk = opt['splitted_chunk_length']
         self.doc_chunk_split_mode = opt['doc_chunk_split_mode']
         n_doc_chunks = opt['n_ranked_doc_chunks']
-        chunk_ranker_type = opt['doc_chunks_ranker']
-        if chunk_ranker_type == 'tfidf':
+        self.chunk_ranker_type = opt['doc_chunks_ranker']
+        if self.chunk_ranker_type == 'tfidf':
             self.chunk_reranker = TfidfChunkRanker(n_doc_chunks)
-        elif chunk_ranker_type == 'head':
+        elif self.chunk_ranker_type == 'head':
             self.chunk_reranker = HeadChunkRanker(n_doc_chunks)
         else:
             self.chunk_reranker = RetrievedChunkRanker(
@@ -1131,7 +1131,7 @@ class SearchQueryRetriever(RagRetriever):
             # When there is no search query for the context
             return [("", 0)]
         tokens = self.text2tokens(doc_text)
-        if self.chunk_reranker != 'woi_chunk_retrieved_docs':
+        if self.chunk_reranker_type != 'woi_chunk_retrieved_docs':
             doc_chunks = [
                 self.tokens2text(tokens[i : i + self.len_chunk])
                 for i in range(0, len(tokens), self.len_chunk)

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -34,6 +34,8 @@ from parlai.core.loader import register_agent
 from parlai.core.opt import Opt
 from parlai.core.torch_generator_agent import TorchGeneratorAgent
 from parlai.core.torch_ranker_agent import TorchRankerAgent
+from parlai.tasks.wizard_of_internet.mutators import chunk_docs_in_message
+import parlai.tasks.wizard_of_internet.constants as CONST
 import parlai.utils.logging as logging
 from parlai.utils.torch import padded_tensor
 from parlai.utils.typing import TShared
@@ -1047,8 +1049,10 @@ class SearchQueryRetriever(RagRetriever):
         chunk_ranker_type = opt['doc_chunks_ranker']
         if chunk_ranker_type == 'tfidf':
             self.chunk_reranker = TfidfChunkRanker(n_doc_chunks)
-        else:
+        elif chunk_ranker_type == 'head':
             self.chunk_reranker = HeadChunkRanker(n_doc_chunks)
+        else:
+            self.chunk_reranker = RetrievedChunkRanker(n_doc_chunks)
 
         if not shared:
             self.query_generator = self.init_search_query_generator(opt)
@@ -1102,19 +1106,19 @@ class SearchQueryRetriever(RagRetriever):
             opt, dpr_model=opt['query_model'], pretrained_path=opt['dpr_model_file']
         )
 
-    def text2tokens(self, txt: str):
+    def text2tokens(self, txt: str) -> Union[List[str], List[int]]:
         if self.doc_chunk_split_mode == 'word':
             return txt.split(' ')
         else:
             return self.dict.txt2vec(txt)
 
-    def tokens2text(self, tokens: List[int]):
+    def tokens2text(self, tokens: Union[List[int], List[str]]) -> str:
         if self.doc_chunk_split_mode == 'word':
             return ' '.join(tokens)
         else:
             return self.dict.vec2txt(tokens)
 
-    def pick_chunk(self, query, doc_text):
+    def pick_chunk(self, query: str, doc_title: str, doc_text: str, doc_url: str):
         """
         Splits the document and returns the selected chunks.
 
@@ -1125,11 +1129,14 @@ class SearchQueryRetriever(RagRetriever):
             # When there is no search query for the context
             return [("", 0)]
         tokens = self.text2tokens(doc_text)
-        doc_chunks = [
-            self.tokens2text(tokens[i : i + self.len_chunk])
-            for i in range(0, len(tokens), self.len_chunk)
-        ]
-        return self.chunk_reranker.get_top_chunks(query, doc_chunks)
+        if self.chunk_reranker != 'woi_chunk_retrieved_docs':
+            doc_chunks = [
+                self.tokens2text(tokens[i : i + self.len_chunk])
+                for i in range(0, len(tokens), self.len_chunk)
+            ]
+        else:
+            doc_chunks = self.tokens2text(tokens)
+        return self.chunk_reranker.get_top_chunks(query, doc_title, doc_chunks, doc_url)
 
 
 class SearchQuerySearchEngineRetriever(SearchQueryRetriever):
@@ -1203,6 +1210,7 @@ class SearchQuerySearchEngineRetriever(SearchQueryRetriever):
         # step 3
         top_docs = []
         top_doc_scores = []
+        max_n_docs: int = self.n_docs
         for sq, search_results in zip(search_queries, search_results_batch):
             if not search_results:
                 search_results = self._empty_docs(self.n_docs)
@@ -1224,7 +1232,9 @@ class SearchQuerySearchEngineRetriever(SearchQueryRetriever):
                 full_text = (
                     dcontent if isinstance(dcontent, str) else '\n'.join(doc['content'])
                 )
-                doc_chunks = [dc[0] for dc in self.pick_chunk(sq, full_text)]
+                doc_chunks = [
+                    dc[0] for dc in self.pick_chunk(sq, title, full_text, url)
+                ]
                 for splt_id, splt_content in enumerate(doc_chunks):
                     docs_i.append(
                         Document(
@@ -1232,8 +1242,15 @@ class SearchQuerySearchEngineRetriever(SearchQueryRetriever):
                         )
                     )
                     scors_i.append(self.rank_score(i))
+            max_n_docs = max(max_n_docs, len(docs_i))
             top_docs.append(docs_i)
             top_doc_scores.append(scors_i)
+        # Pad with empty docs
+        for i in range(len(top_docs)):
+            n_empty = max_n_docs - len(top_docs[i])
+            if n_empty:
+                top_docs[i] = top_docs[i] + [BLANK_DOC] * n_empty
+                top_doc_scores[i] = top_doc_scores[i] + [0] * n_empty
         self.top_docs = top_docs
         return top_docs, torch.Tensor(top_doc_scores).to(query.device)
 
@@ -1329,7 +1346,13 @@ class DocumentChunkRanker:
         self.n_ret_chunks = n_retrieved_chunks
 
     @abstractmethod
-    def get_top_chunks(self, query, doc_chunks):
+    def get_top_chunks(
+        self,
+        query: str,
+        doc_title: str,
+        doc_chunks: Union[List[str], str],
+        doc_url: str,
+    ):
         """
         Ranks documents (chunk) based on their relevance to `query`
         """
@@ -1340,11 +1363,47 @@ class HeadChunkRanker(DocumentChunkRanker):
     Returns the head chunks only.
     """
 
-    def get_top_chunks(self, query, doc_chunks):
+    def get_top_chunks(
+        self,
+        query: str,
+        doc_title: str,
+        doc_chunks: Union[List[str], str],
+        doc_url: str,
+    ):
         """
         Return chunks in doc-present order.
         """
         return [(c,) for c in doc_chunks[: self.n_ret_chunks]]
+
+
+class RetrievedChunkRanker(DocumentChunkRanker):
+    """
+    Utilize retrieved doc chunk mutator.
+    """
+
+    def get_top_chunks(
+        self,
+        query: str,
+        doc_title: str,
+        doc_chunks: Union[List[str], str],
+        doc_url: str,
+    ):
+        """
+        Return chunks according to the woi_chunk_retrieved_docs_mutator
+        """
+        assert isinstance(doc_chunks, list)
+        chunks = chunk_docs_in_message(
+            Message(
+                {
+                    CONST.RETRIEVED_DOCS: [''.join(doc_chunks)],
+                    CONST.RETRIEVED_DOCS_TITLES: [doc_title],
+                    CONST.RETRIEVED_DOCS_URLS: [doc_url],
+                    CONST.SELECTED_SENTENCES: [CONST.NO_SELECTED_SENTENCES_TOKEN],
+                }
+            ),
+            500,
+        )[CONST.RETRIEVED_DOCS]
+        return [(c,) for c in chunks[: self.n_ret_chunks]]
 
 
 class TfidfChunkRanker(DocumentChunkRanker):
@@ -1356,7 +1415,14 @@ class TfidfChunkRanker(DocumentChunkRanker):
         super().__init__(n_retrieved_chunks)
         self._vectorizer = TfidfVectorizer()
 
-    def get_top_chunks(self, query, doc_chunks):
+    def get_top_chunks(
+        self,
+        query: str,
+        doc_title: str,
+        doc_chunks: Union[List[str], str],
+        doc_url: str,
+    ):
+        assert isinstance(doc_chunks, list)
         vectorized_corpus = self._vectorizer.fit_transform(doc_chunks + [query])
         docs_vec = vectorized_corpus[:-1, :]
         q_vec = vectorized_corpus[-1, :]

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -1052,7 +1052,9 @@ class SearchQueryRetriever(RagRetriever):
         elif chunk_ranker_type == 'head':
             self.chunk_reranker = HeadChunkRanker(n_doc_chunks)
         else:
-            self.chunk_reranker = RetrievedChunkRanker(n_doc_chunks)
+            self.chunk_reranker = RetrievedChunkRanker(
+                n_doc_chunks, opt['woi_doc_chunk_size']
+            )
 
         if not shared:
             self.query_generator = self.init_search_query_generator(opt)
@@ -1381,6 +1383,10 @@ class RetrievedChunkRanker(DocumentChunkRanker):
     Utilize retrieved doc chunk mutator.
     """
 
+    def __init__(self, n_retrieved_chunks, chunk_size: int = 500):
+        super().__init__(n_retrieved_chunks)
+        self.chunk_size = chunk_size
+
     def get_top_chunks(
         self,
         query: str,
@@ -1401,7 +1407,7 @@ class RetrievedChunkRanker(DocumentChunkRanker):
                     CONST.SELECTED_SENTENCES: [CONST.NO_SELECTED_SENTENCES_TOKEN],
                 }
             ),
-            500,
+            self.chunk_size,
         )[CONST.RETRIEVED_DOCS]
         return [(c,) for c in chunks[: self.n_ret_chunks]]
 

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -1046,10 +1046,10 @@ class SearchQueryRetriever(RagRetriever):
         self.len_chunk = opt['splitted_chunk_length']
         self.doc_chunk_split_mode = opt['doc_chunk_split_mode']
         n_doc_chunks = opt['n_ranked_doc_chunks']
-        self.chunk_ranker_type = opt['doc_chunks_ranker']
-        if self.chunk_ranker_type == 'tfidf':
+        chunk_ranker_type = opt['doc_chunks_ranker']
+        if chunk_ranker_type == 'tfidf':
             self.chunk_reranker = TfidfChunkRanker(n_doc_chunks)
-        elif self.chunk_ranker_type == 'head':
+        elif chunk_ranker_type == 'head':
             self.chunk_reranker = HeadChunkRanker(n_doc_chunks)
         else:
             self.chunk_reranker = RetrievedChunkRanker(
@@ -1131,7 +1131,7 @@ class SearchQueryRetriever(RagRetriever):
             # When there is no search query for the context
             return [("", 0)]
         tokens = self.text2tokens(doc_text)
-        if self.chunk_reranker_type != 'woi_chunk_retrieved_docs':
+        if self.opt['doc_chunks_ranker'] != 'woi_chunk_retrieved_docs':
             doc_chunks = [
                 self.tokens2text(tokens[i : i + self.len_chunk])
                 for i in range(0, len(tokens), self.len_chunk)

--- a/tests/nightly/gpu/test_rag.py
+++ b/tests/nightly/gpu/test_rag.py
@@ -18,6 +18,7 @@ import parlai.utils.testing as testing_utils
 
 try:
     from parlai.agents.rag.dpr import DprQueryEncoder
+    from parlai.agents.rag.retrievers import RetrievedChunkRanker
 except ImportError:
     pass
 
@@ -529,6 +530,28 @@ class TestRagSelfChat(unittest.TestCase):
             with open(seed_utt_file, 'w') as f:
                 f.writelines(["Hi, my name is Bob", "Hi, my name is Alice"])
             SelfChat.main(**opt)
+
+
+class TestWOIChunking(unittest.TestCase):
+    """
+    Test that the woi_chunk_retrieved_docs Chunker works as intended.
+    """
+
+    DOC_TITLE = 'I AM FAKE'
+    DOC_CONTENT = ['hello there old friend ' * 100]
+
+    def test_chunker(self):
+        n_chunks = 1
+        chunk_sz = 500
+        chunker = RetrievedChunkRanker(n_chunks, chunk_sz)
+        chunks = chunker.get_top_chunks(
+            query='', doc_title=self.DOC_TITLE, doc_chunks=self.DOC_CONTENT, doc_url=''
+        )
+        assert len(chunks) == 1 and len(chunks[0]) == 1
+        assert (
+            chunks[0][0]
+            == self.DOC_CONTENT[0][: self.DOC_CONTENT[0].find(' ', chunk_sz)]
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Patch description**
This PR is intended to copy the functionality of the [`woi_chunk_retrieved_docs` mutator](https://github.com/facebookresearch/ParlAI/blob/d9548b567d8c5a271b157e9a8bbbf9a24714a2a1/parlai/tasks/wizard_of_internet/mutators.py#L182-L201) within the search engine retriever.

**Testing steps**
Added CI 
