### PR TITLE
fix frame heights in annotation task

### DIFF
--- a/parlai/crowdsourcing/tasks/turn_annotations_static/turn_annotations_blueprint.py
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/turn_annotations_blueprint.py
@@ -217,7 +217,7 @@ class TurnAnnotationsStaticBlueprint(StaticReactBlueprint):
             "annotation_buckets": annotation_buckets,
             "ask_reason": self.args.blueprint.ask_reason,
             "response_field": self.args.blueprint.response_field,
-            "frame_height": '100%',
+            "frame_height": 0,
             "num_subtasks": self.args.blueprint.subtasks_per_unit,
             "block_mobile": True,
         }


### PR DESCRIPTION
**Patch description**
The current "frame_height": '100%', will cause the annotation task to fail. The proposed change fixed this. 
