### PR TITLE
Fix end time update rule for TimerMetric

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -431,7 +431,7 @@ class TimerMetric(Metric):
             return self
         total: TScalar = self._value + other._value
         start: float = min(self._start, other._start)
-        end: float = max(self._start, other._end)
+        end: float = max(self._end, other._end)
         return type(self)(total, start, end)
 
     def value(self) -> float:


### PR DESCRIPTION
**Patch description**
Fix end time update rule for TimerMetric.

**Testing steps**

**Other information**
This doesn't seem to cause any bug at the moment, but it seems like a typo.
