### PR TITLE
train_model: set default   --eval-dynamic-batching to off

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,26 +222,26 @@ commands:
             - setupcuda
       - fixgit
       - restore_cache:
-          key: deps-20220331-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20220328-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - << parameters.more_installs >>
       - save_cache:
-          key: deps-20220331-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20220328-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
       - findtests:
           marker: << parameters.marker >>
       - restore_cache:
-          key: data-20220331-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20220328-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
       - run:
           name: Run tests
           no_output_timeout: 60m
           command: |
             coverage run -m pytest -m << parameters.marker >> << parameters.pytest_flags >> --junitxml=test-results/junit.xml
       - save_cache:
-          key: data-20220331-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20220328-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
           paths:
             - "~/ParlAI/data"
       - codecov
@@ -258,12 +258,12 @@ commands:
       - checkout
       - fixgit
       - restore_cache:
-          key: deps-20220331-bw-{{ checksum "requirements.txt" }}
+          key: deps-20220328-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - installtorchgpu
       - save_cache:
-          key: deps-20220331-bw-{{ checksum "requirements.txt" }}
+          key: deps-20220328-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,26 +222,26 @@ commands:
             - setupcuda
       - fixgit
       - restore_cache:
-          key: deps-20220328-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20220331-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - << parameters.more_installs >>
       - save_cache:
-          key: deps-20220328-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20220331-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
       - findtests:
           marker: << parameters.marker >>
       - restore_cache:
-          key: data-20220328-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20220331-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
       - run:
           name: Run tests
           no_output_timeout: 60m
           command: |
             coverage run -m pytest -m << parameters.marker >> << parameters.pytest_flags >> --junitxml=test-results/junit.xml
       - save_cache:
-          key: data-20220328-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20220331-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
           paths:
             - "~/ParlAI/data"
       - codecov
@@ -258,12 +258,12 @@ commands:
       - checkout
       - fixgit
       - restore_cache:
-          key: deps-20220328-bw-{{ checksum "requirements.txt" }}
+          key: deps-20220331-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - installtorchgpu
       - save_cache:
-          key: deps-20220328-bw-{{ checksum "requirements.txt" }}
+          key: deps-20220331-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -110,7 +110,7 @@ def setup_args(parser=None) -> ParlaiParser:
         choices={None, 'off', 'full', 'batchsort'},
         help=(
             'Set dynamic batching at evaluation time. Set to off (default) for '
-            'train-only dynamic batching (which maintains the order of examples during validation). ' 
+            'train-only dynamic batching (which maintains the order of examples during validation). '
             'Set to none to use same setting as --dynamic-batching.'
         ),
     )

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -110,7 +110,7 @@ def setup_args(parser=None) -> ParlaiParser:
         choices={None, 'off', 'full', 'batchsort'},
         help=(
             'Set dynamic batching at evaluation time. Set to off (default) for '
-            'train-only dynamic batching (which maintains the order of examples during validation). '
+            'train-only dynamic batching (which maintains the order of examples during validation). ' 
             'Set to none to use same setting as --dynamic-batching.'
         ),
     )

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -105,13 +105,13 @@ def setup_args(parser=None) -> ParlaiParser:
     )
     train.add_argument(
         '--eval-dynamic-batching',  # FIXME: see https://github.com/facebookresearch/ParlAI/issues/3367
-        default=None,
+        default='off',
         type='nonestr',
         choices={None, 'off', 'full', 'batchsort'},
         help=(
-            'Set dynamic batching at evaluation time. Set to off for '
-            'train-only dynamic batching. Set to none (default) to use same '
-            'setting as --dynamic-batching.'
+            'Set dynamic batching at evaluation time. Set to off (default) for '
+            'train-only dynamic batching (which maintains the order of examples during validation). ' 
+            'Set to none to use same setting as --dynamic-batching.'
         ),
     )
     train.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 boto3==1.17.95
 botocore==1.20.95
 coloredlogs==14.0
+click=7.1.2
 datasets>=1.4.1
 docutils<0.16,>=0.14
 emoji==0.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 boto3==1.17.95
 botocore==1.20.95
 coloredlogs==14.0
-click=7.1.2
+click==7.1.2
 datasets>=1.4.1
 docutils<0.16,>=0.14
 emoji==0.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 boto3==1.17.95
 botocore==1.20.95
 coloredlogs==14.0
-click==7.1.2
 datasets>=1.4.1
 docutils<0.16,>=0.14
 emoji==0.5.4


### PR DESCRIPTION
**Patch description**
'eval-dynamic-batching' shuffles the order of the validation set which when using --validation-max-exs may give different results to not using dynamic batching, so this should be by default off I think, to maintain the original order of the validation set.

**Testing steps**
Ran scripts on cluster to verify when eval-dynamic-batching is off, validation numbers are reproducible on commandline without dynamic batching using the original validation order (otherwise they are not) 
