### PR TITLE
Trainstats Clobber Bug

### DIFF
--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -493,6 +493,9 @@ class TrainLoop:
                 pass
 
     def _save_train_stats(self, suffix=None):
+        if not is_primary_worker():
+            # never do IO as a non-primary worker
+            return
         fn = self.opt.get('model_file', None)
         if not fn:
             return


### PR DESCRIPTION
**Patch description**
`TrainLoop._save_train_stats` is currently called in two places: `TrainLoop.train` and `TrainLoop.save_model`. `TrainLoop.save_model` returns early if it's not the primary worker, but `TrainLoop.train` does not. To make sure the `.trainstats` file isn't written to from multiple workers at once, this PR adds a return-early check directly in `TrainLoop._save_train_stats`.

**Testing steps**
Circle CI

