### PR TITLE
[SeeKeR] Opt construction for Python 3.8

### DIFF
--- a/projects/seeker/agents/seeker.py
+++ b/projects/seeker/agents/seeker.py
@@ -201,7 +201,7 @@ class SeekerAgent(Agent):
         """
         additional_agent_parser = cls.get_additional_agent_args()
         for action in additional_agent_parser._actions:
-            key = action.option_strings[-1]
+            key = sorted(action.option_strings, key=lambda x: len(x))[-1]
             type = action.type
 
             for prefix in ['krm', 'drm', 'sqm', 'sdm']:

--- a/projects/seeker/agents/seeker.py
+++ b/projects/seeker/agents/seeker.py
@@ -201,7 +201,7 @@ class SeekerAgent(Agent):
         """
         additional_agent_parser = cls.get_additional_agent_args()
         for action in additional_agent_parser._actions:
-            key = sorted(action.option_strings, key=lambda x: len(x))[-1]
+            key = max(action.option_strings, key=lambda x: len(x))
             type = action.type
 
             for prefix in ['krm', 'drm', 'sqm', 'sdm']:


### PR DESCRIPTION
**Patch description**
Fixes issue in #4451 

The opt construction for sub-opts for each agent takes the final option string in the parser; for python < 3.8, this would *always* be the `--` option when a `-` was also present. In Python >=3.8, this seems to be non-deterministic.

The new logic ensures we get the long option every time.

**Testing steps**
Tested sample commands from #4451 
