### PR TITLE
Search query API timeout and retry

### DIFF
--- a/parlai/agents/rag/retrieve_api.py
+++ b/parlai/agents/rag/retrieve_api.py
@@ -18,6 +18,7 @@ from parlai.utils import logging
 
 
 CONTENT = 'content'
+RETRIEVER_TIMEOUT = 'retriever-timeout'
 DEFAULT_NUM_TO_RETRIEVE = 5
 
 
@@ -86,17 +87,29 @@ class SearchEngineRetriever(RetrieverAPI):
             if opt.get('search_server_timeout', 0) > 0
             else None
         )
+        self._max_num_retries = opt.get('max_num_retries', 0)
 
     def _query_search_server(self, query_term, n):
         server = self.server_address
         req = {'q': query_term, 'n': n}
-        logging.debug(f'sending search request to {server}')
-        server_response = requests.post(server, data=req, timeout=self._server_timeout)
-        resp_status = server_response.status_code
-        if resp_status == 200:
-            return server_response.json().get('response', None)
+        trials = []
+        while True:
+            try:
+                logging.debug(f'sending search request to {server}')
+                server_response = requests.post(
+                    server, data=req, timeout=self._server_timeout
+                )
+                resp_status = server_response.status_code
+                trials.append(f'Response code: {resp_status}')
+                if resp_status == 200:
+                    return server_response.json().get('response', None)
+            except requests.exceptions.Timeout:
+                if len(trials) > self._max_num_retries:
+                    break
+                trials.append(f'Timeout after {self._server_timeout} seconds.')
         logging.error(
-            f'Failed to retrieve data from server! Search server returned status {resp_status}'
+            f'Failed to retrieve data from server after  {len(trials)+1} trials.'
+            f'\nFailed responses: {trials}'
         )
 
     def _validate_server(self, address):

--- a/parlai/agents/rag/retrieve_api.py
+++ b/parlai/agents/rag/retrieve_api.py
@@ -81,12 +81,17 @@ class SearchEngineRetriever(RetrieverAPI):
     def __init__(self, opt: Opt):
         super().__init__(opt=opt)
         self.server_address = self._validate_server(opt.get('search_server'))
+        self._server_timeout = (
+            opt['search_server_timeout']
+            if opt.get('search_server_timeout', 0) > 0
+            else None
+        )
 
     def _query_search_server(self, query_term, n):
         server = self.server_address
         req = {'q': query_term, 'n': n}
         logging.debug(f'sending search request to {server}')
-        server_response = requests.post(server, data=req)
+        server_response = requests.post(server, data=req, timeout=self._server_timeout)
         resp_status = server_response.status_code
         if resp_status == 200:
             return server_response.json().get('response', None)

--- a/parlai/agents/rag/retrieve_api.py
+++ b/parlai/agents/rag/retrieve_api.py
@@ -18,7 +18,6 @@ from parlai.utils import logging
 
 
 CONTENT = 'content'
-RETRIEVER_TIMEOUT = 'retriever-timeout'
 DEFAULT_NUM_TO_RETRIEVE = 5
 
 


### PR DESCRIPTION
# Patch description
Right now, the `SearchEngineRetriever` agent sends a single search request to the search server and waits on that. Without timeout, this may mean that the agent will be blocked until receiving a response (which may never happen). Also upon failure on request, it does not retry. This patch solve this issue. 
Two more opt are added the to the agent:
* `search_server_timeout` that controls timeout in seconds
* `max_num_retries` for the number of times to retry until there is a 200 response from the server.
