### PR TITLE
Fix Acute-Eval output dataframe size

### DIFF
--- a/parlai/crowdsourcing/tasks/acute_eval/analysis.py
+++ b/parlai/crowdsourcing/tasks/acute_eval/analysis.py
@@ -279,7 +279,7 @@ class AcuteAnalyzer(object):
             ~df["worker"].isin(workers_failing_onboarding) & ~df["is_onboarding"]
         ]
         print(
-            f'{self.dataframe.size:d} dataframe entries remaining after removing users who failed onboarding.'
+            f'{self.dataframe.index.size:d} dataframe entries remaining after removing users who failed onboarding.'
         )
 
     def _load_pairing_files(self):


### PR DESCRIPTION
**Patch description**
Fixes the print statement of the number of Acute-Eval ratings remaining after filtering out workers who failed onboarding

**Testing steps**
CI checks