### PR TITLE
LCCC_large Dataset

### DIFF
--- a/parlai/tasks/lccc_large/__init__.py
+++ b/parlai/tasks/lccc_large/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/parlai/tasks/lccc_large/agents.py
+++ b/parlai/tasks/lccc_large/agents.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This task simply loads the specified file: useful for quick tests without
+# setting up a new task.
+
+from typing import Optional
+from parlai.core.params import ParlaiParser
+from parlai.core.opt import Opt
+from parlai.utils.misc import warn_once
+import copy
+import os
+from .build import build
+
+from parlai.core.teachers import ConversationTeacher
+
+
+def _path(opt):
+    # build the data if it does not exist
+    build(opt)
+    # set up path to data
+    datatype = opt['datatype'].split(':')[0]
+    if datatype != 'train':
+        warn_once("WARNING: Test set or valid set not included. Setting datatype to train.")
+        datatype = 'train'
+    return os.path.join(opt['datapath'], 'LCCC_large', 'LCCC_large' + '.json')
+
+
+class LCCCTeacher(ConversationTeacher):
+    @classmethod
+    def add_cmdline_args(
+        cls, parser: ParlaiParser, partial_opt: Optional[Opt] = None
+    ) -> ParlaiParser:
+        super().add_cmdline_args(parser, partial_opt)
+        agent = parser.add_argument_group('LCCC Task Arguments')
+        agent.add_argument(
+            '--label-turns',
+            type=str,
+            help='which speaker to use as label',
+            choices=['firstspeaker', 'secondspeaker', 'both'],
+            default='secondspeaker',
+        )
+        return parser
+
+    def __init__(self, opt, shared=None):
+        opt = copy.deepcopy(opt)
+        # get datafile
+        opt['conversationteacher_datafile'] = _path(opt)
+        super().__init__(opt, shared)
+
+
+class DefaultTeacher(LCCCTeacher):
+    pass

--- a/parlai/tasks/lccc_large/build.py
+++ b/parlai/tasks/lccc_large/build.py
@@ -1,0 +1,54 @@
+from parlai.core.build_data import DownloadableFile
+from parlai.utils.io import PathManager
+import parlai.core.build_data as build_data
+import os
+import json
+
+RESOURCES = [
+    DownloadableFile(
+        'https://cloud.tsinghua.edu.cn/f/8424e7b9454c4e628c24/?dl=1',
+        'LCCC-large.zip',
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    ),
+]
+
+
+def build(opt):
+    dpath = os.path.join(opt['datapath'], 'LCCC_large')
+    version = None
+
+    if not build_data.built(dpath, version_string=version):
+        if build_data.built(dpath):
+            # An older version exists, so remove these outdated files.
+            build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # Download the data.
+        RESOURCES[0].download_file(dpath)
+        # Format it for use with ParlAIDialogTeacher
+        _create_parlai_format(dpath)
+        # Mark the data as built.
+        build_data.mark_done(dpath, version_string=version)
+
+
+def _create_parlai_format(dpath: str):
+    """
+    Copy data into the format read by ConversationTeacher.
+    """
+    load_path = os.path.join(dpath, f'LCCD.json')
+    save_path = os.path.join(dpath, f'LCCC_large.json')
+    with PathManager.open(load_path, 'r', encoding='utf8') as f_read:
+        data = json.load(f_read)
+    with PathManager.open(save_path, 'w', encoding='utf8') as f_write:
+        for episode in data:
+            new_episode = []
+            pid = 0
+            for text in episode:
+                new_episode.append(
+                    {'id': 'partner{}'.format(pid + 1), 'text': text.replace(' ', '')}
+                )
+                pid = (pid + 1) % 2
+            print(
+                json.dumps({'dialog': [new_episode]}, ensure_ascii=False), file=f_write
+            )
+    os.remove(load_path)

--- a/parlai/tasks/lccc_large/test.py
+++ b/parlai/tasks/lccc_large/test.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+
+from parlai.utils.testing import AutoTeacherTest  # noqa: F401
+
+
+class TestDefaultTeacher(AutoTeacherTest):
+    task = 'lccc_large'

