### PR TITLE
[bug fix] Torch Classifier agent should call self.backward(loss)

### DIFF
--- a/parlai/core/torch_classifier_agent.py
+++ b/parlai/core/torch_classifier_agent.py
@@ -654,7 +654,7 @@ class TorchClassifierAgent(TorchAgent):
         loss = self.criterion(scores, labels)
         self.record_local_metric('loss', AverageMetric.many(loss))
         loss = loss.mean()
-        loss.backward()
+        self.backward(loss)
         self.update_params()
 
         # get predictions


### PR DESCRIPTION
**Patch description**
The current torch classifier agent uses ```loss.backward``` instead of ```self.backward(loss)```. A lot of optimizer behaviors depend on the backward function. While the backward function was ignored in the previous version. 
For example:
1. In ```SafeFP16Optimizer```, the fp32 gradient will be zeros as no synchronizing flag is set. The model doesn't train. https://github.com/facebookresearch/ParlAI/blob/66c71e01b79b118a717c1115fecea5e99b12429a/parlai/utils/fp16.py#L200. 
2. In ```MemoryEfficientFP16Optimizer``` the loss loss_scale multiplier is omitted.  We should improve performance with this fix.
https://github.com/facebookresearch/ParlAI/blob/66c71e01b79b118a717c1115fecea5e99b12429a/parlai/utils/fp16.py#L521


**Testing steps**
Train any classifier agent. Verified with a classifier agent training with SafeFP16Optimizer.
In our case, we retrained a safety classifier and compared its performance with the model in the zoo.
FP32 matched the performance, and FP16 performance worse. The performance shifted a bit between the tasks, we are comparing the average class_notok__ f1, it is the validation metric used for all the trainings.  

![image](https://user-images.githubusercontent.com/5313281/147110651-d4b79be5-97e5-45f3-9a92-a43b0b658045.png)
