### PR TITLE
Bump Version, Require Python>=3.8

### DIFF
--- a/parlai/__init__.py
+++ b/parlai/__init__.py
@@ -4,4 +4,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-__version__ = '1.5.1'
+__version__ = '1.6.0'

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ import sys
 
 from setuptools import setup, find_packages
 
-VERSION = '1.5.1'  # if you update, update parlai/__init__.py too!
+VERSION = '1.6.0'  # if you update, update parlai/__init__.py too!
 
-if sys.version_info < (3, 7):
-    sys.exit('Sorry, Python >=3.7 is required for ParlAI.')
+if sys.version_info < (3, 8):
+    sys.exit('Sorry, Python >=3.8 is required for ParlAI.')
 
 with open('README.md', encoding="utf8") as f:
     # strip the header and badges etc


### PR DESCRIPTION
**Patch description**
Prep for release of 1.6.0. Also bumping the required Python version.