### PR TITLE
BlenderBot2 memory generation batching

### DIFF
--- a/projects/blenderbot2/agents/sub_modules.py
+++ b/projects/blenderbot2/agents/sub_modules.py
@@ -313,12 +313,10 @@ class MemoryDecoder(BB2SubmoduleMixin):
         """
         assert self.agent_dict is not None
         memories = []
-        offset = 0
-        for idx, i in enumerate(input):
+        for idx, input_i in enumerate(input):
             if num_inputs[idx] == 0:
                 continue
-            context_lines_vec = i[offset : offset + num_inputs[idx]]
-            offset += num_inputs[idx]
+            context_lines_vec = input_i[: num_inputs[idx]]
             context_lines = [
                 self.agent_dict.vec2txt(self.clean_input(j)) for j in context_lines_vec
             ]


### PR DESCRIPTION
**Patch description**
The offset value in `MemoryDecoder` was generating empty memories for all the examples in a batch (except the first one). This patch fixes that by removing the offset and passing the whole input.
