### PR TITLE
cache api calls and responses on setup

### DIFF
--- a/parlai/tasks/multiwoz_v22/agents.py
+++ b/parlai/tasks/multiwoz_v22/agents.py
@@ -15,6 +15,7 @@ import pandas as pd
 from parlai.core.opt import Opt
 import parlai.core.tod.tod_core as tod
 import json
+import pickle
 from typing import Optional
 from parlai.utils.data import DatatypeHelper
 from parlai.utils.io import PathManager
@@ -262,10 +263,20 @@ class MultiwozV22Parser(tod_agents.TodStructuredDataParser):
                                     )
                                 if not valid:
                                     continue
+
                             call = maybe_call
-                            resp = self._get_find_api_response(
-                                intent, frame["state"]["slot_values"], sys_dialog_act
-                            )
+                            call_key = frozenset(call.items())
+
+                            if call_key not in self.call_response_cache:
+                                resp = self._get_find_api_response(
+                                    intent,
+                                    frame["state"]["slot_values"],
+                                    sys_dialog_act,
+                                )
+                                self.call_response_cache[call_key] = resp
+                            else:
+                                resp = self.call_response_cache[call_key]
+
                 elif "book" in intent:
                     for key in sys_dialog_act:
                         if "Book" in key:  # and "Inform" not in key:
@@ -300,8 +311,23 @@ class MultiwozV22Parser(tod_agents.TodStructuredDataParser):
         """
         Parses into TodStructuredEpisode.
         """
-        self.dbs = self.load_dbs()
         self.schemas = self.load_schemas()
+        valid_path = self.dpath + "/valid_call_response_cache"
+        train_path = self.dpath + "/train_call_response_cache"
+        test_path = self.dpath + "/test_call_response_cache"
+        if fold == "valid" and os.path.isfile(valid_path):
+            self.call_response_cache = pickle.load(open(valid_path, "rb"))
+            self.dbs = None
+        elif fold == "train" and os.path.isfile(train_path):
+            self.call_response_cache = pickle.load(open(train_path, "rb"))
+            self.dbs = None
+        elif fold == "test" and os.path.isfile(test_path):
+            self.call_response_cache = pickle.load(open(test_path, "rb"))
+            self.dbs = None
+        else:
+            self.call_response_cache = {}
+            self.dbs = self.load_dbs()
+
         with PathManager.open(os.path.join(self.dpath, "dialog_acts.json")) as f:
             self.dialog_acts = json.load(f)
 
@@ -345,6 +371,17 @@ class MultiwozV22Parser(tod_agents.TodStructuredDataParser):
                 rounds=rounds,
             )
             episodes.append(episode)
+
+        if fold == "valid":
+            with (open(valid_path, "wb")) as openfile:
+                pickle.dump(self.call_response_cache, openfile)
+        if fold == "train":
+            with (open(train_path, "wb")) as openfile:
+                pickle.dump(self.call_response_cache, openfile)
+        if fold == "test":
+            with (open(test_path, "wb")) as openfile:
+                pickle.dump(self.call_response_cache, openfile)
+
         return episodes
 
     def get_id_task_prefix(self):

--- a/parlai/tasks/multiwoz_v22/agents.py
+++ b/parlai/tasks/multiwoz_v22/agents.py
@@ -306,7 +306,7 @@ class MultiwozV22Parser(tod_agents.TodStructuredDataParser):
         return result
 
     def setup_episodes(self, fold):
-        """s
+        """
         Parses into TodStructuredEpisode.
         """
         self.schemas = self.load_schemas()

--- a/parlai/tasks/multiwoz_v22/agents.py
+++ b/parlai/tasks/multiwoz_v22/agents.py
@@ -306,15 +306,15 @@ class MultiwozV22Parser(tod_agents.TodStructuredDataParser):
         return result
 
     def setup_episodes(self, fold):
-        """
+        """s
         Parses into TodStructuredEpisode.
         """
         self.schemas = self.load_schemas()
         cache_path = os.path.join(self.dpath, f"{fold}_call_response_cache.json")
 
         if PathManager.exists(cache_path):
-            with PathManager.open(cache_path) as f:
-                self.call_response_cache = json.load(open(cache_path, "rb"))
+            with PathManager.open(cache_path, 'r') as f:
+                self.call_response_cache = json.load(f)
             self.dbs = None
         else:
             self.call_response_cache = {}
@@ -365,8 +365,7 @@ class MultiwozV22Parser(tod_agents.TodStructuredDataParser):
             episodes.append(episode)
 
         with PathManager.open(cache_path, 'w') as f:
-            json_cache_data = json.dumps(self.call_response_cache)
-            f.write(json_cache_data)
+            json.dump(self.call_response_cache, f)
 
         return episodes
 


### PR DESCRIPTION
**Patch description**
Cache api calls to responses dictionary on setup for multiwoz_v22

**Testing steps**
Unit tests all pass
![image](https://user-images.githubusercontent.com/13056432/171430429-4bff63cf-e734-4eec-9ad9-fcafe23258e2.png)

Train dataset output validation:
Original output on left, new output on right
![image](https://user-images.githubusercontent.com/13056432/171430774-2579ed7e-d637-4d77-8daf-b7a619550acd.png)

Test dataset output:
![image](https://user-images.githubusercontent.com/13056432/171430988-aaba81f9-a753-4548-a3ef-d4a1f26a09e6.png)

Valid dataset output:
![image](https://user-images.githubusercontent.com/13056432/171431076-107ce579-3ac3-4feb-8d31-c892ea4d509f.png)


**Other information**
Unit tests run in 1/4 the time with caching vs without
~63 seconds vs ~257 seconds