### PR TITLE
Model chat: allow multiple final ratings

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/README.md
+++ b/parlai/crowdsourcing/tasks/model_chat/README.md
@@ -12,6 +12,8 @@ Set `mephisto.blueprint.model_opt_path` to specify a path to a YAML file listing
 
 Set `mephisto.blueprint.chat_data_folder` to the root folder that you want all results of HITs to be saved in: all results will be saved to a date folder (of format `2021_01_15`) within that root folder.
 
+Set `mephisto.blueprint.final_rating_question` to specify the question to ask the worker at the end of the task, for which the worker will respond with a 1-to-5 Likert score. Separate multiple questions with a `|`.
+
 ## Passing in task config files
 
 The following flags can be passed in to specify filepaths for overriding the text shown to the workers and the settings of the annotation categories. If they are not specified, the defaults in the `task_config/` folder will be used.

--- a/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
+++ b/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
@@ -123,48 +123,51 @@ function FinalSurvey({ taskConfig, onMessageSend, active, currentCheckboxes }) {
 
   if (listRatingSelectors.length > 1) {
     // Show ratings to the right of the questions
-    const form = (
-      <Form
-        horizontal
-      >
-        {listRatingSelectors}
-        <Button
-          className="btn btn-submit submit-response"
-          id="id_send_msg_button"
-          disabled={!active || sending}
-          onClick={() => tryMessageSend()}
+    return (
+      <div className="response-type-module">
+        <div>
+          You've completed the conversation. Please annotate the final turn, fill out
+          the following, and hit Done.
+        </div>
+        <br />
+        <Form
+          horizontal
         >
-          Done
-        </Button>
-      </Form>
+          {listRatingSelectors}
+          <Button
+            className="btn btn-submit submit-response"
+            id="id_send_msg_button"
+            disabled={!active || sending}
+            onClick={() => tryMessageSend()}
+          >
+            Done
+          </Button>
+        </Form>
+      </div>
     );
   } else {
     // Show the single rating below the single question
-    const form = (
-      <div className="response-bar">
-        {listRatingSelectors}
-        <Button
-          className="btn btn-submit submit-response"
-          id="id_send_msg_button"
-          disabled={!active || sending}
-          onClick={() => tryMessageSend()}
-        >
-          Done
-        </Button>
+    return (
+      <div className="response-type-module">
+        <div>
+          You've completed the conversation. Please annotate the final turn, fill out
+          the following, and hit Done.
+        </div>
+        <br />
+        <div className="response-bar">
+          {listRatingSelectors}
+          <Button
+            className="btn btn-submit submit-response"
+            id="id_send_msg_button"
+            disabled={!active || sending}
+            onClick={() => tryMessageSend()}
+          >
+            Done
+          </Button>
+        </div>
       </div>
     );
   }
-
-  return (
-    <div className="response-type-module">
-      <div>
-        You've completed the conversation. Please annotate the final turn, fill out
-        the following, and hit Done.
-      </div>
-      <br />
-      {form}
-    </div>
-  );
 }
 
 function CheckboxTextResponse({ onMessageSend, active, currentCheckboxes }) {

--- a/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
+++ b/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
@@ -121,13 +121,9 @@ function FinalSurvey({ taskConfig, onMessageSend, active, currentCheckboxes }) {
     );
   });
 
-  return (
-    <div className="response-type-module">
-      <div>
-        You've completed the conversation. Please annotate the final turn, fill out
-        the following, and hit Done.
-      </div>
-      <br />
+  if (listRatingSelectors.length > 1) {
+    // Show ratings to the right of the questions
+    const form = (
       <Form
         horizontal
       >
@@ -141,6 +137,32 @@ function FinalSurvey({ taskConfig, onMessageSend, active, currentCheckboxes }) {
           Done
         </Button>
       </Form>
+    );
+  } else {
+    // Show the single rating below the single question
+    const form = (
+      <div className="response-bar">
+        {listRatingSelectors}
+        <Button
+          className="btn btn-submit submit-response"
+          id="id_send_msg_button"
+          disabled={!active || sending}
+          onClick={() => tryMessageSend()}
+        >
+          Done
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="response-type-module">
+      <div>
+        You've completed the conversation. Please annotate the final turn, fill out
+        the following, and hit Done.
+      </div>
+      <br />
+      {form}
     </div>
   );
 }

--- a/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
+++ b/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
@@ -33,8 +33,6 @@ function RatingSelector({ active, ratings, sending, ratingQuestion, ratingIndex,
   );
 
   function handleRatingSelection(val) {
-    console.log('Old ratings: ')
-    console.log(ratings)
     const newRatings = ratings.map((item, index) => {
       if (index === ratingIndex) {
         return val;
@@ -42,9 +40,6 @@ function RatingSelector({ active, ratings, sending, ratingQuestion, ratingIndex,
         return item;
       }
     });
-    console.log('New ratings: ')
-    console.log(newRatings)
-    // TODO: remove all logging
     setRatings(newRatings);
   }
 

--- a/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
+++ b/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
@@ -80,18 +80,8 @@ function FinalSurvey({ taskConfig, onMessageSend, active, currentCheckboxes }) {
 
   const tryMessageSend = React.useCallback(() => {
 
-    let all_ratings_filled = true;
-    let rating = "";
-    for (let i = 0; i < ratings.length; i++) {
-      if (ratings[i] === "") {
-        all_ratings_filled = false;
-      }
-      if (i === 0) {
-        rating += ratings[i];
-      } else {
-        rating += "|" + ratings[i];
-      }
-    }
+    let all_ratings_filled = ratings.every((r) => r !== "");
+    let rating = ratings.join('|');
 
     if (all_ratings_filled && active && !sending) {
       setSending(true);

--- a/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
+++ b/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
@@ -137,7 +137,12 @@ class BaseModelChatBlueprintArgs(ParlAIChatBlueprintArgs):
     )
     final_rating_question: str = field(
         default='Please rate your partner on a scale of 1-5.',
-        metadata={"help": "Text to show when asking worker to make their final rating"},
+        metadata={
+            "help": (
+                "Text to show when asking worker to make their final rating. For "
+                "multiple final ratings, separate text strings with a '|'."
+            )
+        },
     )
     max_concurrent_responses: int = field(
         default=1,


### PR DESCRIPTION
**Patch description**
In the model chat crowdsourcing task, ask for and save **multiple** 1-to-5 ratings at the end of the HIT. Questions can be specified through `mephisto.blueprint.final_rating_question`, with multiple questions separated by a pipe character. Multiple ratings will be saved in the format `'2|4|3'`.

**Testing steps**
With 1 final question:
```
python parlai/crowdsourcing/tasks/model_chat/run.py \
mephisto.architect.port=3006 \
mephisto.task.maximum_units_per_worker=1000000 \
mephisto.task.task_name=${TASK_NAME} \
mephisto.blueprint.num_turns=2
```
![with PR, 1 question](https://user-images.githubusercontent.com/5393263/147298729-0b433a60-8eed-4d40-b86d-ba0d196b845e.png)

With multiple final questions:
```
python parlai/crowdsourcing/tasks/model_chat/run.py \
mephisto.architect.port=3006 \
mephisto.task.maximum_units_per_worker=1000000 \
mephisto.task.task_name=${TASK_NAME} \
mephisto.blueprint.num_turns=2 \
mephisto.blueprint.final_rating_question=\'Please\ rate\ your\ partner\ on\ a\ scale\ of\ 1-5.\|On\ a\ scale\ of\ 1\ to\ 5,\ what\ is\ your\ favorite\ number?\'
```
![with PR, 2 questions](https://user-images.githubusercontent.com/5393263/147298744-f5c81b30-4361-4e7c-b067-d106c44e94ca.png)

