### PR TITLE
feat: add exception handling to _unzip method in build_data.py to con…

### DIFF
--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -380,8 +380,13 @@ def _unzip(path, fname, delete=True):
                 PathManager.mkdirs(outpath)
                 continue
             logging.debug(f"Extracting to {outpath}")
-            with zf.open(member, 'r') as inf, PathManager.open(outpath, 'wb') as outf:
-                shutil.copyfileobj(inf, outf)
+            try:
+                with zf.open(member, 'r') as inf, PathManager.open(
+                    outpath, 'wb'
+                ) as outf:
+                    shutil.copyfileobj(inf, outf)
+            except:
+                logging.error(f"Failed to open ${member} and extract to ${outpath}")
     if delete:
         try:
             PathManager.rm(fullpath)

--- a/parlai/core/build_data.py
+++ b/parlai/core/build_data.py
@@ -385,7 +385,7 @@ def _unzip(path, fname, delete=True):
                     outpath, 'wb'
                 ) as outf:
                     shutil.copyfileobj(inf, outf)
-            except:
+            except FileNotFoundError:
                 logging.error(f"Failed to open ${member} and extract to ${outpath}")
     if delete:
         try:


### PR DESCRIPTION
**Patch description**
This patch fixe issue https://github.com/facebookresearch/ParlAI/issues/4567
When _unzip fails to unzip a certain file, execution continues for other files without stopping the whole flow.