### PR TITLE
[Rerank] Ensure other batch fields are in re-ranker `batch_act`

### DIFF
--- a/parlai/agents/reranker/reranker.py
+++ b/parlai/agents/reranker/reranker.py
@@ -514,6 +514,7 @@ class AbstractGeneratorRerankAgentMixin:
             inference_batch_reply = super().batch_act(observations)
             for i, resp in enumerate(inference_batch_reply):
                 beam_texts = batch_reply[i].get('beam_texts', [])
+                batch_reply[i] = resp  # add metrics, other response items
                 new_beam_texts = [(*b, strategy) for b in resp.get('beam_texts', [])]
                 batch_reply[i].force_set('beam_texts', beam_texts + new_beam_texts)
         # 2. Rerank


### PR DESCRIPTION
**Patch description**
The `AbstractGeneratorRerankAgentMixin` was ignoring anything besides `beam_texts` and `text` within a batch reply, resulting in failures to bubble up e.g. agent metrics. This PR fixes that.

**Testing steps**
Tested locally, also ensured that `pytest test_light_whoami.py` passed.
