### PR TITLE
Fix crowdsourcing CI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,8 @@ commands:
             python -m pip install --progress-bar off 'transformers==4.3.3'
             python -m pip install --progress-bar off 'fairseq==0.10.0'
             python -m pip install --progress-bar off 'faiss-gpu==1.7.0'
+            python -m pip uninstall dataclasses -y
+            # This pre-Python-3.7 package will break use of Python-3.7-style dataclasses
             python -c 'import torch; print("Torch version:", torch.__version__)'
             python -m torch.utils.collect_env
 
@@ -120,6 +122,8 @@ commands:
             python -m pip install --progress-bar off 'transformers==4.3.3'
             python -m pip install --progress-bar off 'fairseq==0.10.0'
             python -m pip install --progress-bar off 'faiss-gpu==1.7.0'
+            python -m pip uninstall dataclasses -y
+            # This pre-Python-3.7 package will break use of Python-3.7-style dataclasses
             python -c 'import torch; print("Torch version:", torch.__version__)'
             python -m torch.utils.collect_env
             python -c 'import torch; print("Torch version:", torch.__version__)'


### PR DESCRIPTION
**Patch description**
Fix the currently broken crowdsourcing CI check by uninstalling the [`dataclasses`](https://pypi.org/project/dataclasses/) package, which is a requirement of [`transformers`](https://github.com/huggingface/transformers/blob/master/setup.py), our current version of [`fairseq`](https://github.com/pytorch/fairseq/blob/3e5a2739bce92b2516d060959a1aa3dd51d221dc/setup.py#L152), and maybe others. The `dataclasses` package is deprecated because it is a backport of functionality already built into Python 3.7+, but if it is used with Python 3.7+ it will cause an [error with omegaconf](https://app.circleci.com/pipelines/github/facebookresearch/ParlAI/10681/workflows/2c05db95-b685-4c60-ba95-65919646b983/jobs/88305) that prevents installation of Mephisto. Since ParlAI requires Python 3.7+, it seems that this package should be able to be uninstalled without consequence.

See also for reference: https://github.com/huggingface/transformers/issues/8638#issuecomment-790772391

**Testing steps**
CI checks