### PR TITLE
[BB2] loading BB2 without skip-search-key flag.

### DIFF
--- a/projects/blenderbot2/agents/blenderbot2.py
+++ b/projects/blenderbot2/agents/blenderbot2.py
@@ -719,7 +719,7 @@ class BlenderBot2RagAgent(RagAgent):
             batch = self._set_batch_gold_doc_vec(valid_exs, batch)
         if any(ex.get('memory_decoder_vec') is not None for ex in valid_exs):
             batch = self._set_batch_memory_decoder_vec(valid_exs, batch)
-        if any(ex.get(self.opt['skip_search_key']) is not None for ex in valid_exs):
+        if any(ex.get(self.opt.get('skip_search_key')) is not None for ex in valid_exs):
             batch = self._set_batch_skip_search(valid_exs, batch)
         return batch
 


### PR DESCRIPTION
**Patch description**
Trying to load a BB2 model, because the new flag is not in the main opt, it was crashing (dict key error).
 
![Screen Shot 2022-01-06 at 11 47 36 AM](https://user-images.githubusercontent.com/11262163/148421464-a225f583-c4ae-44f7-887d-c0571b1b95bd.png)

Using `get` from the `opt` to avoid the crash.