### PR TITLE
Add help string to crowdsourcing task

### DIFF
--- a/projects/safety_recipes/human_safety_evaluation/run.py
+++ b/projects/safety_recipes/human_safety_evaluation/run.py
@@ -19,6 +19,11 @@ from parlai.crowdsourcing.tasks.turn_annotations_static.run import (
 )
 from parlai.crowdsourcing.tasks.turn_annotations_static.run import defaults
 
+"""
+Read parlai/crowdsourcing/README.md to learn how to launch
+crowdsourcing tasks with this script.
+"""
+
 TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 


### PR DESCRIPTION
Adds a help string to a crowdsourcing task to let users know how to run it. Based on https://github.com/facebookresearch/ParlAI/pull/4297