### PR TITLE
[Reranker] Set decoding method

### DIFF
--- a/parlai/agents/reranker/reranker.py
+++ b/parlai/agents/reranker/reranker.py
@@ -12,7 +12,7 @@ candidate outputs.
 import logging
 import torch
 from abc import ABC, abstractmethod, abstractclassmethod
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 from parlai.agents.transformer.transformer import TransformerGeneratorAgent
 from parlai.core.agents import create_agent_from_model_file, Agent
 from parlai.core.build_data import modelzoo_path
@@ -283,7 +283,7 @@ class AbstractReranker(ABC):
     def rerank(
         self,
         observation: Message,
-        response_cands: List[str],
+        response_cands: Union[List[str], List[Message]],
         response_cand_scores: torch.Tensor,
     ) -> Tuple[List[str], List[int]]:
         """

--- a/parlai/agents/reranker/reranker.py
+++ b/parlai/agents/reranker/reranker.py
@@ -516,6 +516,9 @@ class AbstractGeneratorRerankAgentMixin:
     def set_decoding_method(self, strategy):
         self.opt['inference'] = strategy
 
+    def get_response_cands(self, generator_response):
+        return [b[0] for b in generator_response['beam_texts']]
+
     def batch_act(self, observations: List[Message]) -> List[Message]:
         """
         Batch process a list of observations.
@@ -548,7 +551,7 @@ class AbstractGeneratorRerankAgentMixin:
                 continue
             reranked_candidates, indices = self.reranker.rerank(
                 observation,
-                [b[0] for b in generator_response['beam_texts']],  # text
+                self.get_response_cands(generator_response),  # text
                 torch.tensor([b[1] for b in generator_response['beam_texts']]),  # score
             )
             if self.debug_mode:


### PR DESCRIPTION
**Patch description**
1. Add the `set_decoding_method` for flexibility.
Seems like for the SeeKeR models, in order to use the --inference-strategies one must set decoding through:
`agent_clone.opt['inference'] = XXXX for agent_clone in self.dialogue_agent_clones`
instead of `self.opt['drm_inference'] = XXXX`, since `self.opt['drm_inference']` is only used during initialization.
2. Add the  `batch_reply` as the parameter of  `get_observations_for_reranker` for flexibility:
For the SeeKeR case,  the knowledge sentence can only be accessed thru `batch_reply[i].knowledge_response`. Adding `batch_reply` to the function `get_observations_for_reranker` would be useful for make the context + knowledge_ sentence as the `observation['full_text']`

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
