### PR TITLE
[T5] Support Distributed Training

### DIFF
--- a/parlai/agents/rag/modules.py
+++ b/parlai/agents/rag/modules.py
@@ -535,6 +535,7 @@ class T5RagModel(RagModel):
         super().__init__(opt, dictionary, retriever_shared)
         self.embedding_size = opt['t5'].model_dim
         self.t5 = opt.pop('t5', None)
+        self.paralleled = not opt['t5_model_parallel']
 
     @classmethod
     def build_encoder(

--- a/tests/nightly/gpu/test_t5.py
+++ b/tests/nightly/gpu/test_t5.py
@@ -34,6 +34,8 @@ import parlai.utils.testing as testing_utils
 from parlai.utils.torch import padded_tensor
 from parlai.utils.testing import tempdir
 
+from tests.test_distributed import _AbstractTest
+
 
 device = 'cpu' if not torch.cuda.is_available() else 'cuda:0'
 
@@ -260,6 +262,31 @@ class TestT5Model(unittest.TestCase):
                     t5_model_arch='t5-small',
                 )
             )
+
+
+class TestT5Distributed(_AbstractTest):
+    base_config = dict(
+        task='integration_tests:overfit',
+        model='hugging_face/t5',
+        optimizer='adam',
+        batchsize=1,
+        num_epochs=50,
+        short_final_eval=True,
+        validation_max_exs=12,
+        t5_model_arch='t5-small',
+        validation_metric='ppl',
+        skip_generation=True,
+        learningrate=1e-2,
+        validation_every_n_epochs=25,
+        verbose=True,
+        save_after_valid=False,
+    )
+
+    def test_t5_distributed(self):
+        valid, test = self._distributed_train_model()
+
+        self.assertLessEqual(valid['ppl'], 1.60)
+        self.assertLessEqual(test['ppl'], 1.60)
 
 
 if __name__ == '__main__':

--- a/tests/nightly/gpu/test_t5.py
+++ b/tests/nightly/gpu/test_t5.py
@@ -264,6 +264,7 @@ class TestT5Model(unittest.TestCase):
             )
 
 
+@testing_utils.skipUnlessGPU
 class TestT5Distributed(_AbstractTest):
     base_config = dict(
         task='integration_tests:overfit',


### PR DESCRIPTION
**Patch description**
Per #4430 , T5 was hanging with distributed calls. This was due to the forced setting of the CUDA device required for training with T5 model parallel. This is now a protected call.

**Testing steps**
1. Tested with the command provided in #4430 
2. New distributed test for t5:

```
$ pytest test_t5.py
======test session starts ======
platform linux -- Python 3.7.9, pytest-5.3.2, py-1.10.0, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini
plugins: hydra-core-1.1.0, requests-mock-1.7.0, regressions-2.1.1, datadir-1.3.1
collected 9 items

test_t5.py .........                                                                                                                                                          [100%]

======slowest 10 test durations ======
97.49s call     tests/nightly/gpu/test_t5.py::TestT5Distributed::test_t5_distributed
60.84s call     tests/nightly/gpu/test_t5.py::TestT5Model::test_t5_model_parallel
46.50s call     tests/nightly/gpu/test_t5.py::TestT5Model::test_t5_ft
19.85s call     tests/nightly/gpu/test_t5.py::TestT5Model::test_t5_gen
16.18s call     tests/nightly/gpu/test_t5.py::TestT5Model::test_small
12.19s call     tests/nightly/gpu/test_t5.py::TestT5Model::test_summarization
10.75s call     tests/nightly/gpu/test_t5.py::TestT5Model::test_translation_en_to_fr
9.85s call     tests/nightly/gpu/test_t5.py::TestT5Model::test_translation_en_to_de
9.79s call     tests/nightly/gpu/test_t5.py::TestT5Model::test_translation_en_to_ro

(0.00 durations hidden.  Use -vv to show these durations.)
======9 passed, 9 warnings in 290.46s (0:04:50) ======

```

**Other information**
<!-- Any other information or context you would like to provide. -->
