### PR TITLE
Upgrade Mephisto, Remove old deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ commands:
             command: |
               cd ..
               git clone git@github.com:facebookresearch/Mephisto.git Mephisto
-              cd Mephisto; git checkout v1.0.2 -b stable
+              cd Mephisto; git checkout v1.0.3 -b stable
               pip install -e .
               # `echo` so that ENTER will be pressed at the prompt
               echo | mephisto check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,9 +147,8 @@ commands:
             command: |
               cd ..
               git clone git@github.com:facebookresearch/Mephisto.git Mephisto
-              cd Mephisto; git checkout v1.0.1 -b stable
-              pip install -r requirements.txt
-              python setup.py develop
+              cd Mephisto; git checkout v1.0.2 -b stable
+              pip install -e .
               # `echo` so that ENTER will be pressed at the prompt
               echo | mephisto check
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,26 +207,26 @@ commands:
             - setupcuda
       - fixgit
       - restore_cache:
-          key: deps-20220622-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20220625-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - << parameters.more_installs >>
       - save_cache:
-          key: deps-20220622-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20220625-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
       - findtests:
           marker: << parameters.marker >>
       - restore_cache:
-          key: data-20220615-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20220625-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
       - run:
           name: Run tests
           no_output_timeout: 60m
           command: |
             coverage run -m pytest -m << parameters.marker >> << parameters.pytest_flags >> --junitxml=test-results/junit.xml
       - save_cache:
-          key: data-20220615-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20220625-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
           paths:
             - "~/ParlAI/data"
       - codecov
@@ -243,12 +243,12 @@ commands:
       - checkout
       - fixgit
       - restore_cache:
-          key: deps-20220622-bw-{{ checksum "requirements.txt" }}
+          key: deps-20220625-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - installtorchgpu
       - save_cache:
-          key: deps-20220622-bw-{{ checksum "requirements.txt" }}
+          key: deps-20220625-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,12 +207,12 @@ commands:
             - setupcuda
       - fixgit
       - restore_cache:
-          key: deps-20220615-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20220622-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - << parameters.more_installs >>
       - save_cache:
-          key: deps-20220615-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20220622-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -243,12 +243,12 @@ commands:
       - checkout
       - fixgit
       - restore_cache:
-          key: deps-20220615-bw-{{ checksum "requirements.txt" }}
+          key: deps-20220622-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - installtorchgpu
       - save_cache:
-          key: deps-20220615-bw-{{ checksum "requirements.txt" }}
+          key: deps-20220622-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/parlai/crowdsourcing/tasks/acute_eval/acute_eval_agent_state.py
+++ b/parlai/crowdsourcing/tasks/acute_eval/acute_eval_agent_state.py
@@ -4,17 +4,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Dict, Any, TYPE_CHECKING
+from typing import List, Dict, Any
 from mephisto.abstractions.blueprints.abstract.static_task.static_agent_state import (
     StaticAgentState,
 )
-import time
-
-if TYPE_CHECKING:
-    from mephisto.data_model.packet import Packet
-
-
-DATA_FILE = "agent_data.json"
 
 
 class AcuteEvalAgentState(StaticAgentState):

--- a/parlai/crowdsourcing/tasks/acute_eval/acute_eval_agent_state.py
+++ b/parlai/crowdsourcing/tasks/acute_eval/acute_eval_agent_state.py
@@ -38,14 +38,3 @@ class AcuteEvalAgentState(StaticAgentState):
             entry.update(outputs["final_data"][idx])
             response_list.append(entry)
         return response_list
-
-    def update_data(self, packet: "Packet") -> None:
-        """
-        Process the incoming data packet, and handle updating the state.
-        """
-        assert (
-            packet.data.get("MEPHISTO_is_submit") is True
-        ), "Static tasks should only have final act"
-        self.state["times"]["task_end"] = time.time()
-        self.state["outputs"] = packet.data["task_data"]
-        self.save_data()

--- a/parlai/crowdsourcing/tasks/acute_eval/webapp/package.json
+++ b/parlai/crowdsourcing/tasks/acute_eval/webapp/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bootstrap": "^4.3.1",
     "jquery": "^3.0.0",
-    "mephisto-task": "^2.0.1",
+    "mephisto-task": "^2.0.2",
     "react": "16.13.1",
     "react-bootstrap": "^0.32.4",
     "react-dom": "16.13.1",

