### PR TITLE
[crowdsourcing] add pointer to documentation in run scripts

### DIFF
--- a/parlai/crowdsourcing/projects/multisession_chat/human_eval/run.py
+++ b/parlai/crowdsourcing/projects/multisession_chat/human_eval/run.py
@@ -17,6 +17,10 @@ from parlai.crowdsourcing.tasks.model_chat.impl import run_task
 from parlai.crowdsourcing.utils.mturk import MTurkRunScriptConfig
 import json
 
+"""
+Read parlai/crowdsourcing/README.md to learn how to launch
+crowdsourcing tasks with this script.
+"""
 
 _ = BLUEPRINT_TYPE
 

--- a/parlai/crowdsourcing/projects/wizard_of_internet/run.py
+++ b/parlai/crowdsourcing/projects/wizard_of_internet/run.py
@@ -27,6 +27,10 @@ from mephisto.operations.operator import Operator
 from mephisto.operations.hydra_config import register_script_config
 from mephisto.tools.scripts import load_db_and_process_config
 
+"""
+Read parlai/crowdsourcing/README.md to learn how to launch
+crowdsourcing tasks with this script.
+"""
 
 _ = WIZARD_INTERNET_PARLAICHAT_BLUEPRINT
 

--- a/parlai/crowdsourcing/tasks/acute_eval/run.py
+++ b/parlai/crowdsourcing/tasks/acute_eval/run.py
@@ -19,6 +19,9 @@ from parlai.crowdsourcing.utils.mturk import MTurkRunScriptConfig
 
 
 """
+Read parlai/crowdsourcing/README.md to learn how to launch
+crowdsourcing tasks with this script.
+
 Script for running ACUTE-Evals.
 The only argument that *must* be set for this to be run is:
 ``pairings_filepath``:  Path to pairings file in the format specified in the README.md

--- a/parlai/crowdsourcing/tasks/chat_demo/run.py
+++ b/parlai/crowdsourcing/tasks/chat_demo/run.py
@@ -24,6 +24,11 @@ from mephisto.tools.scripts import load_db_and_process_config
 
 from parlai.crowdsourcing.utils.mturk import MTurkRunScriptConfigMixin
 
+"""
+Read parlai/crowdsourcing/README.md to learn how to launch
+crowdsourcing tasks with this script.
+"""
+
 
 @dataclass
 class ScriptConfig(MTurkRunScriptConfigMixin, TestScriptConfig):

--- a/parlai/crowdsourcing/tasks/model_chat/run.py
+++ b/parlai/crowdsourcing/tasks/model_chat/run.py
@@ -16,6 +16,10 @@ from parlai.crowdsourcing.tasks.model_chat.impl import run_task
 from parlai.crowdsourcing.utils.mturk import MTurkRunScriptConfig
 import parlai.crowdsourcing.tasks.model_chat.worlds as world_module
 
+"""
+Read parlai/crowdsourcing/README.md to learn how to launch
+crowdsourcing tasks with this script.
+"""
 
 TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 

--- a/parlai/crowdsourcing/tasks/qa_data_collection/run.py
+++ b/parlai/crowdsourcing/tasks/qa_data_collection/run.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 import os
 from dataclasses import dataclass, field
 from typing import List, Any
@@ -22,6 +21,10 @@ from parlai.crowdsourcing.tasks.qa_data_collection.util import get_teacher
 from parlai.crowdsourcing.utils.frontend import build_task
 from parlai.crowdsourcing.utils.mturk import MTurkRunScriptConfig
 
+"""
+Read parlai/crowdsourcing/README.md to learn how to launch
+crowdsourcing tasks with this script.
+"""
 
 TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/run.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/run.py
@@ -18,15 +18,14 @@ from parlai.crowdsourcing.tasks.turn_annotations_static.turn_annotations_bluepri
 from parlai.crowdsourcing.tasks.turn_annotations_static.util import run_static_task
 from parlai.crowdsourcing.utils.mturk import MTurkRunScriptConfig
 
+"""
+Read parlai/crowdsourcing/README.md to learn how to launch
+crowdsourcing tasks with this script.
+"""
 
 _ = STATIC_BLUEPRINT_TYPE
 
 TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
-
-# To run the task with your own config outside this folder (recommended!)
-# Use the command formulation below. For more info,
-# check the README in parlai/crowdsourcing/
-# python turn_annotations_static/run.py conf=<conf name sans yaml> --config-dir <path to directory with a conf/ folder>
 
 defaults = ["_self_", {"conf": 'example'}]
 


### PR DESCRIPTION
just adding comments in the run.py scripts to read `parlai/crowdsourcing/README.md` for more info for running tasks after all the updates following hydra 1.1

