### PR TITLE
Add k-fold cross validation and noise mutators

### DIFF
--- a/parlai/mutators/flip_labels.py
+++ b/parlai/mutators/flip_labels.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+from parlai.core.message import Message
+from parlai.core.mutators import MessageMutator, register_mutator
+from parlai.core.opt import Opt
+from parlai.core.params import ParlaiParser
+from parlai.utils.data import DatatypeHelper
+from parlai.utils.misc import warn_once
+import hashlib
+import parlai.utils.logging as logging
+
+import copy
+
+
+"""
+This mutator introduces noise to the training data by either fliping the labels or random set the labels,
+work with binary classification only.
+"""
+
+
+@register_mutator("flip_label")
+class FlipLabelMutator(MessageMutator):
+    @classmethod
+    def add_cmdline_args(
+        cls, parser: ParlaiParser, partial_opt: Optional[Opt] = None
+    ) -> ParlaiParser:
+        super().add_cmdline_args(parser, partial_opt)
+        agent = parser.add_argument_group('FlipLabelMutator args')
+        agent.add_argument(
+            '--noise-level',
+            type=float,
+            help='The probability of label flipping',
+        )
+        return parser
+
+    def __init__(self, opt: Opt):
+        super().__init__(opt)
+        if opt['noise_level'] > 1 or opt['noise_level'] < 0:
+            raise Exception('Noise_level should be within 0 - 1.')
+        if opt['noise_level'] == 0:
+            logging.info('No noise, teacher should be the same as before.')
+        if opt['noise_level'] == 1:
+            logging.info('Labels are exact the opposite.')
+        self.noise_level = opt['noise_level']
+        logging.info(f'Flipping with noise level {self.noise_level}')
+        self.is_training = DatatypeHelper.is_training(opt['datatype'])
+        self.flip_cnt = 0
+        return
+
+    def message_mutation(self, message: Message) -> Message:
+        message = copy.deepcopy(message)
+        if 'labels' in message:
+            labels = message['labels']
+            text = message['text']
+            new_labels = []
+            flip = hashlib.md5(text.encode('utf8')).digest()[0] < self.noise_level * 256
+            if len(labels) != 1:
+                raise ValueError(
+                    f'{type(self).__name__} can only be used with one label!'
+                )
+            else:
+                # deterministic flipping for each example
+                if flip:
+                    self.flip_cnt += 1
+                    if labels[0] == '__ok__':
+                        new_labels = ['__notok__']
+                    elif labels[0] == '__notok__':
+                        new_labels = ['__ok__']
+                    else:
+                        raise ValueError(
+                            f'{type(self).__name__} labels are not in the right format!'
+                        )
+                    assert len(new_labels) == 1
+            if flip:
+                message.force_set('labels', new_labels)
+        return message
+
+    def __del__(self):
+        logging.info(f'Flipped {self.flip_cnt}')
+
+
+@register_mutator("flip_label_train_only")
+class FlipLabelTrainOnlyMutator(FlipLabelMutator):
+    def __init__(self, opt: Opt):
+        super().__init__(opt)
+        if not self.is_training:
+            logging.info('No flipping in eval / test mode.')
+        return
+
+    def message_mutation(self, message: Message) -> Message:
+        if not self.is_training:
+            return message
+        else:
+            return super().message_mutation(message)
+
+
+@register_mutator("flip_label_valid_only")
+class FlipLabelValidOnlyMutator(FlipLabelMutator):
+    def __init__(self, opt: Opt):
+        super().__init__(opt)
+        if not self.is_training:
+            logging.info('No flipping in train mode.')
+        return
+
+    def message_mutation(self, message: Message) -> Message:
+        if self.is_training:
+            return message
+        else:
+            return super().message_mutation(message)
+
+
+@register_mutator("random_label")
+class RandomLabelMutator(FlipLabelMutator):
+    def message_mutation(self, message: Message) -> Message:
+        message = copy.deepcopy(message)
+        if 'labels' in message:
+            labels = message['labels']
+            text = message['text']
+            new_labels = []
+            flip = hashlib.md5(text.encode('utf8')).digest()[0] < self.noise_level * 256
+            if len(labels) != 1:
+                raise ValueError(
+                    f'{type(self).__name__} can only be used with one label!'
+                )
+            else:
+                # deterministic flipping for each example
+                if flip:
+                    self.flip_cnt += 1
+                    if hashlib.md5(text.encode('utf8')).digest()[1] / 256 > 0.5:
+                        new_labels = ['__notok__']
+                    else:
+                        new_labels = ['__ok__']
+
+                    assert len(new_labels) == 1
+            if flip:
+                message.force_set('labels', new_labels)
+        return message

