### PR TITLE
Fix default tokenizer for HuggingFace Agents

### DIFF
--- a/parlai/agents/hugging_face/dict.py
+++ b/parlai/agents/hugging_face/dict.py
@@ -58,6 +58,14 @@ class HuggingFaceDictionaryAgent(DictionaryAgent, ABC):
             self.opt.get('text_truncate') or self.hf_tokenizer.model_max_length
         )
 
+    def is_prebuilt(self):
+        """
+        Indicates whether the dictionary is fixed, and does not require building.
+
+        Overrides DictionaryAgent.is_prebuilt
+        """
+        return True
+
     @abstractmethod
     def get_tokenizer(self, opt):
         """
@@ -116,12 +124,6 @@ class HuggingFaceDictionaryAgent(DictionaryAgent, ABC):
 
 
 class Gpt2DictionaryAgent(HuggingFaceDictionaryAgent):
-    def is_prebuilt(self):
-        """
-        Indicates whether the dictionary is fixed, and does not require building.
-        """
-        return True
-
     @property
     def add_special_tokens(self) -> bool:
         """


### PR DESCRIPTION
**Patch description**
Updates the HuggingFace agent to over-ride `is_prebuilt` to return True, since HuggingFace agents build their own dictionaries.

Using the default tokenizer setting with T5 caused the exception `ValueError('Dictionaries should be pre-built before distributed train.')`

**Testing steps**
```
parlai mp_train -m parlai.agents.hugging_face.t5:T5Agent -mf /tmp/model_file -t jsonfile --jsonfile-datapath $PATH --fp16 true --t5-model-parallel False --ddp-backend zero2 --jsonfile-datatype-extension True
```


