### PR TITLE
[Acute-Eval] Mephisto 1.0 compatibility

### DIFF
--- a/parlai/crowdsourcing/tasks/acute_eval/webapp/package-lock.json
+++ b/parlai/crowdsourcing/tasks/acute_eval/webapp/package-lock.json
@@ -2401,9 +2401,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -3037,9 +3037,9 @@
       }
     },
     "mephisto-task": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/mephisto-task/-/mephisto-task-1.0.16.tgz",
-      "integrity": "sha512-16lKIUhao89FELL42W6WqmyEhQqe0RuSbOSYprGKFTE7FtUsi3csoYzj3uzCW3P0zwAVbq6J/lV57QoLT7yzoQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mephisto-task/-/mephisto-task-2.0.1.tgz",
+      "integrity": "sha512-kH38qzk/6zkCWb8TUw23S4MwHBQdClm6k0PS37xkHUzsAIy9CYiRvkhWQ3Tu0zJn3Vhe6T4rC6NIzAK9PmCwaA==",
       "requires": {
         "axios": "^0.21.1",
         "babel-eslint": "10.x",

--- a/parlai/crowdsourcing/tasks/acute_eval/webapp/src/components/core_components.jsx
+++ b/parlai/crowdsourcing/tasks/acute_eval/webapp/src/components/core_components.jsx
@@ -749,7 +749,7 @@ class MultitaskFrontend extends React.Component {
     let passed_props = {
       onValidDataChange: (valid, data) => this.onValidData(valid, data),
       nextButtonCallback: () => this.nextButtonCallback(),
-      allDoneCallback: () => this.props.onSubmit(this.state.response_data),
+      allDoneCallback: () => this.props.onSubmit({final_data: this.state.response_data}),
       show_next_task_button: this.state.show_next_task_button,
       frame_height: frame_height,
       task_config: task_config,


### PR DESCRIPTION
**Patch description**
- Upgrade Acute-Eval frontend code to make it compatible with the style of output passing allowed by Mephisto 1.0
- Update package-lock file accordingly to work with Mephisto 1.0

**Testing steps**
(TBD)