--- a/parlai/tasks/lccc_large/test/lccc_large_test.yml
+++ b/parlai/tasks/lccc_large/test/lccc_large_test.yml
@@ -1,0 +1,28 @@
+acts:
+- - episode_done: true
+    eval_labels:
+    - 哈哈哈哈！那我的嘴巴可能要烂掉！
+    id: lccc_large
+    text: 火锅我在重庆成都吃了七八顿火锅
+- - episode_done: true
+    eval_labels:
+    - 啥时候带我们见嫂子？
+    id: lccc_large
+    text: 刚应该带着你和我接你嫂子去坐车太没劲了
+- - episode_done: false
+    eval_labels:
+    - 你又知道
+    id: lccc_large
+    text: 头不圆
+- - episode_done: true
+    eval_labels:
+    - 好吧，你赢了，头真的不圆~~
+    id: lccc_large
+    text: 脸长的人头怎么可能圆
+- - episode_done: false
+    eval_labels:
+    - 有道理
+    id: lccc_large
+    text: 也许人在国外呢，时差懂不懂
+num_episodes: 12007759
+num_examples: 14697626

--- a/parlai/tasks/lccc_large/test/lccc_large_train.yml
+++ b/parlai/tasks/lccc_large/test/lccc_large_train.yml
@@ -1,0 +1,28 @@
+acts:
+- - episode_done: true
+    id: lccc_large
+    labels:
+    - 哈哈哈哈！那我的嘴巴可能要烂掉！
+    text: 火锅我在重庆成都吃了七八顿火锅
+- - episode_done: true
+    id: lccc_large
+    labels:
+    - 啥时候带我们见嫂子？
+    text: 刚应该带着你和我接你嫂子去坐车太没劲了
+- - episode_done: false
+    id: lccc_large
+    labels:
+    - 你又知道
+    text: 头不圆
+- - episode_done: true
+    id: lccc_large
+    labels:
+    - 好吧，你赢了，头真的不圆~~
+    text: 脸长的人头怎么可能圆
+- - episode_done: false
+    id: lccc_large
+    labels:
+    - 有道理
+    text: 也许人在国外呢，时差懂不懂
+num_episodes: 12007759
+num_examples: 14697626

--- a/parlai/tasks/lccc_large/test/lccc_large_valid.yml
+++ b/parlai/tasks/lccc_large/test/lccc_large_valid.yml
@@ -1,0 +1,28 @@
+acts:
+- - episode_done: true
+    eval_labels:
+    - 哈哈哈哈！那我的嘴巴可能要烂掉！
+    id: lccc_large
+    text: 火锅我在重庆成都吃了七八顿火锅
+- - episode_done: true
+    eval_labels:
+    - 啥时候带我们见嫂子？
+    id: lccc_large
+    text: 刚应该带着你和我接你嫂子去坐车太没劲了
+- - episode_done: false
+    eval_labels:
+    - 你又知道
+    id: lccc_large
+    text: 头不圆
+- - episode_done: true
+    eval_labels:
+    - 好吧，你赢了，头真的不圆~~
+    id: lccc_large
+    text: 脸长的人头怎么可能圆
+- - episode_done: false
+    eval_labels:
+    - 有道理
+    id: lccc_large
+    text: 也许人在国外呢，时差懂不懂
+num_episodes: 12007759
+num_examples: 14697626

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -1562,4 +1562,17 @@ task_list = [
             "website": "https://github.com/thu-coai/CDial-GPT",
         },
     },
+    {
+        "id": "LCCC_large",
+        "display_name": "LCCC_large",
+        "task": "lccc_large",
+        "tags": ["ChitChat"],
+        "description": (
+            "Large-scale cleaned Chinese conversation dataset."
+        ),
+        "links": {
+            "arXiv": "https://arxiv.org/pdf/2008.03946",
+            "website": "https://github.com/thu-coai/CDial-GPT",
+        },
+    },
 ]


### PR DESCRIPTION
	新文件：   lccc/agents.py
	新文件：   lccc/build.py
	新文件：   lccc/test.py
	新文件：   lccc/test/lccc_test.yml
	新文件：   lccc/test/lccc_train.yml
	新文件：   lccc/test/lccc_valid.yml
	修改：     task_list.py

**Patch description**
Add the large version of [LCCC](https://github.com/thu-coai/CDial-GPT) dataset. 


**Testing steps**
Display the default dataset：(train set)
`parlai display_data -t lccc`
Display train set：
`parlai display_data -t lccc -dt train`

