### PR TITLE
[RAG] Handle TFIDF retriever with pre-trained model

### DIFF
--- a/parlai/agents/rag/rag.py
+++ b/parlai/agents/rag/rag.py
@@ -553,18 +553,6 @@ class RagAgent(TransformerGeneratorRagAgent, BartRagAgent, T5RagAgent):
         """
         return self._generation_agent._set_text_vec(self, obs, history, truncate)
 
-    def _add_generation_metrics(self, batch: Batch, preds: List[torch.Tensor]):
-        """
-        Can be overridden to allow for some metrics on the generations calculated at
-        eval.
-        """
-        self.record_local_metric(
-            'gen_n_toks',
-            AverageMetric.many(
-                [p.size(0) for p in preds], [1] * len(preds)
-            ),  # type: ignore
-        )
-
     ##### 3. Custom Batch handling #####
 
     def set_batch_query(self, batch: Batch, queries: List[torch.LongTensor]) -> Batch:

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -820,7 +820,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         """
         self.record_local_metric(
             'gen_n_toks',
-            AverageMetric.many([p.size(0) for p in preds], [1] * batch.batchsize),
+            AverageMetric.many([p.size(0) for p in preds], [1] * len(preds)),
         )
 
     def rank_eval_label_candidates(self, batch, batchsize):


### PR DESCRIPTION
**Patch description**
There is currently an issue (#4422) If using a pre-trained RAG/FiD model from the zoo with a TFIDF retriever. This fix includes the `query_encoder` in the TFIDF retriever state dict.

**Testing steps**
CI

```
$ pytest tests/nightly/gpu/test_rag.py  -x
================================================================================ test session starts ================================================================================
platform linux -- Python 3.7.9, pytest-5.3.2, py-1.10.0, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini
plugins: hydra-core-1.1.0, requests-mock-1.7.0, regressions-2.1.1, datadir-1.3.1
collected 43 items

tests/nightly/gpu/test_rag.py ...........................................                                                                                                     [100%]

============================================================================= slowest 10 test durations =============================================================================
69.95s call     tests/nightly/gpu/test_rag.py::TestRagZooModels::test_bart_rag_dpr_poly
67.92s call     tests/nightly/gpu/test_rag.py::TestRagTfidf::test_rag_token
53.12s call     tests/nightly/gpu/test_rag.py::TestFidZooModels::test_bart_fid_rag_dpr_poly
52.52s call     tests/nightly/gpu/test_rag.py::TestRagDprPoly::test_rag_sequence
50.83s call     tests/nightly/gpu/test_rag.py::TestLoadDPRModel::test_load_dpr
47.06s call     tests/nightly/gpu/test_rag.py::TestRagDprPoly::test_rag_turn
45.98s call     tests/nightly/gpu/test_rag.py::TestRagZooModels::test_bart_rag_sequence
45.39s call     tests/nightly/gpu/test_rag.py::TestRagZooModels::test_bart_rag_turn_do
45.07s call     tests/nightly/gpu/test_rag.py::TestRagZooModels::test_bart_rag_turn_dtt
44.52s call     tests/nightly/gpu/test_rag.py::TestFidZooModels::test_bart_fid_dpr
=================================================================== 43 passed, 24 warnings in 1095.44s (0:18:15) ====================================================================
```
