### PR TITLE
Fix downloading of TOD models

### DIFF
--- a/parlai/zoo/tod/tod_base_no_api.py
+++ b/parlai/zoo/tod/tod_base_no_api.py
@@ -15,10 +15,10 @@ import os.path
 def download(datapath):
     ddir = os.path.join(get_model_dir(datapath), 'tod_base_no_api')
     model_type = 'tod_base_no_api'
-    version = 'v1.0'
+    version = 'v2.0'
     if not built(os.path.join(ddir, model_type), version):
         opt = {'datapath': datapath, 'model_type': model_type}
-        fnames = ['model.tar.gz']
+        fnames = ['model_v2.tar.gz']
         download_models(
             opt, fnames, 'tod', version=version, path='aws', use_model_type=True
         )

--- a/parlai/zoo/tod/tod_base_yes_api.py
+++ b/parlai/zoo/tod/tod_base_yes_api.py
@@ -16,10 +16,10 @@ def download(datapath):
     ddir = os.path.join(get_model_dir(datapath), 'tod_base_yes_api')
     print(datapath)
     model_type = 'tod_base_yes_api'
-    version = 'v1.0'
+    version = 'v2.0'
     if not built(os.path.join(ddir, model_type), version):
         opt = {'datapath': datapath, 'model_type': model_type}
-        fnames = ['model.tar.gz']
+        fnames = ['model_v2.tar.gz']
         download_models(
             opt, fnames, 'tod', version=version, path='aws', use_model_type=True
         )


### PR DESCRIPTION
Fixing https://github.com/facebookresearch/ParlAI/issues/4627 Definitions inside the models were using the Bart R3F versions which we never actually open sourced. Regular old BART is pretty much the same though.

Test Plan:
On a completely fresh git clone of ParlAI only, run
```
parlai dm -mf zoo:tod/tod_base_no_api/model --skip-generation false  --task  google_sgd_simulation_splits:OutDomainSystemTeacher -dt valid
```

<img width="867" alt="image" src="https://user-images.githubusercontent.com/72097364/177435760-1f9b43b4-6d66-44b5-8885-f88cdcfce03a.png">


and

```
parlai dm -mf zoo:tod/tod_base_yes_api/model --skip-generation false  --task  google_sgd_simulation_splits:OutDomainSystemTeacher -dt valid --api-schemas true
```

<img width="886" alt="image" src="https://user-images.githubusercontent.com/72097364/177435788-fe5f41ae-928b-4b87-8511-f6d5bf73a730.png">


Validate models load properly and don't crash on the `parlai_fb` thing