### PR TITLE
[BlenderBot2] Fix ObservationEchoRetriever

### DIFF
--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -409,7 +409,7 @@ class WizIntGoldDocRetrieverFiDAgent(GoldDocRetrieverFiDAgent):
         for doc_idx in range(n_docs_in_message):
             doc_content = message[consts.RETRIEVED_DOCS][doc_idx]
             for sel_sentc in selected_sentences:
-                if sel_sentc in doc_content:
+                if sel_sentc in doc_content and doc_idx not in already_added_doc_idx:
                     retrieved_docs.append(
                         self._extract_doc_from_message(message, doc_idx)
                     )

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -1305,10 +1305,17 @@ class ObservationEchoRetriever(RagRetriever):
         self.n_docs = opt['n_docs']
         self._query_ids = dict()
         self._saved_docs = dict()
+        self._largest_seen_idx = -1
         super().__init__(opt, dictionary, shared=shared)
 
     def add_retrieve_doc(self, query: str, retrieved_docs: List[Document]):
-        new_idx = len(self._query_ids)
+        self._largest_seen_idx += 1
+        new_idx = max(len(self._query_ids), self._largest_seen_idx)
+        if new_idx in self._query_ids.values() or new_idx in self._saved_docs:
+            raise RuntimeError(
+                "Nonunique new_idx created in add_retrieve_doc in ObservationEchoRetriever \n"
+                "this might return the same set of docs for two distinct queries"
+            )
         self._query_ids[query] = new_idx
         self._saved_docs[new_idx] = retrieved_docs or [
             BLANK_DOC for _ in range(self.n_docs)
@@ -1319,6 +1326,11 @@ class ObservationEchoRetriever(RagRetriever):
 
     def get_delimiter(self) -> str:
         return self._delimiter
+
+    def _clear_mapping(self):
+        self._query_ids = dict()
+        self._saved_docs = dict()
+        self._largest_seen_idx = -1
 
     def retrieve_and_score(
         self, query: torch.LongTensor
@@ -1336,6 +1348,10 @@ class ObservationEchoRetriever(RagRetriever):
         retrieved_doc_scores = retrieved_doc_scores.repeat(batch_size, 1).to(
             query.device
         )
+
+        # empty the 2 mappings after each retrieval
+        self._clear_mapping()
+
         return retrieved_docs, retrieved_doc_scores
 
 

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -1310,7 +1310,7 @@ class ObservationEchoRetriever(RagRetriever):
 
     def add_retrieve_doc(self, query: str, retrieved_docs: List[Document]):
         self._largest_seen_idx += 1
-        new_idx = max(len(self._query_ids), self._largest_seen_idx)
+        new_idx = self._largest_seen_idx
         if new_idx in self._query_ids.values() or new_idx in self._saved_docs:
             raise RuntimeError(
                 "Nonunique new_idx created in add_retrieve_doc in ObservationEchoRetriever \n"

--- a/projects/blenderbot2/agents/blenderbot2.py
+++ b/projects/blenderbot2/agents/blenderbot2.py
@@ -924,6 +924,4 @@ class BlenderBot2SearchQueryFiDAgent(BlenderBot2FidAgent):
 class BlenderBot2WizIntGoldDocRetrieverFiDAgent(
     WizIntGoldDocRetrieverFiDAgent, BlenderBot2FidAgent
 ):
-    def _set_query_vec(self, observation: Message) -> Message:
-        self.show_observation_to_echo_retriever(observation)
-        super()._set_query_vec(observation)
+    pass


### PR DESCRIPTION
**Patch description**
This is to fix some corner cases in `ObservationEchoRetriever` and `BlenderBot2WizIntGoldDocRetrieverFiDAgent`:
1.
-  the `show_observation_to_echo_retriever` is called twice in `BlenderBot2WizIntGoldDocRetrieverFiDAgent._set_qyert_vec`, which means the `self.model_api.retriever.add_retrieve_doc(observation[self._query_key], retrieved_docs)` is also called twice, which would mess up with the query → idx → doc mapping in `ObservationEchoRetriever`, and  the same docs might be returned for distinct queries in a single batch.
- For example when batch size = 2, in  `add_retrieve_doc`: `new_idx = 0`,  `_query_ids = {query0 : 0}` ,` _saved_docs={0 : docs0}`
- When the same  `show_observation_to_echo_retriever` is called the 2nd time, `new_idx = 1`, `_query_ids={query0 : 1}` , `_saved_docs={1 : docs0}` ; 
- When the 2nd query in the same batch arrives, `new_idx = 1`,  `_query_ids={query0 : 1, query1: 1}` ,` _saved_docs={1: docs1 }`. **_notice that 1: docs0 was overriden_**. After the 2nd call, `new_idx = 2, _query_ids={query0 : 1, query1: 2} , _saved_docs={1 : docs1, 2: docs1}` .
- In this case, the 2 queries share the same docs `docs1` since the new_idx for the new query1 isn't unique when created.

Another issue is that in ObservationEchoRetriever: the `_query_ids` dictionary can grow linearly with the number of unique queries it see during training. 

The fix is to 
- create a new new_idx and make sure it's **unseen**.
- clear the `_query_ids` and `_saved_doc` dictionaries after batch retrieval is done.


**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
