### PR TITLE
[TGA] Record Generation Length

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -818,7 +818,10 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         Can be overridden to allow for some metrics on the generations calculated at
         eval.
         """
-        pass
+        self.record_local_metric(
+            'gen_n_toks',
+            AverageMetric.many([p.size(0) for p in preds], [1] * batch.batchsize),
+        )
 
     def rank_eval_label_candidates(self, batch, batchsize):
         """


### PR DESCRIPTION
**Patch description**
Add a new metric, `gen_n_toks`, that shows the average generation length by a `TorchGeneratorAgent`

**Testing steps**
Relying on existing CI to catch any bugs here.
