### PR TITLE
[TOD][Agents] Helper Agents for simulation + tests

### DIFF
--- a/parlai/core/tod/tod_agents.py
+++ b/parlai/core/tod/tod_agents.py
@@ -116,6 +116,438 @@ class TodStructuredDataParser(Agent):
         )
 
 
+######### Agents that dump information from a dataset as gold (explicitly should *not* be used with teachers)
+class _TodDataDumpAgent(TodStructuredDataParser):
+    """
+    For agents which dump data from some dataset, without training/other modifications.
+
+    Implements an "epoch done"
+
+    Member variables assumed to be set in init downstream:
+        self.fold
+    """
+
+    def __init__(self, opt: Opt, shared=None):
+        super().__init__(opt, shared)
+        self.epochDone = False
+        self.batchsize = opt.get("batchsize", 1)
+        self.max_episodes = len(self.episodes)
+        if opt.get("num_episodes", 0) > 0:
+            self.max_episodes = min(self.max_episodes, opt.get("num_episodes"))
+        self.episode_idx = opt.get("batchindex", 0)
+        self._setup_next_episode()
+        self.round_idx = 0  # for some downstream utt + sysUttAndApiCallAgents.
+        if is_distributed():  # cause gotta manually handle
+            rank = get_rank()
+            chunk_size = ceil(self.max_episodes / num_workers())
+            self.episode_idx += rank * chunk_size
+            self.max_episodes = min(self.max_episodes, (rank + 1) * chunk_size)
+
+    def _setup_next_episode(self):
+        self.epochDone = not self.episode_idx < self.max_episodes
+        self.episode = None
+        if not self.epochDone:
+            self.episode = self.episodes[self.episode_idx]
+        self.round_idx = (
+            0  # so downstream agents know which round they are in. Update in `act()`
+        )
+
+    def epoch_done(self) -> bool:
+        return self.epochDone
+
+    def episode_done(self) -> bool:
+        """
+        This is not actually "episode_done" so much as "we want to signify to the world
+        that we have gone past the batch".
+
+        This class should not control whether or not the episode is actually done since
+        the TodWorld expects that to come from the User agent.
+        """
+        return self.epochDone
+
+    def num_episodes(self) -> int:
+        return len(self.episodes)
+
+    def reset(self):
+        self.episode_idx += self.batchsize
+        self._setup_next_episode()
+
+
+class TodGoalAgent(_TodDataDumpAgent):
+    """
+    Use as a mixin with classes that also extend + implement TodStructuredDataParser.
+    """
+
+    def act(self):
+        return {
+            "text": f"{tod.STANDARD_GOAL}{self.episode.goal_calls_utt}",
+            "id": self.id,
+            "domain": self.episode.domain,
+            "episode_done": False,
+        }
+
+    def _get_agent_type_suffix(self):
+        return "Goal"
+
+
+class TodApiSchemaAgent(_TodDataDumpAgent):
+    def act(self):
+        return {
+            "text": f"{tod.STANDARD_API_SCHEMAS}{self.episode.api_schemas_utt}",
+            "id": self.id,
+            "domain": self.episode.domain,
+            "episode_done": False,
+        }
+
+    def _get_agent_type_suffix(self):
+        return "ApiSchema"
+
+
+############# Single Goal + Api Schema Agent
+class _EpisodeToSingleGoalProcessor(_TodDataDumpAgent):
+    """
+    Iterate through all of the goals of a dataset, one by one.
+
+    Slightly different logic than the dump agent since how we count + setup examples for
+    an episode are different
+
+    Used as a mixin in the SingleGoal and SingleApiSchema agents below.
+
+    This class exposes a `filter_goals()` function that can be overridden by downstream agents.
+    """
+
+    def __init__(self, opt: Opt, shared=None):
+        super().__init__(opt, shared)
+        self.epochDone = False
+        if shared is None:
+            self.episodes = self._setup_single_goal_episodes()
+        else:
+            # Handled fine in _TodDataDumpAgent
+            pass
+
+        self.max_episodes = len(self.episodes)
+        if opt.get("num_episodes", 0) > 0:
+            self.max_episodes = min(self.max_episodes, opt.get("num_episodes"))
+        if is_distributed():  # cause gotta manually handle
+            rank = get_rank()
+            chunk_size = ceil(self.max_episodes / num_workers())
+            self.max_episodes = min(self.max_episodes, (rank + 1) * chunk_size)
+
+        self._setup_next_episode()
+
+    def _setup_single_goal_episodes(self) -> List[tod.TodStructuredEpisode]:
+        """
+        This function assumes that `self.setup_episodes()` has already been called
+        prior.
+
+        Based on the `__init__` order of this class, it should be done in
+        `TodStructuredDataParser` by this point.
+        """
+        raw_episodes = self.episodes
+        result = []
+        for raw in raw_episodes:
+            for call in self.filter_goals(raw.goal_calls_machine):
+                schema = {}
+                for cand in raw.api_schemas_machine:
+                    if (
+                        cand[tod.STANDARD_API_NAME_SLOT]
+                        == call[tod.STANDARD_API_NAME_SLOT]
+                    ):
+                        schema = cand
+
+                result.append(
+                    tod.TodStructuredEpisode(
+                        domain=raw.domain,
+                        api_schemas_machine=[schema],
+                        goal_calls_machine=[call],
+                        rounds=[],
+                    )
+                )
+        return result
+
+    def filter_goals(self, goals):
+        """
+        Some downstream agents may want to filter the goals.
+
+        Override this if so.
+        """
+        return goals
+
+
+class TodSingleGoalAgent(_EpisodeToSingleGoalProcessor, TodGoalAgent):
+    """
+    Use as a mixin with classes that also extend + implement TodStructuredDataParser.
+
+    NOTE: If an API schema agent is used, this *must* be used with `TodSingleApiSchemaAgent` since it will be nonsensicle otherwise. Additionally, this agent will not function properly with UserUtt + SystemUttAndApiCall agent, since episodes will not align.
+    """
+
+    def _get_agent_type_suffix(self):
+        return "SingleGoal"
+
+
+class TodSingleApiSchemaAgent(_EpisodeToSingleGoalProcessor, TodApiSchemaAgent):
+    """
+    Use as a mixin with classes that also extend + implement TodStructuredDataParser.
+
+    NOTE: Must be used with TodSingleGoalAgent since nonsensicle otherwise. Additionally, this agent will not function properly with UserUtt + SystemUttAndApiCall agent, since episodes will not align.
+    """
+
+    def _get_agent_type_suffix(self):
+        return "SingleApiSchema"
+
+
+###### Agents used for calculating TOD World Metrics based on a dataset. See `tod_world_script` or `parlai/projects/tod_simulator/` for examples.
+class TodUserUttAgent(_TodDataDumpAgent):
+    """
+    Agent used to calculate TOD World Metrics on a dataset. Represents the "User" agent.
+
+    This class should only ever be used with the model-model chat world which will stop
+    upon seeing the '[DONE]' utterance; may go out of bounds otherwise.
+    """
+
+    def act(self):
+        result = {
+            "text": f"{tod.STANDARD_USER_UTTERANCE}{self.episode.rounds[self.round_idx].user_utt}",
+            "id": self.id,
+            "domain": self.episode.domain,
+            "episode_done": False,
+        }
+        self.round_idx += 1
+        return result
+
+    def reset(self):
+        super().reset()  # setup next episode
+        self.round_idx = 0
+
+    def _get_agent_type_suffix(self):
+        return "User"
+
+
+class TodApiCallAndSysUttAgent(_TodDataDumpAgent):
+    """
+    Agent used to calculate TOD World Metrics on a dataset. Represents the "System"
+    agent.
+
+    This class should only ever be used with the model-model chat world which will stop
+    upon seeing the '[DONE]' utterance; may go out of bounds otherwise.
+    """
+
+    def __init__(self, opt: Opt, shared=None):
+        # This class represents two "agents" so need to make sure we don't increment episode number (reset) twice
+        self.already_reset = False
+        self.api_call_turn = True
+        super().__init__(opt, shared)
+
+    def act(self):
+        self.already_reset = False
+        if tod.STANDARD_API_SCHEMAS in self.observation.get("text", ""):
+            return {
+                "text": tod.STANDARD_API_SCHEMAS,
+                "id": self.id,
+                "domain": self.episode.domain,
+                "episode_down": False,
+            }
+
+        if self.api_call_turn:  # comes first, don't iterate round #
+            result = {
+                "text": f"{tod.STANDARD_CALL}{self.episode.rounds[self.round_idx].api_call_utt}",
+                "id": self.id,
+                "domain": self.episode.domain,
+                "episode_done": False,
+            }
+        else:
+            result = {
+                "text": f"{tod.STANDARD_SYSTEM_UTTERANCE}{self.episode.rounds[self.round_idx].sys_utt}",
+                "id": self.id,
+                "domain": self.episode.domain,
+                "episode_done": False,
+            }
+            self.round_idx += 1
+
+        self.api_call_turn ^= True
+        return result
+
+    def reset(self):
+        if not self.already_reset:
+            super().reset()  # setup next episode
+            self.api_call_turn = True
+            self.already_reset = True
+
+    def _get_agent_type_suffix(self):
+        return "System"
+
+
+class TodApiResponseAgent(_TodDataDumpAgent):
+    """
+    Agent used to calculate TOD World Metrics on a dataset. Represents the API
+    Simulator.
+
+    This class should only ever be used with the model-model chat world which will stop
+    upon seeing the '[DONE]' utterance; may go out of bounds otherwise.
+    """
+
+    def act(self):
+        result = {
+            "text": f"{tod.STANDARD_RESP}{self.episode.rounds[self.round_idx].api_resp_utt}",
+            "id": self.id,
+            "domain": self.episode.domain,
+            "episode_done": False,
+        }
+        self.round_idx += 1
+        return result
+
+    def reset(self):
+        super().reset()  # setup next episode
+        self.round_idx = 0
+
+    def _get_agent_type_suffix(self):
+        return "ApiResponse"
+
+
+###### Standalone API agent
+class StandaloneApiAgent(Agent):
+    """
+    Trainable agent that saves API calls and responses.
+
+    Use `TodStandaloneApiTeacher` to train this class. For example for a MultiWoz V2.2
+    standalone API, use ``` parlai train -t multiwoz_v22:StandaloneApiTeacher -m
+    parlai.core.tod.tod_agents:StandaloneApiAgent -eps 4 -mf output ``` to generate the
+    `.pickle` file to use.
+    """
+
+    EMPTY_RESP = {
+        "text": tod.STANDARD_RESP,
+        "id": "StandaloneApiAgent",
+        "episode_done": False,
+    }
+
+    @classmethod
+    def add_cmdline_args(
+        cls, parser: ParlaiParser, partial_opt: Optional[Opt] = None
+    ) -> ParlaiParser:
+        group = parser.add_argument_group("TOD Standalone API args")
+        group.add_argument(
+            "--exact-api-call",
+            type=bool,
+            default=True,
+            help="Validation-time flag. If true, will return '' if exact api call values not found. If false, will pick response from the same intent with similar api parameters (assuming intent is the same when available)",
+        )
+
+        group.add_argument(
+            "--fail-hard",
+            type=bool,
+            default=False,
+            help="Aids in deugging. Will throw exception if API call not found and '--exact-api-call' is set.",
+        )
+
+        group.add_argument(
+            "--standalone-api-file",
+            type=str,
+            default=None,
+            help="Path to file holding `.pickle` of standalone api for validation (will intelligently strip if suffix included). If not set, assumes the `model_file` argument will contain the `.pickle` file. ",
+        )
+        return parser
+
+    def __init__(self, opt, shared=None):
+        super().__init__(opt, shared)
+        self.id = "StandaloneApiAgent"
+        file_key = "model_file"
+        if self.opt["standalone_api_file"] is not None:
+            file_key = "standalone_api_file"
+        self.path_base = self.opt[file_key].replace(".pickle", "")
+        self.db_path = self.path_base + ".pickle"
+        self.exact_api_call = self.opt["exact_api_call"]
+        try:
+            with (open(self.db_path, "rb")) as openfile:
+                self.data = pickle.load(openfile)
+                self.training = True
+                print("Loaded Standalone API data successfully")
+            if self.exact_api_call != self.data.get("exact_api_call", True):
+                raise RuntimeError(
+                    f"Standalone API .pickle file generated with `exact_api_call` of {self.data.get('exact_api_call', False)} but StandaloneApiAgent sets it to {self.exact_api_call}"
+                )
+        except Exception:
+            print(f"No file at {self.db_path}; ASSUMING WE ARE TRAINING")
+            self.data = {}
+            self.data["exact_api_call"] = self.exact_api_call
+            self.training = True
+
+    def _maybe_filter_prefix(self, text, prefix):
+        if prefix in text:
+            return text[len(prefix) :].strip()
+        return text.strip()
+
+    def act(self):
+        if not self.observation["text"].startswith(tod.STANDARD_CALL):
+            return self.EMPTY_RESP
+        call_text_raw = self.observation["text"]
+        # decode then reencode the API call so that we get the API calls in a consistent order
+        call_text = SerializationHelpers.api_dict_to_str(
+            SerializationHelpers.str_to_api_dict(
+                call_text_raw[len(tod.STANDARD_CALL) :]
+            )
+        )
+        if "labels" in self.observation:
+            return self._do_train(call_text)
+        return self._do_fetch(call_text)
+
+    def _do_train(self, call_text):
+        assert self.training is True
+        self.data[call_text] = self.observation["labels"][0]
+        return self.EMPTY_RESP
+
+    def _do_fetch(self, call_text):
+        if self.exact_api_call:
+            if self.opt.get("fail_hard", False):
+                resp = self.data[call_text]
+            else:
+                resp = self.data.get(call_text, tod.STANDARD_RESP)
+            return {"text": resp, "id": self.id, "episode_done": False}
+
+        # Not exact case
+        best_key = difflib.get_close_matches(call_text, self.data.keys(), 1)
+        if len(best_key) == 0:
+            return self.EMPTY_RESP
+        return {
+            "text": self.data.get(best_key[0], tod.STANDARD_RESP),
+            "id": self.id,
+            "episode_done": False,
+        }
+
+    def shutdown(self):
+        if self.training:
+            with (open(self.db_path, "wb")) as openfile:
+                pickle.dump(self.data, openfile)
+                print(f"Dumped output to {self.db_path}")
+            with open(self.path_base + ".opt", "w") as f:
+                json.dump(self.opt, f)
+
+
+######### Empty agents
+class EmptyApiSchemaAgent(Agent):
+    def __init__(self, opt, shared=None):
+        super().__init__(opt)
+        self.id = "EmptyApiSchemaAgent"
+
+    def act(self):
+        msg = {
+            "id": self.getID(),
+            "text": tod.STANDARD_API_SCHEMAS,
+            "episode_done": False,
+        }
+        return Message(msg)
+
+
+class EmptyGoalAgent(Agent):
+    def __init__(self, opt, shared=None):
+        super().__init__(opt)
+        self.id = "EmptyGoalAgent"
+
+    def act(self):
+        msg = {"id": self.getID(), "text": tod.STANDARD_GOAL, "episode_done": False}
+        return Message(msg)
+
+
 ############# Teachers
 class TodSystemTeacher(TodStructuredDataParser, DialogTeacher):
     """

--- a/parlai/core/tod/tod_test_utils/__init__.py
+++ b/parlai/core/tod/tod_test_utils/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/parlai/core/tod/tod_test_utils/test_agents.py
+++ b/parlai/core/tod/tod_test_utils/test_agents.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Helpers so we don't need to create agents all over.
+"""
+
+import parlai.core.tod.tod_agents as tod_agents
+import parlai.core.tod.tod_core as tod_core
+
+import os
+
+API_DATABASE_FILE = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "standalone_api_file.pickle"
+)
+
+
+def episode_has_broken_api_turn(episode_idx, max_turns):
+    return episode_idx % 2 == 1 and max_turns > 0
+
+
+def use_broken_api_calls_this_turn(round_idx, episode_idx):
+    return episode_idx % 2 == 1 and round_idx % 3 == 1
+
+
+def make_api_call_machine(round_idx, episode_idx=0, use_broken_mock_api_calls=False):
+    if round_idx == 0:
+        return {}
+    if use_broken_mock_api_calls:
+        # Hack as a way to test metrics reporting in tod world script
+        if use_broken_api_calls_this_turn(round_idx, episode_idx):
+            round_idx = -1 * round_idx
+    return {tod_core.STANDARD_API_NAME_SLOT: f"name_{round_idx}", "in": round_idx}
+
+
+def make_api_resp_machine(round_idx):
+    if round_idx == 0:
+        return {}
+    return {"out": round_idx}
+
+
+def make_api_schemas_machine(max_rounds):
+    return [
+        {
+            tod_core.STANDARD_API_NAME_SLOT: f"name_{round_idx}",
+            tod_core.STANDARD_REQUIRED_KEY: ["in"],
+            tod_core.STANDARD_OPTIONAL_KEY: [],
+        }
+        for round_idx in range(1, max_rounds)
+    ]
+
+
+def make_goal_calls_machine(max_rounds):
+    return [make_api_call_machine(x) for x in range(1, max_rounds)]
+
+
+def get_rounds(episode_idx, max_rounds, use_broken_mock_api_calls=False):
+    return [
+        tod_core.TodStructuredRound(
+            user_utt=f"user_utt_{episode_idx}_{round_idx}",
+            api_call_machine=make_api_call_machine(
+                round_idx, episode_idx, use_broken_mock_api_calls
+            ),
+            api_resp_machine=make_api_resp_machine(round_idx),
+            sys_utt=f"sys_utt_{episode_idx}_{round_idx}",
+        )
+        for round_idx in range(max_rounds)
+    ]
+
+
+def get_round_utts(episode_idx, max_rounds, filter_utts=None):
+    if max_rounds < 1:
+        return []
+    utts = [
+        [
+            f"USER: user_utt_{episode_idx}_0",
+            "APICALL: ",
+            "APIRESP: ",
+            f"SYSTEM: sys_utt_{episode_idx}_0",
+        ]
+    ]
+    for i in range(1, max_rounds):
+        utts.append(
+            [
+                f"USER: user_utt_{episode_idx}_{i}",
+                f"APICALL: api_name = name_{i} ; in = {i}",
+                f"APIRESP: out = {i}",
+                f"SYSTEM: sys_utt_{episode_idx}_{i}",
+            ]
+        )
+    utts.append(["USER: [DONE]", "APICALL: ", "APIRESP: ", "SYSTEM: "])
+    if filter_utts is not None:
+        utts = [
+            [turn for i, turn in enumerate(round_data) if filter_utts[i]]
+            for round_data in utts
+        ]
+    return utts
+
+
+TEST_NUM_EPISODES_OPT_KEY = "test_num_episodes"
+TEST_NUM_ROUNDS_OPT_KEY = "test_num_rounds"
+
+# No api calls in this setup
+EPISODE_SETUP__UTTERANCES_ONLY = {
+    TEST_NUM_ROUNDS_OPT_KEY: 1,
+    TEST_NUM_EPISODES_OPT_KEY: 1,
+}
+
+# No one call, one goal, one api desscription in this setup
+EPISODE_SETUP__SINGLE_API_CALL = {
+    TEST_NUM_ROUNDS_OPT_KEY: 2,
+    TEST_NUM_EPISODES_OPT_KEY: 1,
+}
+# Will start testing multiple api calls + schemas, multi-round logic
+EPISODE_SETUP__MULTI_ROUND = {TEST_NUM_ROUNDS_OPT_KEY: 5, TEST_NUM_EPISODES_OPT_KEY: 1}
+
+# Test that episode logic is correct
+EPISODE_SETUP__MULTI_EPISODE = {
+    TEST_NUM_ROUNDS_OPT_KEY: 5,
+    TEST_NUM_EPISODES_OPT_KEY: 8,
+}
+
+# Test that episode + pesky-off-by-one batchinglogic is correct
+EPISODE_SETUP__MULTI_EPISODE_BS = {
+    TEST_NUM_ROUNDS_OPT_KEY: 5,
+    TEST_NUM_EPISODES_OPT_KEY: 35,
+}
+
+
+class TestDataParser(tod_agents.TodStructuredDataParser):
+    """
+    Assume that when we init, we init w/ num of episodes + rounds as opts.
+    """
+
+    def __init__(self, opt, shared=None):
+        opt["datafile"] = "DUMMY"
+        self.fold = "DUMMY"
+        # Following lines are only reelvant in training the standalone api teacher
+        if TEST_NUM_EPISODES_OPT_KEY not in opt:
+            opt[TEST_NUM_EPISODES_OPT_KEY] = 35
+        if TEST_NUM_ROUNDS_OPT_KEY not in opt:
+            opt[TEST_NUM_ROUNDS_OPT_KEY] = 5
+        super().__init__(opt, shared)
+
+    def setup_episodes(self, _):
+        result = []
+        for ep_idx in range(0, self.opt[TEST_NUM_EPISODES_OPT_KEY]):
+            result.append(
+                tod_core.TodStructuredEpisode(
+                    goal_calls_machine=[
+                        make_api_call_machine(x)
+                        for x in range(1, self.opt[TEST_NUM_ROUNDS_OPT_KEY])
+                    ],
+                    api_schemas_machine=make_api_schemas_machine(
+                        self.opt[TEST_NUM_ROUNDS_OPT_KEY]
+                    ),
+                    rounds=get_rounds(
+                        ep_idx,
+                        self.opt[TEST_NUM_ROUNDS_OPT_KEY],
+                        self.opt.get("use_broken_mock_api_calls", False),
+                    ),
+                )
+            )
+        return result
+
+    def get_id_task_prefix(self):
+        return "Test"
+
+
+class SystemTeacher(TestDataParser, tod_agents.TodSystemTeacher):
+    pass
+
+
+class UserSimulatorTeacher(TestDataParser, tod_agents.TodUserSimulatorTeacher):
+    pass
+
+
+class StandaloneApiTeacher(TestDataParser, tod_agents.TodStandaloneApiTeacher):
+    pass
+
+
+class GoalAgent(TestDataParser, tod_agents.TodGoalAgent):
+    pass
+
+
+class ApiSchemaAgent(TestDataParser, tod_agents.TodApiSchemaAgent):
+    pass
+
+
+class SingleGoalAgent(TestDataParser, tod_agents.TodSingleGoalAgent):
+    pass
+
+
+class SingleApiSchemaAgent(TestDataParser, tod_agents.TodSingleApiSchemaAgent):
+    pass
+
+
+# Tested in tod world code
+class UserUttAgent(TestDataParser, tod_agents.TodUserUttAgent):
+    pass
+
+
+# Tested in tod world code
+class ApiCallAndSysUttAgent(TestDataParser, tod_agents.TodApiCallAndSysUttAgent):
+    pass

