### PR TITLE
[RAG/FiD] Support Left Padded Inputs

### DIFF
--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -465,6 +465,8 @@ def concat_enc_outs(
         emb/hidden size of the enc representations
     :param padding_idx:
         pad token index; used for mask purposes.
+    :param right_padded:
+        whether the input is right padded
 
     :return (new_out, new_mask):
         return the encoder output and encoder mask, appropriately concatenated.

--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -466,7 +466,7 @@ def concat_enc_outs(
     :param padding_idx:
         pad token index; used for mask purposes.
     :param right_padded:
-        whether the input is right padded
+        whether the input is right padded (true) or left padded (false)
 
     :return (new_out, new_mask):
         return the encoder output and encoder mask, appropriately concatenated.

--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -447,6 +447,7 @@ def concat_enc_outs(
     mask: torch.BoolTensor,
     embedding_size: int,
     padding_idx: int,
+    right_padded: bool = True,
 ) -> Tuple[torch.Tensor, torch.BoolTensor]:
     """
     Concatenate Encoder Outputs.
@@ -486,7 +487,11 @@ def concat_enc_outs(
     new_mask.fill_(False)
 
     for i, (out_i, length_i) in enumerate(zip(concat_outs, concat_lengths)):
-        new_out[i, :length_i] = out_i
-        new_mask[i, :length_i] = True
+        if right_padded:
+            new_out[i, :length_i] = out_i
+            new_mask[i, :length_i] = True
+        else:
+            new_out[i, new_out.size(1) - length_i :] = out_i
+            new_mask[i, new_out.size(1) - length_i :] = True
 
     return new_out, new_mask

--- a/parlai/agents/rag/modules.py
+++ b/parlai/agents/rag/modules.py
@@ -342,6 +342,8 @@ class RagModel(TorchGeneratorModel):
             list of n_docs top documents for each input sequence
         :param max_num_docs:
             maximum number of docs out of all examples
+        :param right_padded:
+            whether the input is right padded.
 
         :return (tokens, lengths):
             return expanded token vectors & corresponding lengths

--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -300,8 +300,7 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
         output = super().eval_step(batch)
         if output is None or not hasattr(self.model, 'retriever'):
             return output
-        assert isinstance(self.model, RagModel)
-        if hasattr(self.model.retriever, 'top_docs'):
+        if hasattr(self.model.retriever, 'top_docs'):  # type: ignore
             output.top_docs = self.model.retriever.top_docs  # type: ignore
         return output
 

--- a/tests/nightly/gpu/test_rag.py
+++ b/tests/nightly/gpu/test_rag.py
@@ -18,7 +18,8 @@ import parlai.utils.testing as testing_utils
 
 try:
     from parlai.agents.rag.dpr import DprQueryEncoder
-    from parlai.agents.rag.retrievers import RetrievedChunkRanker
+    from parlai.agents.rag.retrievers import RetrievedChunkRanker, Document
+    from parlai.agents.fid.fid import concat_enc_outs
 except ImportError:
     pass
 
@@ -553,6 +554,107 @@ class TestWOIChunking(unittest.TestCase):
         assert (
             chunks[0][0]
             == self.DOC_CONTENT[0][: self.DOC_CONTENT[0].find(' ', chunk_sz)]
+        )
+
+
+class TestLeftPadding(unittest.TestCase):
+    """
+    Test whether left-padding functionality works.
+    """
+
+    bsz = 4
+    seqlen = 32
+    n_docs = 5
+    esz = 16
+    batch_lens = [4, 8, 16, 32]
+    pad_idx = 0
+
+    def _create_input_and_mask(self, right_padded=True):
+        enc_input = torch.LongTensor(self.bsz, self.seqlen).fill_(0)
+        mask = torch.BoolTensor(self.bsz, self.seqlen).fill_(False)
+        for i, input_len in enumerate(self.batch_lens):
+            if right_padded:
+                enc_input[i, :input_len] = torch.arange(1, input_len + 1)
+                mask[i, :input_len] = True
+            else:
+                enc_input[i, -input_len:] = torch.arange(1, input_len + 1)
+                mask[i, -input_len:] = True
+        return enc_input, mask
+
+    def test_concat_enc_outs(self):
+        enc_output = torch.rand(self.bsz * self.n_docs, self.seqlen, self.esz)
+        enc_input, mask = self._create_input_and_mask()
+        # Right padded
+        mask = mask.repeat_interleave(self.n_docs, dim=0)
+        _, new_mask = concat_enc_outs(
+            enc_input, enc_output, mask, self.esz, self.pad_idx
+        )
+        assert all(
+            new_mask[i, : self.batch_lens[i] * self.n_docs].sum()
+            == self.n_docs * self.batch_lens[i]
+            for i in range(self.bsz)
+        )
+        # Left padded
+        enc_input, mask = self._create_input_and_mask(right_padded=False)
+        mask = mask.repeat_interleave(self.n_docs, dim=0)
+        _, new_mask = concat_enc_outs(
+            enc_input, enc_output, mask, self.esz, self.pad_idx, right_padded=False
+        )
+        assert all(
+            new_mask[i, -(self.batch_lens[i] * self.n_docs) :].sum()
+            == self.n_docs * self.batch_lens[i]
+            for i in range(self.bsz)
+        )
+
+    def test_concat_docs_and_input(self):
+        rag = create_agent(Opt({**test_opt, 'n_docs': self.n_docs}))
+        enc_input, _ = self._create_input_and_mask()
+        docs = [
+            [Document("title", "I am a document!", i) for i in range(self.n_docs)]
+            for _ in range(self.bsz)
+        ]
+        doc_len = len(rag.dict.txt2vec(docs[0][0].get_passage_str()))
+        # right padded
+        expanded_output = rag.model.concat_docs_and_input(
+            enc_input, torch.LongTensor(self.batch_lens), docs, self.n_docs
+        )
+        assert all(
+            expanded_output[i, : doc_len + self.batch_lens[i // self.n_docs]]
+            .eq(0)
+            .sum()
+            == 0
+            for i in range(self.n_docs * self.bsz)
+        )
+        assert all(
+            expanded_output[i, doc_len + self.batch_lens[i // self.n_docs] :]
+            .eq(0)
+            .sum()
+            == expanded_output.size(1) - (doc_len + self.batch_lens[i // self.n_docs])
+            for i in range(self.n_docs * self.bsz)
+        )
+
+        # Left padded
+        enc_input, _ = self._create_input_and_mask(right_padded=False)
+        expanded_output = rag.model.concat_docs_and_input(
+            enc_input,
+            torch.LongTensor(self.batch_lens),
+            docs,
+            self.n_docs,
+            right_padded=False,
+        )
+        assert all(
+            expanded_output[i, -(doc_len + self.batch_lens[i // self.n_docs]) :]
+            .eq(0)
+            .sum()
+            == 0
+            for i in range(self.n_docs * self.bsz)
+        )
+        assert all(
+            expanded_output[i, : -(doc_len + self.batch_lens[i // self.n_docs])]
+            .eq(0)
+            .sum()
+            == expanded_output.size(1) - (doc_len + self.batch_lens[i // self.n_docs])
+            for i in range(self.n_docs * self.bsz)
         )
 
 

--- a/tests/nightly/gpu/test_rag.py
+++ b/tests/nightly/gpu/test_rag.py
@@ -589,6 +589,10 @@ class TestLeftPadding(unittest.TestCase):
         _, new_mask = concat_enc_outs(
             enc_input, enc_output, mask, self.esz, self.pad_idx
         )
+        ########################################################################
+        # Assertion: new mask has `True` elements in first (n_docs * seqlen_i) #
+        # tokens in concatenated output                                        #
+        ########################################################################
         assert all(
             new_mask[i, : self.batch_lens[i] * self.n_docs].sum()
             == self.n_docs * self.batch_lens[i]
@@ -600,6 +604,10 @@ class TestLeftPadding(unittest.TestCase):
         _, new_mask = concat_enc_outs(
             enc_input, enc_output, mask, self.esz, self.pad_idx, right_padded=False
         )
+        #######################################################################
+        # Assertion: new mask has `True` elements in last (n_docs * seqlen_i) #
+        # tokens in concatenated output                                       #
+        #######################################################################
         assert all(
             new_mask[i, -(self.batch_lens[i] * self.n_docs) :].sum()
             == self.n_docs * self.batch_lens[i]
@@ -618,6 +626,10 @@ class TestLeftPadding(unittest.TestCase):
         expanded_output = rag.model.concat_docs_and_input(
             enc_input, torch.LongTensor(self.batch_lens), docs, self.n_docs
         )
+        ############################################################
+        # Assertion: expanded output has non-pad elements in first #
+        # (doc_len + seq_len_i) tokens                             #
+        ############################################################
         assert all(
             expanded_output[i, : doc_len + self.batch_lens[i // self.n_docs]]
             .eq(0)
@@ -625,6 +637,10 @@ class TestLeftPadding(unittest.TestCase):
             == 0
             for i in range(self.n_docs * self.bsz)
         )
+        #######################################################
+        # Assertion: expanded output has pad elements in last #
+        # total_len - (doc_len + seq_len_i) tokens            #
+        #######################################################
         assert all(
             expanded_output[i, doc_len + self.batch_lens[i // self.n_docs] :]
             .eq(0)
@@ -642,6 +658,10 @@ class TestLeftPadding(unittest.TestCase):
             self.n_docs,
             right_padded=False,
         )
+        ###########################################################
+        # Assertion: expanded output has non-pad elements in last #
+        # (doc_len + seq_len_i) tokens                            #
+        ###########################################################
         assert all(
             expanded_output[i, -(doc_len + self.batch_lens[i // self.n_docs]) :]
             .eq(0)
@@ -649,6 +669,10 @@ class TestLeftPadding(unittest.TestCase):
             == 0
             for i in range(self.n_docs * self.bsz)
         )
+        ########################################################
+        # Assertion: expanded output has pad elements in first #
+        # total_len - (doc_len + seq_len_i) tokens             #
+        ########################################################
         assert all(
             expanded_output[i, : -(doc_len + self.batch_lens[i // self.n_docs])]
             .eq(0)


### PR DESCRIPTION
**Patch description**
This patch provides support for RAG and FiD with left-padded input, if desired. 

Two methods are required to change:
1. `RagModel.concat_docs_and_input` - when left padding, we need to make sure that the concatenated docs and input are padded appropriately
2. `concat_enc_outs` - When concatenating encoder outputs for FiD, we need to make sure that we are concatenating the correct parts of the input.

**Testing steps**
Added CI test.

```
$ pytest -k TestLeftPadding
=====test session starts =====
platform linux -- Python 3.7.9, pytest-5.3.2, py-1.10.0, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini, testpaths: tests, parlai/tasks
plugins: hydra-core-1.1.0, requests-mock-1.7.0, regressions-2.1.1, datadir-1.3.1
collected 1312 items / 1310 deselected / 2 selected

tests/nightly/gpu/test_rag.py ..                                                                                                                                              [100%]

====slowest 10 test durations ====
10.29s call     tests/nightly/gpu/test_rag.py::TestLeftPadding::test_concat_docs_and_input

(0.00 durations hidden.  Use -vv to show these durations.)
====2 passed, 1310 deselected, 4 warnings in 21.34s ====
```