### PR TITLE
[Bug] Several misc. fixes

### DIFF
--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -59,7 +59,7 @@ class ImageLoader:
         self.netCNN = None
         self.image_mode = opt.get('image_mode', 'no_image_model')
         self.use_cuda = not self.opt.get('no_cuda', False) and torch.cuda.is_available()
-        if self.image_mode not in ['no_image_model', 'raw', 'ascii', 'none']:
+        if self.image_mode not in ['no_image_model', 'raw', 'ascii']:
             if 'image_mode' not in opt or 'image_size' not in opt:
                 raise RuntimeError(
                     'Need to add image arguments to opt. See '

--- a/parlai/core/image_featurizers.py
+++ b/parlai/core/image_featurizers.py
@@ -59,7 +59,7 @@ class ImageLoader:
         self.netCNN = None
         self.image_mode = opt.get('image_mode', 'no_image_model')
         self.use_cuda = not self.opt.get('no_cuda', False) and torch.cuda.is_available()
-        if self.image_mode not in ['no_image_model', 'raw', 'ascii']:
+        if self.image_mode not in ['no_image_model', 'raw', 'ascii', 'none']:
             if 'image_mode' not in opt or 'image_size' not in opt:
                 raise RuntimeError(
                     'Need to add image arguments to opt. See '
@@ -100,7 +100,7 @@ class ImageLoader:
 
         self.transform = self.transforms.Compose(
             [
-                self.transforms.Scale(self.image_size),
+                self.transforms.Resize(self.image_size),
                 self.transforms.CenterCrop(self.crop_size),
                 self.transforms.ToTensor(),
                 self.transforms.Normalize(

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -2113,6 +2113,11 @@ class TorchAgent(ABC, Agent):
             # model it MUST add the fp16 tokens, even if it's not fp16 mode now.
             opt_from_disk['force_fp16_tokens'] = True
 
+        if opt_from_disk.get('image_mode') == 'none':
+            # 2022-03-28 this mode changed to 'no_image_model'
+            opt_from_disk['image_mode'] = 'no_image_model'
+            opt_from_disk['force_fp16_tokens'] = True
+
         return opt_from_disk
 
     def reset(self):

--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -2114,9 +2114,8 @@ class TorchAgent(ABC, Agent):
             opt_from_disk['force_fp16_tokens'] = True
 
         if opt_from_disk.get('image_mode') == 'none':
-            # 2022-03-28 this mode changed to 'no_image_model'
+            # 2022-03-28 this mode changed to 'no_image_model' a long time ago.
             opt_from_disk['image_mode'] = 'no_image_model'
-            opt_from_disk['force_fp16_tokens'] = True
 
         return opt_from_disk
 

--- a/parlai/scripts/interactive_web.py
+++ b/parlai/scripts/interactive_web.py
@@ -275,7 +275,7 @@ def interactive_web(opt):
     agent.opt.log()
     SHARED['opt'] = agent.opt
     SHARED['agent'] = agent
-    SHARED['world'] = create_task(SHARED.get('opt'), [human_agent, SHARED['agent']])
+    SHARED['world'] = create_task(opt, [human_agent, SHARED['agent']])
 
     MyHandler.protocol_version = 'HTTP/1.0'
     httpd = HTTPServer((opt['host'], opt['port']), MyHandler)


### PR DESCRIPTION
**Patch description**
1. `torchvision.transforms.Scale` has been deprecated, replaced with `Resize`
2. `'image_mode': 'none'` is no longer a correct option but still exists in some old model files.
3. `interactive_web` was creating worlds based on agent's opt, not on the actual parsed opt.

**Testing steps**
Tested command in #4454, confirmed that it worked.
