### PR TITLE
[RAG] Fix Extra Positions Bug

### DIFF
--- a/parlai/agents/rag/modules.py
+++ b/parlai/agents/rag/modules.py
@@ -74,9 +74,10 @@ class RagModel(TorchGeneratorModel):
             opt['text_truncate'] or opt['truncate'], get_n_positions_from_options(opt)
         )
         if self.n_extra_positions > 0:
-            self.expanded_input_truncate = max(
-                self.expanded_input_truncate, self.n_extra_positions
-            )
+            # This attribute is overloaded.
+            # when n_extra_positions == 0, it is the truncation of the full expanded input
+            # when >0, it is the maximum length of the knowledge tokens.
+            self.expanded_input_truncate = self.n_extra_positions
         self.min_doc_token_length = opt['min_doc_token_length']
 
         # modules

--- a/tests/nightly/gpu/test_rag.py
+++ b/tests/nightly/gpu/test_rag.py
@@ -682,5 +682,34 @@ class TestLeftPadding(unittest.TestCase):
         )
 
 
+class TestExtraPositionsDocConcat(unittest.TestCase):
+    """
+    Ensure docs and input are concatenated appropriately
+    When using extra position embs.
+    """
+
+    bsz = 1
+    seqlen = 1024
+    n_docs = 3
+
+    def test_concat_docs_and_input(self):
+        for n_extra in [128, 2048]:
+            rag = create_agent(
+                Opt({**test_opt, 'n_docs': self.n_docs, 'n_extra_positions': n_extra})
+            )
+            enc_input = torch.LongTensor(self.bsz, self.seqlen).fill_(0)
+            docs = [
+                [
+                    Document("title", "I am a document!" * 1000, i)
+                    for i in range(self.n_docs)
+                ]
+                for _ in range(self.bsz)
+            ]
+            expanded_output = rag.model.concat_docs_and_input(
+                enc_input, self.seqlen, docs, self.n_docs
+            )
+            assert expanded_output.size(1) == self.seqlen + n_extra
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Patch description**
`--n-extra-positions` can be used to expand the total number of positions used when encoding documents + input in pre-trained transformers. If we set this >0, then we are *supposed* to fill up all of end positions with the doc tokens, leaving the beginning positions for the input text. 

In the current RAG implementation, if we specify `--n-extra-positions M` < `--n-positions N`, we encounter an issue where the documents were not properly truncated. This is found in the `concat_docs_and_input` function, where `self.expanded_input_truncate` is used to determine the maximum length of the documents. This is an overloaded attribute, hence why the bug was a bit subtle.

This bug was not previously caught, as in all of my experiments, `--n-extra-positions > --n-positions`. 

**Testing steps**
Added a test to confirm that `concat_docs_and_input` respects the `n_positions` available in the model.
