### PR TITLE
Add WorldLogger to train_model script.

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -25,6 +25,7 @@ parlai train_model --model seq2seq --task babi:Task10k:1 --model-file '/tmp/mode
 # * More logging (e.g. to files), make things prettier.
 import copy
 import json
+import os
 import numpy as np
 import signal
 from typing import Tuple
@@ -42,14 +43,17 @@ from parlai.core.opt import Opt
 from parlai.core.params import ParlaiParser, print_announcements
 from parlai.core.worlds import create_task, World
 from parlai.scripts.build_dict import build_dict, setup_args as setup_dict_args
+from parlai.scripts.eval_model import get_task_world_logs
 from parlai.utils.distributed import (
     sync_object,
     is_primary_worker,
     all_gather_list,
     is_distributed,
+    get_rank,
     num_workers,
 )
 from parlai.utils.misc import Timer, nice_report
+from parlai.utils.world_logging import WorldLogger
 from parlai.core.script import ParlaiScript, register_script
 import parlai.utils.logging as logging
 from parlai.utils.io import PathManager
@@ -257,6 +261,20 @@ def setup_args(parser=None) -> ParlaiParser:
         help='Report micro-averaged metrics instead of macro averaged metrics.',
         recommended=False,
     )
+    train.add_argument(
+        '--world-logs',
+        type=str,
+        default='',
+        help='Saves a jsonl file of the world logs.'
+        'Set to the empty string to not save at all.',
+    )
+    train.add_argument(
+        '--save-format',
+        type=str,
+        default='conversations',
+        choices=['conversations', 'parlai'],
+    )
+    WorldLogger.add_cmdline_args(parser, partial_opt=None)
     TensorboardLogger.add_cmdline_args(parser, partial_opt=None)
     WandbLogger.add_cmdline_args(parser, partial_opt=None)
 
@@ -598,19 +616,41 @@ class TrainLoop:
             return True
         return False
 
-    def _run_single_eval(self, opt, valid_world, max_exs):
+    def _run_single_eval(self, opt, valid_world, max_exs, datatype, is_multitask):
 
         # run evaluation on a single world
         valid_world.reset()
+
+        world_logger = None
+        task_opt = opt.copy()
+        # set up world logger for the "test" fold
+        if opt['world_logs'] and datatype == 'test':
+            task_opt['world_logs'] = get_task_world_logs(
+                valid_world.getID(), opt['world_logs'], is_multitask
+            )
+            world_logger = WorldLogger(task_opt)
 
         cnt = 0
         max_cnt = max_exs if max_exs > 0 else float('inf')
         while not valid_world.epoch_done() and cnt < max_cnt:
             valid_world.parley()
+            if world_logger is not None:
+                world_logger.log(valid_world)
             if cnt == 0 and opt['display_examples']:
                 print(valid_world.display() + '\n~~')
                 print(valid_world.report())
             cnt = valid_world.report().get('exs') or 0
+
+        if world_logger is not None:
+            # dump world acts to file
+            world_logger.reset()  # add final acts to logs
+            if is_distributed():
+                rank = get_rank()
+                base_outfile, extension = os.path.splitext(task_opt['world_logs'])
+                outfile = base_outfile + f'_{rank}' + extension
+            else:
+                outfile = task_opt['world_logs']
+            world_logger.write(outfile, valid_world, file_format=opt['save_format'])
 
         valid_report = valid_world.report()
         if opt.get('validation_share_agent', False):
@@ -647,8 +687,11 @@ class TrainLoop:
         reports = []
 
         max_exs_per_worker = max_exs / (len(valid_worlds) * num_workers())
+        is_multitask = len(valid_worlds) > 1
         for v_world in valid_worlds:
-            task_report = self._run_single_eval(opt, v_world, max_exs_per_worker)
+            task_report = self._run_single_eval(
+                opt, v_world, max_exs_per_worker, datatype, is_multitask
+            )
             reports.append(task_report)
 
         tasks = [world.getID() for world in valid_worlds]

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -238,7 +238,7 @@ class TestTrainModel(unittest.TestCase):
                     'model': 'repeat_label',
                     'short_final_eval': True,
                     'num_epochs': 1.0,
