### PR TITLE
[ReRanker] Add reranker-delimiter, adapt it slightly to work with SeeKeR

### DIFF
--- a/parlai/agents/reranker/reranker.py
+++ b/parlai/agents/reranker/reranker.py
@@ -58,6 +58,12 @@ class AbstractReranker(ABC):
             help='Which strategy to use when re-ranking response candidates. '
             f"Choices: {','.join(RERANKER_STRATEGIES)}",
         )
+        reranker.add_argument(
+            '--reranker-delimiter',
+            type=str,
+            default=None,
+            help='delimiter for the retriever',
+        )
         return parser
 
     def __init__(self, opt: Opt, shared=None):
@@ -69,7 +75,9 @@ class AbstractReranker(ABC):
         )
         self.reranker_strategy = opt['reranker_strategy']
         self.normalize_candidates = opt['normalize_candidates']
-        self.delimiter = opt.get('delimiter', '\n')
+        self.delimiter = opt.get('reranker_delimiter', None)
+        if not self.delimiter:
+            self.delimiter = opt.get('delimiter', '\n')
         self.include_context = True
         self.include_label_cand_only = False
         self.init_predictor(opt, shared)
@@ -459,6 +467,12 @@ class AbstractGeneratorRerankAgentMixin:
             default=False,
             help='specify to enable certain debugging procedures.',
         )
+        gen_agent.add_argument(
+            '--inference-opt-key',
+            type=str,
+            default='inference',
+            help='specify inference opt key for dialogue response model',
+        )
 
         return parser
 
@@ -468,8 +482,9 @@ class AbstractGeneratorRerankAgentMixin:
         """
         super().__init__(opt, shared)
         reranker_class = self.get_reranker_class()
+        self.inference_opt_key = opt.get('inference_opt_key', 'inference')
         self.inference_strategies = (
-            opt['inference_strategies'] or opt['inference']
+            opt['inference_strategies'] or opt[self.inference_opt_key]
         ).split(',')
         self.debug_mode = opt.get('debug_mode', False)
         if not shared:
@@ -489,6 +504,11 @@ class AbstractGeneratorRerankAgentMixin:
         """
         assert strategy in RERANKER_STRATEGIES
         self.reranker.reranker_strategy = strategy
+
+    def get_observations_for_reranker(
+        self, observations: List[Message]
+    ) -> List[Message]:
+        return observations
 
     def share(self):
         """
@@ -510,7 +530,7 @@ class AbstractGeneratorRerankAgentMixin:
         batch_reply = [Message() for _ in range(len(observations))]
         # 1. get all beam texts to consider
         for strategy in self.inference_strategies:
-            self.opt['inference'] = strategy
+            self.opt[self.inference_opt_key] = strategy
             inference_batch_reply = super().batch_act(observations)
             for i, resp in enumerate(inference_batch_reply):
                 beam_texts = batch_reply[i].get('beam_texts', [])
@@ -518,7 +538,10 @@ class AbstractGeneratorRerankAgentMixin:
                 new_beam_texts = [(*b, strategy) for b in resp.get('beam_texts', [])]
                 batch_reply[i].force_set('beam_texts', beam_texts + new_beam_texts)
         # 2. Rerank
-        for observation, generator_response in zip(observations, batch_reply):
+        observations_for_reranker = self.get_observations_for_reranker(observations)
+        for observation, generator_response in zip(
+            observations_for_reranker, batch_reply
+        ):
             if (
                 'beam_texts' not in generator_response
                 or not generator_response['beam_texts']


### PR DESCRIPTION
**Patch description**
Changes:
1. Add `reranker_delimiter` arg as otherwise it will share the same delimiter as the transformer generator agent
2. Add field to change the inference opt key. For SeeKeR, the inference key in `op` is 'drm_inference' not 'inference'
3. Add the `get_observations_for_reranker` function. Again useful for SeeKeR case, where the observations come from observations['knowledge_agent'] 

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
