### PR TITLE
Fix execute bug in BatchWorld parley function (wrong batch_act index used to send action to `w.execute`)

### DIFF
--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -814,7 +814,7 @@ class BatchWorld(World):
             observation = None
             if batch_actions[i] is None:
                 # shouldn't send None, should send empty observations
-                batch_actions[i] = [{}] * len(self.worlds)
+                batch_actions[i] = {}
 
             if hasattr(w, 'observe'):
                 # The world has its own observe function, which the action

--- a/parlai/core/worlds.py
+++ b/parlai/core/worlds.py
@@ -881,8 +881,8 @@ class BatchWorld(World):
             self.acts[agent_idx] = batch_act
             # We possibly execute this action in the world.
             if hasattr(self.world, 'execute'):
-                for w in self.worlds:
-                    w.execute(w.agents[agent_idx], batch_act[agent_idx])
+                for i, w in enumerate(self.worlds):
+                    w.execute(w.agents[agent_idx], batch_act[i])
             # All agents (might) observe the results.
             for other_index in range(num_agents):
                 obs = self.batch_observe(other_index, batch_act, agent_idx)


### PR DESCRIPTION
**Patch description**
This patch fixes a bug in the `parley` function of `BatchWorld` inside `worlds.py`.
The index of the action it sends to perform `w.execute` was previously incorrect.


**Bug Report**

Previously, `agent_idx` was always used for sending actions for `w.execute`:
`w.execute(w.agents[agent_idx], batch_act[agent_idx])`

This is incorrect because `batch_act` is an array of the same size as `len(self.worlds)`.

In the `__init__` function, `self.worlds` is initialized to be the same size as `--batch-size`, i.e. each world is one sample in the batch. Similartly, `batch_act` is an array containing exactly `--batch-size` elements, where each element in the list corresponds to an action taken by the agent inside each `world`. There is a 1:1 correspondence.

Therefore, this original code block is incorrect:
```
for agent_idx in range(num_agents):
      # The agent acts.
      batch_act = self.batch_act(agent_idx, batch_observations[agent_idx])
      self.acts[agent_idx] = batch_act
      # We possibly execute this action in the world.
      if hasattr(self.world, 'execute'):
          for w in self.worlds:
              w.execute(w.agents[agent_idx], batch_act[agent_idx])
```

This PR fixes the index that gets sent to `w.execute`:

```
for agent_idx in range(num_agents):
      # The agent acts.
      batch_act = self.batch_act(agent_idx, batch_observations[agent_idx])
      self.acts[agent_idx] = batch_act
      # We possibly execute this action in the world.
      if hasattr(self.world, 'execute'):
          for i, w in enumerate(self.worlds):
              w.execute(w.agents[agent_idx], batch_act[i])
```