### PR TITLE
Add gen_n_toks to metrics documentation

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -81,6 +81,9 @@ METRICS_DISPLAY_DATA = {
     "f1": MetricDisplayData(
         "F1", "Unigram F1 overlap, under a standardized (model-independent) tokenizer"
     ),
+    "gen_n_toks": MetricDisplayData(
+        "Generation Length", "Average length of generated outputs in number of tokens"
+    ),
     "gnorm": MetricDisplayData("Gradient Norm", "Gradient norm"),
     "gpu_mem": MetricDisplayData(
         "GPU Memory",


### PR DESCRIPTION
**Patch description**
As in title. Adds documentation for `gen_n_toks` to https://parl.ai/docs/tutorial_metrics.html#list-of-metrics