--- a/parlai/mutators/flip_labels.py
+++ b/parlai/mutators/flip_labels.py
@@ -11,7 +11,6 @@ from parlai.core.mutators import MessageMutator, register_mutator
 from parlai.core.opt import Opt
 from parlai.core.params import ParlaiParser
 from parlai.utils.data import DatatypeHelper
-from parlai.utils.misc import warn_once
 import hashlib
 import parlai.utils.logging as logging
 
@@ -24,8 +23,8 @@ work with binary classification only.
 """
 
 
-@register_mutator("flip_label")
-class FlipLabelMutator(MessageMutator):
+@register_mutator("flip_classification_label")
+class FlipClassificationLabelMutator(MessageMutator):
     @classmethod
     def add_cmdline_args(
         cls, parser: ParlaiParser, partial_opt: Optional[Opt] = None
@@ -73,9 +72,7 @@ class FlipLabelMutator(MessageMutator):
                     elif labels[0] == '__notok__':
                         new_labels = ['__ok__']
                     else:
-                        raise ValueError(
-                            f'{type(self).__name__} labels are not in the right format!'
-                        )
+                        raise ValueError("labels must be '__ok__' and '__notok__'")
                     assert len(new_labels) == 1
             if flip:
                 message.force_set('labels', new_labels)
@@ -85,8 +82,8 @@ class FlipLabelMutator(MessageMutator):
         logging.info(f'Flipped {self.flip_cnt}')
 
 
-@register_mutator("flip_label_train_only")
-class FlipLabelTrainOnlyMutator(FlipLabelMutator):
+@register_mutator("flip_classification_label_train_only")
+class FlipClassificationLabelTrainOnlyMutator(FlipClassificationLabelMutator):
     def __init__(self, opt: Opt):
         super().__init__(opt)
         if not self.is_training:
@@ -101,10 +98,10 @@ class FlipLabelTrainOnlyMutator(FlipLabelMutator):
 
 
 @register_mutator("flip_label_valid_only")
-class FlipLabelValidOnlyMutator(FlipLabelMutator):
+class FlipClassificationLabelValidOnlyMutator(FlipClassificationLabelMutator):
     def __init__(self, opt: Opt):
         super().__init__(opt)
-        if not self.is_training:
+        if self.is_training:
             logging.info('No flipping in train mode.')
         return
 
@@ -115,8 +112,8 @@ class FlipLabelValidOnlyMutator(FlipLabelMutator):
             return super().message_mutation(message)
 
 
-@register_mutator("random_label")
-class RandomLabelMutator(FlipLabelMutator):
+@register_mutator("random_classification_label")
+class RandomClassificationLabelMutator(FlipClassificationLabelMutator):
     def message_mutation(self, message: Message) -> Message:
         message = copy.deepcopy(message)
         if 'labels' in message:

--- a/parlai/mutators/k_fold.py
+++ b/parlai/mutators/k_fold.py
@@ -40,7 +40,7 @@ class KFoldWithholdOnTrainMutator(ManyEpisodeMutator):
         agent.add_argument(
             '--held-fold',
             type=int,
-            help='the curent fold reserved from training',
+            help='the current fold reserved from training',
         )
         return parser
 
@@ -48,6 +48,10 @@ class KFoldWithholdOnTrainMutator(ManyEpisodeMutator):
         super().__init__(opt)
         self.k_fold = opt['k_fold']
         self.held_fold = opt['held_fold']
+        assert self.held_fold >= 0, f'held_fold should be greater than 0.'
+        assert (
+            self.held_fold < self.k_fold
+        ), f'held_fold should be smaller than {self.k_fold}.'
         logging.info(
             f'We are doing {self.k_fold}-fold with {self.held_fold} held from training.'
         )

--- a/parlai/mutators/k_fold.py
+++ b/parlai/mutators/k_fold.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional
+
+from parlai.core.message import Message
+from parlai.core.mutators import ManyEpisodeMutator, Mutator, register_mutator
+from parlai.core.opt import Opt
+from parlai.core.params import ParlaiParser
+from parlai.utils.data import DatatypeHelper
+import hashlib
+import parlai.utils.logging as logging
+
+
+"""
+This introduces a k-fold cross validation mutator, that withholds one fold from the train set and then uses this fold for validation purpose.
+"""
+
+
+@register_mutator("k_fold_withhold_on_train")
+class KFoldWithholdOnTrainMutator(ManyEpisodeMutator):
+    """
+    Cross validation mutator, withhold a fold
+    """
+
+    @classmethod
+    def add_cmdline_args(
+        cls, parser: ParlaiParser, partial_opt: Optional[Opt] = None
+    ) -> ParlaiParser:
+        super().add_cmdline_args(parser, partial_opt)
+        agent = parser.add_argument_group('KFoldWithholdOnTrainMutator args')
+        agent.add_argument(
+            '--k-fold',
+            type=int,
+            help='the number of k-fold',
+        )
+        agent.add_argument(
+            '--held-fold',
+            type=int,
+            help='the curent fold reserved from training',
+        )
+        return parser
+
+    def __init__(self, opt: Opt):
+        super().__init__(opt)
+        self.k_fold = opt['k_fold']
+        self.held_fold = opt['held_fold']
+        logging.info(
+            f'We are doing {self.k_fold}-fold with {self.held_fold} held from training.'
+        )
+        self.is_training = DatatypeHelper.is_training(opt['datatype'])
+        self.fold_cnt = 0
+        return
+
+    def many_episode_mutation(self, episode: List[Message]) -> List[List[Message]]:
+        # assuming single message episode
+        if not self.is_training:
+            return [episode]
+        message = episode[0]
+        text = message['text']
+        fold = hashlib.sha256(text.encode('utf8')).digest()[0] % self.k_fold
+        if fold == self.held_fold:
+            self.fold_cnt += 1
+            return []
+        return [episode]
+
+    def __del__(self):
+        logging.info(f'withhold fold has {self.fold_cnt}')
+
+
+@register_mutator("k_fold_release_on_valid")
+class KFoldReleaseOnValidMutator(KFoldWithholdOnTrainMutator):
+    # only use fold k for validation
+    def many_episode_mutation(self, episode: List[Message]) -> List[List[Message]]:
+        # assuming single message episode
+        if self.is_training:
+            return [episode]
+        message = episode[0]
+        text = message['text']
+        fold = hashlib.sha256(text.encode('utf8')).digest()[0] % self.k_fold
+        if fold != self.held_fold:
+            return []
+        self.fold_cnt += 1
+        return [episode]
+
+    def __del__(self):
+        logging.info(f'withhold fold has {self.fold_cnt}')

--- a/parlai/mutators/k_fold.py
+++ b/parlai/mutators/k_fold.py
@@ -7,7 +7,7 @@
 from typing import List, Optional
 
 from parlai.core.message import Message
-from parlai.core.mutators import ManyEpisodeMutator, Mutator, register_mutator
+from parlai.core.mutators import ManyEpisodeMutator, register_mutator
 from parlai.core.opt import Opt
 from parlai.core.params import ParlaiParser
 from parlai.utils.data import DatatypeHelper
@@ -23,7 +23,7 @@ This introduces a k-fold cross validation mutator, that withholds one fold from 
 @register_mutator("k_fold_withhold_on_train")
 class KFoldWithholdOnTrainMutator(ManyEpisodeMutator):
     """
