### PR TITLE
Fix lr scheduler tests & lr schedulers

### DIFF
--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -86,7 +86,7 @@ class ParlAILRScheduler(object):
         return (
             hasattr(self, 'warmup_scheduler')
             and self.warmup_scheduler is not None
-            and self._number_training_updates <= self.warmup_updates
+            and self.warmup_scheduler.get_last_lr()[0] < 1.0
         )
 
     def _warmup_lr(self, step):

--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -86,7 +86,7 @@ class ParlAILRScheduler(object):
         return (
             hasattr(self, 'warmup_scheduler')
             and self.warmup_scheduler is not None
-            and self._number_training_updates < self.warmup_updates
+            and self._number_training_updates <= self.warmup_updates
         )
 
     def _warmup_lr(self, step):

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -202,7 +202,7 @@ class TestLRIntegration(unittest.TestCase):
             )
             assert logs_first[20]['lr'] == logs_second[0]['lr']
 
-            if 'warump_updates' in kwargs:
+            if 'warmup_updates' in kwargs:
                 full_logs = logs_first[:20] + logs_second
                 assert full_logs[kwargs['warmup_updates']]['lr'] == 1.0
 

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -204,7 +204,7 @@ class TestLRIntegration(unittest.TestCase):
 
             if 'warmup_updates' in kwargs:
                 full_logs = logs_first[:20] + logs_second
-                assert full_logs[kwargs['warmup_updates']]['lr'] == 1.0
+                assert full_logs[kwargs['warmup_updates'] - 1]['lr'] == 1.0
 
             return logs_first, logs_second
 


### PR DESCRIPTION
**Patch description**
This patch fixes a wrong parameter name in LR schedulers test

**Testing steps**
This is a fix for tests

**Other information**
Seems, like warmup implementation for all schedulers has never been tested. This was because the testing code was unreachable due to the wrong parameter name ('warump_updates'). After fixing the parameter of the test, some tests started to fail.