### PR TITLE
Report final evaluation scores mid-way.

### DIFF
--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -238,6 +238,7 @@ def eval_model(opt):
     for task in tasks:
         task_report = _eval_single_world(opt, agent, task)
         reports.append(task_report)
+        logging.report(f"Report for {task}:\n{nice_report(task_report)}")
 
     report = aggregate_named_reports(
         dict(zip(tasks, reports)), micro_average=opt.get('aggregate_micro', False)


### PR DESCRIPTION
**Patch description**
For risky multitask evals that might crash, it's convenient to have printed the final results for a dataset before the very final report at the end.

**Testing steps**
`parlai em -t blended_skill_talk,empathetic_dialogues` on a private model.