### PR TITLE
trying prev version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ commands:
       - run:
           name: Installs basic dependencies
           command: |
-            python -m pip install --progress-bar off pip setuptools==62.3.2
+            python -m pip install --progress-bar off pip setuptools==62.3.4
             python -m pip install --progress-bar off coverage
             python -m pip install --progress-bar off codecov
             mkdir -p ~/ParlAI/test-results
@@ -301,7 +301,7 @@ jobs:
           name: Test installation instructions
           no_output_timeout: 60m
           command: |
-            python -m pip install --progress-bar off pip setuptools==62.3.2
+            python -m pip install --progress-bar off pip setuptools==62.3.4
             python setup.py develop
             parlai display_data -t integration_tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ commands:
       - run:
           name: Installs basic dependencies
           command: |
-            python -m pip install --progress-bar off setuptools==62.3.2
+            python -m pip install --progress-bar off pip setuptools==62.3.2
             python -m pip install --progress-bar off coverage
             python -m pip install --progress-bar off codecov
             mkdir -p ~/ParlAI/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ commands:
       - run:
           name: Installs basic dependencies
           command: |
-            python -m pip install --progress-bar off --upgrade pip setuptools
+            python -m pip install --progress-bar off setuptools==62.3.2
             python -m pip install --progress-bar off coverage
             python -m pip install --progress-bar off codecov
             mkdir -p ~/ParlAI/test-results
@@ -301,7 +301,7 @@ jobs:
           name: Test installation instructions
           no_output_timeout: 60m
           command: |
-            python -m pip install --progress-bar off --upgrade pip setuptools
+            python -m pip install --progress-bar off pip setuptools==62.3.2
             python setup.py develop
             parlai display_data -t integration_tests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,6 @@ sphinx_rtd_theme==0.4.3
 sphinx-autodoc-typehints~=1.10.3
 Sphinx~=2.2.0
 subword-nmt==0.3.7
-tensorboard>2.9.0
 tensorboardX==2.1
 tokenizers>=0.8.0
 tomli<2.0.0
@@ -57,4 +56,3 @@ jsonlines==1.2.0
 numpy<=1.21 # Used to be `==1.17.5` before but tests -- pulling in latest at 1.22 not happy
 markdown<=3.3.2 # Pin to something that works so tests are happy
 jinja2==3.0.3
-protobuf<3.20,>=3.9.2 # required by {'tensorboard'}


### PR DESCRIPTION
**Patch description**
Reverted setuptools to the version that didn't fail 
Reverted removal for the tensorflow and protobuf dependencies that didn't help to resolve the failure, but somehow happened to clear tests

In [v62.4.0 version of setuptools](https://setuptools.pypa.io/en/latest/history.html) they [added a new command](https://github.com/pypa/setuptools/pull/3256) "setuptools.command.build" to match distutils.command.build . For some reason, our pipeline fails to find corresponding scripts. With this commit, including temporary workaround that reverts setuptools to its previous state. Ideally we would need to figure why circleCI can't see updates, although logs indicate that newest version was installed.

Failures:
<img width="1124" alt="Screen Shot 2022-06-17 at 11 08 16 PM" src="https://user-images.githubusercontent.com/103262907/174420412-94f95489-5cad-430d-85a9-83f06f0a1c9e.png">

Corresponding version:
<img width="974" alt="Screen Shot 2022-06-17 at 11 08 54 PM" src="https://user-images.githubusercontent.com/103262907/174420437-23637285-f727-4495-b5df-1bbd58820118.png">

