### PR TITLE
[empathetic dialogues] Whitespace changes

### DIFF
--- a/parlai/tasks/empathetic_dialogues/agents.py
+++ b/parlai/tasks/empathetic_dialogues/agents.py
@@ -95,7 +95,7 @@ class EmpatheticDialoguesTeacher(DialogTeacher):
                 )
 
                 contextt = cparts[5].replace("_comma_", ",")
-                label = sparts[5].replace("_comma_", ",")
+                label = sparts[5].replace("_comma_", ",").strip()
                 prompt = sparts[2]
                 sit = sparts[3].replace("_comma_", ",")
                 if len(sparts) == 9:
@@ -120,6 +120,9 @@ class EmpatheticDialoguesTeacher(DialogTeacher):
                     }
                 )
                 if inline_label_candidates is not None:
+                    inline_label_candidates = [
+                        lc.strip() for lc in inline_label_candidates
+                    ]
                     dialogue_parts.force_set(
                         'label_candidates', inline_label_candidates
                     )

--- a/parlai/tasks/empathetic_dialogues/test/empathetic_dialogues_test.yml
+++ b/parlai/tasks/empathetic_dialogues/test/empathetic_dialogues_test.yml
@@ -19,14 +19,14 @@ acts:
     - Oh my, did you have a good time?
     - I do feel that way, I try to always have a Christian attitude.
     - Ahaha, I hate running too
-    - 'That is so nice that she made note that you had been wanting it for so long! '
+    - That is so nice that she made note that you had been wanting it for so long!
     - Oh wow, I love hippos and I don't know what sloth look like will let google
       help me out :)
     - What platform do you play it on? PC or PS4?
     - I do hope they stopped the car at least ! That sounds disgusting, but its better
       than throwing up in the car right ?
     - Do you have any idea where you will go? Is it accompanied?
-    - 'so you were really prepared. '
+    - so you were really prepared.
     - That happened to me too.. with the other Exorcist movies and the Ring movies.
       Even though they scared me, I was too curious to not see the others.
     - oh its hurts a little
@@ -47,14 +47,14 @@ acts:
     id: empathetic_dialogues
     label_candidates:
     - Yep! or if you're house will be hit.  Many possibilities with tornadoes!
-    - 'Wow! I better! I Stopped at Associates of General Studies, because I wanted
-      to be a mom more. So that is a HUGE step for you! '
+    - Wow! I better! I Stopped at Associates of General Studies, because I wanted
+      to be a mom more. So that is a HUGE step for you!
     - You have to :) Everyone has bad moments and if you can't laugh at them, then
       they just eat you up!
     - that is awesome, i hope that happens to me on my next trip, where where you
       going
     - Oh, I would love time away like that! How did you enjoy it?
-    - 'I remember these game well, like Contra and Battle Toads. '
+    - I remember these game well, like Contra and Battle Toads.
     - I love going to the Spurs games.
     - That sounds good. I bet it was fun to hangout and eat with your friend.
     - Yes I've got one.  She's a stray that showed up to work one day.
@@ -64,7 +64,7 @@ acts:
     - It must have been! Have you guys been apart before?
     - That is a terrible tragedy, my friend. Did the dog get sick?
     - I bet you were really proud!
-    - 'That blows dude , i bet it was not your fault '
+    - That blows dude , i bet it was not your fault
     - oh no! that's terrible! I've had that happen before and it sucks
     - Oh? That's not good. Do you think he has lots of secrets?
     - Oh wow. How far away did you move??
@@ -97,8 +97,8 @@ acts:
     - Wow! What a great team to be on!
     - My dream job is being born rich. Its too late for that
     - Oh man, the beach always sounds nice
-    - 'It seems like it''s a lot of ruckus, I''ve visited friends who have your situation
-      and I can only imagine. '
+    - It seems like it's a lot of ruckus, I've visited friends who have your situation
+      and I can only imagine.
     - I know how you feel. I'm working right now :(
     - That sounds so good i love steaks
     - Sounds good, when she got back I hope you schooled her on Halo ?
@@ -139,8 +139,8 @@ acts:
     - You should install security cameras outside your house.
     - Border collie. She was great!
     - Oh dear me.. So sorry to hear that! what did you do?
-    - 'Praise God man! He really is amazing and we should always be grateful for we
-      have '
+    - Praise God man! He really is amazing and we should always be grateful for we
+      have
     - Oh no.. Did he pass away?
     situation: My mother stopped by my house one day and said she saw 3 dogs on the
       road, down from our house. They were starving, with ribs showing, and it was
@@ -180,7 +180,7 @@ acts:
       now?
     - sorry to hear! do you have any idea about the break up? did you think about
       it ?
-    - 'That''s a silver lining in all of it at least! '
+    - That's a silver lining in all of it at least!
     - Of course, no one deserves to have their heartbroken like that. I hope you find
       someone who treats you with the respect and kindness you deserve.
     - Wow thats really cool! You must be happy to know about that stuff its interesting!

