### PR TITLE
Lrsched missing step

### DIFF
--- a/parlai/nn/lr_scheduler.py
+++ b/parlai/nn/lr_scheduler.py
@@ -83,7 +83,7 @@ class ParlAILRScheduler(object):
         """
         return (
             self.warmup_scheduler is not None
-            and self._number_training_updates < self.warmup_updates
+            and self._number_training_updates <= self.warmup_updates
         )
 
     def _warmup_lr(self, step):
@@ -414,7 +414,7 @@ class InvSqrtLRScheduler(ParlAILRScheduler):
         return self.decay_factor / np.sqrt(max(1, self.invsqrt_lr_decay_gamma + step))
 
     def train_step(self, scheduler_steps):
-        if self.max_lr_steps > 0 and scheduler_steps >= self.max_lr_steps:
+        if self.max_lr_steps > 0 and scheduler_steps > self.max_lr_steps:
             raise StopTrainException('Maximum LR steps')
         self.scheduler.step()
 
@@ -448,7 +448,7 @@ class CosineLRScheduler(ParlAILRScheduler):
         return math.cos(math.pi * step / (2 * self.max_lr_steps))
 
     def train_step(self, scheduler_steps):
-        if scheduler_steps >= self.max_lr_steps:
+        if scheduler_steps > self.max_lr_steps:
             raise StopTrainException('End of Cosine LR Schedule')
         self.scheduler.step()
 
@@ -482,7 +482,7 @@ class LinearLRScheduler(ParlAILRScheduler):
         return lr_mult
 
     def train_step(self, scheduler_steps):
-        if scheduler_steps >= self.max_lr_steps:
+        if scheduler_steps > self.max_lr_steps:
             raise StopTrainException('End of Linear LR Schedule')
         self.scheduler.step()
 

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -922,7 +922,7 @@ class TrainLoop:
                 if train_time > self.max_train_time:
                     logging.info(f'max_train_time elapsed:{train_time}s')
                     break
-                if self._train_steps >= self.max_train_steps:
+                if self._train_steps > self.max_train_steps:
                     logging.info(
                         f'max_train_steps elapsed:{self._train_steps} '
                         f'time elapsed:{train_time}s'

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -23,7 +23,7 @@ class TestLRSchedulers(unittest.TestCase):
             args, optimizer, {}, True
         )
         output = []
-        for step in range(total_steps):
+        for step in range(1, total_steps + 1):
             scheduler.step(step)
             output.append(scheduler.get_last_lr())
         for value in output:

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -35,6 +35,8 @@ class TestLRSchedulers(unittest.TestCase):
         assert warmup_updates >= 0
         if warmup_updates > 0:
             assert output[warmup_updates - 1] == max_lr
+            if warmup_updates < len(output):
+                assert output[warmup_updates - 1] < max_lr
             # LR is always linear
             for step in range(warmup_updates - 2):
                 self.assertAlmostEqual(

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -88,18 +88,36 @@ class TestLRSchedulers(unittest.TestCase):
     def test_cosine(self):
         self._run_pass(lr_scheduler='cosine', warmup_updates=0, end_zero=True)
         self._run_pass(lr_scheduler='cosine', warmup_updates=50, end_zero=True)
+        self._run_pass(
+            lr_scheduler='cosine', warmup_updates=50, end_zero=True, max_lr=0.5
+        )
+        self._run_pass(
+            lr_scheduler='cosine', warmup_updates=50, end_zero=True, max_lr=1.5
+        )
         with self.assertRaises(lr_scheduler.StopTrainException):
             self._run_pass(lr_scheduler='cosine', max_train_steps=100, total_steps=1000)
 
     def test_linear(self):
         self._run_pass(lr_scheduler='linear', warmup_updates=0, end_zero=True)
         self._run_pass(lr_scheduler='linear', warmup_updates=50, end_zero=True)
+        self._run_pass(
+            lr_scheduler='linear', warmup_updates=50, end_zero=True, max_lr=0.5
+        )
+        self._run_pass(
+            lr_scheduler='linear', warmup_updates=50, end_zero=True, max_lr=1.5
+        )
         with self.assertRaises(lr_scheduler.StopTrainException):
             self._run_pass(lr_scheduler='linear', max_train_steps=100, total_steps=1000)
 
     def test_invsqrt(self):
         self._run_pass(lr_scheduler='invsqrt', warmup_updates=0, end_zero=False)
         self._run_pass(lr_scheduler='invsqrt', warmup_updates=50, end_zero=False)
+        self._run_pass(
+            lr_scheduler='invsqrt', warmup_updates=50, end_zero=True, max_lr=0.5
+        )
+        self._run_pass(
+            lr_scheduler='invsqrt', warmup_updates=50, end_zero=True, max_lr=1.5
+        )
 
         # decay very fast
         steps = self._run_pass(

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -34,7 +34,7 @@ class TestLRSchedulers(unittest.TestCase):
         warmup_updates = args.get('warmup_updates', 0)
         assert warmup_updates >= 0
         if warmup_updates > 0:
-            assert abs(max_lr - output[warmup_updates - 1]) < 0.04
+            assert output[warmup_updates - 1] == max_lr
             # LR is always linear
             for step in range(warmup_updates - 2):
                 self.assertAlmostEqual(
@@ -204,7 +204,7 @@ class TestLRIntegration(unittest.TestCase):
 
             if 'warmup_updates' in kwargs:
                 full_logs = logs_first[:20] + logs_second
-                assert abs(1.0 - full_logs[kwargs['warmup_updates'] - 1]['lr']) < 0.04
+                assert full_logs[kwargs['warmup_updates'] - 1]['lr'] == 1.0
 
             return logs_first, logs_second
 

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -36,7 +36,7 @@ class TestLRSchedulers(unittest.TestCase):
         if warmup_updates > 0:
             assert output[warmup_updates - 1] == max_lr
             if warmup_updates < len(output):
-                assert output[warmup_updates - 1] < max_lr
+                assert output[warmup_updates] < max_lr
             # LR is always linear
             for step in range(warmup_updates - 2):
                 self.assertAlmostEqual(
@@ -113,10 +113,10 @@ class TestLRSchedulers(unittest.TestCase):
         self._run_pass(lr_scheduler='invsqrt', warmup_updates=0, end_zero=False)
         self._run_pass(lr_scheduler='invsqrt', warmup_updates=50, end_zero=False)
         self._run_pass(
-            lr_scheduler='invsqrt', warmup_updates=50, end_zero=True, max_lr=0.5
+            lr_scheduler='invsqrt', warmup_updates=50, end_zero=False, max_lr=0.5
         )
         self._run_pass(
-            lr_scheduler='invsqrt', warmup_updates=50, end_zero=True, max_lr=1.5
+            lr_scheduler='invsqrt', warmup_updates=50, end_zero=False, max_lr=1.5
         )
 
         # decay very fast

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -40,7 +40,7 @@ class TestLRSchedulers(unittest.TestCase):
             # LR is always linear
             for step in range(warmup_updates - 2):
                 self.assertAlmostEqual(
-                    output[step + 1] - output[step], 1 / warmup_updates
+                    output[step + 1] - output[step], max_lr / warmup_updates
                 )
         if end_zero:
             self.assertAlmostEquals(output[-1], 0)


### PR DESCRIPTION
**Patch description**
Follow up from #4384: Unrelaxed relaxed conditions in tests and modified scheduler logic to fit unrelaxed conditions.

- changed `self._number_training_updates < self.warmup_updates` `-->` `self._number_training_updates <= self.warmup_updates` to hit the exact `max_lr`. 
   - In this case the lr doesn't anneal to 0 due to a missing step.
- Modified stopping conditions in `parlai/nn/lr_scheduler.py` and `parlai/scripts/train.py` to allow the missing step to be taken
- Modified `test_lr_schedulers.py` to step from 1 -> total_steps rather than 0 -> total_steps - 1 to match the behavior in `lr_scheduler.py`

**Testing steps**
```
parlai tm -t convai2 -m transformer/generator --lr-scheduler linear --warmup-updates 10 -lstep 1 -vstep 10000000 --max-lr-steps 100 --skip-generation True --warmup-rate 0.01 -lr 0.00001 --dict-file /tmp/test123.dict
```
should now show 100 steps instead of 99

**Other information**
Still not sure if this is the desired behavior, is there an implicit step (0) taken?