--- a/parlai/crowdsourcing/tasks/dialcrowd/webapp-results/src/components/requesters/template/category/CategoryQuality.js
+++ b/parlai/crowdsourcing/tasks/dialcrowd/webapp-results/src/components/requesters/template/category/CategoryQuality.js
@@ -66,9 +66,18 @@ function getWorkerQuality(t) {
         var userdata = {}
         var userid = user['userId']
 
-        timings.push((user['mephisto_data']['times']['task_end'] - user['mephisto_data']['times']['task_start']).toFixed(2))
+        var has_times_dict = user['mephisto_data']['times'] !== undefined;
+        var run_time = -1;
+        if (has_times_dict) {
+          run_time = user['mephisto_data']['times']['task_end'] - user['mephisto_data']['times']['task_start']
+        } else {
+          console.log("Run time could not be computed, as it must be pulled from metadata.")
+          console.log("Please update the server if you want this functionality.")
+        }
 
-        userdata['time'] = (user['mephisto_data']['times']['task_end'] - user['mephisto_data']['times']['task_start']).toFixed(2)
+        timings.push((run_time).toFixed(2))
+
+        userdata['time'] = (run_time).toFixed(2)
 
         user['mephisto_data']['inputs'].forEach((data, j) => {
           input_sentences[data['id']] = data['sentences'][0]

--- a/parlai/crowdsourcing/tasks/qa_data_collection/webapp/package.json
+++ b/parlai/crowdsourcing/tasks/qa_data_collection/webapp/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bootstrap": "^4.3.1",
     "bootstrap-chat": "^2.0.0",
-    "mephisto-task": "^2.0.1",
+    "mephisto-task": "^2.0.2",
     "rc-slider": "^8.6.3",
     "react": "16.13.1",
     "react-bootstrap": "^0.32.4",

--- a/parlai/crowdsourcing/utils/tests.py
+++ b/parlai/crowdsourcing/utils/tests.py
@@ -261,7 +261,6 @@ class AbstractOneTurnCrowdsourcingTest(AbstractCrowdsourcingTest):
         """
         Given an agent state, test that it is as expected.
         """
-        del state['times']  # Delete variable timestamps
         data_regression.check(state)
 
 
@@ -431,6 +430,16 @@ class AbstractParlAIChatTest(AbstractCrowdsourcingTest):
         self.await_channel_requests()
 
 
+def collapse_whitespace(in_string: str):
+    """
+    Helper function to remove extra whitespace that may make table outputs
+    direct checks fail
+    """
+    while "  " in in_string:
+        in_string = in_string.replace("  ", " ")
+    return in_string
+
+
 def check_stdout(actual_stdout: str, expected_stdout_path: str):
     """
     Check that actual and expected stdouts match.
@@ -447,7 +456,10 @@ def check_stdout(actual_stdout: str, expected_stdout_path: str):
     with open(expected_stdout_path) as f:
         expected_stdout = f.read()
     for expected_line in expected_stdout.split('\n'):
-        if not any(expected_line in actual_line for actual_line in actual_stdout_lines):
+        if not any(
+            collapse_whitespace(expected_line) in collapse_whitespace(actual_line)
+            for actual_line in actual_stdout_lines
+        ):
             raise ValueError(
                 f'\n\tThe following line:\n\n{expected_line}\n\n\twas not found '
                 f'in the actual stdout:\n\n{actual_stdout}'

--- a/parlai/crowdsourcing/utils/tests.py
+++ b/parlai/crowdsourcing/utils/tests.py
@@ -432,8 +432,8 @@ class AbstractParlAIChatTest(AbstractCrowdsourcingTest):
 
 def collapse_whitespace(in_string: str):
     """
-    Helper function to remove extra whitespace that may make table outputs
-    direct checks fail
+    Helper function to remove extra whitespace that may make table outputs direct checks
+    fail.
     """
     while "  " in in_string:
         in_string = in_string.replace("  ", " ")

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,7 @@ tqdm~=4.62.1
 typing-extensions==3.7.4.3
 Unidecode==1.1.1
 urllib3>=1.26.5
+websocket-client==0.56.0
 jsonlines==1.2.0
 numpy<=1.21 # Used to be `==1.17.5` before but tests -- pulling in latest at 1.22 not happy
 markdown<=3.3.2 # Pin to something that works so tests are happy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 # comment just to bump caches
-boto3==1.17.95
-botocore==1.20.95
 coloredlogs==14.0
 datasets<2.2.2,>=1.4.1
 docutils<0.16,>=0.14
@@ -14,12 +12,12 @@ importlib-metadata<4.3
 iopath~=0.1.8
 gitdb2==2.0.5
 GitPython==3.0.3
-hydra-core~=1.1.0
+hydra-core>=1.1.0
 ipython==7.31.1
 torch>=1.4.0
 joblib==0.14.1
 nltk==3.6.6
-omegaconf~=2.1.1
+omegaconf>=2.1.1
 pandas==1.4.0
 pytest_regressions==2.1.1
 pytest==5.3.2
@@ -50,8 +48,6 @@ tqdm~=4.62.1
 typing-extensions==3.7.4.3
 Unidecode==1.1.1
 urllib3>=1.26.5
-websocket-client==0.56.0
-websocket-server==0.4
 jsonlines==1.2.0
 numpy<=1.21 # Used to be `==1.17.5` before but tests -- pulling in latest at 1.22 not happy
 markdown<=3.3.2 # Pin to something that works so tests are happy


### PR DESCRIPTION
**Patch description**
I updated Mephisto here to use our new poetry-prepared version, which should resolve some dependency mismatch issues that had surfaced before between Mephisto and ParlAI. (Poetry is great by the way! May be worth it to adopt).

I also dropped out some dependencies from ParlAI that used to exist for the parlai-mturk implementation. Now that all of the correct requirements are installed when installing Mephisto, they don't belong here.

**Testing steps**
Crowdsourcing tests are passing