-                    'world_logs': log_report
+                    'world_logs': log_report,
                 }
             )
             with PathManager.open(log_report) as f:
@@ -251,7 +251,7 @@ class TestTrainModel(unittest.TestCase):
         """
         with testing_utils.tempdir() as tmpdir:
             log_report = os.path.join(tmpdir, 'world_logs.jsonl')
-            multitask = 'integration_tests,blended_skill_talk'
+            multitask = 'integration_tests,integration_tests:ReverseTeacher'
             valid, test = testing_utils.train_model(
                 {
                     'task': multitask,
@@ -259,7 +259,7 @@ class TestTrainModel(unittest.TestCase):
                     'model': 'repeat_label',
                     'short_final_eval': True,
                     'num_epochs': 1.0,
-                    'world_logs': log_report
+                    'world_logs': log_report,
                 }
             )
 
@@ -269,7 +269,7 @@ class TestTrainModel(unittest.TestCase):
                 )
                 with PathManager.open(task_log_report) as f:
                     json_lines = f.readlines()
-                assert len(json_lines) == 10
+                assert len(json_lines) == 5
 
 
 @register_agent("fake_report")

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -11,11 +11,13 @@ import os
 import unittest
 import json
 import parlai.utils.testing as testing_utils
+from parlai.utils.io import PathManager
 from parlai.core.metrics import AverageMetric
 from parlai.core.worlds import create_task
 from parlai.core.opt import Opt
 from parlai.core.params import ParlaiParser
 from parlai.core.agents import register_agent, Agent
+from parlai.scripts.eval_model import get_task_world_logs
 
 
 class TestTrainModel(unittest.TestCase):
@@ -222,6 +224,52 @@ class TestTrainModel(unittest.TestCase):
 
     def test_opt_step_update_freq_2(self):
         self._test_opt_step_opts(2)
+
+    def test_save_world_logs(self):
+        """
+        Test that we can save world logs from train model.
+        """
+        with testing_utils.tempdir() as tmpdir:
+            log_report = os.path.join(tmpdir, 'world_logs.jsonl')
+            valid, test = testing_utils.train_model(
+                {
+                    'task': 'integration_tests',
+                    'validation_max_exs': 10,
+                    'model': 'repeat_label',
+                    'short_final_eval': True,
+                    'num_epochs': 1.0,
+                    'world_logs': log_report
+                }
+            )
+            with PathManager.open(log_report) as f:
+                json_lines = f.readlines()
+            assert len(json_lines) == 10
+
+    def test_save_multiple_world_logs(self):
+        """
+        Test that we can save multiple world_logs from train model on multiple tasks.
+        """
+        with testing_utils.tempdir() as tmpdir:
+            log_report = os.path.join(tmpdir, 'world_logs.jsonl')
+            multitask = 'integration_tests,blended_skill_talk'
+            valid, test = testing_utils.train_model(
+                {
+                    'task': multitask,
+                    'validation_max_exs': 10,
+                    'model': 'repeat_label',
+                    'short_final_eval': True,
+                    'num_epochs': 1.0,
+                    'world_logs': log_report
+                }
+            )
+
+            for task in multitask.split(','):
+                task_log_report = get_task_world_logs(
+                    task, log_report, is_multitask=True
+                )
+                with PathManager.open(task_log_report) as f:
+                    json_lines = f.readlines()
+                assert len(json_lines) == 10
 
 
 @register_agent("fake_report")


### PR DESCRIPTION
**Patch description**
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->
We'd like to dump the world logs for the "test" fold in the final evaluation during training. This way we can skip running the eval_model script while running training and evaluation back to back, and we can retrieve all the evaluation information from the world logs.


**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->
Added unittests in tests/test_train_model.py

**Other information**
<!-- Any other information or context you would like to provide. -->
