### PR TITLE
Updating to Mephisto 1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ commands:
       - run:
             name: Install Mephisto
             command: |
-              pip install mephisto==1.0.0b1
+              pip install mephisto==1.0.0b2
               echo | mephisto check
 
   setupcuda:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ commands:
       - run:
             name: Install Mephisto
             command: |
-              pip install mephisto=1.0.0b1
+              pip install mephisto==1.0.0b1
               echo | mephisto check
 
   setupcuda:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,12 +159,7 @@ commands:
       - run:
             name: Install Mephisto
             command: |
-              cd ..
-              git clone git@github.com:facebookresearch/Mephisto.git Mephisto
-              cd Mephisto; git checkout v0.4.2 -b stable
-              pip install -r requirements.txt
-              python setup.py develop
-              # `echo` so that ENTER will be pressed at the prompt
+              pip install mephisto=1.0.0b1
               echo | mephisto check
 
   setupcuda:

--- a/parlai/crowdsourcing/tasks/acute_eval/webapp/package.json
+++ b/parlai/crowdsourcing/tasks/acute_eval/webapp/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bootstrap": "^4.3.1",
     "jquery": "^3.0.0",
-    "mephisto-task": "^1.0.10",
+    "mephisto-task": "^2.0.0",
     "react": "16.13.1",
     "react-bootstrap": "^0.32.4",
     "react-dom": "16.13.1",

--- a/parlai/crowdsourcing/tasks/acute_eval/webapp/webpack.config.js
+++ b/parlai/crowdsourcing/tasks/acute_eval/webapp/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
   output: {
     path: __dirname,
     filename: "build/bundle.js",
+    hashFunction: "sha256",
   },
   resolve: {
     alias: {

--- a/parlai/crowdsourcing/tasks/qa_data_collection/webapp/package.json
+++ b/parlai/crowdsourcing/tasks/qa_data_collection/webapp/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "dependencies": {
     "bootstrap": "^4.3.1",
-    "bootstrap-chat": "^1.0.7",
-    "mephisto-task": "^1.0.13",
+    "bootstrap-chat": "^2.0.0",
+    "mephisto-task": "^2.0.0",
     "rc-slider": "^8.6.3",
     "react": "16.13.1",
     "react-bootstrap": "^0.32.4",

--- a/parlai/crowdsourcing/tasks/qa_data_collection/webapp/webpack.config.js
+++ b/parlai/crowdsourcing/tasks/qa_data_collection/webapp/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
   output: {
     path: __dirname,
     filename: "build/bundle.js",
+    hashFunction: "sha256",
   },
   node: {
     net: "empty",

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/webapp/package.json
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/webapp/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "dependencies": {
     "bootstrap": "^4.3.1",
-    "mephisto-task": "^1.0.3",
+    "mephisto-task": "^2.0.0",
     "react": "16.13.1",
     "react-bootstrap": "^0.32.4",
     "react-dom": "16.13.1",

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/webapp/webpack.config.js
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/webapp/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
   output: {
     path: __dirname,
     filename: "build/bundle.js",
+    hashFunction: "sha256",
   },
   node: {
     net: "empty",

--- a/tests/crowdsourcing/tasks/model_chat/test_model_chat.py
+++ b/tests/crowdsourcing/tasks/model_chat/test_model_chat.py
@@ -120,7 +120,7 @@ fixed_response: >
                 self._set_up_server(shared_state=shared_state)
 
                 # Check that the agent states are as they should be
-                self._get_channel_info().job.task_runner.task_run.get_blueprint().use_onboarding = (
+                self._get_live_run().task_runner.task_run.get_blueprint().use_onboarding = (
                     False
                 )
                 # Don't require onboarding for this test agent

--- a/tests/crowdsourcing/tasks/model_chat/test_model_image_chat.py
+++ b/tests/crowdsourcing/tasks/model_chat/test_model_image_chat.py
@@ -134,7 +134,7 @@ try:
                 self._set_up_server(shared_state=shared_state)
 
                 # Check that the agent states are as they should be
-                self._get_channel_info().job.task_runner.task_run.get_blueprint().use_onboarding = (
+                self._get_live_run().task_runner.task_run.get_blueprint().use_onboarding = (
                     False
                 )
                 # Don't require onboarding for this test agent

--- a/tests/crowdsourcing/tasks/test_chat_demo.py
+++ b/tests/crowdsourcing/tasks/test_chat_demo.py
@@ -386,6 +386,7 @@ try:
                 '++mephisto.task.maximum_units_per_worker=0',
                 '++num_turns=3',
                 '++turn_timeout=300',
+                '++mephisto.task.submission_timout=10',
             ]
             self._set_up_config(task_directory=TASK_DIRECTORY, overrides=overrides)
 

--- a/tests/crowdsourcing/test_analysis.py
+++ b/tests/crowdsourcing/test_analysis.py
@@ -55,7 +55,7 @@ class MockMephistoBrowser:
         self._data = dict()
         db = MockMephistoDB()
         for idx in range(LEN_MOCK_DATA):
-            unit = MockUnit(db, "mock_db", defaultdict(int))
+            unit = MockUnit.get(db, "mock_db", defaultdict(int))
             self._data[unit] = {
                 'unit_id': idx * 10,
                 'worker_id': idx,


### PR DESCRIPTION
**Patch description**
First set of steps that get `crowdsourcing` tests _running_ (no longer breaking the newer mephisto conventions), but still not **passing**. More work is to be done there, leaving this open as a starting point for others to make comments and take over.

**Testing steps**
```
pytest tests/crowdsourcing
```

