### PR TITLE
tighten test_xlm bound

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -534,8 +534,8 @@ class TestTransformerGenerator(TestTransformerBase):
             adam_eps=1e-6,  # just to test another flag simultaneously
         )
 
-        self.assertLessEqual(valid['ppl'], 1.30)
-        self.assertLessEqual(test['ppl'], 1.30)
+        self.assertLessEqual(valid['ppl'], 1.02)
+        self.assertLessEqual(test['ppl'], 1.02)
 
     @testing_utils.retry(ntries=3)
     def test_prelayernorm(self):


### PR DESCRIPTION
**Patch description**
Hi,

The test `test_xlm` in `test_transformers.py` has an assertion bound (`self.assertLessEqual(test['ppl'], 1.3)`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/146682582-6b1e4699-4fc0-4569-892a-e59c83d0ee02.png" width="450">
</p>

Here we see that the bound of `1.3` is too loose since the original distribution (in orange) is much less than `1.3`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are below the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/146682595-edd8773d-8222-4b80-a5fe-a75feb908bd4.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `1.3` (red dotted line) has a catch rate of 0.

To improve this test, I propose to tighten the bound to `1.02` (the blue dotted line). The new bound has a catch rate of 0.17 (+0.17 increase compare to original) while still has >99 % pass rate (test is not flaky, I ran the updated test 500 times and observed >99 % pass rate). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Furthermore, I observed that the value of the assertions in this test never goes below 1. Would it be helpful to include an additional assertion for example `assertGreaterEqual(test['ppl'], 1)` as well? Some mutants can change the value to below 1 and current assertion setup would miss those mutants/bugs. By adding the additional assertion of greaterthan 1 we can improve the catch rate further to 0.23

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.7.11
pytorch=1.10.0
```

my parlai Experiment SHA:
`4b1d07d0eeb14f849ad930eeb001327f9bfc2db1`
