### PR TITLE
[fsdp] Bring back flatten parameters.

### DIFF
--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -159,6 +159,7 @@ class TestDistributed(_AbstractTest):
         assert test['exs'].value() == inttests.NUM_TEST
 
 
+@testing_utils.skipIfCircleCI
 @testing_utils.skipUnlessGPU
 class TestZero2(TestDistributed):
     """


### PR DESCRIPTION
**Patch description**
A recent patch (#4343) changed fairscale from using flatten parameters True to False. However, this seems broken in recent versions of fairscale. Several users (internal and external) have reported switching this back resolves a crash, so switching it back.

**Testing steps**
CI. User reports.