### PR TITLE
tighten test_alt_reduction bound

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -253,8 +253,8 @@ class TestTransformerRanker(unittest.TestCase):
             reduction_type='first',  # this is really what we're trying to test for
         )
 
-        self.assertGreaterEqual(valid['hits@1'], 0.90)
-        self.assertGreaterEqual(test['hits@1'], 0.90)
+        self.assertGreaterEqual(valid['hits@1'], 0.99)
+        self.assertGreaterEqual(test['hits@1'], 0.99)
 
 
 class TestTransformerGenerator(TestTransformerBase):


### PR DESCRIPTION
**Patch description**
Hi,

The test `test_alt_reduction` in `test_transformers.py` has an assertion bound (`self.assertGreaterEqual(test['hits@1'], 0.90)`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. Each mutant is generated using simple mutation operators (e.g. > can become < ) on source code covered by the test. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/149831489-888f7a16-bafd-48af-be2d-291bba9f9095.png" width="450">
</p>

Here we see that the bound of `0.9` is too loose since the original distribution (in orange) is greater than `0.9`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are above the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/149831365-3b5d81ce-6339-4a2e-9cb0-c6dde5d494de.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `0.9` (red dotted line) has a catch rate of 0.1.

To improve this test, I propose to tighten the bound to `0.99` (the blue dotted line). The new bound has a catch rate of 0.26 (+0.16 increase compare to original) while still has >99 % pass rate (test is not flaky, I ran the updated test 500 times and observed >99 % pass rate). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.7.11
pytorch=1.10.0
```

my parlai Experiment SHA:
`4b1d07d0eeb14f849ad930eeb001327f9bfc2db1`