-    Cross validation mutator, withhold a fold
+    Cross validation mutator, withhold a fold.
     """
 
     @classmethod
@@ -57,6 +57,9 @@ class KFoldWithholdOnTrainMutator(ManyEpisodeMutator):
 
     def many_episode_mutation(self, episode: List[Message]) -> List[List[Message]]:
         # assuming single message episode
+        assert (
+            len(episode) == 1
+        ), 'k_fold mutator only works with single message episode.'
         if not self.is_training:
             return [episode]
         message = episode[0]
@@ -76,6 +79,9 @@ class KFoldReleaseOnValidMutator(KFoldWithholdOnTrainMutator):
     # only use fold k for validation
     def many_episode_mutation(self, episode: List[Message]) -> List[List[Message]]:
         # assuming single message episode
+        assert (
+            len(episode) == 1
+        ), 'k_fold mutator only works with single message episode.'
         if self.is_training:
             return [episode]
         message = episode[0]


### PR DESCRIPTION
**Patch description**
This PR adds some mutators:
1. k-fold mutators, where it withholds a certain fold in the train set and later uses that in the validation.
2. Flip labels / random label mutators, they worked in binary classification case, will introduce artificial noise to the data.  
**Testing steps**
```
 parlai display_data -t dialogue_safety:standard --mutators flip_label,k_fold_withhold_on_train  --k-fold 3  --held-fold 1 -dt train -n 8000 --noise-level 1.0
```