### PR TITLE
[torchscript] use device type when concatenating tensors

### DIFF
--- a/parlai/torchscript/modules.py
+++ b/parlai/torchscript/modules.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import defaultdict
-from typing import List, Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch.jit
 from parlai.agents.bart.bart import BartAgent
@@ -218,9 +218,13 @@ class TorchScriptGreedySearch(nn.Module):
         if self.is_bart:
             flattened_text_vec = torch.cat(
                 [
-                    torch.tensor([self.start_idx], dtype=torch.long),
-                    flattened_text_vec,
-                    torch.tensor([self.end_idx], dtype=torch.long),
+                    torch.tensor([self.start_idx], dtype=torch.long).to(
+                        self.get_device()
+                    ),
+                    flattened_text_vec.to(self.get_device()),
+                    torch.tensor([self.end_idx], dtype=torch.long).to(
+                        self.get_device()
+                    ),
                 ],
                 dim=0,
             )


### PR DESCRIPTION
**Patch description**

there were errors on some predictor gpu machines for device mismatch so explicitly using the device type when concatenating the tensors

**Testing steps**
Fixing the error
before

![281281826_325898053026523_7071148804019578843_n](https://user-images.githubusercontent.com/17059154/169177912-08621648-e5e4-4dcd-886c-fe95167b52f3.png)


after:
<img width="1358" alt="Screen Shot 2022-05-18 at 4 44 11 PM" src="https://user-images.githubusercontent.com/17059154/169177981-dc32a057-fde5-434f-b178-ffba3b946ad3.png">

**Other information**
