### PR TITLE
Removed empty key/value in validate_onboarding

### DIFF
--- a/parlai/crowdsourcing/tasks/pairwise_per_turn_eval/worlds.py
+++ b/parlai/crowdsourcing/tasks/pairwise_per_turn_eval/worlds.py
@@ -517,10 +517,7 @@ def validate_onboarding(data):
     status_message = messages[-2]
     if status_message is None:
         return False
-    submitted_data = status_message.get('data')
-    if submitted_data is None:
-        return False
-    final_status = submitted_data.get('final_status')
+    final_status = status_message.get('final_status')
     return final_status == ONBOARD_SUCCESS
 
 


### PR DESCRIPTION
I removed `submitted_data` in `validate_onboarding`, as `data` was not in `status_message` and caused an empty value in the `final_status`

**Patch description**
In per_turn_eval's `worlds.py`, the function `validate_onboarding` was trying to get the variable `data` in the dict of `status_message`.But `data` does not exist in the `status_message` and it is causing `final_status` to always be None, therefore blocking all workers. 

Here's the issue https://github.com/facebookresearch/Mephisto/issues/748  where I wanted to reset onboarding qualification, I used a different worker id but found out `validate_onboarding` ended up keep blocking me because the `final_status` is always None. 

**Testing steps**
Launch `run.py` and do onboarding. Perform onboarding correctly and incorrectly to test qualified and disqualified workers and check if `data` ever exists in `status_message` for this task.
