### PR TITLE
[GoldDocFidAgent] clear mapping at the end of each eval_step rather than retrieve step

### DIFF
--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -376,6 +376,12 @@ class GoldDocRetrieverFiDAgent(SearchQueryFiDAgent):
         self.show_observation_to_echo_retriever(observation)
         super()._set_query_vec(observation)
 
+    def eval_step(self, batch):
+        output = super().eval_step(batch)
+        if hasattr(self.model_api.retriever, 'clear_mapping'):
+            self.model_api.retriever.clear_mapping()
+        return output
+
 
 class WizIntGoldDocRetrieverFiDAgent(GoldDocRetrieverFiDAgent):
     """

--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -348,9 +348,9 @@ class GoldDocRetrieverFiDAgent(SearchQueryFiDAgent):
                 'GoldDocRetrieverFiDAgent only works with `rag_retriever_query` being `"full_history"`. '
                 f'Changing opt value for `rag_retriever_query`: `"{prev_sel}"` -> `"full_history"`'
             )
-        if (
-            opt['dynamic_batching'] == 'full'
-            or opt.get('eval_dynamic_batching') == 'full'
+        if not (
+            opt['dynamic_batching'] in [None, 'off']
+            and opt.get('eval_dynamic_batching') in [None, 'off']
         ):
             raise RuntimeError(
                 "For now dynamic batching doesn't work with ObservationEchoRetriever as it cleans up _saved_docs mapping after each batch act."

--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -384,7 +384,7 @@ class GoldDocRetrieverFiDAgent(SearchQueryFiDAgent):
 
     def batch_act(self, observations):
         """
-        Clear the _saved_docs and _query_ids mappings in ObservationEchoRetriever
+        Clear the _saved_docs and _query_ids mappings in ObservationEchoRetriever.
         """
         batch_reply = super().batch_act(observations)
         if hasattr(self.model_api.retriever, 'clear_mapping'):

--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -348,7 +348,13 @@ class GoldDocRetrieverFiDAgent(SearchQueryFiDAgent):
                 'GoldDocRetrieverFiDAgent only works with `rag_retriever_query` being `"full_history"`. '
                 f'Changing opt value for `rag_retriever_query`: `"{prev_sel}"` -> `"full_history"`'
             )
-
+        if (
+            opt['dynamic_batching'] == 'full'
+            or opt.get('eval_dynamic_batching') == 'full'
+        ):
+            raise RuntimeError(
+                "For now dynamic batching doesn't work with ObservationEchoRetriever as it cleans up _saved_docs mapping after each batch act."
+            )
         super().__init__(opt, shared=shared)
 
     @abstractmethod
@@ -377,10 +383,13 @@ class GoldDocRetrieverFiDAgent(SearchQueryFiDAgent):
         super()._set_query_vec(observation)
 
     def batch_act(self, observations):
-        output = super().batch_act(observations)
+        """
+        Clear the _saved_docs and _query_ids mappings in ObservationEchoRetriever
+        """
+        batch_reply = super().batch_act(observations)
         if hasattr(self.model_api.retriever, 'clear_mapping'):
             self.model_api.retriever.clear_mapping()
-        return output
+        return batch_reply
 
 
 class WizIntGoldDocRetrieverFiDAgent(GoldDocRetrieverFiDAgent):

--- a/parlai/agents/fid/fid.py
+++ b/parlai/agents/fid/fid.py
@@ -376,8 +376,8 @@ class GoldDocRetrieverFiDAgent(SearchQueryFiDAgent):
         self.show_observation_to_echo_retriever(observation)
         super()._set_query_vec(observation)
 
-    def eval_step(self, batch):
-        output = super().eval_step(batch)
+    def batch_act(self, observations):
+        output = super().batch_act(observations)
         if hasattr(self.model_api.retriever, 'clear_mapping'):
             self.model_api.retriever.clear_mapping()
         return output

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -1413,7 +1413,7 @@ class RetrievedChunkRanker(DocumentChunkRanker):
         doc_url: str,
     ):
         """
-        Return chunks according to the woi_chunk_retrieved_docs_mutator
+        Return chunks according to the woi_chunk_retrieved_docs_mutator.
         """
         if isinstance(doc_chunks, list):
             docs = ''.join(doc_chunks)

--- a/parlai/agents/rag/retrievers.py
+++ b/parlai/agents/rag/retrievers.py
@@ -1332,7 +1332,7 @@ class ObservationEchoRetriever(RagRetriever):
     def get_delimiter(self) -> str:
         return self._delimiter
 
-    def _clear_mapping(self):
+    def clear_mapping(self):
         self._query_ids = dict()
         self._saved_docs = dict()
         self._largest_seen_idx = -1
@@ -1353,9 +1353,6 @@ class ObservationEchoRetriever(RagRetriever):
         retrieved_doc_scores = retrieved_doc_scores.repeat(batch_size, 1).to(
             query.device
         )
-
-        # empty the 2 mappings after each retrieval
-        self._clear_mapping()
 
         return retrieved_docs, retrieved_doc_scores
 


### PR DESCRIPTION
**Patch description**
When running `parlai em -m BlenderBot2WizIntGoldDocRetrieverFiDAgent --skip-generation False` the `model.encoder` will be called twice, however the `_saved_docs` and `_query_ids` mapping in the observation_echo_retriever will get reset after the retrieval step in the 1st `model.encoder`, and one will run into KeyError when trying to access the `_saved_docs` again during the 2nd `model.encoder`.

The fix is to clear the two mappings at the end of the batch_act

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
