### PR TITLE
switch to python3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,26 +11,19 @@ executors:
       PYTHONUNBUFFERED: 1
     resource_class: xlarge
 
-  standard_cpu37:
+  small_cpu38:
     docker:
-      - image: circleci/python:3.7.5-buster-node
-    environment:
-      PYTHONUNBUFFERED: 1
-    resource_class: xlarge
-
-  small_cpu37:
-    docker:
-      - image: circleci/python:3.7.5-buster-node
+      - image: circleci/python:3.8.0-buster-node
     environment:
       PYTHONUNBUFFERED: 1
     resource_class: medium
 
-  osx_cpu37:
+  osx_cpu38:
     macos:
       # https://circleci.com/docs/2.0/testing-ios/
       xcode: "11.3.1"
     environment:
-      PYTHON: 3.7.1
+      PYTHON: 3.8.0
       PYTHONUNBUFFERED: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
 
@@ -316,8 +309,8 @@ commands:
 # Actual jobs
 # -------------------------------------------------------------------------------------
 jobs:
-  cleaninstall_37:
-    executor: standard_cpu37
+  cleaninstall_38:
+    executor: standard_cpu38
     working_directory: ~/ParlAI
     parallelism: 1
     steps:
@@ -333,23 +326,12 @@ jobs:
             parlai display_data -t integration_tests
 
   unittests_osx:
-    executor: osx_cpu37
+    executor: osx_cpu38
     working_directory: ~/ParlAI
     parallelism: 2
     steps:
       - runtests:
           cachename: osx
-          marker: unit
-
-  unittests_37:
-    executor: standard_cpu37
-    working_directory: ~/ParlAI
-    parallelism: 8
-    steps:
-      - runtests:
-          more_installs:
-            - installtorchcpu
-          cachename: ut37
           marker: unit
 
   unittests_38:
@@ -403,7 +385,7 @@ jobs:
           pytest_flags: -v -s
 
   crowdsourcing_tests:
-    executor: small_cpu37
+    executor: small_cpu38
     working_directory: ~/ParlAI
     parallelism: 1
     steps:
@@ -415,7 +397,7 @@ jobs:
             - installcrowdsourcingdeps
 
   teacher_tests:
-    executor: standard_cpu37
+    executor: standard_cpu38
     working_directory: ~/ParlAI
     parallelism: 16
     steps:
@@ -425,7 +407,7 @@ jobs:
           pytest_flags: -v -s
 
   build_website:
-    executor: small_cpu37
+    executor: small_cpu38
     working_directory: ~/ParlAI
     parallelism: 1
     steps:
@@ -433,14 +415,14 @@ jobs:
           deploy: false
 
   deploy_website:
-    executor: small_cpu37
+    executor: small_cpu38
     working_directory: ~/ParlAI
     steps:
       - website:
           deploy: true
 
   test_website:
-    executor: small_cpu37
+    executor: small_cpu38
     working_directory: ~/ParlAI
     steps:
       - run:
@@ -463,29 +445,26 @@ workflows:
   version: 2
   commit:
     jobs:
-      - cleaninstall_37
+      - cleaninstall_38
       - unittests_gpu17:
           requires:
-            - unittests_37
+            - unittests_38
       - unittests_gpu18:
           requires:
-            - unittests_37
-      - unittests_38:
-          requires:
-            - unittests_37
-      - unittests_37
+            - unittests_38
+      - unittests_38
       - unittests_osx:
           requires:
-            - unittests_37
+            - unittests_38
       - long_gpu_tests:
           requires:
-            - unittests_37
+            - unittests_38
       - crowdsourcing_tests:
           requires:
-            - unittests_37
+            - unittests_38
       - teacher_tests:
           requires:
-            - unittests_37
+            - unittests_38
       - build_website:
           filters:
             branches:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For those who want to start with ParlAI now, you can try our [Colab Tutorial](ht
 
 ## Installing ParlAI
 
-ParlAI currently requires Python3.7+ and [Pytorch](https://pytorch.org) 1.6 or higher.
+ParlAI currently requires Python3.8+ and [Pytorch](https://pytorch.org) 1.6 or higher.
 Dependencies of the core modules are listed in [`requirements.txt`](https://github.com/facebookresearch/ParlAI/blob/main/requirements.txt). Some
 models included (in [`parlai/agents`](https://github.com/facebookresearch/ParlAI/tree/main/parlai/agents)) have additional requirements.
 We *strongly* recommend you install ParlAI in a [venv](https://docs.python.org/3/library/venv.html) or [conda](https://www.anaconda.com/) environment.

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ subword-nmt==0.3.7
 tensorboard==2.3.0
 tensorboardX==2.1
 tokenizers>=0.8.0
+tomli<2.0.0
 torchtext>=0.5.0
 tornado==6.0.4
 tqdm~=4.62.1


### PR DESCRIPTION
`clean_install37` failing because a dependency bump now requires python 3.8 so we switch to python 3.8:
- Update the circle CI config file to use python 3.8 and remove 3.7
- add `tomli<2.0.0` requirement to get around black error:
ran into another error: [cleaninstall_38 is failing](https://app.circleci.com/pipelines/github/facebookresearch/ParlAI/10809/workflows/31eb0f9a-e4a0-456e-a241-d21dc96b4bc6/jobs/89511) due to a [black issue (the fix hasn’t been in a release)](https://github.com/psf/black/issues/2703)