### PR TITLE
Fixing bug in core/teachers.py where opt['task'] is modified unnecess…

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -2636,7 +2636,6 @@ def _add_task_flags_to_agent_opt(agent, opt: Opt, flags):
             opt[key] = value
         else:
             task.append(f)
-    opt['task'] = ':'.join(task)
 
 
 def create_task_agent_from_taskname(opt: Opt):

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -251,7 +251,7 @@ class TestTrainModel(unittest.TestCase):
         """
         with testing_utils.tempdir() as tmpdir:
             log_report = os.path.join(tmpdir, 'world_logs.jsonl')
-            multitask = 'integration_tests,integration_tests:ReverseTeacher'
+            multitask = 'integration_tests:mutators=flatten,integration_tests:ReverseTeacher'
             valid, test = testing_utils.train_model(
                 {
                     'task': multitask,


### PR DESCRIPTION
**Patch description**

When `opt["task"] = 'integration_tests:mutators=flatten'` for example, this line (2648) in core/teachers.py changes the `opt["task"]`. In this case, `opt["task"]` is changed to `integration_tests`, this is bcoz of the clause in line 2626 which fails to record the `mutators=flatten` in `task`.

This saves the task name incorrectly in the `self.id` (also called by `world.getID()`) attribute of the `World`. Which in turn messes up retrieving the `world_log_dir` correctly during the final test fold in training.

`test_save_multiple_world_logs()` fails currently when you have a mutator in the tasks. Removing this line fixes this failure.

<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

`pytest tests/test_train_model.py`

**Other information**
<!-- Any other information or context you would like to provide. -->
