### PR TITLE
save model checkpoint + run validation

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -893,6 +893,9 @@ class TrainLoop:
                 ):
                     yield self.log()
                 if stop_training:
+                    import ipdb
+
+                    ipdb.set_trace()
                     self.validate()
                 elif (
                     validate_time > self.val_every_n_secs
@@ -915,8 +918,10 @@ class TrainLoop:
                     self._last_valid_steps = self._train_steps
                     # make sure metrics are clean before we log
                     world.reset_metrics()
-                if (stop_training or save_time > self.save_every_n_secs) and opt.get(
-                    'model_file'
+                if (
+                    not stop_training
+                    and save_time > self.save_every_n_secs
+                    and opt.get('model_file')
                 ):
                     logging.info(
                         f"saving model checkpoint: {opt['model_file']}.checkpoint"

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -893,9 +893,6 @@ class TrainLoop:
                 ):
                     yield self.log()
                 if stop_training:
-                    import ipdb
-
-                    ipdb.set_trace()
                     self.validate()
                 elif (
                     validate_time > self.val_every_n_secs

--- a/tests/test_ir_baseline.py
+++ b/tests/test_ir_baseline.py
@@ -35,7 +35,7 @@ class TestIrBaseline(unittest.TestCase):
             }
         )
         assert valid['f1'] >= 0.41
-        assert test['f1'] >= 0.437
+        assert test['f1'] >= 0.434
 
     def test_fixed_label(self):
         with testing_utils.tempdir() as tmpdir:

--- a/tests/test_ir_baseline.py
+++ b/tests/test_ir_baseline.py
@@ -34,7 +34,7 @@ class TestIrBaseline(unittest.TestCase):
                 'num_epochs': 1,
             }
         )
-        assert valid['f1'] == 0.41
+        assert valid['f1'] >= 0.41
         assert test['f1'] >= 0.437
 
     def test_fixed_label(self):

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -211,9 +211,7 @@ class TestTrainModel(unittest.TestCase):
             tl = get_tl(tmpdir)
             valid, _ = tl.train()
 
-        self.assertEqual(
-            tl.valid_reports[-1]['total_train_updates'], num_train_steps - 1
-        )
+        self.assertEqual(tl.valid_reports[-1]['total_train_updates'], num_train_steps)
         self.assertEqual(len(tl.valid_reports), num_validations)
         self.assertEqual(len(tl.train_reports), num_logs)  # log every valid as well
 

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -212,7 +212,7 @@ class TestTrainModel(unittest.TestCase):
             valid, _ = tl.train()
 
         self.assertEqual(tl.valid_reports[-1]['total_train_updates'], num_train_steps)
-        self.assertEqual(len(tl.valid_reports), num_validations)
+        self.assertEqual(len(tl.valid_reports), num_validations + 1)
         self.assertEqual(len(tl.train_reports), num_logs)  # log every valid as well
 
     def test_opt_step(self):


### PR DESCRIPTION
**Patch description**
In a recent sweep with  `--validation-every-epoch 0.1 --num-epochs 1`, we noticed that the model was evaluated and saved at epoch = 0.1, 0.2, ...., 0.9, but not 1.0

According to the train_model script , when the model training stops because of
- total_epochs >= max_num_epochs
- train_time > max_train_time
- train_steps >= max_train_steps
it breaks the while loop, and
1) skip the checkpoint saving step
2) skip the validation step.
 
This fix is to run valid and save model checkpoint when model stops training not due to early stopping.

A test run cmd: `parlai train --dict-file dictfile --model transformer/generator  --task convai2 --num-epochs 1.0 --batchsize 64 --n-layers 8      --embedding-size 250 --ffn-size 1000 --optimizer adam --learningrate 1e-3 --validation-every-n-epochs 0.1 --num-epochs  0.5 --validation-max-exs 100 --save-after-valid True -mf /tmp/model`. As one could see from below, it run the eval and save the model.checkpoint, as well as updating the best_valid before generating the *final* valid report

