### PR TITLE
[🤗] Safely get model_name from opt

### DIFF
--- a/parlai/agents/hugging_face/dict.py
+++ b/parlai/agents/hugging_face/dict.py
@@ -140,7 +140,7 @@ class Gpt2DictionaryAgent(HuggingFaceDictionaryAgent):
         """
         Instantiate tokenizer.
         """
-        if opt["model_name"]:
+        if opt.get("model_name"):
             fle_key = opt["model_name"]
         else:
             model_sz = opt["gpt2_size"]

--- a/parlai/agents/hugging_face/gpt2.py
+++ b/parlai/agents/hugging_face/gpt2.py
@@ -58,7 +58,7 @@ class GPT2Decoder(torch.nn.Module):
 
     def _init_from_pretrained(self, opt):
         # load model
-        if opt["model_name"]:
+        if opt.get("model_name"):
             fle_key = opt["model_name"]
         else:
             model_sz = opt["gpt2_size"]

--- a/parlai/tasks/lccc/build.py
+++ b/parlai/tasks/lccc/build.py
@@ -9,7 +9,7 @@ RESOURCES = [
         'https://cloud.tsinghua.edu.cn/f/f131a4d259184566a29c/?dl=1',
         'LCCC.zip',
         'f5203511cd8d6a608008af0aa290aa516d983abc16aa510471e3c4ee6bca7886',
-    ),
+    )
 ]
 
 

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -1554,9 +1554,7 @@ task_list = [
         "display_name": "LCCC",
         "task": "lccc",
         "tags": ["ChitChat"],
-        "description": (
-            "Large-scale cleaned Chinese conversation dataset."
-        ),
+        "description": ("Large-scale cleaned Chinese conversation dataset."),
         "links": {
             "arXiv": "https://arxiv.org/pdf/2008.03946",
             "website": "https://github.com/thu-coai/CDial-GPT",


### PR DESCRIPTION
**Patch description**
I used `HuggingFaceDictionaryAgent` in my own agent, which crashed because my agent doesn't have the `--model-name` flag. By accessing `"model_name"` with `.get()`, these conditions work as expected in agents other than `Gpt2Agent`.

Context of breaking change: https://github.com/facebookresearch/ParlAI/pull/4360

**Testing steps**
Used my agent (code not checked in) and verified code did not crash.
CircleCI
