### PR TITLE
[minor][wandb] Save task arguments as separate config values

### DIFF
--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -194,7 +194,7 @@ class WandbLogger(object):
                     for task_opt in maybe_task_opts:
                         if len(task_opt.split("=")) == 2:
                             k, v = task_opt.split("=")
-                            setattr(self.run.config, k, v)
+                            setattr(self.run.config, k, v, allow_val_change=True)
         if model is not None:
             self.run.watch(model)
 

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -181,20 +181,25 @@ class WandbLogger(object):
             entity=opt.get('wandb_entity'),
             reinit=True,  # in case of preemption
             resume=True,  # requeued runs should be treated as single run
+            allow_val_change=True,
         )
         # suppress wandb's output
         logging.getLogger("wandb").setLevel(logging.ERROR)
 
+        def set_config_value(self, key, value):
+            if self.run.config.get(key, None) != None:
+                setattr(self.run.config, k, v)
+
         if not self.run.resumed:
             for key, value in opt.items():
                 if value is None or isinstance(value, (str, numbers.Number, tuple)):
-                    setattr(self.run.config, key, value)
+                    set_config_value(self, key, value)
                 if key == "task":  # For ags specified in the task argument
                     maybe_task_opts = value.split(":")
                     for task_opt in maybe_task_opts:
                         if len(task_opt.split("=")) == 2:
                             k, v = task_opt.split("=")
-                            setattr(self.run.config, k, v, allow_val_change=True)
+                            set_config_value(self, k, v)
         if model is not None:
             self.run.watch(model)
 

--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -189,6 +189,12 @@ class WandbLogger(object):
             for key, value in opt.items():
                 if value is None or isinstance(value, (str, numbers.Number, tuple)):
                     setattr(self.run.config, key, value)
+                if key == "task":  # For ags specified in the task argument
+                    maybe_task_opts = value.split(":")
+                    for task_opt in maybe_task_opts:
+                        if len(task_opt.split("=")) == 2:
+                            k, v = task_opt.split("=")
+                            setattr(self.run.config, k, v)
         if model is not None:
             self.run.watch(model)
 


### PR DESCRIPTION
Convenience so that we can do UI filters in wandb on values for task arguments.

Test plan:
```
    >>> from parlai.core.logs import WandbLogger
    >>> opt= {"wandb_name": "test_3", "wandb_project": "blah_2", "model_file": "dummy_mf", "task": "blah:x=y:a=2"}
    >>> dummy = WandbLogger(opt)
    >>> dummy.run.config
    {'wandb_name': 'test_3', 'wandb_project': 'blah_2', 'model_file': 'dummy_mf', 'task': 'blah:x=y:a=2', 'x': 'y', 'a': '2'}
```
Also ran a run on SLURM. 