### PR TITLE
[bugfix] Update `frame_height` to integer for turn_annotations

### DIFF
--- a/parlai/crowdsourcing/tasks/dialcrowd/dialcrowd_blueprint.py
+++ b/parlai/crowdsourcing/tasks/dialcrowd/dialcrowd_blueprint.py
@@ -99,7 +99,7 @@ class DialCrowdStaticBlueprint(StaticReactBlueprint):
             {
                 "task_description": self.args.task.get('task_description', None),
                 "task_title": self.args.task.get('task_title', None),
-                "frame_height": '100%',
+                "frame_height": 0,
                 "num_subtasks": self.args.blueprint.subtasks_per_unit,
                 "block_mobile": True,
             }

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/turn_annotations_blueprint.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/turn_annotations_blueprint.py
@@ -217,7 +217,7 @@ class TurnAnnotationsStaticBlueprint(StaticReactBlueprint):
             "annotation_buckets": annotation_buckets,
             "ask_reason": self.args.blueprint.ask_reason,
             "response_field": self.args.blueprint.response_field,
-            "frame_height": '100%',
+            "frame_height": 0,
             "num_subtasks": self.args.blueprint.subtasks_per_unit,
             "block_mobile": True,
         }


### PR DESCRIPTION
**Patch description**

The `frame_height` variable is set to `"100%"` for `turn_annotations_blueprint.py`. (**UPDATE**: Also found and fixed the issue for the dialcrowd task as well.)

https://github.com/facebookresearch/ParlAI/blob/38e08b0b09473b0cb04c25bff736d8e43078e9c3/parlai/crowdsourcing/tasks/turn_annotations_static/turn_annotations_blueprint.py#L220

This will cause an error at task launch time.:

`botocore.exceptions.ClientError: An error occurred (ParameterValidationError) when calling the CreateHITWithHITType operation:
There was an error parsing the XML question or answer data in your request. Please make sure the data is well-formed and validates against the appropriate schema. Details: cvc-elt.1.a: Cannot find the declaration of element 'ExternalQuestion'`

---

There are two issues here.

The first is that only integer values are permitted and we are passing a string here.

The second is that [per MTurk guidelines](https://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_ExternalQuestionArticle.html#ApiReference_ExternalQuestionArticle-the-externalquestion-data-structure), the integer `0` should be used for `FrameHeight` to designate full height.

Both issues are fixed.