--- a/parlai/tasks/empathetic_dialogues/test/empathetic_dialogues_valid.yml
+++ b/parlai/tasks/empathetic_dialogues/test/empathetic_dialogues_valid.yml
@@ -10,7 +10,7 @@ acts:
     - The loss of a pet is heartbreaking. I know how you feel. How old was Trevor.
     - I guess that was what you call a temporary situation. Sometimes moving on is
       required.
-    - 'That''s great news, well done. '
+    - That's great news, well done.
     - Oh nice, where are you going?
     - Never late you know!
     - Yes,i am
@@ -21,7 +21,7 @@ acts:
     - Oh my, I hope that doesn't mean more workload for you.
     - That's too bad. What happened? Is everyone OK?
     - That is good. Where you running late
-    - 'That makes all the difference. I am glad you were able to get out of that position. '
+    - That makes all the difference. I am glad you were able to get out of that position.
     - Yea I know that feel, outside of a few people I knew nearly know one and avoided
       lots of people cause no one cared
     - It seems most responsible to alert someone to clean it.
@@ -41,7 +41,7 @@ acts:
     - I've actually never gone there. What's it like?
     - College is when the tear will start to flow. I love children.
     - Ho, I am sorry to hear that.
-    - 'I think it''s very common that we take things for granted. '
+    - I think it's very common that we take things for granted.
     - That's awesome! I'm very excited for you this is a good event for you!
     - What kind of con was it
     - Personally I'm a huge fan of red velvet, but black forest is amazing too!
@@ -51,7 +51,7 @@ acts:
       be thankful for but I know I need to work on just a little bit before I am fully
       content.
     - Well thank you as well.
-    - 'as long as the cake is funfetti i am more than there '
+    - as long as the cake is funfetti i am more than there
     - I don't understand the context of this conversation.
     - well how did it go? did you do well?
     - It ain't so bad. I'm sure you'll make a few new friends and everything will
@@ -81,12 +81,12 @@ acts:
     - How'd it go
     - I agree.. Did something happen?
     - I agree, you need money for everything these days and it controls us.
-    - 'That does sound like a really fun job. I also work freelance and would also
-      like something more stable. '
+    - That does sound like a really fun job. I also work freelance and would also
+      like something more stable.
     - Who did you go see? And are you still friends with all the same people? I wonder
       if any of them kept their ticket stubs too.
     - how did it go
-    - 'That must be so much fun. I have never surfed but love to be on a boat. '
+    - That must be so much fun. I have never surfed but love to be on a boat.
     - That's a good idea. I haven't done that in years. I always feel like I barely
       dodge a bullet by not getting it.
     - That's great! It's definitely a good thing when you can be yourself.
@@ -109,7 +109,7 @@ acts:
     - I would probably scream also.
     id: empathetic_dialogues
     label_candidates:
-    - 'That really does make it special. I''m glad you have that. '
+    - That really does make it special. I'm glad you have that.
     - It must've have been. Glad they are okay now.
     - Well sometimes companies make mistakes. I doubt it's anything you did.
     - Oh no, I'm so so sorry. I've always had at least one pet throughout my life,
@@ -140,7 +140,7 @@ acts:
 - - emotion: excited
     episode_done: false
     eval_labels:
-    - 'Wow! That sounds amazing. Where are you going? '
+    - Wow! That sounds amazing. Where are you going?
     id: empathetic_dialogues
     label_candidates:
     - What kind of school was she at before?
@@ -163,7 +163,7 @@ acts:
       on his face!
     - Where are you located ?
     - Have you talked to him about it?
-    - 'They say dogs are mans best friend. '
+    - They say dogs are mans best friend.
     - That is terrible. How long have you had this pet?
     - That's so exciting! Have you run a marathon before?
     - woohoo! you are one lucky child!


### PR DESCRIPTION
**Patch description**
We had a small bug with one label not being in the label candidates causing a crash in the new ED teacher (#4405). Upon inspection, it was because of a trailing whitespace in the candidate but not the text. Upon further inspection, I found the data had lots of trailing whitespaces. This normalizes that.

**Testing steps**

CI and `parlai em -t empathetic_dialogues -m repeat_query/repeat_label`

Before #4405:
```
$ parlai em -t empathetic_dialogues -m repeat_query
    accuracy   bleu-4  exs    f1
    .0001743 .0007299 5738 .1060

$ parlai em -t empathetic_dialogues -m repeat_label
    accuracy  bleu-4  exs    f1
           1   .9645 5738 .9998
```
After #4405:
(Crashes)

With this PR:
```
$ parlai em -t empathetic_dialogues -m repeat_query
    accuracy   bleu-4  exs    f1
    .0001743 .0007299 5738 .1060

$ parlai em -t empathetic_dialogues -m repeat_label
    accuracy  bleu-4  exs    f1
           1   .9645 5738 .9998
```