### PR TITLE
docs: adding ELI5 video to the home page

### DIFF
--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -14,8 +14,13 @@ letter-spacing: 0em;">Seamless integration of Amazon Mechanical Turk for data co
 </div>
 
 <section class="install-wizard wrap" style="background-color: #f7f7f7">
-    <div class="container">
 
+    <div class="container">
+        <div style="margin-top: 32px; text-align: center;">
+            <h2>Watch Introductory Video</h2>
+            <iframe width="560" height="315" src="https://www.youtube.com/embed/uiVZZaFHOcA" 
+            title="Explain Like I'm 5: ParlAI" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen ></iframe>
+        </div>
         <!-- <div class="row"> -->
         <h2>What's new?</h2>
         <article class="markdown-body">


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Recoil](https://recoiljs.org/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.
