### PR TITLE
add emoji input functionality to model chat crowdsourcing task

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
+++ b/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
@@ -161,7 +161,7 @@ function FinalSurvey({ taskConfig, onMessageSend, active, currentCheckboxes }) {
   }
 }
 
-function CheckboxTextResponse({ onMessageSend, active, currentCheckboxes }) {
+function CheckboxTextResponse({ onMessageSend, taskConfig, active, currentCheckboxes }) {
   const [textValue, setTextValue] = React.useState("");
   const [sending, setSending] = React.useState(false);
 
@@ -197,28 +197,56 @@ function CheckboxTextResponse({ onMessageSend, active, currentCheckboxes }) {
     [tryMessageSend]
   );
 
-  return (
-    <div className="response-type-module">
-      <div className="response-bar">
+  if (taskConfig.emoji_picker){
+    return (
+      <div className="response-type-module">
+        <div className="response-bar">
         <InputEmoji
-        value={textValue}
-        className="response-text-input"
-        onEnter={(e) => handleKeyPress(e)}
-        onChange={setTextValue}
-        placeholder="Please enter here..."
-        disabled={!active || sending}
-      />        
-        <Button
-          className="btn btn-primary submit-response"
-          id="id_send_msg_button"
-          disabled={textValue === "" || !active || sending}
-          onClick={() => tryMessageSend()}
-        >
-          Send
-        </Button>
+            value={textValue}
+            className="response-text-input"
+            onEnter={(e) => handleKeyPress(e)}
+            onChange={setTextValue}
+            placeholder="Please enter here..."
+          /> 
+          <Button
+            className="btn btn-primary submit-response"
+            id="id_send_msg_button"
+            disabled={textValue === "" || !active || sending}
+            onClick={() => tryMessageSend()}
+          >
+            Send
+          </Button>
+        </div>
       </div>
-    </div>
-  );
+    );
+  } else {
+    return (
+      <div className="response-type-module">
+        <div className="response-bar">
+        <FormControl
+            type="text"
+            className="response-text-input"
+            inputRef={(ref) => {
+              inputRef.current = ref;
+            }}
+            value={textValue}
+            placeholder="Please enter here..."
+            onKeyPress={(e) => handleKeyPress(e)}
+            onChange={(e) => setTextValue(e.target.value)}
+            disabled={!active || sending}
+          /> 
+          <Button
+            className="btn btn-primary submit-response"
+            id="id_send_msg_button"
+            disabled={textValue === "" || !active || sending}
+            onClick={() => tryMessageSend()}
+          >
+            Send
+          </Button>
+        </div>
+      </div>
+    );    
+  }
 }
 
 function ResponseComponent({ taskConfig, appSettings, onMessageSend, active }) {
@@ -244,6 +272,7 @@ function ResponseComponent({ taskConfig, appSettings, onMessageSend, active }) {
     return (
       <CheckboxTextResponse
         onMessageSend={onMessageSend}
+        taskConfig={taskConfig}
         active={computedActive}
         currentCheckboxes={lastMessageAnnotations}
       />

--- a/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
+++ b/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
@@ -8,6 +8,7 @@
 
 import React from "react";
 
+import InputEmoji from 'react-input-emoji'
 import { Button, Col, ControlLabel, Form, FormControl, FormGroup } from "react-bootstrap";
 
 
@@ -199,18 +200,14 @@ function CheckboxTextResponse({ onMessageSend, active, currentCheckboxes }) {
   return (
     <div className="response-type-module">
       <div className="response-bar">
-        <FormControl
-          type="text"
-          className="response-text-input"
-          inputRef={(ref) => {
-            inputRef.current = ref;
-          }}
-          value={textValue}
-          placeholder="Please enter here..."
-          onKeyPress={(e) => handleKeyPress(e)}
-          onChange={(e) => setTextValue(e.target.value)}
-          disabled={!active || sending}
-        />
+        <InputEmoji
+        value={textValue}
+        className="response-text-input"
+        onEnter={(e) => handleKeyPress(e)}
+        onChange={setTextValue}
+        placeholder="Please enter here..."
+        disabled={!active || sending}
+      />        
         <Button
           className="btn btn-primary submit-response"
           id="id_send_msg_button"

--- a/parlai/crowdsourcing/tasks/model_chat/hydra_configs/conf/example.yaml
+++ b/parlai/crowdsourcing/tasks/model_chat/hydra_configs/conf/example.yaml
@@ -17,6 +17,7 @@ mephisto:
     conversation_start_mode: 'hi'
     annotation_question: Does this comment from your partner have any of the following attributes? (Check all that apply)
     conversations_needed_string: "blender_90M:10"
+    emoji_picker: false
   task:
     allowed_concurrent: 1
     assignment_duration_in_seconds: 600

--- a/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
+++ b/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
@@ -155,6 +155,10 @@ class BaseModelChatBlueprintArgs(ParlAIChatBlueprintArgs):
             "in order to override the parlai parser defaults."
         },
     )
+    emoji_picker: bool = field(
+        default=False,
+        metadata={"help": "Show emoji picker."},
+    )
 
 
 class BaseModelChatBlueprint(ParlAIChatBlueprint, ABC):
@@ -295,6 +299,7 @@ class BaseModelChatBlueprint(ParlAIChatBlueprint, ABC):
             "frame_height": 650,
             "final_rating_question": self.args.blueprint.final_rating_question,
             "block_mobile": True,
+            "emoji_picker": self.args.blueprint.emoji_picker,
         }
 
 


### PR DESCRIPTION
Users can now add emojis to the text box by using the emoji picker. To show the emoji picker, you need to set the emoji_picker flag to true (it's set to false by default).

# Test plan:
`npm install react-input-emoji`
`python parlai/crowdsourcing/tasks/model_chat/run.py mephisto.blueprint.emoji_picker=true`

<img width="1347" alt="Screen Shot 2022-07-13 at 5 00 21 PM" src="https://user-images.githubusercontent.com/7689748/178833500-d0830a19-e606-4edf-bec8-a62f1089d738.png">
