### PR TITLE
Fix model chat speakers and personas

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/frontend/main.js
+++ b/parlai/crowdsourcing/tasks/model_chat/frontend/main.js
@@ -31,7 +31,13 @@ function MainApp() {
       renderSidePane={({ mephistoContext: { taskConfig }, appContext: { taskContext } }) => (
         <DefaultTaskDescription
           chatTitle={taskConfig.task_title}
-          taskDescriptionHtml={taskConfig.left_pane_text}
+          taskDescriptionHtml={
+              taskConfig.left_pane_text.replace(
+                  "[persona_string_1]", taskContext.human_persona_string_1,
+              ).replace(
+                  "[persona_string_2]", taskContext.human_persona_string_2,
+              )
+          }
         >
           {(taskContext.hasOwnProperty('image_src') && taskContext['image_src']) ? (
             <div>
@@ -45,24 +51,23 @@ function MainApp() {
         </DefaultTaskDescription>
       )}
       renderTextResponse={
-        ({ 
-          mephistoContext: { taskConfig }, 
+        ({
+          mephistoContext: { taskConfig },
           appContext: { appSettings },
           onMessageSend,
           active,
 
         }) => (
-          <ResponseComponent 
+          <ResponseComponent
             appSettings={appSettings}
             taskConfig={taskConfig}
             active={active}
             onMessageSend={onMessageSend}
           />
-        )  
+        )
       }
     />
   );
 }
 
 ReactDOM.render(<MainApp />, document.getElementById("app"));
-

--- a/parlai/crowdsourcing/tasks/model_chat/run.py
+++ b/parlai/crowdsourcing/tasks/model_chat/run.py
@@ -14,7 +14,6 @@ from omegaconf import DictConfig
 
 from parlai.crowdsourcing.tasks.model_chat.impl import run_task
 from parlai.crowdsourcing.utils.mturk import MTurkRunScriptConfig
-import parlai.crowdsourcing.tasks.model_chat.worlds as world_module
 
 
 TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
@@ -40,7 +39,7 @@ register_script_config(name='scriptconfig', module=ScriptConfig)
 
 @hydra.main(config_path="hydra_configs", config_name="scriptconfig")
 def main(cfg: DictConfig) -> None:
-    run_task(cfg=cfg, task_directory=TASK_DIRECTORY, world_module=world_module)
+    run_task(cfg=cfg, task_directory=TASK_DIRECTORY)
 
 
 if __name__ == "__main__":

--- a/parlai/crowdsourcing/tasks/model_chat/utils.py
+++ b/parlai/crowdsourcing/tasks/model_chat/utils.py
@@ -381,13 +381,16 @@ class AbstractModelChatTest(AbstractParlAIChatTest, unittest.TestCase):
                 for actual_message, expected_message in zip(
                     actual_value[key_inner], expected_value_inner
                 ):
-                    self.assertEqual(
-                        {k: v for k, v in actual_message.items() if k != 'message_id'},
-                        {
-                            k: v
-                            for k, v in expected_message.items()
-                            if k != 'message_id'
-                        },
+                    clean_actual_message = {
+                        k: v for k, v in actual_message.items() if k != 'message_id'
+                    }
+                    clean_expected_message = {
+                        k: v for k, v in expected_message.items() if k != 'message_id'
+                    }
+                    self.assertDictEqual(
+                        clean_actual_message,
+                        clean_actual_message,
+                        f'The following dictionaries are different: {clean_actual_message} and {clean_expected_message}',
                     )
             elif key_inner == 'task_description':
                 for (key_inner2, expected_value_inner2) in expected_value_inner.items():

--- a/parlai/crowdsourcing/tasks/model_chat/utils.py
+++ b/parlai/crowdsourcing/tasks/model_chat/utils.py
@@ -389,7 +389,7 @@ class AbstractModelChatTest(AbstractParlAIChatTest, unittest.TestCase):
                     }
                     self.assertDictEqual(
                         clean_actual_message,
-                        clean_actual_message,
+                        clean_expected_message,
                         f'The following dictionaries are different: {clean_actual_message} and {clean_expected_message}',
                     )
             elif key_inner == 'task_description':

--- a/parlai/crowdsourcing/tasks/model_chat/worlds_image_chat.py
+++ b/parlai/crowdsourcing/tasks/model_chat/worlds_image_chat.py
@@ -78,6 +78,7 @@ Be sure to talk about this image a little bit before discussing other things!
         bot_first_act_raw = Message(
             Compatibility.maybe_fix_act(bot_first_act_raw)
         ).json_safe_payload()
+        bot_first_act_raw['id'] = self.bot.agent_id
         self.agent.observe(validate(bot_first_act_raw))
         bot_first_act = {
             'episode_done': False,

--- a/parlai/crowdsourcing/tasks/model_chat/worlds_image_chat.py
+++ b/parlai/crowdsourcing/tasks/model_chat/worlds_image_chat.py
@@ -134,8 +134,6 @@ Be sure to talk about this image a little bit before discussing other things!
 
 def make_world(opt, agents):
 
-    agents[0].agent_id = "Worker"
-
     # We are showing an image to the worker and bot, so grab the image path and other
     # context info
     image_idx, model_name, no_more_work = opt['image_stack'].get_next_image(

--- a/tests/crowdsourcing/tasks/model_chat/expected_states/final_chat_data.json
+++ b/tests/crowdsourcing/tasks/model_chat/expected_states/final_chat_data.json
@@ -11,7 +11,11 @@
             "text": "Hi!",
             "fake_start": true,
             "agent_idx": 0,
-            "message_id": "4f72800c-e1ff-4411-8ee5-286336c27859"
+            "message_id": "4f72800c-e1ff-4411-8ee5-286336c27859",
+            "task_data": {
+                "human_persona_string_1": "",
+                "human_persona_string_2": ""
+            }
         },
         {
             "agent_idx": 1,

--- a/tests/crowdsourcing/tasks/model_chat/expected_states/final_chat_data.json
+++ b/tests/crowdsourcing/tasks/model_chat/expected_states/final_chat_data.json
@@ -7,7 +7,7 @@
     "dialog": [
         {
             "episode_done": false,
-            "id": "Worker",
+            "id": "Speaker 1",
             "text": "Hi!",
             "fake_start": true,
             "agent_idx": 0,
@@ -16,7 +16,7 @@
         {
             "agent_idx": 1,
             "text": "I don't know.",
-            "id": "FixedResponseAgent",
+            "id": "Speaker 2",
             "problem_data": {
                 "bucket_0": false,
                 "bucket_1": false,
@@ -29,12 +29,12 @@
         {
             "agent_idx": 0,
             "text": "What are you nervous about?",
-            "id": "Worker"
+            "id": "Speaker 1"
         },
         {
             "agent_idx": 1,
             "text": "I don't know.",
-            "id": "FixedResponseAgent",
+            "id": "Speaker 2",
             "problem_data": {
                 "bucket_0": false,
                 "bucket_1": false,
@@ -47,12 +47,12 @@
         {
             "agent_idx": 0,
             "text": "Do you have any plans for the weekend?",
-            "id": "Worker"
+            "id": "Speaker 1"
         },
         {
             "agent_idx": 1,
             "text": "I don't know.",
-            "id": "FixedResponseAgent",
+            "id": "Speaker 2",
             "problem_data": {
                 "bucket_0": false,
                 "bucket_1": false,
@@ -65,12 +65,12 @@
         {
             "agent_idx": 0,
             "text": "Yeah that sounds great! I like to bike and try new restaurants.",
-            "id": "Worker"
+            "id": "Speaker 1"
         },
         {
             "agent_idx": 1,
             "text": "I don't know.",
-            "id": "FixedResponseAgent",
+            "id": "Speaker 2",
             "problem_data": {
                 "bucket_0": false,
                 "bucket_1": false,
@@ -83,12 +83,12 @@
         {
             "agent_idx": 0,
             "text": "Oh, Italian food is great. I also love Thai and Indian.",
-            "id": "Worker"
+            "id": "Speaker 1"
         },
         {
             "agent_idx": 1,
             "text": "I don't know.",
-            "id": "FixedResponseAgent",
+            "id": "Speaker 2",
             "problem_data": {
                 "bucket_0": false,
                 "bucket_1": false,
@@ -101,12 +101,12 @@
         {
             "agent_idx": 0,
             "text": "Hmmm - anything with peanuts? Or I like when they have spicy licorice-like herbs.",
-            "id": "Worker"
+            "id": "Speaker 1"
         },
         {
             "agent_idx": 1,
             "text": "I don't know.",
-            "id": "FixedResponseAgent",
+            "id": "Speaker 2",
             "problem_data": {
                 "bucket_0": false,
                 "bucket_1": false,

--- a/tests/crowdsourcing/tasks/model_chat/expected_states/final_chat_data__image_chat.json
+++ b/tests/crowdsourcing/tasks/model_chat/expected_states/final_chat_data__image_chat.json
@@ -16,69 +16,69 @@
         },
         {
             "episode_done": false,
-            "id": "TransresnetAgent",
+            "id": "Speaker 2",
             "text": "I must learn that bird's name!",
             "agent_idx": 1
         },
         {
             "agent_idx": 0,
             "text": "Response 1",
-            "id": "Worker"
+            "id": "Speaker 1"
         },
         {
             "agent_idx": 1,
             "text": "My, aren't you a pretty bird?",
-            "id": "TransresnetAgent"
+            "id": "Speaker 2"
         },
         {
             "agent_idx": 0,
             "text": "Response 2",
-            "id": "Worker"
+            "id": "Speaker 1"
         },
         {
             "agent_idx": 1,
             "text": "My, aren't you a pretty bird?",
-            "id": "TransresnetAgent"
+            "id": "Speaker 2"
         },
         {
             "agent_idx": 0,
             "text": "Response 3",
-            "id": "Worker"
+            "id": "Speaker 1"
         },
         {
             "agent_idx": 1,
             "text": "My, aren't you a pretty bird?",
-            "id": "TransresnetAgent"
+            "id": "Speaker 2"
         },
         {
             "agent_idx": 0,
             "text": "Response 4",
-            "id": "Worker"
+            "id": "Speaker 1"
         },
         {
             "agent_idx": 1,
             "text": "My, aren't you a pretty bird?",
-            "id": "TransresnetAgent"
+            "id": "Speaker 2"
         },
         {
             "agent_idx": 0,
             "text": "Response 5",
-            "id": "Worker"
+            "id": "Speaker 1"
         },
         {
             "agent_idx": 1,
             "text": "My, aren't you a pretty bird?",
-            "id": "TransresnetAgent"
+            "id": "Speaker 2"
         },
         {
             "agent_idx": 0,
             "text": "Response 6",
-            "id": "Worker"
+            "id": "Speaker 1"
         },
         {
             "agent_idx": 1,
             "text": "My, aren't you a pretty bird?",
-            "id": "TransresnetAgent",
+            "id": "Speaker 2",
             "final_rating": 0
         }
     ],

--- a/tests/crowdsourcing/tasks/model_chat/expected_states/state.json
+++ b/tests/crowdsourcing/tasks/model_chat/expected_states/state.json
@@ -5,7 +5,9 @@
             {
                 "data": {
                     "message_id": "3a289317-8519-4da8-be8f-9a515a6ec3da",
-                    "state": {"agent_display_name": "Speaker 1"}
+                    "state": {
+                        "agent_display_name": "Speaker 1"
+                    }
                 },
                 "packet_type": "update_status",
                 "receiver_id": "1",
@@ -19,7 +21,11 @@
                     "fake_start": true,
                     "id": "Speaker 1",
                     "message_id": "4f72800c-e1ff-4411-8ee5-286336c27859",
-                    "text": "Hi!"
+                    "text": "Hi!",
+                    "task_data": {
+                        "human_persona_string_1": "",
+                        "human_persona_string_2": ""
+                    }
                 },
                 "packet_type": "agent_action",
                 "receiver_id": "1",
@@ -233,9 +239,13 @@
             },
             {
                 "final_chat_data": {
-                    "acceptability_violations": [null],
+                    "acceptability_violations": [
+                        null
+                    ],
                     "additional_context": null,
-                    "assignment_ids": ["1"],
+                    "assignment_ids": [
+                        "1"
+                    ],
                     "bad_workers": [],
                     "context_dataset": null,
                     "dialog": [
@@ -245,7 +255,11 @@
                             "fake_start": true,
                             "id": "Speaker 1",
                             "message_id": "4f72800c-e1ff-4411-8ee5-286336c27859",
-                            "text": "Hi!"
+                            "text": "Hi!",
+                            "task_data": {
+                                "human_persona_string_1": "",
+                                "human_persona_string_2": ""
+                            }
                         },
                         {
                             "agent_idx": 1,
@@ -352,7 +366,9 @@
                             "text": "I don't know."
                         }
                     ],
-                    "hit_ids": ["1"],
+                    "hit_ids": [
+                        "1"
+                    ],
                     "person1_seed_utterance": null,
                     "person2_seed_utterance": null,
                     "personas": null,
@@ -368,7 +384,9 @@
                             "datatype": "train",
                             "image_mode": "raw",
                             "hide_labels": false,
-                            "multitask_weights": [1],
+                            "multitask_weights": [
+                                1
+                            ],
                             "batchsize": 1,
                             "dynamic_batching": null,
                             "verbose": false,
@@ -389,7 +407,9 @@
                             "starttime": "Jan08_11-16"
                         }
                     },
-                    "workers": ["--NOT-MTURK-AGENT-MOCK_WORKER_0"]
+                    "workers": [
+                        "--NOT-MTURK-AGENT-MOCK_WORKER_0"
+                    ]
                 }
             },
             {
@@ -402,7 +422,11 @@
                                     "id": "Speaker 1",
                                     "text": "Hi!",
                                     "fake_start": true,
-                                    "agent_idx": 0
+                                    "agent_idx": 0,
+                                    "task_data": {
+                                        "human_persona_string_1": "",
+                                        "human_persona_string_2": ""
+                                    }
                                 },
                                 {
                                     "agent_idx": 1,
@@ -509,11 +533,19 @@
                                     "final_rating": 4
                                 }
                             ],
-                            "workers": ["--NOT-MTURK-AGENT-MOCK_WORKER_0"],
+                            "workers": [
+                                "--NOT-MTURK-AGENT-MOCK_WORKER_0"
+                            ],
                             "bad_workers": [],
-                            "acceptability_violations": [null],
-                            "hit_ids": ["1"],
-                            "assignment_ids": ["1"],
+                            "acceptability_violations": [
+                                null
+                            ],
+                            "hit_ids": [
+                                "1"
+                            ],
+                            "assignment_ids": [
+                                "1"
+                            ],
                             "task_description": {
                                 "annotations_config": "{\n    \"config\": {\n        \"bucket_0\": {\n            \"name\": \"Bucket 0\",\n            \"description\": \"this response implies something...0\"\n        },\n        \"bucket_1\": {\n            \"name\": \"Bucket 1\",\n            \"description\": \"this response implies something...1\"\n        },\n        \"bucket_2\": {\n            \"name\": \"Bucket 2\",\n            \"description\": \"this response implies something...2\"\n        },\n        \"bucket_3\": {\n            \"name\": \"Bucket 3\",\n            \"description\": \"this response implies something...3\"\n        },\n        \"bucket_4\": {\n            \"name\": \"Bucket 4\",\n            \"description\": \"this response implies something...4\"\n        },\n        \"none_all_good\": {\n            \"name\": \"None, all good\",\n            \"description\": \"This response implies that there are no problems with the data\"\n        }\n    }\n}\n",
                                 "model_nickname": "fixed_response",
@@ -527,7 +559,9 @@
                                     "datatype": "train",
                                     "image_mode": "raw",
                                     "hide_labels": false,
-                                    "multitask_weights": [1],
+                                    "multitask_weights": [
+                                        1
+                                    ],
                                     "batchsize": 1,
                                     "dynamic_batching": null,
                                     "verbose": false,
@@ -564,7 +598,12 @@
                 "timestamp": 1606748839.8638673
             },
             {
-                "data": {"MEPHISTO_is_submit": true, "task_data": {"final_data": {}}},
+                "data": {
+                    "MEPHISTO_is_submit": true,
+                    "task_data": {
+                        "final_data": {}
+                    }
+                },
                 "packet_type": "agent_action",
                 "receiver_id": "Mephisto",
                 "sender_id": "1",

--- a/tests/crowdsourcing/tasks/model_chat/expected_states/state.json
+++ b/tests/crowdsourcing/tasks/model_chat/expected_states/state.json
@@ -5,7 +5,7 @@
             {
                 "data": {
                     "message_id": "3a289317-8519-4da8-be8f-9a515a6ec3da",
-                    "state": {"agent_display_name": "Worker"}
+                    "state": {"agent_display_name": "Speaker 1"}
                 },
                 "packet_type": "update_status",
                 "receiver_id": "1",
@@ -17,7 +17,7 @@
                     "agent_idx": 0,
                     "episode_done": false,
                     "fake_start": true,
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "message_id": "4f72800c-e1ff-4411-8ee5-286336c27859",
                     "text": "Hi!"
                 },
@@ -29,7 +29,7 @@
             {
                 "data": {
                     "episode_done": false,
-                    "id": "FixedResponseAgent",
+                    "id": "Speaker 2",
                     "message_id": "43ef23af-a9fc-4f67-bd06-6e083ba45678",
                     "text": "I don't know."
                 },
@@ -41,7 +41,7 @@
             {
                 "data": {
                     "episode_done": false,
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "message_id": "fb168956-cfe1-40e2-b28b-1ca66207a39e",
                     "task_data": {
                         "problem_data_for_prior_message": {
@@ -63,7 +63,7 @@
             {
                 "data": {
                     "episode_done": false,
-                    "id": "FixedResponseAgent",
+                    "id": "Speaker 2",
                     "message_id": "05fefda5-dfa0-44e2-81ad-ba9ca203ed1d",
                     "text": "I don't know."
                 },
@@ -75,7 +75,7 @@
             {
                 "data": {
                     "episode_done": false,
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "message_id": "49740817-1443-47b4-b91d-3260fd12bf7d",
                     "task_data": {
                         "problem_data_for_prior_message": {
@@ -97,7 +97,7 @@
             {
                 "data": {
                     "episode_done": false,
-                    "id": "FixedResponseAgent",
+                    "id": "Speaker 2",
                     "message_id": "6a52d8ee-1955-4d08-a7f8-007feea3ecfd",
                     "text": "I don't know."
                 },
@@ -109,7 +109,7 @@
             {
                 "data": {
                     "episode_done": false,
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "message_id": "db9a475a-a47f-4328-92f4-130f2227dfbb",
                     "task_data": {
                         "problem_data_for_prior_message": {
@@ -131,7 +131,7 @@
             {
                 "data": {
                     "episode_done": false,
-                    "id": "FixedResponseAgent",
+                    "id": "Speaker 2",
                     "message_id": "550f71a4-f441-4546-bd73-45313932ec3c",
                     "text": "I don't know."
                 },
@@ -143,7 +143,7 @@
             {
                 "data": {
                     "episode_done": false,
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "message_id": "9dc9241c-73f6-4724-bad6-50038ab64522",
                     "task_data": {
                         "problem_data_for_prior_message": {
@@ -165,7 +165,7 @@
             {
                 "data": {
                     "episode_done": false,
-                    "id": "FixedResponseAgent",
+                    "id": "Speaker 2",
                     "message_id": "3a046372-6204-452d-8877-88a1d1a9583a",
                     "text": "I don't know."
                 },
@@ -177,7 +177,7 @@
             {
                 "data": {
                     "episode_done": false,
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "message_id": "64816a92-5e8a-4ab9-b194-2a93499f47dc",
                     "task_data": {
                         "problem_data_for_prior_message": {
@@ -199,7 +199,7 @@
             {
                 "data": {
                     "episode_done": false,
-                    "id": "FixedResponseAgent",
+                    "id": "Speaker 2",
                     "message_id": "f68faec0-b2c2-434d-98a6-b4cc9f1f42b3",
                     "text": "I don't know."
                 },
@@ -211,7 +211,7 @@
             {
                 "data": {
                     "episode_done": false,
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "message_id": "524d5a56-71a5-4b00-8595-0df720004eb6",
                     "task_data": {
                         "final_rating": 4,
@@ -243,13 +243,13 @@
                             "agent_idx": 0,
                             "episode_done": false,
                             "fake_start": true,
-                            "id": "Worker",
+                            "id": "Speaker 1",
                             "message_id": "4f72800c-e1ff-4411-8ee5-286336c27859",
                             "text": "Hi!"
                         },
                         {
                             "agent_idx": 1,
-                            "id": "FixedResponseAgent",
+                            "id": "Speaker 2",
                             "problem_data": {
                                 "bucket_0": false,
                                 "bucket_1": false,
@@ -262,12 +262,12 @@
                         },
                         {
                             "agent_idx": 0,
-                            "id": "Worker",
+                            "id": "Speaker 1",
                             "text": "What are you nervous about?"
                         },
                         {
                             "agent_idx": 1,
-                            "id": "FixedResponseAgent",
+                            "id": "Speaker 2",
                             "problem_data": {
                                 "bucket_0": false,
                                 "bucket_1": false,
@@ -280,12 +280,12 @@
                         },
                         {
                             "agent_idx": 0,
-                            "id": "Worker",
+                            "id": "Speaker 1",
                             "text": "Do you have any plans for the weekend?"
                         },
                         {
                             "agent_idx": 1,
-                            "id": "FixedResponseAgent",
+                            "id": "Speaker 2",
                             "problem_data": {
                                 "bucket_0": false,
                                 "bucket_1": false,
@@ -298,12 +298,12 @@
                         },
                         {
                             "agent_idx": 0,
-                            "id": "Worker",
+                            "id": "Speaker 1",
                             "text": "Yeah that sounds great! I like to bike and try new restaurants."
                         },
                         {
                             "agent_idx": 1,
-                            "id": "FixedResponseAgent",
+                            "id": "Speaker 2",
                             "problem_data": {
                                 "bucket_0": false,
                                 "bucket_1": false,
@@ -316,12 +316,12 @@
                         },
                         {
                             "agent_idx": 0,
-                            "id": "Worker",
+                            "id": "Speaker 1",
                             "text": "Oh, Italian food is great. I also love Thai and Indian."
                         },
                         {
                             "agent_idx": 1,
-                            "id": "FixedResponseAgent",
+                            "id": "Speaker 2",
                             "problem_data": {
                                 "bucket_0": false,
                                 "bucket_1": false,
@@ -334,12 +334,12 @@
                         },
                         {
                             "agent_idx": 0,
-                            "id": "Worker",
+                            "id": "Speaker 1",
                             "text": "Hmmm - anything with peanuts? Or I like when they have spicy licorice-like herbs."
                         },
                         {
                             "agent_idx": 1,
-                            "id": "FixedResponseAgent",
+                            "id": "Speaker 2",
                             "problem_data": {
                                 "bucket_0": false,
                                 "bucket_1": false,
@@ -399,7 +399,7 @@
                             "dialog": [
                                 {
                                     "episode_done": false,
-                                    "id": "Worker",
+                                    "id": "Speaker 1",
                                     "text": "Hi!",
                                     "fake_start": true,
                                     "agent_idx": 0
@@ -407,7 +407,7 @@
                                 {
                                     "agent_idx": 1,
                                     "text": "I don't know.",
-                                    "id": "FixedResponseAgent",
+                                    "id": "Speaker 2",
                                     "problem_data": {
                                         "bucket_0": false,
                                         "bucket_1": false,
@@ -420,12 +420,12 @@
                                 {
                                     "agent_idx": 0,
                                     "text": "What are you nervous about?",
-                                    "id": "Worker"
+                                    "id": "Speaker 1"
                                 },
                                 {
                                     "agent_idx": 1,
                                     "text": "I don't know.",
-                                    "id": "FixedResponseAgent",
+                                    "id": "Speaker 2",
                                     "problem_data": {
                                         "bucket_0": false,
                                         "bucket_1": false,
@@ -438,12 +438,12 @@
                                 {
                                     "agent_idx": 0,
                                     "text": "Do you have any plans for the weekend?",
-                                    "id": "Worker"
+                                    "id": "Speaker 1"
                                 },
                                 {
                                     "agent_idx": 1,
                                     "text": "I don't know.",
-                                    "id": "FixedResponseAgent",
+                                    "id": "Speaker 2",
                                     "problem_data": {
                                         "bucket_0": false,
                                         "bucket_1": false,
@@ -456,12 +456,12 @@
                                 {
                                     "agent_idx": 0,
                                     "text": "Yeah that sounds great! I like to bike and try new restaurants.",
-                                    "id": "Worker"
+                                    "id": "Speaker 1"
                                 },
                                 {
                                     "agent_idx": 1,
                                     "text": "I don't know.",
-                                    "id": "FixedResponseAgent",
+                                    "id": "Speaker 2",
                                     "problem_data": {
                                         "bucket_0": false,
                                         "bucket_1": false,
@@ -474,12 +474,12 @@
                                 {
                                     "agent_idx": 0,
                                     "text": "Oh, Italian food is great. I also love Thai and Indian.",
-                                    "id": "Worker"
+                                    "id": "Speaker 1"
                                 },
                                 {
                                     "agent_idx": 1,
                                     "text": "I don't know.",
-                                    "id": "FixedResponseAgent",
+                                    "id": "Speaker 2",
                                     "problem_data": {
                                         "bucket_0": false,
                                         "bucket_1": false,
@@ -492,12 +492,12 @@
                                 {
                                     "agent_idx": 0,
                                     "text": "Hmmm - anything with peanuts? Or I like when they have spicy licorice-like herbs.",
-                                    "id": "Worker"
+                                    "id": "Speaker 1"
                                 },
                                 {
                                     "agent_idx": 1,
                                     "text": "I don't know.",
-                                    "id": "FixedResponseAgent",
+                                    "id": "Speaker 2",
                                     "problem_data": {
                                         "bucket_0": false,
                                         "bucket_1": false,

--- a/tests/crowdsourcing/tasks/model_chat/expected_states/state__image_chat.json
+++ b/tests/crowdsourcing/tasks/model_chat/expected_states/state__image_chat.json
@@ -6,7 +6,7 @@
                 "sender_id": "mephisto",
                 "receiver_id": "1",
                 "data": {
-                    "state": {"agent_display_name": "Worker"},
+                    "state": {"agent_display_name": "Speaker 1"},
                     "message_id": "79ee17f5-0edd-45ea-9e12-0f73782de2c4"
                 },
                 "timestamp": 1609255262.574956
@@ -33,7 +33,7 @@
                 "receiver_id": "1",
                 "data": {
                     "text": "I must learn that bird's name!",
-                    "id": "TransresnetAgent",
+                    "id": "Speaker 2",
                     "text_candidates": [
                         "I must learn that bird's name!",
                         "My, aren't you a pretty bird?"
@@ -50,7 +50,7 @@
                 "data": {
                     "text": "Response 1",
                     "task_data": {},
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "episode_done": false
                 },
                 "timestamp": 1609255264.653284
@@ -61,7 +61,7 @@
                 "receiver_id": "1",
                 "data": {
                     "text": "My, aren't you a pretty bird?",
-                    "id": "TransresnetAgent",
+                    "id": "Speaker 2",
                     "text_candidates": [
                         "My, aren't you a pretty bird?",
                         "I must learn that bird's name!"
@@ -78,7 +78,7 @@
                 "data": {
                     "text": "Response 2",
                     "task_data": {},
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "episode_done": false
                 },
                 "timestamp": 1609255264.6686988
@@ -89,7 +89,7 @@
                 "receiver_id": "1",
                 "data": {
                     "text": "My, aren't you a pretty bird?",
-                    "id": "TransresnetAgent",
+                    "id": "Speaker 2",
                     "text_candidates": [
                         "My, aren't you a pretty bird?",
                         "I must learn that bird's name!"
@@ -106,7 +106,7 @@
                 "data": {
                     "text": "Response 3",
                     "task_data": {},
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "episode_done": false
                 },
                 "timestamp": 1609255264.6849954
@@ -117,7 +117,7 @@
                 "receiver_id": "1",
                 "data": {
                     "text": "My, aren't you a pretty bird?",
-                    "id": "TransresnetAgent",
+                    "id": "Speaker 2",
                     "text_candidates": [
                         "My, aren't you a pretty bird?",
                         "I must learn that bird's name!"
@@ -134,7 +134,7 @@
                 "data": {
                     "text": "Response 4",
                     "task_data": {},
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "episode_done": false
                 },
                 "timestamp": 1609255264.701345
@@ -145,7 +145,7 @@
                 "receiver_id": "1",
                 "data": {
                     "text": "My, aren't you a pretty bird?",
-                    "id": "TransresnetAgent",
+                    "id": "Speaker 2",
                     "text_candidates": [
                         "My, aren't you a pretty bird?",
                         "I must learn that bird's name!"
@@ -162,7 +162,7 @@
                 "data": {
                     "text": "Response 5",
                     "task_data": {},
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "episode_done": false
                 },
                 "timestamp": 1609255264.7193751
@@ -173,7 +173,7 @@
                 "receiver_id": "1",
                 "data": {
                     "text": "My, aren't you a pretty bird?",
-                    "id": "TransresnetAgent",
+                    "id": "Speaker 2",
                     "text_candidates": [
                         "My, aren't you a pretty bird?",
                         "I must learn that bird's name!"
@@ -190,7 +190,7 @@
                 "data": {
                     "text": "Response 6",
                     "task_data": {},
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "episode_done": false
                 },
                 "timestamp": 1609255264.7359936
@@ -201,7 +201,7 @@
                 "receiver_id": "1",
                 "data": {
                     "text": "My, aren't you a pretty bird?",
-                    "id": "TransresnetAgent",
+                    "id": "Speaker 2",
                     "text_candidates": [
                         "My, aren't you a pretty bird?",
                         "I must learn that bird's name!"
@@ -218,7 +218,7 @@
                 "data": {
                     "text": "",
                     "task_data": {"final_rating": 0},
-                    "id": "Worker",
+                    "id": "Speaker 1",
                     "episode_done": false
                 },
                 "timestamp": 1609255264.7529757
@@ -240,45 +240,45 @@
                         },
                         {
                             "episode_done": false,
-                            "id": "TransresnetAgent",
+                            "id": "Speaker 2",
                             "text": "I must learn that bird's name!",
                             "agent_idx": 1
                         },
-                        {"agent_idx": 0, "text": "Response 1", "id": "Worker"},
+                        {"agent_idx": 0, "text": "Response 1", "id": "Speaker 1"},
                         {
                             "agent_idx": 1,
                             "text": "My, aren't you a pretty bird?",
-                            "id": "TransresnetAgent"
+                            "id": "Speaker 2"
                         },
-                        {"agent_idx": 0, "text": "Response 2", "id": "Worker"},
+                        {"agent_idx": 0, "text": "Response 2", "id": "Speaker 1"},
                         {
                             "agent_idx": 1,
                             "text": "My, aren't you a pretty bird?",
-                            "id": "TransresnetAgent"
+                            "id": "Speaker 2"
                         },
-                        {"agent_idx": 0, "text": "Response 3", "id": "Worker"},
+                        {"agent_idx": 0, "text": "Response 3", "id": "Speaker 1"},
                         {
                             "agent_idx": 1,
                             "text": "My, aren't you a pretty bird?",
-                            "id": "TransresnetAgent"
+                            "id": "Speaker 2"
                         },
-                        {"agent_idx": 0, "text": "Response 4", "id": "Worker"},
+                        {"agent_idx": 0, "text": "Response 4", "id": "Speaker 1"},
                         {
                             "agent_idx": 1,
                             "text": "My, aren't you a pretty bird?",
-                            "id": "TransresnetAgent"
+                            "id": "Speaker 2"
                         },
-                        {"agent_idx": 0, "text": "Response 5", "id": "Worker"},
+                        {"agent_idx": 0, "text": "Response 5", "id": "Speaker 1"},
                         {
                             "agent_idx": 1,
                             "text": "My, aren't you a pretty bird?",
-                            "id": "TransresnetAgent"
+                            "id": "Speaker 2"
                         },
-                        {"agent_idx": 0, "text": "Response 6", "id": "Worker"},
+                        {"agent_idx": 0, "text": "Response 6", "id": "Speaker 1"},
                         {
                             "agent_idx": 1,
                             "text": "My, aren't you a pretty bird?",
-                            "id": "TransresnetAgent",
+                            "id": "Speaker 2",
                             "final_rating": 0
                         }
                     ],
@@ -463,45 +463,45 @@
                                 },
                                 {
                                     "episode_done": false,
-                                    "id": "TransresnetAgent",
+                                    "id": "Speaker 2",
                                     "text": "I must learn that bird's name!",
                                     "agent_idx": 1
                                 },
-                                {"agent_idx": 0, "text": "Response 1", "id": "Worker"},
+                                {"agent_idx": 0, "text": "Response 1", "id": "Speaker 1"},
                                 {
                                     "agent_idx": 1,
                                     "text": "My, aren't you a pretty bird?",
-                                    "id": "TransresnetAgent"
+                                    "id": "Speaker 2"
                                 },
-                                {"agent_idx": 0, "text": "Response 2", "id": "Worker"},
+                                {"agent_idx": 0, "text": "Response 2", "id": "Speaker 1"},
                                 {
                                     "agent_idx": 1,
                                     "text": "My, aren't you a pretty bird?",
-                                    "id": "TransresnetAgent"
+                                    "id": "Speaker 2"
                                 },
-                                {"agent_idx": 0, "text": "Response 3", "id": "Worker"},
+                                {"agent_idx": 0, "text": "Response 3", "id": "Speaker 1"},
                                 {
                                     "agent_idx": 1,
                                     "text": "My, aren't you a pretty bird?",
-                                    "id": "TransresnetAgent"
+                                    "id": "Speaker 2"
                                 },
-                                {"agent_idx": 0, "text": "Response 4", "id": "Worker"},
+                                {"agent_idx": 0, "text": "Response 4", "id": "Speaker 1"},
                                 {
                                     "agent_idx": 1,
                                     "text": "My, aren't you a pretty bird?",
-                                    "id": "TransresnetAgent"
+                                    "id": "Speaker 2"
                                 },
-                                {"agent_idx": 0, "text": "Response 5", "id": "Worker"},
+                                {"agent_idx": 0, "text": "Response 5", "id": "Speaker 1"},
                                 {
                                     "agent_idx": 1,
                                     "text": "My, aren't you a pretty bird?",
-                                    "id": "TransresnetAgent"
+                                    "id": "Speaker 2"
                                 },
-                                {"agent_idx": 0, "text": "Response 6", "id": "Worker"},
+                                {"agent_idx": 0, "text": "Response 6", "id": "Speaker 1"},
                                 {
                                     "agent_idx": 1,
                                     "text": "My, aren't you a pretty bird?",
-                                    "id": "TransresnetAgent",
+                                    "id": "Speaker 2",
                                     "final_rating": 0
                                 }
                             ],

--- a/tests/crowdsourcing/tasks/model_chat/test_model_chat.py
+++ b/tests/crowdsourcing/tasks/model_chat/test_model_chat.py
@@ -16,7 +16,7 @@ import parlai.utils.testing as testing_utils
 
 
 # Inputs
-AGENT_DISPLAY_IDS = ('Worker',)
+AGENT_DISPLAY_IDS = ('Speaker 1',)
 AGENT_MESSAGES = [
     ("What are you nervous about?",),
     ("Do you have any plans for the weekend?",),

--- a/tests/crowdsourcing/tasks/model_chat/test_model_image_chat.py
+++ b/tests/crowdsourcing/tasks/model_chat/test_model_image_chat.py
@@ -23,7 +23,7 @@ from parlai.zoo.image_chat.transresnet_multimodal import (
 
 
 # Inputs
-AGENT_DISPLAY_IDS = ('Worker',)
+AGENT_DISPLAY_IDS = ('Speaker 1',)
 AGENT_MESSAGES = [
     ("Response 1",),
     ("Response 2",),


### PR DESCRIPTION
# Patch description
- When running the model chat task, display the speaker names as "Speaker 1" and "Speaker 2" instead of showing the Turker the name of the model id (`"TransformerGenerator"`, etc.)
  - Change this for both the regular model chat and the image chat variant
- Also, allow the persona strings to be shown on the left-hand pane if your pane's text includes the strings `"[persona_string_1]"` or `"[persona_string_2]"`
- Also fix an issue with using `run.py` to run model image chat: `worlds_image_chat.py` wasn't being set as the correct words file

# Testing steps

## Regular model chat

Command: 
```
python parlai/crowdsourcing/tasks/model_chat/run.py \
mephisto.architect.port=3002 \
mephisto.task.maximum_units_per_worker=1000000
```
### Before
![Screen Shot 2021-12-23 at 1 23 29 PM](https://user-images.githubusercontent.com/5393263/147282799-5c6e1fbe-d9dd-4982-a381-75e41244fb35.png)

### After
![Screen Shot 2021-12-23 at 2 01 15 PM](https://user-images.githubusercontent.com/5393263/147282841-d42b316c-e978-47da-a20c-55c1646aecc1.png)


## Model image chat

Command: 
```
python parlai/crowdsourcing/tasks/model_chat/run.py \
mephisto.architect.port=3002 \
conf=example_image_chat \
mephisto.task.maximum_units_per_worker=1000000
```
### Before
![Screen Shot 2021-12-23 at 1 49 36 PM](https://user-images.githubusercontent.com/5393263/147282853-e9b6a421-aa52-4b34-91d1-0f71d1204a81.png)

### After
![Screen Shot 2021-12-23 at 2 00 07 PM](https://user-images.githubusercontent.com/5393263/147282869-b005a89e-1e87-449d-89d5-a2c7df68ba8d.png)

## Testing showing the personas on the left-hand side

### Example:
![SM-Turn UI with refactored code](https://user-images.githubusercontent.com/5393263/147283015-847a318c-be7a-4345-af9b-3b1afc396995.png)

