### PR TITLE
update the LCCC download link

### DIFF
--- a/parlai/tasks/lccc/build.py
+++ b/parlai/tasks/lccc/build.py
@@ -6,9 +6,10 @@ import json
 
 RESOURCES = [
     DownloadableFile(
-        'https://cloud.tsinghua.edu.cn/f/f131a4d259184566a29c/?dl=1',
-        'LCCC.zip',
+        '1oobhYW_S_vPPzP5bLAUTIm7TaRzryxgW',
+        'LCCC-base-split.zip',
         'f5203511cd8d6a608008af0aa290aa516d983abc16aa510471e3c4ee6bca7886',
+        from_google=True,
     )
 ]
 


### PR DESCRIPTION
updated the LCCC teacher links to reflect the update here: https://github.com/thu-coai/CDial-GPT/commit/40f2e90d0b239ad9a45ee1edd641905c0df3b088

pytest LCCC teacher test passes.