--- a/tests/tod/test_tod_agents_and_teachers.py
+++ b/tests/tod/test_tod_agents_and_teachers.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests teachers + agent implementations, assuming parser to conversations format has
+already been done and teachers/agents already created.
+
+`test_agents.py` includes functions for generating the raw data used in this file as
+well as the data parser.
+"""
+
+import unittest
+
+import copy
+import parlai.core.tod.tod_core as tod_core
+import parlai.core.tod.tod_test_utils.test_agents as test_agents
+
+
+class TestTodAgentsAndTeachersBase(unittest.TestCase):
+    """
+    Base class with convenience functions for setting up agents, dumping text, etc.
+    """
+
+    def setup_agent_or_teacher(self, class_type, round_opt, opt):
+        full_opts = {**round_opt, **opt}
+        full_opts["datatype"] = "DUMMY"
+        full_opts["datafile"] = "DUMMY"
+        full_opts["episodes_randomization_seed"] = -1  # no random here
+        return class_type(full_opts)
+
+    def dump_single_utt_per_episode_agent_text(self, class_type, round_opt, opt):
+        """
+        Continuously dumps data from an agent until it's done.
+        """
+        agent = self.setup_agent_or_teacher(class_type, round_opt, opt)
+        result = []
+        while not agent.epoch_done():
+            result.append(agent.act()["text"])
+            agent.reset()
+        return result
+
+    def dump_teacher_text(self, class_type, round_opt, opt):
+        """
+        Array where [episode_idx][turn_idx][text=0,label=1]
+        """
+        teacher = self.setup_agent_or_teacher(class_type, round_opt, opt)
+        data = []
+        here = []
+        for x, new in teacher.setup_data("dummy"):
+            if new and len(here) > 0:
+                data.append(copy.deepcopy(here))
+                here = []
+            here.append([x["text"], x["label"]])
+        if len(here) > 0:
+            data.append(here)
+        return data
+
+    def _test_roundDataCorrect(self):
+        """
+        Convenience function that runs on different episode setups.
+
+        Prefix with `_` since not all tests necessarily need this
+        """
+        self._test_roundDataCorrect_helper(test_agents.EPISODE_SETUP__UTTERANCES_ONLY)
+        self._test_roundDataCorrect_helper(test_agents.EPISODE_SETUP__SINGLE_API_CALL)
+        self._test_roundDataCorrect_helper(test_agents.EPISODE_SETUP__MULTI_ROUND)
+        self._test_roundDataCorrect_helper(test_agents.EPISODE_SETUP__MULTI_EPISODE)
+
+    def _test_roundDataCorrect_helper(self, config):
+        """
+        Implement this in downstream classes to define what is "correct" for a round (Ie
+        checking serialization data for a given class vs only checking utterances)
+        """
+        raise RuntimeError("Not implemented")
+
+
+class TestSystemTeacher(TestTodAgentsAndTeachersBase):
+    def test_apiSchemas_with_yesApiSchemas(self):
+        """
+        Tests to make sure that data from first turn is correct when we include API
+        Schemas.
+        """
+        values = self.dump_teacher_text(
+            test_agents.SystemTeacher,
+            test_agents.EPISODE_SETUP__SINGLE_API_CALL,
+            {"api_schemas": True},
+        )
+        self.assertEqual(
+            values[0][0][0],
+            "APIS: "
+            + tod_core.SerializationHelpers.list_of_maps_to_str(
+                test_agents.make_api_schemas_machine(2)
+            ),
+        )
+
+    def test_apiSchemas_with_noApiSchemas(self):
+        """
+        Tests to make sure that data from first turn is correct when we do not include
+        API Schemas.
+        """
+        values = self.dump_teacher_text(
+            test_agents.SystemTeacher,
+            test_agents.EPISODE_SETUP__SINGLE_API_CALL,
+            {"api_schemas": False},
+        )
+        self.assertEqual(values[0][0][0], "APIS: ")
+
+    def _test_roundDataCorrect_helper(self, config):
+        max_rounds = config[test_agents.TEST_NUM_ROUNDS_OPT_KEY]
+        values = self.dump_teacher_text(test_agents.SystemTeacher, config, {})
+        for episode_idx, episode in enumerate(values):
+            utts = test_agents.get_round_utts(episode_idx, max_rounds)
+            comp = []
+            for utt in utts:
+                comp.append([utt[0], utt[1]])
+                comp.append([utt[2], utt[3]])
+            # Skip grounding turn cause we check it in the other teachers
+            self.assertEqual(episode[1:], comp)
+
+    def test_roundDataCorrect(self):
+        self._test_roundDataCorrect()
+
+
+class TestUserTeacher(TestTodAgentsAndTeachersBase):
+    def _test_roundDataCorrect_helper(self, config):
+        """
+        Make sure that all of the User teacher data is correct relative to ground truth,
+        including grounding turn.
+        """
+        max_rounds = config[test_agents.TEST_NUM_ROUNDS_OPT_KEY]
+        values = self.dump_teacher_text(test_agents.UserSimulatorTeacher, config, {})
+        for episode_idx, episode in enumerate(values):
+            utts = test_agents.get_round_utts(episode_idx, max_rounds)
+            comp = []
+            comp.append(
+                [
+                    "GOAL: "
+                    + tod_core.SerializationHelpers.list_of_maps_to_str(
+                        test_agents.make_goal_calls_machine(max_rounds)
+                    ),
+                    utts[0][0],
+                ]
+            )
+            last_sys = utts[0][3]
+            for i in range(1, len(utts)):
+                comp.append([last_sys, utts[i][0]])
+                last_sys = utts[i][3]
+            self.assertEqual(episode, comp)
+
+    def test_roundDataCorrect(self):
+        self._test_roundDataCorrect()
+
+
+class TestGoalAgent(TestTodAgentsAndTeachersBase):
+    def _test_roundDataCorrect_helper(self, config):
+        """
+        Make sure goal agent data is correct with (possibly) multiple goals.
+        """
+        max_rounds = config[test_agents.TEST_NUM_ROUNDS_OPT_KEY]
+        max_episodes = config[test_agents.TEST_NUM_EPISODES_OPT_KEY]
+        values = self.dump_single_utt_per_episode_agent_text(
+            test_agents.GoalAgent, config, {}
+        )
+
+        goal_text = [
+            "GOAL: "
+            + tod_core.SerializationHelpers.list_of_maps_to_str(
+                test_agents.make_goal_calls_machine(max_rounds)
+            )
+            for _ in range(max_episodes)
+        ]
+
+        self.assertEqual(values, goal_text)
+
+    def test_roundDataCorrect(self):
+        self._test_roundDataCorrect()
+
+
+class TestApiSchemaAgent(TestTodAgentsAndTeachersBase):
+    def _test_roundDataCorrect_helper(self, config):
+        """
+        Make sure api schema information is correct with (possibly) multiple goals.
+        """
+        max_rounds = config[test_agents.TEST_NUM_ROUNDS_OPT_KEY]
+        max_episodes = config[test_agents.TEST_NUM_EPISODES_OPT_KEY]
+        values = self.dump_single_utt_per_episode_agent_text(
+            test_agents.ApiSchemaAgent, config, {}
+        )
+
+        apis_texts = [
+            "APIS: "
+            + tod_core.SerializationHelpers.list_of_maps_to_str(
+                test_agents.make_api_schemas_machine(max_rounds)
+            )
+            for _ in range(max_episodes)
+        ]
+
+        self.assertEqual(values, apis_texts)
+
+    def test_roundDataCorrect(self):
+        self._test_roundDataCorrect()
+
+
+class TestSingleGoalAgent(TestTodAgentsAndTeachersBase):
+    def _test_roundDataCorrect_helper(self, config):
+        """
+        Make sure single goal agent correctly splits conversations with multiple goals
+        into single goals for the agent.
+        """
+        max_rounds = config[test_agents.TEST_NUM_ROUNDS_OPT_KEY]
+        max_episodes = config[test_agents.TEST_NUM_EPISODES_OPT_KEY]
+        values = self.dump_single_utt_per_episode_agent_text(
+            test_agents.SingleGoalAgent, config, {}
+        )
+
+        goal_text = []
+        for _ in range(max_episodes):
+            goals = test_agents.make_goal_calls_machine(max_rounds)
+            for x in goals:
+                goal_text.append(
+                    "GOAL: " + tod_core.SerializationHelpers.list_of_maps_to_str([x])
+                )
+
+        self.assertEqual(values, goal_text)
+
+    def test_roundDataCorrect(self):
+        self._test_roundDataCorrect()
+
+
+class TestSingleApiSchemaAgent(TestTodAgentsAndTeachersBase):
+    def _test_roundDataCorrect_helper(self, config):
+        """
+        Make sure single api schema agent correctly splits conversations with multiple
+        goals into single goals for the agent.
+        """
+        max_rounds = config[test_agents.TEST_NUM_ROUNDS_OPT_KEY]
+        max_episodes = config[test_agents.TEST_NUM_EPISODES_OPT_KEY]
+        values = self.dump_single_utt_per_episode_agent_text(
+            test_agents.SingleApiSchemaAgent, config, {}
+        )
+
+        apis_text = []
+        for _ in range(max_episodes):
+            apis = test_agents.make_api_schemas_machine(max_rounds)
+            for x in apis:
+                apis_text.append(
+                    "APIS: " + tod_core.SerializationHelpers.list_of_maps_to_str([x])
+                )
+        self.assertEqual(values, apis_text)
+
+    def test_roundDataCorrect(self):
+        self._test_roundDataCorrect()
+
+
+class TestSingleGoalWithSingleApiSchemaAgent(TestTodAgentsAndTeachersBase):
+    """
+    Make sure the SingleGoal + SingleApiSchema agents correspond.
+    """
+
+    def _test_roundDataCorrect_helper(self, config):
+        goals = self.dump_single_utt_per_episode_agent_text(
+            test_agents.SingleGoalAgent, config, {}
+        )
+        apis = self.dump_single_utt_per_episode_agent_text(
+            test_agents.SingleApiSchemaAgent, config, {}
+        )
+
+        for i in range(len(goals)):
+            goal = tod_core.SerializationHelpers.str_to_goals(goals[i][len("GOALS:") :])
+            api = tod_core.SerializationHelpers.str_to_api_schemas(
+                apis[i][len("APIS:") :]
+            )
+            self.assertEqual(
+                goal[0].get("api_name", None), api[0].get("api_name", None)
+            )
+
+    def test_roundDataCorrect(self):
+        self._test_roundDataCorrect()
+
+
+class TestLowShot(TestTodAgentsAndTeachersBase):
+    FEW_SHOT_SAMPLES = [0, 1, 5, 15]
+    PERCENTAGES = [0, 0.1, 0.3, 0.5]
+
+    def setup_agent_or_teacher(self, class_type, round_opt, opt):
+        full_opts = {**round_opt, **opt}
+        full_opts["datatype"] = "DUMMY"
+        full_opts["datafile"] = "DUMMY"
+        return class_type(full_opts)
+
+    def test_few_shot_lengths_correct(self):
+        def helper(n_shot):
+            values = self.dump_teacher_text(
+                test_agents.SystemTeacher,
+                test_agents.EPISODE_SETUP__MULTI_EPISODE_BS,
+                {"episodes_randomization_seed": 0, "n_shot": n_shot},
+            )
+            self.assertEqual(len(values), n_shot)
+
+        for i in self.FEW_SHOT_SAMPLES:
+            helper(i)
+
+    def _test_subsets(self, data_dumps):
+        for i in range(len(data_dumps) - 1):
+            small = data_dumps[i]
+            larger = data_dumps[i + 1]
+            for i, episode in enumerate(small):
+                self.assertEqual(episode, larger[i])
+
+    def test_few_shot_subset(self):
+        """
+        Make sure specifying few-shot by n-shot works correctly.
+        """
+
+        def helper(n_shot, seed):
+            return self.dump_teacher_text(
+                test_agents.SystemTeacher,
+                test_agents.EPISODE_SETUP__MULTI_EPISODE,
+                {"episodes_randomization_seed": seed, "n_shot": n_shot},
+            )
+
+        data_dumps_seed_zero = [helper(i, 0) for i in self.FEW_SHOT_SAMPLES]
+        self._test_subsets(data_dumps_seed_zero)
+        data_dumps_seed_three = [helper(i, 3) for i in self.FEW_SHOT_SAMPLES]
+        self._test_subsets(data_dumps_seed_three)
+        self.assertNotEqual(data_dumps_seed_zero[-1], data_dumps_seed_three[-1])
+
+    def test_percent_shot_lengths_correct(self):
+        """
+        Make sure specifying few-shot by percentages works correctly.
+        """
+
+        def helper(percent_shot, correct):
+            values = self.dump_teacher_text(
+                test_agents.SystemTeacher,
+                test_agents.EPISODE_SETUP__MULTI_EPISODE_BS,  # 35 episodes
+                {"episodes_randomization_seed": 0, "percent_shot": percent_shot},
+            )
+            self.assertEqual(len(values), correct)
+
+        helper(0, 0)
+        helper(0.1, 3)
+        helper(0.3, 10)
+
+    def test_percent_shot_subset(self):
+        """
+        Make sure specifying few-shot by percentages works correctly.
+        """
+
+        def helper(percent_shot, seed):
+            return self.dump_teacher_text(
+                test_agents.SystemTeacher,
+                test_agents.EPISODE_SETUP__MULTI_EPISODE_BS,  # 35 episodes
+                {"episodes_randomization_seed": seed, "percent_shot": percent_shot},
+            )
+
+        data_dumps_seed_zero = [helper(i, 0) for i in self.PERCENTAGES]
+        self._test_subsets(data_dumps_seed_zero)
+        data_dumps_seed_three = [helper(i, 3) for i in self.PERCENTAGES]
+        self._test_subsets(data_dumps_seed_three)
+
+    def test_correct_throw_when_both_shots_defined(self):
+        self.assertRaises(
+            RuntimeError,
+            self.dump_teacher_text,
+            test_agents.SystemTeacher,
+            test_agents.EPISODE_SETUP__MULTI_EPISODE_BS,  # 35 episodes
+            {"episodes_randomization_seed": 0, "percent_shot": 0.3, "n_shot": 3},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Effectively does same thing as https://github.com/facebookresearch/ParlAI/pull/4176 but broken out to be easier to review.

This diff does 2 things:
1. Adds the helper agents for simulation (Goal + API Description agents necessary for simulation; agents for dumping data from a dataset) in `tod_agents.py`. 
2. Adds tests for these agents + the teachers in the previous diff in the stack. 