### PR TITLE
Early stopping and finetuned optimizer state

### DIFF
--- a/parlai/core/torch_agent.py
+++ b/parlai/core/torch_agent.py
@@ -563,7 +563,7 @@ class TorchAgent(ABC, Agent):
             "--preserve-optimizer-for-finetuning",
             default=False,
             type='bool',
-            help='When starting a finetuning run, preserve the optimizer state from the prior run'
+            help='When starting a finetuning run, preserve the optimizer state from the prior run',
         )
         optim_group.add_argument(
             '-lr', '--learningrate', type=float, default=1, help='Learning rate'
@@ -1080,7 +1080,9 @@ class TorchAgent(ABC, Agent):
         is_finetune_preserving_optimizer = False
         if is_finetune:
             if opt.get("preserve_optimizer_for_finetuning", False):
-                logging.warning('Detected a fine-tune run. But NOT resetting the optimizer since -preserve-optimizer-for-finetuning was set.')
+                logging.warning(
+                    'Detected a fine-tune run. But NOT resetting the optimizer since -preserve-optimizer-for-finetuning was set.'
+                )
                 is_finetune_preserving_optimizer = True
             else:
                 logging.warning('Detected a fine-tune run. Resetting the optimizer.')
@@ -1109,10 +1111,12 @@ class TorchAgent(ABC, Agent):
                 try:
                     self.optimizer.load_state_dict(optim_states)
                     # If we're preserving the optimizer state but still starting
-                    # a new finetuning run, we need to change the learning rate 
+                    # a new finetuning run, we need to change the learning rate
                     # of the optimizer over to the learning rate of the new run.
                     if is_finetune_preserving_optimizer:
-                        logging.warning("Overriding old optimizer state lr to {opt['learningrate']}")
+                        logging.warning(
+                            "Overriding old optimizer state lr to {opt['learningrate']}"
+                        )
                         for group in self.optimizer.param_groups:
                             group['lr'] = opt['learningrate']
                             group['initial_lr'] = opt['learningrate']
@@ -1131,10 +1135,12 @@ class TorchAgent(ABC, Agent):
             try:
                 self.optimizer.load_state_dict(optim_states)
                 # If we're preserving the optimizer state but still starting
-                # a new finetuning run, we need to change the learning rate 
+                # a new finetuning run, we need to change the learning rate
                 # of the optimizer over to the learning rate of the new run.
                 if is_finetune_preserving_optimizer:
-                    logging.warning("Overriding old optimizer state lr to {opt['learningrate']}")
+                    logging.warning(
+                        "Overriding old optimizer state lr to {opt['learningrate']}"
+                    )
                     for group in self.optimizer.param_groups:
                         group['lr'] = opt['learningrate']
                         group['initial_lr'] = opt['learningrate']

--- a/parlai/scripts/train_model.py
+++ b/parlai/scripts/train_model.py
@@ -393,7 +393,7 @@ class TrainLoop:
             opt, 'max_train_time', distributed_warn=True
         )
         self.max_train_steps = _num_else_inf(opt, 'max_train_steps')
-        self.early_stop_at_n_steps =  _num_else_inf(opt, 'early_stop_at_n_steps')
+        self.early_stop_at_n_steps = _num_else_inf(opt, 'early_stop_at_n_steps')
         self.log_every_n_secs = _num_else_inf(
             opt, 'log_every_n_secs', distributed_warn=True
         )

--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -294,8 +294,8 @@ def train_model(opt: Opt) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     If model_file is not in opt, then this helper will create a temporary
     directory to store the model, dict, etc.
 
-    :return: (stdout, valid_results, test_results)
-    :rtype: (str, dict, dict)
+    :return: (valid_results, test_results)
+    :rtype: (dict, dict)
     """
     import parlai.scripts.train_model as tms
 

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -141,7 +141,7 @@ class TestLRSchedulers(unittest.TestCase):
                 'max_train_steps': total_steps,
                 'warmup_updates': warmup_updates,
                 'learningrate': max_lr,
-                **kwargs
+                **kwargs,
             }
         )
 
@@ -165,11 +165,15 @@ class TestLRSchedulers(unittest.TestCase):
         self._run_end2end(lr_scheduler='invsqrt', warmup_updates=50)
 
     def test_end2end_early_stopping(self):
-        _, train_metrics = self._run_end2end(lr_scheduler='linear', warmup_updates=0, early_stop_at_n_steps=75)
+        _, train_metrics = self._run_end2end(
+            lr_scheduler='linear', warmup_updates=0, early_stop_at_n_steps=75
+        )
         self.assertEquals(train_metrics["total_train_updates"].value(), 75)
         # Similarly, here training to 75 steps from LR 1.0 to 0.0 ends at 0.25 LR.
         self.assertAlmostEquals(train_metrics["lr"].value(), 0.25)
-        _, train_metrics = self._run_end2end(lr_scheduler='linear', warmup_updates=50, early_stop_at_n_steps=75)
+        _, train_metrics = self._run_end2end(
+            lr_scheduler='linear', warmup_updates=50, early_stop_at_n_steps=75
+        )
         self.assertEquals(train_metrics["total_train_updates"].value(), 75)
         # ...but with the first 50 steps being warmup, training for 25/50 additional steps
         # from LR 1.0 to 0.0 ends at 0.48, which again is offset forward by 1 step.


### PR DESCRIPTION
**Patch description**
Adds some additional flags that allow some more flexible uses of ParlAI for running experiments when finetuning models and starting/stopping runs to change between similar datasets or different training parameters with the same model.

`--preserve-optimizer-for-finetuning` - during a finetuning run, preserve the optimizer state from the prior run. This can be important for ADAM to not take erroneous steps when starting training again from the model from a prior run.
`--early-stop-at-n-steps` - Stop training early at n steps. This can be convenient for launching a run in several parts, swapping out the dataset or parameters in the middle of a run after n steps, etc, while still obeying the learning rate schedule and/or any other settings that would be used in a longer run.

**Testing steps**
Added a short integration test for --early-stop-at-n-steps to test_lr_schedulers.py.
For `--preserve-optimizer-for-finetuning` I'm a little bit at a loss as to how to test it in a more automated way. I used essentially this change for my own project, but someone has any suggestions how one would more standardly test within the test framework for this library, or even what dataset/model/command would be a good baseline, please feel free to comment.



