### PR TITLE
[WizInt] Custom eval robust to non-messages

### DIFF
--- a/parlai/tasks/wizard_of_internet/agents.py
+++ b/parlai/tasks/wizard_of_internet/agents.py
@@ -378,6 +378,10 @@ class WizardDialogTeacher(WizardOfInternetBaseTeacher):
         labels: Optional[Tuple[str]],
         model_response: Message,
     ) -> None:
+        if not isinstance(teacher_action, Message):
+            teacher_action = Message(teacher_action)
+        if not isinstance(model_response, Message):
+            model_response = Message(model_response)
         if (
             (
                 teacher_action[CONST.SELECTED_SENTENCES][0]

--- a/tests/tasks/test_wizard_of_internet.py
+++ b/tests/tasks/test_wizard_of_internet.py
@@ -7,6 +7,8 @@ import unittest
 from parlai.scripts.display_data import setup_args
 from parlai.utils.testing import display_data
 import parlai.tasks.wizard_of_internet.constants as CONST
+from parlai.core.message import Message
+from parlai.core.teachers import create_task_agent_from_taskname
 
 
 class TestApprenticeDialogTeacher(unittest.TestCase):
@@ -45,6 +47,24 @@ class TestWizardDialogTeacher(unittest.TestCase):
                     started_knowledge_span = False
 
             self.assertFalse(started_knowledge_span)
+
+
+class TestWizardDialogTeacherCustomEval(unittest.TestCase):
+    def test_custom_eval(self):
+        opt = setup_args().parse_args(
+            ['--task', 'wizard_of_internet', '--datatype', 'valid']
+        )
+        teacher = create_task_agent_from_taskname(opt)[0]
+        teacher_action_message = Message(teacher.get(0))
+        teacher_action_nonmessage = {k: v for k, v in teacher_action_message.items()}
+        labels = teacher_action_message.get(
+            'labels', teacher_action_message.get('eval_labels')
+        )
+        agent_nonmessage = {'text': labels[0], 'episode_done': False}
+        agent_message = Message(agent_nonmessage)
+        for t_act in [teacher_action_nonmessage, teacher_action_message]:
+            for m_act in [agent_nonmessage, agent_message]:
+                teacher.custom_evaluation(t_act, labels, m_act)
 
 
 class TestSearchQueryTeacher(unittest.TestCase):


### PR DESCRIPTION
**Patch description**
This patch ensures that the wizint custom evaluation is robust to model responses that are in `dict`, not `Message`, form.

Addresses issue in #4563 

**Testing steps**
Added test to CI
