### PR TITLE
[Style-Controlled Generation] Open-source a second style classifier

### DIFF
--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1426,7 +1426,13 @@ model_list = [
         "project": 'https://github.com/facebookresearch/ParlAI/tree/main/projects/style_gen',
         "description": "Classifier trained on Image-Chat turns 2 and 3 to classify the personality of an example given that utterance as the sole context.",
         "example": "parlai eval_model --task style_gen:CurrUttOnlyStyle --wrapper-task style_gen:LabeledBlendedSkillTalk --model-file zoo:style_gen/curr_only_classifier/model --model projects.style_gen.classifier:ClassifierAgent --classes-from-file image_chat_personalities_file",
-        "result": None,  # TODO NOW: add this
+        "result": """
+16:46:41 | Finished evaluating tasks ['style_gen:CurrUttOnlyStyle'] using datatype valid
+    accuracy  bleu-4  <PER_CLASS_METRICS_SNIPPED>  clen  ctpb  ctps  ctrunc  ctrunclen  exps  exs    f1  gpu_mem  llen  loss    lr  ltpb  ltps  ltrunc  ltrunclen   tpb   tps  \
+       .4311 .004642                              19.18 19.18 425.9       0          0  22.2 5651 .4363    .1586 5.633 2.658 5e-10 5.633 125.1       0          0 24.82 550.9
+    weighted_f1
+          .4319
+""",  # The accuracy is low here because the task was classified using a different classifier, zoo:style_gen/prev_curr_classifier/model
     },
     {
         "title": "Faster-R-CNN Detectron Features",

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1432,7 +1432,7 @@ model_list = [
        .4311 .004642                              19.18 19.18 425.9       0          0  22.2 5651 .4363    .1586 5.633 2.658 5e-10 5.633 125.1       0          0 24.82 550.9
     weighted_f1
           .4319
-""",  # The accuracy is low here because the task was classified using a different classifier, zoo:style_gen/prev_curr_classifier/model
+""",  # The accuracy is low here because the task was labeled using a different classifier, zoo:style_gen/prev_curr_classifier/model
     },
     {
         "title": "Faster-R-CNN Detectron Features",

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -1418,6 +1418,17 @@ model_list = [
        .9973  .01745 38.08 604.1 15.86 5651 .9973    .1622 2.129 5e-10 5.633 89.36 43.71 693.4""",
     },
     {
+        "title": "Style-controlled generation: current-utterance-only classifier",
+        "id": "style_gen",
+        "path": "zoo:style_gen/curr_only_classifier/model",
+        "agent": "projects.style_gen.classifier:ClassifierAgent",
+        "task": "style_gen:LabeledBlendedSkillTalk",
+        "project": 'https://github.com/facebookresearch/ParlAI/tree/main/projects/style_gen',
+        "description": "Classifier trained on Image-Chat turns 2 and 3 to classify the personality of an example given that utterance as the sole context.",
+        "example": "parlai eval_model --task style_gen:CurrUttOnlyStyle --wrapper-task style_gen:LabeledBlendedSkillTalk --model-file zoo:style_gen/curr_only_classifier/model --model projects.style_gen.classifier:ClassifierAgent --classes-from-file image_chat_personalities_file",
+        "result": None,  # TODO NOW: add this
+    },
+    {
         "title": "Faster-R-CNN Detectron Features",
         "id": "detectron",
         "path": "zoo:detectron/detectron_model.pth",

--- a/parlai/zoo/style_gen/curr_only_classifier.py
+++ b/parlai/zoo/style_gen/curr_only_classifier.py
@@ -13,7 +13,8 @@ from parlai.core.build_data import download_models
 
 def download(datapath):
     model_type = 'curr_only_classifier'
-    version = 'v1.0'
+    # v1.1 vacuumed the model file to be smaller
+    version = 'v1.1'
     opt = {'datapath': datapath, 'model_type': model_type}
     fnames = [f'{version}.tar.gz']
     download_models(

--- a/parlai/zoo/style_gen/curr_only_classifier.py
+++ b/parlai/zoo/style_gen/curr_only_classifier.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Classifier trained on Image-Chat turns 2 and 3 to classify the personality of an example
+given only the current utterance as context.
+"""
+
+from parlai.core.build_data import download_models
+
+
+def download(datapath):
+    model_type = 'curr_only_classifier'
+    version = 'v1.0'
+    opt = {'datapath': datapath, 'model_type': model_type}
+    fnames = [f'{version}.tar.gz']
+    download_models(
+        opt=opt,
+        fnames=fnames,
+        model_folder='style_gen',
+        version=version,
+        use_model_type=True,
+    )

--- a/tests/nightly/gpu/test_style_gen.py
+++ b/tests/nightly/gpu/test_style_gen.py
@@ -67,7 +67,7 @@ class TestClassifierOnGenerator(unittest.TestCase):
         """
         Test the accuracy of the classifier trained on current utterances only.
 
-        The accuracy is low here because the task was classified using a different
+        The accuracy is low here because the task was labeled using a different
         classifier, zoo:style_gen/prev_curr_classifier/model.
         """
         _, test = testing_utils.eval_model(

--- a/tests/nightly/gpu/test_style_gen.py
+++ b/tests/nightly/gpu/test_style_gen.py
@@ -41,7 +41,7 @@ class TestClassifierOnGenerator(unittest.TestCase):
         self.assertEqual(valid['accuracy'], 1.0)
         self.assertEqual(test['accuracy'], 1.0)
 
-    def test_accuracy(self):
+    def test_prev_curr_accuracy(self):
         """
         Test the accuracy of the classifier trained on previous and current utterances.
 
@@ -62,6 +62,29 @@ class TestClassifierOnGenerator(unittest.TestCase):
             skip_valid=True,
         )
         self.assertAlmostEqual(test['accuracy'], 1.0, delta=0.0)
+
+    def test_curr_only_accuracy(self):
+        """
+        Test the accuracy of the classifier trained on current utterances only.
+
+        TODO: add something about the expected accuracy
+        """
+        _, test = testing_utils.eval_model(
+            opt={
+                'batchsize': 4,
+                'fp16': True,
+                'num_examples': 16,
+                'model_file': 'zoo:style_gen/curr_only_classifier/model',
+                'model': 'projects.style_gen.classifier:ClassifierAgent',
+                'classes_from_file': 'image_chat_personalities_file',
+                'task': 'style_gen:CurrUttOnlyStyle',
+                'wrapper_task': 'style_gen:LabeledBlendedSkillTalk',
+            },
+            skip_valid=True,
+        )
+        self.assertAlmostEqual(
+            test['accuracy'], 1.0, delta=0.0
+        )  # TODO: change if not right
 
 
 class TestStyleGen(unittest.TestCase):

--- a/tests/nightly/gpu/test_style_gen.py
+++ b/tests/nightly/gpu/test_style_gen.py
@@ -67,7 +67,8 @@ class TestClassifierOnGenerator(unittest.TestCase):
         """
         Test the accuracy of the classifier trained on current utterances only.
 
-        TODO: add something about the expected accuracy
+        The accuracy is low here because the task was classified using a different
+        classifier, zoo:style_gen/prev_curr_classifier/model.
         """
         _, test = testing_utils.eval_model(
             opt={
@@ -82,9 +83,7 @@ class TestClassifierOnGenerator(unittest.TestCase):
             },
             skip_valid=True,
         )
-        self.assertAlmostEqual(
-            test['accuracy'], 1.0, delta=0.0
-        )  # TODO: change if not right
+        self.assertAlmostEqual(test['accuracy'], 0.4375, delta=0.0)
 
 
 class TestStyleGen(unittest.TestCase):


### PR DESCRIPTION
# Patch description
By request, open-source a second classifier of dialogue style from [Controlling Style in Generated Dialogue](https://arxiv.org/pdf/2009.10855.pdf). Unlike the first classifier, this one takes as context only the specific utterance to be classified, omitting any previous turns of the conversation. Add a teacher for testing this new classifier, as well as a unit test.

# Testing steps

## Unit test

Command:
```
pytest tests/nightly/gpu/test_style_gen.py
```

Output:
```
==== 4 passed, 32 warnings in 159.13s (0:02:39) ====
```

## Evaluating the classifier on a pre-labeled version of BlendedSkillTalk

Command:
```
parlai eval_model \
--task style_gen:CurrUttOnlyStyle \
--wrapper-task style_gen:LabeledBlendedSkillTalk \
--model-file zoo:style_gen/curr_only_classifier/model \
--model projects.style_gen.classifier:ClassifierAgent \
--classes-from-file image_chat_personalities_file
```

Output:
```
16:46:41 | Finished evaluating tasks ['style_gen:CurrUttOnlyStyle'] using datatype valid
    accuracy  bleu-4  <PER_CLASS_METRICS_SNIPPED>  clen  ctpb  ctps  ctrunc  ctrunclen  exps  exs    f1  gpu_mem  llen  loss    lr  ltpb  ltps  ltrunc  ltrunclen   tpb   tps  \
       .4311 .004642                              19.18 19.18 425.9       0          0  22.2 5651 .4363    .1586 5.633 2.658 5e-10 5.633 125.1       0          0 24.82 550.9
    weighted_f1
          .4319
```
The accuracy is low here because the task was labeled using a different classifier, `zoo:style_gen/prev_curr_classifier/model`.

## Displaying test predictions from the classifier

Command:
```
parlai display_model \
--task style_gen:CurrUttOnlyStyle \
--wrapper-task style_gen:LabeledBlendedSkillTalk \
--model-file zoo:style_gen/curr_only_classifier/model \
--model projects.style_gen.classifier:ClassifierAgent \
--classes-from-file image_chat_personalities_file \
--num-examples 10
```

Output:
```
I received on-the-job training when i first started
    labels: Businesslike
     model: Businesslike
- - - NEW EPISODE: style_gen:LabeledBlendedSkillTalk- - -
For a good number of years now.
    labels: Conservative (Traditional, Conventional)
     model: Relaxed
- - - NEW EPISODE: style_gen:LabeledBlendedSkillTalk- - -
That it is,especially if you dont take the proper measures
    labels: Critical
     model: Critical
- - - NEW EPISODE: style_gen:LabeledBlendedSkillTalk- - -
Thats true,especially in this economy
    labels: Realistic
     model: Honest
- - - NEW EPISODE: style_gen:LabeledBlendedSkillTalk- - -
Do you enjoy it?
    labels: Considerate
     model: Questioning
- - - NEW EPISODE: style_gen:LabeledBlendedSkillTalk- - -
I feel you. Stretch along the halls
    labels: Sympathetic
     model: Empathetic
- - - NEW EPISODE: style_gen:LabeledBlendedSkillTalk- - -
Sure, I have friends who I am always free to share with
    labels: Relaxed
     model: Warm
- - - NEW EPISODE: style_gen:LabeledBlendedSkillTalk- - -
I have never done that.  Not really the physical activity type, but I'd be willing to give it a try, I guess
    labels: Open
     model: Open
- - - NEW EPISODE: style_gen:LabeledBlendedSkillTalk- - -
Now that is more my speed. It tastes kind of strange, but I like it
    labels: Erratic
     model: Odd
- - - NEW EPISODE: style_gen:LabeledBlendedSkillTalk- - -
Yea, it's just one of those things. Once you start on it, you can't stop
    labels: Ordinary
     model: Realistic
```
