### PR TITLE
[Chat Services] Display line breaks appropriately

### DIFF
--- a/parlai/chat_service/services/websocket/websocket_manager.py
+++ b/parlai/chat_service/services/websocket/websocket_manager.py
@@ -233,9 +233,7 @@ class WebsocketManager(ChatServiceManager):
         if quick_replies is not None:
             quick_replies = list(quick_replies)
 
-        message = json.dumps(
-            {'text': message.replace('\n', '<br />'), 'quick_replies': quick_replies}
-        )
+        message = json.dumps({'text': message, 'quick_replies': quick_replies})
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         if socket_id not in self.subs:


### PR DESCRIPTION
**Patch description**
This patch removes the replacement of `\n` characters with `<br />`) characters; the latter don't do anything useful, `\n` works just fine.

**Testing steps**
Tested with terminal chat to confirm appropriate behavior.
