### PR TITLE
[PACER] Adding flexibility +  removing padding idx before v2t

### DIFF
--- a/projects/light_whoami/agents/pacer.py
+++ b/projects/light_whoami/agents/pacer.py
@@ -11,6 +11,7 @@ import random
 import torch
 import torch.nn.functional as F
 from typing import Optional, Any, Dict, List
+from parlai.agents.rag.retrievers import clean_vec
 
 from parlai.agents.transformer.transformer import TransformerGeneratorAgent
 from parlai.core.opt import Opt
@@ -34,6 +35,8 @@ from projects.light_whoami.agents.rpa_rerank import (
 from projects.light_whoami.task.utils import extract_characters
 from projects.msc.agents.long_tga import TransformerVariantAgent
 
+from parlai.agents.reranker.reranker import AbstractReranker
+
 
 class PacerAgentMixin:
     """
@@ -41,10 +44,18 @@ class PacerAgentMixin:
     """
 
     @classmethod
+    def get_partial_only_reranker_class(cls) -> AbstractReranker:
+        """
+        Return class to instantiate classifier
+        """
+        return RPAReranker
+
+    @classmethod
     def add_cmdline_args(
         cls, parser: ParlaiParser, partial_opt: Optional[Opt] = None
     ) -> ParlaiParser:
-        RPAReranker.add_cmdline_args(parser, partial_opt=partial_opt)
+        reranker_class = cls.get_partial_only_reranker_class() or AbstractReranker
+        reranker_class.add_cmdline_args(parser, partial_opt=partial_opt)
         group = parser.add_argument_group('PACER Group')
         group.add_argument(
             '--pacer-n-tokens',
@@ -62,8 +73,9 @@ class PacerAgentMixin:
 
     def __init__(self, opt: Opt, shared=None):
         super().__init__(opt, shared)
-        if not shared:
-            self.classifier = RPAReranker(opt)
+        reranker_class = self.get_partial_only_reranker_class()
+        if not (shared and 'classifier' in shared):
+            self.classifier = reranker_class(opt)
         else:
             self.classifier = shared['classifier']
         assert opt[
@@ -181,15 +193,21 @@ class PacerTreeSearchMixin(TreeSearch):
         self.frequency = kwargs.pop('pacer_frequency_ratio')
         super().__init__(*args, **kwargs)
 
+    def get_target_character(self):
+        return extract_characters(self.context_str)['_self_name']
+
     def set_batch_context(
         self: TSType, batch_context_list: List[List[int]], batch_idx: int
     ) -> TSType:
         """
         Override to save de-tokenized version of context.
         """
-        self.context = batch_context_list[batch_idx]
+        # remove pad_idx from the batch vec
+        self.context = clean_vec(
+            batch_context_list[batch_idx], self.agent.END_IDX, [self.agent.NULL_IDX]
+        )
         self.context_str = self.agent._v2t(self.context)
-        self.character = extract_characters(self.context_str)['_self_name']
+        self.character = self.get_target_character()
         return self
 
     def select_paths(
@@ -257,7 +275,7 @@ class PacerTreeSearchMixin(TreeSearch):
             torch.stack(
                 [
                     F.log_softmax(pred['sorted_scores'].float(), dim=0)[
-                        int(pred['text'] == self.character) - 1
+                        pred['text_candidates'].index(self.character)
                     ]
                     for pred in predictor_outputs
                 ]

--- a/projects/light_whoami/agents/pacer.py
+++ b/projects/light_whoami/agents/pacer.py
@@ -203,10 +203,11 @@ class PacerTreeSearchMixin(TreeSearch):
         Override to save de-tokenized version of context.
         """
         # remove pad_idx from the batch vec
-        self.context = clean_vec(
+        self.context = batch_context_list[batch_idx]
+        clean_context = clean_vec(
             batch_context_list[batch_idx], self.agent.END_IDX, [self.agent.NULL_IDX]
         )
-        self.context_str = self.agent._v2t(self.context)
+        self.context_str = self.agent._v2t(clean_context)
         self.character = self.get_target_character()
         return self
 

--- a/projects/light_whoami/agents/pacer.py
+++ b/projects/light_whoami/agents/pacer.py
@@ -46,7 +46,7 @@ class PacerAgentMixin:
     @classmethod
     def get_partial_only_reranker_class(cls) -> AbstractReranker:
         """
-        Return class to instantiate classifier
+        Return class to instantiate classifier.
         """
         return RPAReranker
 


### PR DESCRIPTION
**Patch description**
1. return Any reranker class not just RPAReranker for partial only agent
2. check if `'classifier' is in shared`, this is for the SeeKeR case, where 
`dialogue_agent = model_class(opt, knowledge_agent.share())` but knowledge_agent.share() doesn't have classifier attribute
3. adding `def get_target_character(self):` that returns the target label the reranker tries to optimize for.
4. removing padding id before applying `self.agent_v2t(self.context)`, otherwise during batch generation one might run into this kind of error `KeyError, '__null__' not found in self.dict`
5. `int(pred['text'] == self.character) - 1` replaced with `pred['text_candidates'].index(self.character)` in case the predictor is a multi-class.

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
