### PR TITLE
python 3.8 parser fix on args_that_override

### DIFF
--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -1099,7 +1099,9 @@ class ParlaiParser(argparse.ArgumentParser):
         if args_that_override is None:
             args_that_override = _sys.argv[1:]
 
-        args_that_override = fix_underscores(args_that_override)
+        args_that_override = self._handle_single_dash_addarg(
+            fix_underscores(args_that_override)
+        )
 
         for i in range(len(args_that_override)):
             if args_that_override[i] in option_strings_dict:

--- a/parlai/core/params.py
+++ b/parlai/core/params.py
@@ -974,6 +974,19 @@ class ParlaiParser(argparse.ArgumentParser):
                 'got an attribute error when parsing.'
             )
 
+    def _handle_single_dash_parsearg(self, args, actions):
+        if _sys.version_info >= (3, 8, 0):
+            newargs = []
+            for arg in args:
+                darg = f'-{arg}'
+                if arg.startswith('-') and not arg.startswith('--') and darg in actions:
+                    newargs.append(darg)
+                else:
+                    newargs.append(arg)
+            return newargs
+        else:
+            return args
+
     def parse_known_args(self, args=None, namespace=None, nohelp=False):
         """
         Parse known args to ignore help flag.
@@ -987,16 +1000,7 @@ class ParlaiParser(argparse.ArgumentParser):
         actions = set()
         for action in self._actions:
             actions.update(action.option_strings)
-        if _sys.version_info >= (3, 8, 0):
-            newargs = []
-            for arg in args:
-                darg = f'-{arg}'
-                if arg.startswith('-') and not arg.startswith('--') and darg in actions:
-                    newargs.append(darg)
-                else:
-                    newargs.append(arg)
-            args = newargs
-
+        args = self._handle_single_dash_parsearg(args, actions)
         if nohelp:
             # ignore help
             args = [
@@ -1099,8 +1103,8 @@ class ParlaiParser(argparse.ArgumentParser):
         if args_that_override is None:
             args_that_override = _sys.argv[1:]
 
-        args_that_override = self._handle_single_dash_addarg(
-            fix_underscores(args_that_override)
+        args_that_override = self._handle_single_dash_parsearg(
+            fix_underscores(args_that_override), option_strings_dict.keys()
         )
 
         for i in range(len(args_that_override)):


### PR DESCRIPTION
**Patch description**
<!--Please enter a clear and concise description of what your pull request does, and why
it is necessary. If your patch fixes an issue, please reference that issue here. -->
I'm running into an issue where the `opt['override']` doesn't contain all the arguments in command lines, e.g. when running `-m XXX `, the key `'model'` isn't in `opt['override']`.

My understanding is it's due to single dash isn't handled properly at the [_process_args_to_opts](https://github.com/facebookresearch/ParlAI/blob/main/parlai/core/params.py#L1105). The option `_strings_dict` in python>=3.8 has all the doubledashes and no singledash
`{....'--model': 'model', '--m': 'model', '--model-file': 'model_file', '--mf': 'model_file', '--im': 'init_model', ...}`
however the [args_that_override](https://github.com/facebookresearch/ParlAI/blob/main/parlai/core/params.py#L1105) has both single and double dashes.

Notice that unlike `_handle_single_dash_addarg` where the input consists of only args (e.g. `args = ('--help', '-h')`) and output reordered args, in `_handle_single_dash_parsearg` the input consists of args and values (e.g. `args = ['i', '--mf', 'zoo:blenderbot2/blenderbot2_400M/model', '--search-server', 'devfair0169:3005/search_server', '--knowledge-access-method', 'classify', '--query-generator-model-file', 'zoo:sea/bart_sq_gen/model', '--m', '....agents', ...]` ), and therefore shouldn't be reordered

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
