### PR TITLE
Update task args for wandb logic to be cleaner

### DIFF
--- a/parlai/core/logs.py
+++ b/parlai/core/logs.py
@@ -181,25 +181,27 @@ class WandbLogger(object):
             entity=opt.get('wandb_entity'),
             reinit=True,  # in case of preemption
             resume=True,  # requeued runs should be treated as single run
-            allow_val_change=True,
         )
         # suppress wandb's output
         logging.getLogger("wandb").setLevel(logging.ERROR)
 
-        def set_config_value(self, key, value):
-            if self.run.config.get(key, None) != None:
-                setattr(self.run.config, k, v)
-
         if not self.run.resumed:
-            for key, value in opt.items():
-                if value is None or isinstance(value, (str, numbers.Number, tuple)):
-                    set_config_value(self, key, value)
-                if key == "task":  # For ags specified in the task argument
-                    maybe_task_opts = value.split(":")
+            task_arg = opt.get("task", None)
+            if task_arg:
+                if (
+                    len(task_arg.split(",")) == 1
+                ):  # It gets confusing to parse these args for multitask teachers, so don't.
+                    maybe_task_opts = task_arg.split(":")
                     for task_opt in maybe_task_opts:
                         if len(task_opt.split("=")) == 2:
                             k, v = task_opt.split("=")
-                            set_config_value(self, k, v)
+                            setattr(self.run.config, k, v)
+
+            for key, value in opt.items():
+                if key not in self.run.config:  # set by task logic
+                    if value is None or isinstance(value, (str, numbers.Number, tuple)):
+                        setattr(self.run.config, key, value)
+
         if model is not None:
             self.run.watch(model)
 

--- a/parlai/scripts/eval_model.py
+++ b/parlai/scripts/eval_model.py
@@ -161,7 +161,9 @@ def prepare_tb_logger(opt):
 
 def get_n_parleys(opt):
     trainstats_suffix = '.trainstats'
-    if opt.get('model_file') and PathManager.exists(opt['model_file'] + trainstats_suffix):
+    if opt.get('model_file') and PathManager.exists(
+        opt['model_file'] + trainstats_suffix
+    ):
         with PathManager.open(opt['model_file'] + trainstats_suffix) as ts:
             obj = json.load(ts)
             parleys = obj.get('parleys', 0)


### PR DESCRIPTION
Way easier to reason about things to have the task arg bit be in a separate section; also add in bit to skip splitting for multitask args. 

(Looking at my wandb and commit history, looks like what I ran that was working was a different fork than what I'd used to test on wandb? Not sure at allll how that happened.) 


Test plan:
* Ran locally both with and without multitasking + task args, verified it behaved properly 