### PR TITLE
[BB2] Handling increase in batch size from dynamic batching

### DIFF
--- a/projects/blenderbot2/agents/modules.py
+++ b/projects/blenderbot2/agents/modules.py
@@ -437,6 +437,9 @@ class BlenderBot2RagModel(RagModel):
             input_lengths = input_lengths.repeat_interleave(
                 input_turns_cnt, dim=0
             )  # type: ignore
+
+        # Filtering empty doc_scores added due to dynamic batching (if used)
+        doc_scores = [[s for s in ds if s is not None] for ds in doc_scores if ds]
         top_doc_scores = torch.stack(
             [torch.cat([s_i for s_i in scores_i]) for scores_i in doc_scores]
         )


### PR DESCRIPTION
**Patch description**
Dynamic batching in ParlAI increases the batch size. This causes some issues with empty `doc_score` place-holders that BB2 uses: they don't get filled and remain empty, which results in run-time error during tensor operations. This patch filters the empty `doc_score` place-holders. 