- Before the fix:
```
13:26:46 | num_epochs completed:0.5 time elapsed:219.39339399337769s
13:26:46 | Using CUDA
13:26:46 | loading dictionary from /tmp/model.dict
13:26:46 | num words = 18760
13:26:47 | Total parameters: 19,266,000 (18,754,000 trainable)
13:26:47 | Loading existing model params from /tmp/model
13:26:47 | creating task(s): convai2
13:26:47 | loading fbdialog data: /private/home/jingxu23/ParlAI/data/ConvAI2/valid_self_original.txt
13:26:48 | running eval: valid
13:27:09 | eval completed in 21.84s
13:27:09 | valid:
    accuracy  bleu-4  clen  ctpb  ctps  ctrunc  ctrunclen  exps  exs  f1  gen_n_toks  gpu_mem  llen  loss    lr  ltpb  ltps  ltrunc  ltrunclen   ppl  token_acc  token_em  total_train_updates   tpb   tps
           0       0 155.8  9648 55739       0          0 357.7 7801   0           2  .001156 13.34 5.795 .0010   826  4772       0          0 328.8     .07496         0                  206 10474 60511

13:27:09 | creating task(s): convai2
13:27:09 | WARNING: Test set not included. Setting datatype to valid.
13:27:09 | loading fbdialog data: /private/home/jingxu23/ParlAI/data/ConvAI2/valid_self_original.txt
13:27:10 | running eval: test
13:27:32 | eval completed in 22.22s
13:27:32 | test:
    accuracy  bleu-4  clen  ctpb  ctps  ctrunc  ctrunclen  exps  exs  f1  gen_n_toks  gpu_mem  llen  loss    lr  ltpb  ltps  ltrunc  ltrunclen   ppl  token_acc  token_em  total_train_updates   tpb   tps
           0       0 155.8  9648 54764       0          0 351.4 7801   0           2  .001114 13.34 5.795 .0010   826  4688       0          0 328.8     .07496         0                  206 10474 59453

```
- After the fix:
```
13:18:56 | num_epochs completed:0.5 time elapsed:214.3626093864441s
13:18:56 | running eval: valid
13:18:57 | eval completed in 0.28s
13:18:57 | valid:
    accuracy  bleu-4  clen  ctpb  ctps  ctrunc  ctrunclen  exps  exs  f1  gen_n_toks  gpu_mem  llen  loss    lr  ltpb  ltps  ltrunc  ltrunclen   ppl  token_acc  token_em  total_train_updates  tpb   tps
           0       0 77.09  4934 40447       0          0 524.5  128   0           2  .001398 13.25  5.65 .0010   848  6951       0          0 284.2     .07547         0                 1027 5782 47400

13:18:57 | did not beat best accuracy: 0.0 impatience: 4
13:18:57 | saving model checkpoint: /tmp/model.checkpoint
13:18:57 | Using CUDA
13:18:57 | loading dictionary from /tmp/model.dict
13:18:58 | num words = 18760
13:18:58 | Total parameters: 19,266,000 (18,754,000 trainable)
13:18:58 | Loading existing model params from /tmp/model
13:18:59 | creating task(s): convai2
13:18:59 | loading fbdialog data: /private/home/jingxu23/ParlAI/data/ConvAI2/valid_self_original.txt
13:18:59 | running eval: valid
13:19:20 | eval completed in 21.54s
13:19:20 | valid:
    accuracy  bleu-4  clen  ctpb  ctps  ctrunc  ctrunclen  exps  exs  f1  gen_n_toks  gpu_mem  llen  loss    lr  ltpb  ltps  ltrunc  ltrunclen   ppl  token_acc  token_em  total_train_updates   tpb   tps
           0       0 155.8  9648 56506       0          0 362.6 7801   0           2  .001153 13.34 5.792 .0010   826  4838       0          0 327.8     .07496         0                  206 10474 61344

13:19:20 | creating task(s): convai2
13:19:20 | WARNING: Test set not included. Setting datatype to valid.
13:19:20 | loading fbdialog data: /private/home/jingxu23/ParlAI/data/ConvAI2/valid_self_original.txt
13:19:21 | running eval: test
13:19:42 | eval completed in 21.67s
13:19:42 | test:
    accuracy  bleu-4  clen  ctpb  ctps  ctrunc  ctrunclen  exps  exs  f1  gen_n_toks  gpu_mem  llen  loss    lr  ltpb  ltps  ltrunc  ltrunclen   ppl  token_acc  token_em  total_train_updates   tpb   tps
           0       0 155.8  9648 56176       0          0 360.5 7801   0           2  .001116 13.34 5.792 .0010   826  4809       0          0 327.8     .07496         0                  206 10474 60986

```
**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
