### PR TITLE
Converting the list to ndarray for speedup

### DIFF
--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -656,7 +656,7 @@ class DPRRetriever(RagRetriever):
             query.cpu().detach().to(torch.float32).numpy(), n_docs
         )
         ids, np_vectors = zip(*top_docs_and_scores)
-        vectors = torch.tensor(np_vectors).to(query)
+        vectors = torch.tensor(np.array(np_vectors)).to(query)
         if isinstance(self.indexer, DenseHNSWFlatIndexer):
             vectors = vectors[:, :, :-1]
         # recompute exact FAISS scores


### PR DESCRIPTION
**Patch description**
Creating a tensor from a list of numpy.ndarrays is extremely slow.
converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor.

**Testing steps**
re-run `parlai train_model --model projects.blenderbot2.agents.blenderbot2:BlenderBot2FidAgent ***`, and no UserWarning again.