### PR TITLE
Friends teacher include speaker in context

### DIFF
--- a/parlai/tasks/friends/test/friends_all_characters_test.yml
+++ b/parlai/tasks/friends/test/friends_all_characters_test.yml
@@ -2,36 +2,26 @@ acts:
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Rachel Green: Ooy.'
-    id: friends:all_characters
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
-    episode_done: false
-    eval_labels:
-    - 'Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what
-      is life without love?'
+    - Ooy.
     id: friends:all_characters
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
-      Rachel Green: Ooy.'
+      Rachel Green:'
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Rachel Green: Oh my god, are we supposed to answer?'
+    - And to love. Ah, love. L-O-V-E, love. L is for life. And what is life without
+      love?
     id: friends:all_characters
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
 
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?'
+      Ross Geller:'
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of
-      events, which I''m still fine with by the way. E is for how extremely normal
-      I find it. That you two are together. And now one day you might get married
-      and have children of your own.'
+    - Oh my god, are we supposed to answer?
     id: friends:all_characters
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
@@ -40,11 +30,29 @@ acts:
       Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
       life without love?
 
-      Rachel Green: Oh my god, are we supposed to answer?'
+      Rachel Green:'
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Joey Tribbiani: Dude, are you okay?'
+    - O is for "oh, wow!" The V is for this very surprising turn of events, which
+      I'm still fine with by the way. E is for how extremely normal I find it. That
+      you two are together. And now one day you might get married and have children
+      of your own.
+    id: friends:all_characters
+    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+
+      Rachel Green: Ooy.
+
+      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
+      life without love?
+
+      Rachel Green: Oh my god, are we supposed to answer?
+
+      Ross Geller:'
+- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+    episode_done: false
+    eval_labels:
+    - Dude, are you okay?
     id: friends:all_characters
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
@@ -58,6 +66,8 @@ acts:
       Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
       which I''m still fine with by the way. E is for how extremely normal I find
       it. That you two are together. And now one day you might get married and have
-      children of your own.'
+      children of your own.
+
+      Joey Tribbiani:'
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_all_characters_train.yml
+++ b/parlai/tasks/friends/test/friends_all_characters_train.yml
@@ -3,34 +3,27 @@ acts:
     episode_done: false
     id: friends:all_characters
     labels:
-    - 'Ross Geller: Hi!'
-    text: 'Phoebe Buffay: Oh hey! Wait up!'
-- - characters: Phoebe Buffay,Ross Geller
-    episode_done: false
-    id: friends:all_characters
-    labels:
-    - 'Phoebe Buffay: Congratulations! I didn''t want to say anything in front of
-      Joey ''cause I didn''t know if he knew yet.'
+    - Hi!
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
-      Ross Geller: Hi!'
+      Ross Geller:'
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:all_characters
     labels:
-    - 'Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.'
+    - Congratulations! I didn't want to say anything in front of Joey 'cause I didn't
+      know if he knew yet.
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.'
+      Phoebe Buffay:'
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:all_characters
     labels:
-    - 'Phoebe Buffay: No! No, that you and Rachel are engaged!'
+    - What, that we had a baby? Come on let's give him a little credit, although,
+      he did eat a piece of plastic fruit earlier.
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -38,13 +31,12 @@ acts:
       Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
       ''cause I didn''t know if he knew yet.
 
-      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.'
+      Ross Geller:'
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:all_characters
     labels:
-    - 'Ross Geller: What?'
+    - No! No, that you and Rachel are engaged!
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -55,6 +47,24 @@ acts:
       Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
       although, he did eat a piece of plastic fruit earlier.
 
-      Phoebe Buffay: No! No, that you and Rachel are engaged!'
+      Phoebe Buffay:'
+- - characters: Phoebe Buffay,Ross Geller
+    episode_done: false
+    id: friends:all_characters
+    labels:
+    - What?
+    text: 'Phoebe Buffay: Oh hey! Wait up!
+
+      Ross Geller: Hi!
+
+      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
+      ''cause I didn''t know if he knew yet.
+
+      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
+      although, he did eat a piece of plastic fruit earlier.
+
+      Phoebe Buffay: No! No, that you and Rachel are engaged!
+
+      Ross Geller:'
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_all_characters_valid.yml
+++ b/parlai/tasks/friends/test/friends_all_characters_valid.yml
@@ -3,29 +3,19 @@ acts:
       Geller
     episode_done: false
     eval_labels:
-    - 'Joey Tribbiani: Chandler, if it really hurts that bad you should just tell
-      her.'
-    id: friends:all_characters
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.'
+    - Chandler, if it really hurts that bad you should just tell her.
     id: friends:all_characters
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
 
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.'
+      Joey Tribbiani:'
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
-    - 'Ross Geller: Hey.'
+    - Look, for the first time in my life I'm in a real relationship. Okay, I'm not
+      gonna screw that up by y'know, telling the truth.
     id: friends:all_characters
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -33,13 +23,12 @@ acts:
 
       Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
 
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.'
+      Chandler Bing:'
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
-    - 'Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!'
+    - Hey.
     id: friends:all_characters
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -50,12 +39,12 @@ acts:
       Chandler Bing: Look, for the first time in my life I''m in a real relationship.
       Okay, I''m not gonna screw that up by y''know, telling the truth.
 
-      Ross Geller: Hey.'
+      Ross Geller:'
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
-    - 'Ross Geller: Sorry.'
+    - Whoa, dude, look out! You almost crushed my hat!
     id: friends:all_characters
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -68,6 +57,26 @@ acts:
 
       Ross Geller: Hey.
 
-      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!'
+      Joey Tribbiani:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Sorry.
+    id: friends:all_characters
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller:'
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_chandler_test.yml
+++ b/parlai/tasks/friends/test/friends_chandler_test.yml
@@ -1,59 +1,85 @@
 acts:
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+- - characters: Chandler Bing,Joey Tribbiani
+    episode_done: true
+    eval_labels:
+    - I'm gonna hold him a different way. Look I don't understand, if you hated it
+      so much, why did you buy it in the first place?
+    id: friends:chandler
+    text: 'Chandler Bing: Hey look, are we gonna have to bring this out every time
+      Ross comes over?
+
+      Joey Tribbiani: He paid a lot of money for it.
+
+      Chandler Bing:'
+- - characters: Chandler Bing,Joey Tribbiani
     episode_done: false
     eval_labels:
-    - 'Chandler Bing: __SILENCE__'
+    - So is he housetrained or is he gonna leave little bathroom tiles all over the
+      place? Stay. Good, STAY! Good fake dog.
     id: friends:chandler
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+    text: 'Chandler Bing: Hey look, are we gonna have to bring this out every time
+      Ross comes over?
+
+      Joey Tribbiani: He paid a lot of money for it.
+
+      Chandler Bing: I''m gonna hold him a different way. Look I don''t understand,
+      if you hated it so much, why did you buy it in the first place?
+
+      Joey Tribbiani: Well, I had a whole ceramic zoo thing goin'' over there but
+      now, without the other ones, it just looks tacky.
+
+      Chandler Bing:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay
     episode_done: false
     eval_labels:
-    - 'Chandler Bing: __SILENCE__'
+    - You totally screwed him over.
     id: friends:chandler
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+    text: 'Chandler Bing: You told him to play the boxer gay!!
 
-      Rachel Green: Ooy.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+      Joey Tribbiani: Well, I-I might''ve said supergay.
+
+      Chandler Bing:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
     episode_done: false
     eval_labels:
-    - 'Chandler Bing: __SILENCE__'
+    - You're an actor!
     id: friends:chandler
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+    text: 'Monica Geller: Hey you guys?
 
-      Rachel Green: Ooy.
+      Ross Geller: What?
 
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+      Monica Geller: I know it''s last minute, but we decided to have a Halloween
+      party.
+
+      Phoebe Buffay: Oh good!
+
+      Monica Geller: And everybody has to wear costumes. Come on! It''ll be fun!
+
+      Ross Geller: Well, I''ll-I''ll be there. I mean I have to wear a costume to
+      all my classes that day anyway so...
+
+      Rachel Green: Please tell me you''re not gonna dress up like a dinosaur.
+
+      Ross Geller: Not two years in a row.
+
+      Joey Tribbiani: Look, I''ll come to the party but I''m not dressing up.
+
+      Monica Geller: You have to!
+
+      Joey Tribbiani: No way! Look, Halloween is so stupid! Dressing up, pretending
+      to be someone you''re not...
+
+      Chandler Bing:'
+- - characters: Chandler Bing,Joey Tribbiani
     episode_done: false
     eval_labels:
-    - 'Chandler Bing: __SILENCE__'
+    - Hey-hey-hey. So what happened? A forest tick you off?
     id: friends:chandler
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+    text: 'Chandler Bing: Hey!
 
-      Rachel Green: Ooy.
+      Joey Tribbiani: Hey!
 
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?
-
-      Rachel Green: Oh my god, are we supposed to answer?'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
-    episode_done: false
-    eval_labels:
-    - 'Chandler Bing: __SILENCE__'
-    id: friends:chandler
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
-
-      Rachel Green: Ooy.
-
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?
-
-      Rachel Green: Oh my god, are we supposed to answer?
-
-      Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
-      which I''m still fine with by the way. E is for how extremely normal I find
-      it. That you two are together. And now one day you might get married and have
-      children of your own.'
+      Chandler Bing:'
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_chandler_train.yml
+++ b/parlai/tasks/friends/test/friends_chandler_train.yml
@@ -1,58 +1,82 @@
 acts:
-- - characters: Phoebe Buffay,Ross Geller
+- - characters: Chandler Bing
     episode_done: false
     id: friends:chandler
     labels:
-    - 'Chandler Bing: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!'
-- - characters: Phoebe Buffay,Ross Geller
+    - Oh, no, no, I'm an intern, just like you guys... except for the tie, the briefcase...
+      and the fact that I can rent a car.
+    text: 'Chandler Bing: Good morning, everybody.
+
+      Intern: Can I get you a cup of coffee, Sir?
+
+      Chandler Bing:'
+- - characters: Chandler Bing
     episode_done: false
     id: friends:chandler
     labels:
-    - 'Chandler Bing: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - Yeah, well, I'm kinda heading into a new career direction and, you know, you
+      gotta start at the bottom.
+    text: 'Chandler Bing: Good morning, everybody.
 
-      Ross Geller: Hi!'
-- - characters: Phoebe Buffay,Ross Geller
+      Intern: Can I get you a cup of coffee, Sir?
+
+      Chandler Bing: Oh, no, no, I''m an intern, just like you guys... except for
+      the tie, the briefcase... and the fact that I can rent a car.
+
+      Intern: Seriously, you''re an intern?
+
+      Chandler Bing:'
+- - characters: Chandler Bing
     episode_done: false
     id: friends:chandler
     labels:
-    - 'Chandler Bing: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - Right. Look, I know I'm a little bit older than you guys, but it's not like
+      I'm Bob Hope.
+    text: 'Chandler Bing: Good morning, everybody.
 
-      Ross Geller: Hi!
+      Intern: Can I get you a cup of coffee, Sir?
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.'
-- - characters: Phoebe Buffay,Ross Geller
+      Chandler Bing: Oh, no, no, I''m an intern, just like you guys... except for
+      the tie, the briefcase... and the fact that I can rent a car.
+
+      Intern: Seriously, you''re an intern?
+
+      Chandler Bing: Yeah, well, I''m kinda heading into a new career direction and,
+      you know, you gotta start at the bottom.
+
+      Intern: Dude!
+
+      Chandler Bing:'
+- - characters: Chandler Bing
     episode_done: false
     id: friends:chandler
     labels:
-    - 'Chandler Bing: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - The comedian? USO?!
+    text: 'Chandler Bing: Good morning, everybody.
 
-      Ross Geller: Hi!
+      Intern: Can I get you a cup of coffee, Sir?
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.
+      Chandler Bing: Oh, no, no, I''m an intern, just like you guys... except for
+      the tie, the briefcase... and the fact that I can rent a car.
 
-      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.'
-- - characters: Phoebe Buffay,Ross Geller
+      Intern: Seriously, you''re an intern?
+
+      Chandler Bing: Yeah, well, I''m kinda heading into a new career direction and,
+      you know, you gotta start at the bottom.
+
+      Intern: Dude!
+
+      Chandler Bing: Right. Look, I know I''m a little bit older than you guys, but
+      it''s not like I''m Bob Hope.
+
+      Chandler Bing:'
+- - characters: Chandler Bing,Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:chandler
     labels:
-    - 'Chandler Bing: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - Oh, hey.
+    text: 'Phoebe Buffay: Um, Chandler, Ross, this is Robert.
 
-      Ross Geller: Hi!
-
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.
-
-      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.
-
-      Phoebe Buffay: No! No, that you and Rachel are engaged!'
+      Chandler Bing:'
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_chandler_valid.yml
+++ b/parlai/tasks/friends/test/friends_chandler_valid.yml
@@ -3,28 +3,8 @@ acts:
       Geller
     episode_done: false
     eval_labels:
-    - 'Chandler Bing: __SILENCE__'
-    id: friends:chandler
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.'
-    id: friends:chandler
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Chandler Bing: __SILENCE__'
+    - Look, for the first time in my life I'm in a real relationship. Okay, I'm not
+      gonna screw that up by y'know, telling the truth.
     id: friends:chandler
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -32,29 +12,12 @@ acts:
 
       Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
 
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.'
+      Chandler Bing:'
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
-    - 'Chandler Bing: __SILENCE__'
-    id: friends:chandler
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
-
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.
-
-      Ross Geller: Hey.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Chandler Bing: __SILENCE__'
+    - And the bunny got away.
     id: friends:chandler
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -67,6 +30,124 @@ acts:
 
       Ross Geller: Hey.
 
-      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!'
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - And you're gonna make them all disappear.
+    id: friends:chandler
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Done.
+    id: friends:chandler
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Hey.
+    id: friends:chandler
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller: Hey Pheebs, how''s it going?
+
+      Chandler Bing:'
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_joey_test.yml
+++ b/parlai/tasks/friends/test/friends_joey_test.yml
@@ -2,45 +2,7 @@ acts:
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Joey Tribbiani: __SILENCE__'
-    id: friends:joey
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
-    episode_done: false
-    eval_labels:
-    - 'Joey Tribbiani: __SILENCE__'
-    id: friends:joey
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
-
-      Rachel Green: Ooy.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
-    episode_done: false
-    eval_labels:
-    - 'Joey Tribbiani: __SILENCE__'
-    id: friends:joey
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
-
-      Rachel Green: Ooy.
-
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
-    episode_done: false
-    eval_labels:
-    - 'Joey Tribbiani: __SILENCE__'
-    id: friends:joey
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
-
-      Rachel Green: Ooy.
-
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?
-
-      Rachel Green: Oh my god, are we supposed to answer?'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
-    episode_done: false
-    eval_labels:
-    - 'Joey Tribbiani: Dude, are you okay?'
+    - Dude, are you okay?
     id: friends:joey
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
@@ -54,6 +16,227 @@ acts:
       Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
       which I''m still fine with by the way. E is for how extremely normal I find
       it. That you two are together. And now one day you might get married and have
-      children of your own.'
+      children of your own.
+
+      Joey Tribbiani:'
+- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+    episode_done: false
+    eval_labels:
+    - You know what? I think I'm gonna stay here and make sure he's okay.
+    id: friends:joey
+    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+
+      Rachel Green: Ooy.
+
+      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
+      life without love?
+
+      Rachel Green: Oh my god, are we supposed to answer?
+
+      Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
+      which I''m still fine with by the way. E is for how extremely normal I find
+      it. That you two are together. And now one day you might get married and have
+      children of your own.
+
+      Joey Tribbiani: Dude, are you okay?
+
+      Ross Geller: Totally.
+
+      Rachel Green: Ross, you don''t seem okay.
+
+      Ross Geller: I''m sorry, it must be the pressure of entertaining. I think everyone
+      would feel better if we had some flan.
+
+      Charlie Wheeler: Wait, Ross. Ross. I - I have to take off.
+
+      Ross Geller: No!
+
+      Charlie Wheeler: I''m sorry, I have a really early class in the morning, but
+      this has been lovely.
+
+      Ross Geller: Wasn''t it? And you thought it would be awkward with Joey and that
+      you never really liked Rachel.
+
+      Charlie Wheeler: You''re on fire! I''ll call you in the morning, okay?
+
+      Ross Geller: Okay.
+
+      Charlie Wheeler: Alright.
+
+      Charlie Wheeler: God, Rachel, what Ross just said that is just so..
+
+      Rachel Green: Oh, that''s okay, girls tend not to like me.
+
+      Charlie Wheeler: Bye.
+
+      Ross Geller: Okay, I guess it''s just flan for three! Hey, hey, that rhymed!
+
+      Rachel Green: You know what, Ross? I think we''re gonna take off too.
+
+      Ross Geller: Oh, oh. Of course. God, I''m so stupid. You guys are a couple now.
+      I mean, you probably just want to be alone.
+
+      Rachel Green: No, no, it''s just that it''s getting late...
+
+      Ross Geller: Hey, hey, it''s fine. It''s totally fine. We''ve got plenty of
+      margaritas. It''s all good.
+
+      Ross Geller: I don''t even know what that''s for.
+
+      Joey Tribbiani:'
+- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+    episode_done: true
+    eval_labels:
+    - Yeah. I'll see you in the morning.
+    id: friends:joey
+    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+
+      Rachel Green: Ooy.
+
+      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
+      life without love?
+
+      Rachel Green: Oh my god, are we supposed to answer?
+
+      Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
+      which I''m still fine with by the way. E is for how extremely normal I find
+      it. That you two are together. And now one day you might get married and have
+      children of your own.
+
+      Joey Tribbiani: Dude, are you okay?
+
+      Ross Geller: Totally.
+
+      Rachel Green: Ross, you don''t seem okay.
+
+      Ross Geller: I''m sorry, it must be the pressure of entertaining. I think everyone
+      would feel better if we had some flan.
+
+      Charlie Wheeler: Wait, Ross. Ross. I - I have to take off.
+
+      Ross Geller: No!
+
+      Charlie Wheeler: I''m sorry, I have a really early class in the morning, but
+      this has been lovely.
+
+      Ross Geller: Wasn''t it? And you thought it would be awkward with Joey and that
+      you never really liked Rachel.
+
+      Charlie Wheeler: You''re on fire! I''ll call you in the morning, okay?
+
+      Ross Geller: Okay.
+
+      Charlie Wheeler: Alright.
+
+      Charlie Wheeler: God, Rachel, what Ross just said that is just so..
+
+      Rachel Green: Oh, that''s okay, girls tend not to like me.
+
+      Charlie Wheeler: Bye.
+
+      Ross Geller: Okay, I guess it''s just flan for three! Hey, hey, that rhymed!
+
+      Rachel Green: You know what, Ross? I think we''re gonna take off too.
+
+      Ross Geller: Oh, oh. Of course. God, I''m so stupid. You guys are a couple now.
+      I mean, you probably just want to be alone.
+
+      Rachel Green: No, no, it''s just that it''s getting late...
+
+      Ross Geller: Hey, hey, it''s fine. It''s totally fine. We''ve got plenty of
+      margaritas. It''s all good.
+
+      Ross Geller: I don''t even know what that''s for.
+
+      Joey Tribbiani: You know what? I think I''m gonna stay here and make sure he''s
+      okay.
+
+      Rachel Green: Yeah, that''s probably a good idea.
+
+      Joey Tribbiani:'
+- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+    episode_done: false
+    eval_labels:
+    - It doesn't look good, does it?
+    id: friends:joey
+    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+
+      Rachel Green: Ooy.
+
+      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
+      life without love?
+
+      Rachel Green: Oh my god, are we supposed to answer?
+
+      Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
+      which I''m still fine with by the way. E is for how extremely normal I find
+      it. That you two are together. And now one day you might get married and have
+      children of your own.
+
+      Joey Tribbiani: Dude, are you okay?
+
+      Ross Geller: Totally.
+
+      Rachel Green: Ross, you don''t seem okay.
+
+      Ross Geller: I''m sorry, it must be the pressure of entertaining. I think everyone
+      would feel better if we had some flan.
+
+      Charlie Wheeler: Wait, Ross. Ross. I - I have to take off.
+
+      Ross Geller: No!
+
+      Charlie Wheeler: I''m sorry, I have a really early class in the morning, but
+      this has been lovely.
+
+      Ross Geller: Wasn''t it? And you thought it would be awkward with Joey and that
+      you never really liked Rachel.
+
+      Charlie Wheeler: You''re on fire! I''ll call you in the morning, okay?
+
+      Ross Geller: Okay.
+
+      Charlie Wheeler: Alright.
+
+      Charlie Wheeler: God, Rachel, what Ross just said that is just so..
+
+      Rachel Green: Oh, that''s okay, girls tend not to like me.
+
+      Charlie Wheeler: Bye.
+
+      Ross Geller: Okay, I guess it''s just flan for three! Hey, hey, that rhymed!
+
+      Rachel Green: You know what, Ross? I think we''re gonna take off too.
+
+      Ross Geller: Oh, oh. Of course. God, I''m so stupid. You guys are a couple now.
+      I mean, you probably just want to be alone.
+
+      Rachel Green: No, no, it''s just that it''s getting late...
+
+      Ross Geller: Hey, hey, it''s fine. It''s totally fine. We''ve got plenty of
+      margaritas. It''s all good.
+
+      Ross Geller: I don''t even know what that''s for.
+
+      Joey Tribbiani: You know what? I think I''m gonna stay here and make sure he''s
+      okay.
+
+      Rachel Green: Yeah, that''s probably a good idea.
+
+      Joey Tribbiani: Yeah. I''ll see you in the morning.
+
+      Rachel Green: Uh-huh. Okay. You know what, Joey, I don''t think he''s ever gonna
+      be okay with this.
+
+      Joey Tribbiani:'
+- - characters: Chandler Bing,Joey Tribbiani
+    episode_done: false
+    eval_labels:
+    - He paid a lot of money for it.
+    id: friends:joey
+    text: 'Chandler Bing: Hey look, are we gonna have to bring this out every time
+      Ross comes over?
+
+      Joey Tribbiani:'
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_joey_train.yml
+++ b/parlai/tasks/friends/test/friends_joey_train.yml
@@ -1,58 +1,93 @@
 acts:
-- - characters: Phoebe Buffay,Ross Geller
+- - characters: Joey Tribbiani
     episode_done: false
     id: friends:joey
     labels:
-    - 'Joey Tribbiani: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!'
-- - characters: Phoebe Buffay,Ross Geller
+    - Well, you must be new here. Why don't we get a table and I'll buy you a drink.
+    text: 'The Casting Director: Any time you''re ready, Joey.
+
+      Joey Tribbiani:'
+- - characters: Joey Tribbiani
     episode_done: false
     id: friends:joey
     labels:
-    - 'Joey Tribbiani: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - Yeah, sure. Well, you must be new here. Maybe we should-I'm sorry, can I ask
+      you something?
+    text: 'The Casting Director: Any time you''re ready, Joey.
 
-      Ross Geller: Hi!'
-- - characters: Phoebe Buffay,Ross Geller
+      Joey Tribbiani: Well, you must be new here. Why don''t we get a table and I''ll
+      buy you a drink.
+
+      The Casting Director: I''m sorry. Could you, could you try it without the purse?
+
+      Joey Tribbiani:'
+- - characters: Joey Tribbiani
     episode_done: false
     id: friends:joey
     labels:
-    - 'Joey Tribbiani: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - Well, first it's not a purse.
+    text: 'The Casting Director: Any time you''re ready, Joey.
 
-      Ross Geller: Hi!
+      Joey Tribbiani: Well, you must be new here. Why don''t we get a table and I''ll
+      buy you a drink.
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.'
-- - characters: Phoebe Buffay,Ross Geller
+      The Casting Director: I''m sorry. Could you, could you try it without the purse?
+
+      Joey Tribbiani: Yeah, sure. Well, you must be new here. Maybe we should-I''m
+      sorry, can I ask you something?
+
+      The Casting Director: Sure. What?
+
+      Joey Tribbiani:'
+- - characters: Joey Tribbiani
     episode_done: false
     id: friends:joey
     labels:
-    - 'Joey Tribbiani: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - I mean if-if you're thinking it's a woman's bag, it's not. It's a man's bag!
+    text: 'The Casting Director: Any time you''re ready, Joey.
 
-      Ross Geller: Hi!
+      Joey Tribbiani: Well, you must be new here. Why don''t we get a table and I''ll
+      buy you a drink.
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.
+      The Casting Director: I''m sorry. Could you, could you try it without the purse?
 
-      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.'
-- - characters: Phoebe Buffay,Ross Geller
+      Joey Tribbiani: Yeah, sure. Well, you must be new here. Maybe we should-I''m
+      sorry, can I ask you something?
+
+      The Casting Director: Sure. What?
+
+      Joey Tribbiani: Well, first it''s not a purse.
+
+      The Casting Director: Okay, anytime.
+
+      Joey Tribbiani:'
+- - characters: Joey Tribbiani
     episode_done: false
     id: friends:joey
     labels:
-    - 'Joey Tribbiani: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - All right look, let me show you the catalog! See? Huh? It's the latest thing!
+      Everyone's got one! Men! Women! Children! Everyone's carrying them!
+    text: 'The Casting Director: Any time you''re ready, Joey.
 
-      Ross Geller: Hi!
+      Joey Tribbiani: Well, you must be new here. Why don''t we get a table and I''ll
+      buy you a drink.
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.
+      The Casting Director: I''m sorry. Could you, could you try it without the purse?
 
-      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.
+      Joey Tribbiani: Yeah, sure. Well, you must be new here. Maybe we should-I''m
+      sorry, can I ask you something?
 
-      Phoebe Buffay: No! No, that you and Rachel are engaged!'
+      The Casting Director: Sure. What?
+
+      Joey Tribbiani: Well, first it''s not a purse.
+
+      The Casting Director: Okay, anytime.
+
+      Joey Tribbiani: I mean if-if you''re thinking it''s a woman''s bag, it''s not.
+      It''s a man''s bag!
+
+      The Casting Director: Okayyyy! Anddd, go!
+
+      Joey Tribbiani:'
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_joey_valid.yml
+++ b/parlai/tasks/friends/test/friends_joey_valid.yml
@@ -3,58 +3,18 @@ acts:
       Geller
     episode_done: false
     eval_labels:
-    - 'Joey Tribbiani: Chandler, if it really hurts that bad you should just tell
-      her.'
-    id: friends:joey
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Joey Tribbiani: __SILENCE__'
+    - Chandler, if it really hurts that bad you should just tell her.
     id: friends:joey
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
 
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.'
+      Joey Tribbiani:'
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
-    - 'Joey Tribbiani: __SILENCE__'
-    id: friends:joey
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
-
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!'
-    id: friends:joey
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
-
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.
-
-      Ross Geller: Hey.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Joey Tribbiani: __SILENCE__'
+    - Whoa, dude, look out! You almost crushed my hat!
     id: friends:joey
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -67,6 +27,108 @@ acts:
 
       Ross Geller: Hey.
 
-      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!'
+      Joey Tribbiani:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Oh! Yeah, look there's this play all right? And I'm up for the part of this
+      real cool like suave international guy. A real clothes horse. So I figure that
+      everyone at the audition is gonna be wearing this kinda y'know, ultra-hip, high
+      fashion stuff.
+    id: friends:joey
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Yeah, like you could find something as sophisticated as this.
+    id: friends:joey
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Great! Thanks, Rach!
+    id: friends:joey
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani:'
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_monica_test.yml
+++ b/parlai/tasks/friends/test/friends_monica_test.yml
@@ -1,59 +1,103 @@
 acts:
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay
     episode_done: false
     eval_labels:
-    - 'Monica Geller: __SILENCE__'
+    - Joey, you're this guy's teacher. I mean how could you do this?
     id: friends:monica
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+    text: 'Chandler Bing: You told him to play the boxer gay!!
+
+      Joey Tribbiani: Well, I-I might''ve said supergay.
+
+      Chandler Bing: You totally screwed him over.
+
+      Monica Geller:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
     episode_done: false
     eval_labels:
-    - 'Monica Geller: __SILENCE__'
+    - I know it's last minute, but we decided to have a Halloween party.
     id: friends:monica
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+    text: 'Monica Geller: Hey you guys?
 
-      Rachel Green: Ooy.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+      Ross Geller: What?
+
+      Monica Geller:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
     episode_done: false
     eval_labels:
-    - 'Monica Geller: __SILENCE__'
+    - And everybody has to wear costumes. Come on! It'll be fun!
     id: friends:monica
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+    text: 'Monica Geller: Hey you guys?
 
-      Rachel Green: Ooy.
+      Ross Geller: What?
 
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+      Monica Geller: I know it''s last minute, but we decided to have a Halloween
+      party.
+
+      Phoebe Buffay: Oh good!
+
+      Monica Geller:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
     episode_done: false
     eval_labels:
-    - 'Monica Geller: __SILENCE__'
+    - You have to!
     id: friends:monica
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+    text: 'Monica Geller: Hey you guys?
 
-      Rachel Green: Ooy.
+      Ross Geller: What?
 
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?
+      Monica Geller: I know it''s last minute, but we decided to have a Halloween
+      party.
 
-      Rachel Green: Oh my god, are we supposed to answer?'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+      Phoebe Buffay: Oh good!
+
+      Monica Geller: And everybody has to wear costumes. Come on! It''ll be fun!
+
+      Ross Geller: Well, I''ll-I''ll be there. I mean I have to wear a costume to
+      all my classes that day anyway so...
+
+      Rachel Green: Please tell me you''re not gonna dress up like a dinosaur.
+
+      Ross Geller: Not two years in a row.
+
+      Joey Tribbiani: Look, I''ll come to the party but I''m not dressing up.
+
+      Monica Geller:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
     episode_done: false
     eval_labels:
-    - 'Monica Geller: __SILENCE__'
+    - So Ross, are you gonna bring Mona?
     id: friends:monica
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+    text: 'Monica Geller: Hey you guys?
 
-      Rachel Green: Ooy.
+      Ross Geller: What?
 
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?
+      Monica Geller: I know it''s last minute, but we decided to have a Halloween
+      party.
 
-      Rachel Green: Oh my god, are we supposed to answer?
+      Phoebe Buffay: Oh good!
 
-      Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
-      which I''m still fine with by the way. E is for how extremely normal I find
-      it. That you two are together. And now one day you might get married and have
-      children of your own.'
+      Monica Geller: And everybody has to wear costumes. Come on! It''ll be fun!
+
+      Ross Geller: Well, I''ll-I''ll be there. I mean I have to wear a costume to
+      all my classes that day anyway so...
+
+      Rachel Green: Please tell me you''re not gonna dress up like a dinosaur.
+
+      Ross Geller: Not two years in a row.
+
+      Joey Tribbiani: Look, I''ll come to the party but I''m not dressing up.
+
+      Monica Geller: You have to!
+
+      Joey Tribbiani: No way! Look, Halloween is so stupid! Dressing up, pretending
+      to be someone you''re not...
+
+      Chandler Bing: You''re an actor!
+
+      Monica Geller:'
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_monica_train.yml
+++ b/parlai/tasks/friends/test/friends_monica_train.yml
@@ -1,58 +1,269 @@
 acts:
-- - characters: Phoebe Buffay,Ross Geller
+- - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:monica
     labels:
-    - 'Monica Geller: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!'
-- - characters: Phoebe Buffay,Ross Geller
+    - Ohh, sweetie! Hey, I bet you anything that he's gonna call you again.
+    text: 'Rachel Green: Well, I just called Joshua...
+
+      Phoebe Buffay: Oh, how did it go?
+
+      Rachel Green: Well, I did my best to convince him that I''m not some crazy girl
+      who is dying to get married-I''m just going through a hard time.
+
+      Phoebe Buffay: What did he say?
+
+      Rachel Green: Well uh, his answering machine was very understanding. Ugh. I
+      feel blue.
+
+      Monica Geller:'
+- - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:monica
     labels:
-    - 'Monica Geller: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - Again. Y'know what? I think we all did.
+    text: 'Rachel Green: Well, I just called Joshua...
 
-      Ross Geller: Hi!'
-- - characters: Phoebe Buffay,Ross Geller
+      Phoebe Buffay: Oh, how did it go?
+
+      Rachel Green: Well, I did my best to convince him that I''m not some crazy girl
+      who is dying to get married-I''m just going through a hard time.
+
+      Phoebe Buffay: What did he say?
+
+      Rachel Green: Well uh, his answering machine was very understanding. Ugh. I
+      feel blue.
+
+      Monica Geller: Ohh, sweetie! Hey, I bet you anything that he''s gonna call you
+      again.
+
+      Rachel Green: Yeah, maybe, but I don''t think I even care. I don''t think he''s
+      the one I''m sad about. Y''know, I know that I said that I am totally okay with
+      Ross getting married, but as it turns out, I don''t think I''m handling it all
+      that well.
+
+      Phoebe Buffay: Yeah, maybe.
+
+      Rachel Green: And I-I am just trying to figure out why.
+
+      Phoebe Buffay: Any luck?
+
+      Rachel Green: Well, yeah, y''know how Ross and I were on again, off again, on
+      again, off again? I guess I just figured that somewhere down the road, we would
+      be on again.
+
+      Monica Geller:'
+- - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:monica
     labels:
-    - 'Monica Geller: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - Hey!
+    text: 'Rachel Green: Well, I just called Joshua...
 
-      Ross Geller: Hi!
+      Phoebe Buffay: Oh, how did it go?
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.'
-- - characters: Phoebe Buffay,Ross Geller
+      Rachel Green: Well, I did my best to convince him that I''m not some crazy girl
+      who is dying to get married-I''m just going through a hard time.
+
+      Phoebe Buffay: What did he say?
+
+      Rachel Green: Well uh, his answering machine was very understanding. Ugh. I
+      feel blue.
+
+      Monica Geller: Ohh, sweetie! Hey, I bet you anything that he''s gonna call you
+      again.
+
+      Rachel Green: Yeah, maybe, but I don''t think I even care. I don''t think he''s
+      the one I''m sad about. Y''know, I know that I said that I am totally okay with
+      Ross getting married, but as it turns out, I don''t think I''m handling it all
+      that well.
+
+      Phoebe Buffay: Yeah, maybe.
+
+      Rachel Green: And I-I am just trying to figure out why.
+
+      Phoebe Buffay: Any luck?
+
+      Rachel Green: Well, yeah, y''know how Ross and I were on again, off again, on
+      again, off again? I guess I just figured that somewhere down the road, we would
+      be on again.
+
+      Monica Geller: Again. Y''know what? I think we all did.
+
+      Ross Geller: Hey!
+
+      Monica Geller:'
+- - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:monica
     labels:
-    - 'Monica Geller: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - Oh, I wish there was a job where I could wear this all the time. Maybe someday,
+      there will be.
+    text: 'Rachel Green: Well, I just called Joshua...
 
-      Ross Geller: Hi!
+      Phoebe Buffay: Oh, how did it go?
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.
+      Rachel Green: Well, I did my best to convince him that I''m not some crazy girl
+      who is dying to get married-I''m just going through a hard time.
 
-      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.'
-- - characters: Phoebe Buffay,Ross Geller
+      Phoebe Buffay: What did he say?
+
+      Rachel Green: Well uh, his answering machine was very understanding. Ugh. I
+      feel blue.
+
+      Monica Geller: Ohh, sweetie! Hey, I bet you anything that he''s gonna call you
+      again.
+
+      Rachel Green: Yeah, maybe, but I don''t think I even care. I don''t think he''s
+      the one I''m sad about. Y''know, I know that I said that I am totally okay with
+      Ross getting married, but as it turns out, I don''t think I''m handling it all
+      that well.
+
+      Phoebe Buffay: Yeah, maybe.
+
+      Rachel Green: And I-I am just trying to figure out why.
+
+      Phoebe Buffay: Any luck?
+
+      Rachel Green: Well, yeah, y''know how Ross and I were on again, off again, on
+      again, off again? I guess I just figured that somewhere down the road, we would
+      be on again.
+
+      Monica Geller: Again. Y''know what? I think we all did.
+
+      Ross Geller: Hey!
+
+      Monica Geller: Hey!
+
+      Ross Geller: So, I got us some reservations for Sunday night, okay? How about,
+      Ernie''s at 9 o''clock?
+
+      Rachel Green: Yeah, well, you uh, better make it for three.
+
+      Ross Geller: Oh, see I-I don''t know if we''re gonna be hungry at three.
+
+      Rachel Green: Three people. Joshua''s not gonna be there.
+
+      Ross Geller: What happened?
+
+      Rachel Green: Uh, well, I think, I think he broke up with me.
+
+      Ross Geller: Noo. Why?
+
+      Rachel Green: Well, apparently he scares easy.
+
+      Ross Geller: Oh, Rachel, I''m-I''m sorry.
+
+      Rachel Green: It''s okay. Sometimes, things don''t work out the way you''d thought
+      they would.
+
+      Ross Geller: Come here.
+
+      Rachel Green: Oh, hey, don''t you have to go pick up Emily?
+
+      Ross Geller: Yeah.
+
+      Rachel Green: Yeah.
+
+      Ross Geller: You okay?
+
+      Rachel Green: Yeah! I got my girls.
+
+      Rachel Green: Ugh.
+
+      Phoebe Buffay: Hey, y''know what might cheer you up?
+
+      Rachel Green: What?
+
+      Rachel Green: Y''know, I gotta tell ya, this really does put in a better mood.
+
+      Monica Geller:'
+- - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:monica
     labels:
-    - 'Monica Geller: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - Oh God! He's gonna come by and borrow some candles for his big date!
+    text: 'Rachel Green: Well, I just called Joshua...
 
-      Ross Geller: Hi!
+      Phoebe Buffay: Oh, how did it go?
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.
+      Rachel Green: Well, I did my best to convince him that I''m not some crazy girl
+      who is dying to get married-I''m just going through a hard time.
 
-      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.
+      Phoebe Buffay: What did he say?
 
-      Phoebe Buffay: No! No, that you and Rachel are engaged!'
+      Rachel Green: Well uh, his answering machine was very understanding. Ugh. I
+      feel blue.
+
+      Monica Geller: Ohh, sweetie! Hey, I bet you anything that he''s gonna call you
+      again.
+
+      Rachel Green: Yeah, maybe, but I don''t think I even care. I don''t think he''s
+      the one I''m sad about. Y''know, I know that I said that I am totally okay with
+      Ross getting married, but as it turns out, I don''t think I''m handling it all
+      that well.
+
+      Phoebe Buffay: Yeah, maybe.
+
+      Rachel Green: And I-I am just trying to figure out why.
+
+      Phoebe Buffay: Any luck?
+
+      Rachel Green: Well, yeah, y''know how Ross and I were on again, off again, on
+      again, off again? I guess I just figured that somewhere down the road, we would
+      be on again.
+
+      Monica Geller: Again. Y''know what? I think we all did.
+
+      Ross Geller: Hey!
+
+      Monica Geller: Hey!
+
+      Ross Geller: So, I got us some reservations for Sunday night, okay? How about,
+      Ernie''s at 9 o''clock?
+
+      Rachel Green: Yeah, well, you uh, better make it for three.
+
+      Ross Geller: Oh, see I-I don''t know if we''re gonna be hungry at three.
+
+      Rachel Green: Three people. Joshua''s not gonna be there.
+
+      Ross Geller: What happened?
+
+      Rachel Green: Uh, well, I think, I think he broke up with me.
+
+      Ross Geller: Noo. Why?
+
+      Rachel Green: Well, apparently he scares easy.
+
+      Ross Geller: Oh, Rachel, I''m-I''m sorry.
+
+      Rachel Green: It''s okay. Sometimes, things don''t work out the way you''d thought
+      they would.
+
+      Ross Geller: Come here.
+
+      Rachel Green: Oh, hey, don''t you have to go pick up Emily?
+
+      Ross Geller: Yeah.
+
+      Rachel Green: Yeah.
+
+      Ross Geller: You okay?
+
+      Rachel Green: Yeah! I got my girls.
+
+      Rachel Green: Ugh.
+
+      Phoebe Buffay: Hey, y''know what might cheer you up?
+
+      Rachel Green: What?
+
+      Rachel Green: Y''know, I gotta tell ya, this really does put in a better mood.
+
+      Monica Geller: Oh, I wish there was a job where I could wear this all the time.
+      Maybe someday, there will be.
+
+      Monica Geller:'
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_monica_valid.yml
+++ b/parlai/tasks/friends/test/friends_monica_valid.yml
@@ -3,57 +3,7 @@ acts:
       Geller
     episode_done: false
     eval_labels:
-    - 'Monica Geller: __SILENCE__'
-    id: friends:monica
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Monica Geller: __SILENCE__'
-    id: friends:monica
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Monica Geller: __SILENCE__'
-    id: friends:monica
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
-
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Monica Geller: __SILENCE__'
-    id: friends:monica
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
-
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.
-
-      Ross Geller: Hey.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Monica Geller: __SILENCE__'
+    - Guys! Guys! I just saw two people having sex in a car right outside.
     id: friends:monica
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -66,6 +16,253 @@ acts:
 
       Ross Geller: Hey.
 
-      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!'
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller: Hey Pheebs, how''s it going?
+
+      Chandler Bing: Hey.
+
+      Phoebe Buffay: Hey! Umm, well, only okay because I just got back from, from
+      the hospital.
+
+      Rachel Green: What?
+
+      Ross Geller: Is everything okay?
+
+      Joey Tribbiani: Are you all right?
+
+      Phoebe Buffay: Oh yeah, no-no-no. I''m fine. I''m okay, but umm, my Grandma
+      sorta died.
+
+      Joey Tribbiani: Pheebs! Sorry!
+
+      Phoebe Buffay: It''s okay, I mean she had a really incredible life. And it''s
+      not like I''m never gonna see her again, y''know she''s gonna visit.
+
+      Rachel Green: Well maybe, maybe she''s with us right now?
+
+      Phoebe Buffay: Yeah, her first day on a new spiritual plane and she''s gonna
+      come to the coffeehouse!
+
+      Monica Geller:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Ohh my God, I'm so sorry.
+    id: friends:monica
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller: Hey Pheebs, how''s it going?
+
+      Chandler Bing: Hey.
+
+      Phoebe Buffay: Hey! Umm, well, only okay because I just got back from, from
+      the hospital.
+
+      Rachel Green: What?
+
+      Ross Geller: Is everything okay?
+
+      Joey Tribbiani: Are you all right?
+
+      Phoebe Buffay: Oh yeah, no-no-no. I''m fine. I''m okay, but umm, my Grandma
+      sorta died.
+
+      Joey Tribbiani: Pheebs! Sorry!
+
+      Phoebe Buffay: It''s okay, I mean she had a really incredible life. And it''s
+      not like I''m never gonna see her again, y''know she''s gonna visit.
+
+      Rachel Green: Well maybe, maybe she''s with us right now?
+
+      Phoebe Buffay: Yeah, her first day on a new spiritual plane and she''s gonna
+      come to the coffeehouse!
+
+      Monica Geller: Guys! Guys! I just saw two people having sex in a car right outside.
+
+      Ross Geller: Uhh, Pheebs'' Grandmother just died.
+
+      Monica Geller:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Not the way they're doing it. What, what happened? How did she die?
+    id: friends:monica
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller: Hey Pheebs, how''s it going?
+
+      Chandler Bing: Hey.
+
+      Phoebe Buffay: Hey! Umm, well, only okay because I just got back from, from
+      the hospital.
+
+      Rachel Green: What?
+
+      Ross Geller: Is everything okay?
+
+      Joey Tribbiani: Are you all right?
+
+      Phoebe Buffay: Oh yeah, no-no-no. I''m fine. I''m okay, but umm, my Grandma
+      sorta died.
+
+      Joey Tribbiani: Pheebs! Sorry!
+
+      Phoebe Buffay: It''s okay, I mean she had a really incredible life. And it''s
+      not like I''m never gonna see her again, y''know she''s gonna visit.
+
+      Rachel Green: Well maybe, maybe she''s with us right now?
+
+      Phoebe Buffay: Yeah, her first day on a new spiritual plane and she''s gonna
+      come to the coffeehouse!
+
+      Monica Geller: Guys! Guys! I just saw two people having sex in a car right outside.
+
+      Ross Geller: Uhh, Pheebs'' Grandmother just died.
+
+      Monica Geller: Ohh my God, I''m so sorry.
+
+      Phoebe Buffay: It''s okay. Actually y''know what, it''s kinda cool. ''Cause
+      it''s like y''know, one life ends and another begins.
+
+      Monica Geller:'
+- - characters: Chandler Bing,Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
+    episode_done: false
+    eval_labels:
+    - What happened to your teeth.
+    id: friends:monica
+    text: 'Ross Geller: Hey guys.
+
+      Chandler Bing: Hey.
+
+      Ross Geller: What''s up?
+
+      Chandler Bing: You know...Oh My God.
+
+      Monica Geller:'
+- - characters: Chandler Bing,Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
+    episode_done: false
+    eval_labels:
+    - Well, I think I shouldn't look directly at them.
+    id: friends:monica
+    text: 'Ross Geller: Hey guys.
+
+      Chandler Bing: Hey.
+
+      Ross Geller: What''s up?
+
+      Chandler Bing: You know...Oh My God.
+
+      Monica Geller: What happened to your teeth.
+
+      Ross Geller: I whitened them.
+
+      Chandler Bing: Really.
+
+      Ross Geller: Yeah. What do you think.
+
+      Monica Geller:'
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_phoebe_test.yml
+++ b/parlai/tasks/friends/test/friends_phoebe_test.yml
@@ -1,59 +1,125 @@
 acts:
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+- - characters: Phoebe Buffay
     episode_done: false
     eval_labels:
-    - 'Phoebe Buffay: __SILENCE__'
+    - Alright... Susie, can I call you Susie?
     id: friends:phoebe
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+    text: 'Phoebe Buffay: Okay, bye. Alright, so Mike''s on his way over. See, you
+      thought you guys were meeting here, and he thought you were meeting at the restaurant,
+      so you know... Doesn''t really matter who''s right or wrong. Point is... I''m
+      gonna take off.
+
+      Precious: I''m not letting you leave until you tell me what''s going on here.
+      I mean, are you guys getting back together or something?
+
+      Phoebe Buffay:'
+- - characters: Phoebe Buffay
     episode_done: false
     eval_labels:
-    - 'Phoebe Buffay: __SILENCE__'
+    - Yeah, I can't say that. uhm... Susie, I'm gonna be straight with you... Mike
+      and I are back together... and uhm... unfortunately that effectively ends your
+      relationship with him. And he's very sorry about that and wishes you the best
+      of luck in all your endeavours.
     id: friends:phoebe
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+    text: 'Phoebe Buffay: Okay, bye. Alright, so Mike''s on his way over. See, you
+      thought you guys were meeting here, and he thought you were meeting at the restaurant,
+      so you know... Doesn''t really matter who''s right or wrong. Point is... I''m
+      gonna take off.
 
-      Rachel Green: Ooy.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+      Precious: I''m not letting you leave until you tell me what''s going on here.
+      I mean, are you guys getting back together or something?
+
+      Phoebe Buffay: Alright... Susie, can I call you Susie?
+
+      Precious: My name is Precious.
+
+      Phoebe Buffay:'
+- - characters: Phoebe Buffay
     episode_done: false
     eval_labels:
-    - 'Phoebe Buffay: __SILENCE__'
+    - Well, I don't...
     id: friends:phoebe
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+    text: 'Phoebe Buffay: Okay, bye. Alright, so Mike''s on his way over. See, you
+      thought you guys were meeting here, and he thought you were meeting at the restaurant,
+      so you know... Doesn''t really matter who''s right or wrong. Point is... I''m
+      gonna take off.
 
-      Rachel Green: Ooy.
+      Precious: I''m not letting you leave until you tell me what''s going on here.
+      I mean, are you guys getting back together or something?
 
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+      Phoebe Buffay: Alright... Susie, can I call you Susie?
+
+      Precious: My name is Precious.
+
+      Phoebe Buffay: Yeah, I can''t say that. uhm... Susie, I''m gonna be straight
+      with you... Mike and I are back together... and uhm... unfortunately that effectively
+      ends your relationship with him. And he''s very sorry about that and wishes
+      you the best of luck in all your endeavours.
+
+      Precious: I just can''t believe this... Why?
+
+      Phoebe Buffay:'
+- - characters: Phoebe Buffay
     episode_done: false
     eval_labels:
-    - 'Phoebe Buffay: __SILENCE__'
+    - Nothing, there's nothing wrong with you.
     id: friends:phoebe
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+    text: 'Phoebe Buffay: Okay, bye. Alright, so Mike''s on his way over. See, you
+      thought you guys were meeting here, and he thought you were meeting at the restaurant,
+      so you know... Doesn''t really matter who''s right or wrong. Point is... I''m
+      gonna take off.
 
-      Rachel Green: Ooy.
+      Precious: I''m not letting you leave until you tell me what''s going on here.
+      I mean, are you guys getting back together or something?
 
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?
+      Phoebe Buffay: Alright... Susie, can I call you Susie?
 
-      Rachel Green: Oh my god, are we supposed to answer?'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+      Precious: My name is Precious.
+
+      Phoebe Buffay: Yeah, I can''t say that. uhm... Susie, I''m gonna be straight
+      with you... Mike and I are back together... and uhm... unfortunately that effectively
+      ends your relationship with him. And he''s very sorry about that and wishes
+      you the best of luck in all your endeavours.
+
+      Precious: I just can''t believe this... Why?
+
+      Phoebe Buffay: Well, I don''t...
+
+      Precious: Oh, why would he do this? I mean, what''s wrong with me?
+
+      Phoebe Buffay:'
+- - characters: Phoebe Buffay
     episode_done: false
     eval_labels:
-    - 'Phoebe Buffay: __SILENCE__'
+    - Damn it woman, pull yourself together! Have some pride, for the love of God.
     id: friends:phoebe
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+    text: 'Phoebe Buffay: Okay, bye. Alright, so Mike''s on his way over. See, you
+      thought you guys were meeting here, and he thought you were meeting at the restaurant,
+      so you know... Doesn''t really matter who''s right or wrong. Point is... I''m
+      gonna take off.
 
-      Rachel Green: Ooy.
+      Precious: I''m not letting you leave until you tell me what''s going on here.
+      I mean, are you guys getting back together or something?
 
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?
+      Phoebe Buffay: Alright... Susie, can I call you Susie?
 
-      Rachel Green: Oh my god, are we supposed to answer?
+      Precious: My name is Precious.
 
-      Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
-      which I''m still fine with by the way. E is for how extremely normal I find
-      it. That you two are together. And now one day you might get married and have
-      children of your own.'
+      Phoebe Buffay: Yeah, I can''t say that. uhm... Susie, I''m gonna be straight
+      with you... Mike and I are back together... and uhm... unfortunately that effectively
+      ends your relationship with him. And he''s very sorry about that and wishes
+      you the best of luck in all your endeavours.
+
+      Precious: I just can''t believe this... Why?
+
+      Phoebe Buffay: Well, I don''t...
+
+      Precious: Oh, why would he do this? I mean, what''s wrong with me?
+
+      Phoebe Buffay: Nothing, there''s nothing wrong with you.
+
+      Precious: I mean, what the hell am I supposed to do now?
+
+      Phoebe Buffay:'
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_phoebe_train.yml
+++ b/parlai/tasks/friends/test/friends_phoebe_train.yml
@@ -3,47 +3,18 @@ acts:
     episode_done: false
     id: friends:phoebe
     labels:
-    - 'Phoebe Buffay: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!'
-- - characters: Phoebe Buffay,Ross Geller
-    episode_done: false
-    id: friends:phoebe
-    labels:
-    - 'Phoebe Buffay: Congratulations! I didn''t want to say anything in front of
-      Joey ''cause I didn''t know if he knew yet.'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
-
-      Ross Geller: Hi!'
-- - characters: Phoebe Buffay,Ross Geller
-    episode_done: false
-    id: friends:phoebe
-    labels:
-    - 'Phoebe Buffay: __SILENCE__'
+    - Congratulations! I didn't want to say anything in front of Joey 'cause I didn't
+      know if he knew yet.
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.'
+      Phoebe Buffay:'
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:phoebe
     labels:
-    - 'Phoebe Buffay: No! No, that you and Rachel are engaged!'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
-
-      Ross Geller: Hi!
-
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.
-
-      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.'
-- - characters: Phoebe Buffay,Ross Geller
-    episode_done: false
-    id: friends:phoebe
-    labels:
-    - 'Phoebe Buffay: __SILENCE__'
+    - No! No, that you and Rachel are engaged!
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -54,6 +25,84 @@ acts:
       Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
       although, he did eat a piece of plastic fruit earlier.
 
-      Phoebe Buffay: No! No, that you and Rachel are engaged!'
+      Phoebe Buffay:'
+- - characters: Phoebe Buffay,Ross Geller
+    episode_done: false
+    id: friends:phoebe
+    labels:
+    - Oh, it's a secret. Oh goodie! Yes! We haven't done the secret thing in a long
+      time.
+    text: 'Phoebe Buffay: Oh hey! Wait up!
+
+      Ross Geller: Hi!
+
+      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
+      ''cause I didn''t know if he knew yet.
+
+      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
+      although, he did eat a piece of plastic fruit earlier.
+
+      Phoebe Buffay: No! No, that you and Rachel are engaged!
+
+      Ross Geller: What?
+
+      Phoebe Buffay:'
+- - characters: Phoebe Buffay,Ross Geller
+    episode_done: false
+    id: friends:phoebe
+    labels:
+    - Are you lying? Is this like that time you tried to convince us that you were
+      a doctor?
+    text: 'Phoebe Buffay: Oh hey! Wait up!
+
+      Ross Geller: Hi!
+
+      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
+      ''cause I didn''t know if he knew yet.
+
+      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
+      although, he did eat a piece of plastic fruit earlier.
+
+      Phoebe Buffay: No! No, that you and Rachel are engaged!
+
+      Ross Geller: What?
+
+      Phoebe Buffay: Oh, it''s a secret. Oh goodie! Yes! We haven''t done the secret
+      thing in a long time.
+
+      Ross Geller: Phoebe, there is no secret. Okay? I didn''t propose.
+
+      Phoebe Buffay:'
+- - characters: Phoebe Buffay,Ross Geller
+    episode_done: false
+    id: friends:phoebe
+    labels:
+    - All right, me too. Should we wake her up?
+    text: 'Phoebe Buffay: Oh hey! Wait up!
+
+      Ross Geller: Hi!
+
+      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
+      ''cause I didn''t know if he knew yet.
+
+      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
+      although, he did eat a piece of plastic fruit earlier.
+
+      Phoebe Buffay: No! No, that you and Rachel are engaged!
+
+      Ross Geller: What?
+
+      Phoebe Buffay: Oh, it''s a secret. Oh goodie! Yes! We haven''t done the secret
+      thing in a long time.
+
+      Ross Geller: Phoebe, there is no secret. Okay? I didn''t propose.
+
+      Phoebe Buffay: Are you lying? Is this like that time you tried to convince us
+      that you were a doctor?
+
+      Ross Geller: I am a doctor! Y''know what? I''m just gonna go and talk to Rachel
+      myself.
+
+      Phoebe Buffay:'
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_phoebe_valid.yml
+++ b/parlai/tasks/friends/test/friends_phoebe_valid.yml
@@ -3,57 +3,7 @@ acts:
       Geller
     episode_done: false
     eval_labels:
-    - 'Phoebe Buffay: __SILENCE__'
-    id: friends:phoebe
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Phoebe Buffay: __SILENCE__'
-    id: friends:phoebe
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Phoebe Buffay: __SILENCE__'
-    id: friends:phoebe
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
-
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Phoebe Buffay: __SILENCE__'
-    id: friends:phoebe
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
-
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.
-
-      Ross Geller: Hey.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Phoebe Buffay: __SILENCE__'
+    - Hey! Umm, well, only okay because I just got back from, from the hospital.
     id: friends:phoebe
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -66,6 +16,310 @@ acts:
 
       Ross Geller: Hey.
 
-      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!'
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller: Hey Pheebs, how''s it going?
+
+      Chandler Bing: Hey.
+
+      Phoebe Buffay:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Oh yeah, no-no-no. I'm fine. I'm okay, but umm, my Grandma sorta died.
+    id: friends:phoebe
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller: Hey Pheebs, how''s it going?
+
+      Chandler Bing: Hey.
+
+      Phoebe Buffay: Hey! Umm, well, only okay because I just got back from, from
+      the hospital.
+
+      Rachel Green: What?
+
+      Ross Geller: Is everything okay?
+
+      Joey Tribbiani: Are you all right?
+
+      Phoebe Buffay:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - It's okay, I mean she had a really incredible life. And it's not like I'm never
+      gonna see her again, y'know she's gonna visit.
+    id: friends:phoebe
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller: Hey Pheebs, how''s it going?
+
+      Chandler Bing: Hey.
+
+      Phoebe Buffay: Hey! Umm, well, only okay because I just got back from, from
+      the hospital.
+
+      Rachel Green: What?
+
+      Ross Geller: Is everything okay?
+
+      Joey Tribbiani: Are you all right?
+
+      Phoebe Buffay: Oh yeah, no-no-no. I''m fine. I''m okay, but umm, my Grandma
+      sorta died.
+
+      Joey Tribbiani: Pheebs! Sorry!
+
+      Phoebe Buffay:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Yeah, her first day on a new spiritual plane and she's gonna come to the coffeehouse!
+    id: friends:phoebe
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller: Hey Pheebs, how''s it going?
+
+      Chandler Bing: Hey.
+
+      Phoebe Buffay: Hey! Umm, well, only okay because I just got back from, from
+      the hospital.
+
+      Rachel Green: What?
+
+      Ross Geller: Is everything okay?
+
+      Joey Tribbiani: Are you all right?
+
+      Phoebe Buffay: Oh yeah, no-no-no. I''m fine. I''m okay, but umm, my Grandma
+      sorta died.
+
+      Joey Tribbiani: Pheebs! Sorry!
+
+      Phoebe Buffay: It''s okay, I mean she had a really incredible life. And it''s
+      not like I''m never gonna see her again, y''know she''s gonna visit.
+
+      Rachel Green: Well maybe, maybe she''s with us right now?
+
+      Phoebe Buffay:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - It's okay. Actually y'know what, it's kinda cool. 'Cause it's like y'know, one
+      life ends and another begins.
+    id: friends:phoebe
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller: Hey Pheebs, how''s it going?
+
+      Chandler Bing: Hey.
+
+      Phoebe Buffay: Hey! Umm, well, only okay because I just got back from, from
+      the hospital.
+
+      Rachel Green: What?
+
+      Ross Geller: Is everything okay?
+
+      Joey Tribbiani: Are you all right?
+
+      Phoebe Buffay: Oh yeah, no-no-no. I''m fine. I''m okay, but umm, my Grandma
+      sorta died.
+
+      Joey Tribbiani: Pheebs! Sorry!
+
+      Phoebe Buffay: It''s okay, I mean she had a really incredible life. And it''s
+      not like I''m never gonna see her again, y''know she''s gonna visit.
+
+      Rachel Green: Well maybe, maybe she''s with us right now?
+
+      Phoebe Buffay: Yeah, her first day on a new spiritual plane and she''s gonna
+      come to the coffeehouse!
+
+      Monica Geller: Guys! Guys! I just saw two people having sex in a car right outside.
+
+      Ross Geller: Uhh, Pheebs'' Grandmother just died.
+
+      Monica Geller: Ohh my God, I''m so sorry.
+
+      Phoebe Buffay:'
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_rachel_test.yml
+++ b/parlai/tasks/friends/test/friends_rachel_test.yml
@@ -2,32 +2,15 @@ acts:
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Rachel Green: Ooy.'
-    id: friends:rachel
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
-    episode_done: false
-    eval_labels:
-    - 'Rachel Green: __SILENCE__'
+    - Ooy.
     id: friends:rachel
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
-      Rachel Green: Ooy.'
+      Rachel Green:'
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Rachel Green: Oh my god, are we supposed to answer?'
-    id: friends:rachel
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
-
-      Rachel Green: Ooy.
-
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
-    episode_done: false
-    eval_labels:
-    - 'Rachel Green: __SILENCE__'
+    - Oh my god, are we supposed to answer?
     id: friends:rachel
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
@@ -36,11 +19,11 @@ acts:
       Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
       life without love?
 
-      Rachel Green: Oh my god, are we supposed to answer?'
+      Rachel Green:'
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Rachel Green: __SILENCE__'
+    - Ross, you don't seem okay.
     id: friends:rachel
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
@@ -54,6 +37,112 @@ acts:
       Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
       which I''m still fine with by the way. E is for how extremely normal I find
       it. That you two are together. And now one day you might get married and have
-      children of your own.'
+      children of your own.
+
+      Joey Tribbiani: Dude, are you okay?
+
+      Ross Geller: Totally.
+
+      Rachel Green:'
+- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+    episode_done: false
+    eval_labels:
+    - Oh, that's okay, girls tend not to like me.
+    id: friends:rachel
+    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+
+      Rachel Green: Ooy.
+
+      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
+      life without love?
+
+      Rachel Green: Oh my god, are we supposed to answer?
+
+      Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
+      which I''m still fine with by the way. E is for how extremely normal I find
+      it. That you two are together. And now one day you might get married and have
+      children of your own.
+
+      Joey Tribbiani: Dude, are you okay?
+
+      Ross Geller: Totally.
+
+      Rachel Green: Ross, you don''t seem okay.
+
+      Ross Geller: I''m sorry, it must be the pressure of entertaining. I think everyone
+      would feel better if we had some flan.
+
+      Charlie Wheeler: Wait, Ross. Ross. I - I have to take off.
+
+      Ross Geller: No!
+
+      Charlie Wheeler: I''m sorry, I have a really early class in the morning, but
+      this has been lovely.
+
+      Ross Geller: Wasn''t it? And you thought it would be awkward with Joey and that
+      you never really liked Rachel.
+
+      Charlie Wheeler: You''re on fire! I''ll call you in the morning, okay?
+
+      Ross Geller: Okay.
+
+      Charlie Wheeler: Alright.
+
+      Charlie Wheeler: God, Rachel, what Ross just said that is just so..
+
+      Rachel Green:'
+- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+    episode_done: false
+    eval_labels:
+    - You know what, Ross? I think we're gonna take off too.
+    id: friends:rachel
+    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+
+      Rachel Green: Ooy.
+
+      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
+      life without love?
+
+      Rachel Green: Oh my god, are we supposed to answer?
+
+      Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
+      which I''m still fine with by the way. E is for how extremely normal I find
+      it. That you two are together. And now one day you might get married and have
+      children of your own.
+
+      Joey Tribbiani: Dude, are you okay?
+
+      Ross Geller: Totally.
+
+      Rachel Green: Ross, you don''t seem okay.
+
+      Ross Geller: I''m sorry, it must be the pressure of entertaining. I think everyone
+      would feel better if we had some flan.
+
+      Charlie Wheeler: Wait, Ross. Ross. I - I have to take off.
+
+      Ross Geller: No!
+
+      Charlie Wheeler: I''m sorry, I have a really early class in the morning, but
+      this has been lovely.
+
+      Ross Geller: Wasn''t it? And you thought it would be awkward with Joey and that
+      you never really liked Rachel.
+
+      Charlie Wheeler: You''re on fire! I''ll call you in the morning, okay?
+
+      Ross Geller: Okay.
+
+      Charlie Wheeler: Alright.
+
+      Charlie Wheeler: God, Rachel, what Ross just said that is just so..
+
+      Rachel Green: Oh, that''s okay, girls tend not to like me.
+
+      Charlie Wheeler: Bye.
+
+      Ross Geller: Okay, I guess it''s just flan for three! Hey, hey, that rhymed!
+
+      Rachel Green:'
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_rachel_train.yml
+++ b/parlai/tasks/friends/test/friends_rachel_train.yml
@@ -1,58 +1,113 @@
 acts:
-- - characters: Phoebe Buffay,Ross Geller
+- - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:rachel
     labels:
-    - 'Rachel Green: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!'
-- - characters: Phoebe Buffay,Ross Geller
+    - Well, I did my best to convince him that I'm not some crazy girl who is dying
+      to get married-I'm just going through a hard time.
+    text: 'Rachel Green: Well, I just called Joshua...
+
+      Phoebe Buffay: Oh, how did it go?
+
+      Rachel Green:'
+- - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:rachel
     labels:
-    - 'Rachel Green: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - Well uh, his answering machine was very understanding. Ugh. I feel blue.
+    text: 'Rachel Green: Well, I just called Joshua...
 
-      Ross Geller: Hi!'
-- - characters: Phoebe Buffay,Ross Geller
+      Phoebe Buffay: Oh, how did it go?
+
+      Rachel Green: Well, I did my best to convince him that I''m not some crazy girl
+      who is dying to get married-I''m just going through a hard time.
+
+      Phoebe Buffay: What did he say?
+
+      Rachel Green:'
+- - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:rachel
     labels:
-    - 'Rachel Green: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - Yeah, maybe, but I don't think I even care. I don't think he's the one I'm sad
+      about. Y'know, I know that I said that I am totally okay with Ross getting married,
+      but as it turns out, I don't think I'm handling it all that well.
+    text: 'Rachel Green: Well, I just called Joshua...
 
-      Ross Geller: Hi!
+      Phoebe Buffay: Oh, how did it go?
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.'
-- - characters: Phoebe Buffay,Ross Geller
+      Rachel Green: Well, I did my best to convince him that I''m not some crazy girl
+      who is dying to get married-I''m just going through a hard time.
+
+      Phoebe Buffay: What did he say?
+
+      Rachel Green: Well uh, his answering machine was very understanding. Ugh. I
+      feel blue.
+
+      Monica Geller: Ohh, sweetie! Hey, I bet you anything that he''s gonna call you
+      again.
+
+      Rachel Green:'
+- - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:rachel
     labels:
-    - 'Rachel Green: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - And I-I am just trying to figure out why.
+    text: 'Rachel Green: Well, I just called Joshua...
 
-      Ross Geller: Hi!
+      Phoebe Buffay: Oh, how did it go?
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.
+      Rachel Green: Well, I did my best to convince him that I''m not some crazy girl
+      who is dying to get married-I''m just going through a hard time.
 
-      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.'
-- - characters: Phoebe Buffay,Ross Geller
+      Phoebe Buffay: What did he say?
+
+      Rachel Green: Well uh, his answering machine was very understanding. Ugh. I
+      feel blue.
+
+      Monica Geller: Ohh, sweetie! Hey, I bet you anything that he''s gonna call you
+      again.
+
+      Rachel Green: Yeah, maybe, but I don''t think I even care. I don''t think he''s
+      the one I''m sad about. Y''know, I know that I said that I am totally okay with
+      Ross getting married, but as it turns out, I don''t think I''m handling it all
+      that well.
+
+      Phoebe Buffay: Yeah, maybe.
+
+      Rachel Green:'
+- - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:rachel
     labels:
-    - 'Rachel Green: __SILENCE__'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
+    - Well, yeah, y'know how Ross and I were on again, off again, on again, off again?
+      I guess I just figured that somewhere down the road, we would be on again.
+    text: 'Rachel Green: Well, I just called Joshua...
 
-      Ross Geller: Hi!
+      Phoebe Buffay: Oh, how did it go?
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.
+      Rachel Green: Well, I did my best to convince him that I''m not some crazy girl
+      who is dying to get married-I''m just going through a hard time.
 
-      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.
+      Phoebe Buffay: What did he say?
 
-      Phoebe Buffay: No! No, that you and Rachel are engaged!'
+      Rachel Green: Well uh, his answering machine was very understanding. Ugh. I
+      feel blue.
+
+      Monica Geller: Ohh, sweetie! Hey, I bet you anything that he''s gonna call you
+      again.
+
+      Rachel Green: Yeah, maybe, but I don''t think I even care. I don''t think he''s
+      the one I''m sad about. Y''know, I know that I said that I am totally okay with
+      Ross getting married, but as it turns out, I don''t think I''m handling it all
+      that well.
+
+      Phoebe Buffay: Yeah, maybe.
+
+      Rachel Green: And I-I am just trying to figure out why.
+
+      Phoebe Buffay: Any luck?
+
+      Rachel Green:'
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_rachel_valid.yml
+++ b/parlai/tasks/friends/test/friends_rachel_valid.yml
@@ -3,57 +3,8 @@ acts:
       Geller
     episode_done: false
     eval_labels:
-    - 'Rachel Green: __SILENCE__'
-    id: friends:rachel
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Rachel Green: __SILENCE__'
-    id: friends:rachel
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Rachel Green: __SILENCE__'
-    id: friends:rachel
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
-
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Rachel Green: __SILENCE__'
-    id: friends:rachel
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
-
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.
-
-      Ross Geller: Hey.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Rachel Green: __SILENCE__'
+    - Joey, if you wanna look good, why don't you just come down to the store? I'll
+      help you out.
     id: friends:rachel
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -66,6 +17,236 @@ acts:
 
       Ross Geller: Hey.
 
-      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!'
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Sure! God, please take those off!
+    id: friends:rachel
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - What?
+    id: friends:rachel
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller: Hey Pheebs, how''s it going?
+
+      Chandler Bing: Hey.
+
+      Phoebe Buffay: Hey! Umm, well, only okay because I just got back from, from
+      the hospital.
+
+      Rachel Green:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Well maybe, maybe she's with us right now?
+    id: friends:rachel
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller: Hey Pheebs, how''s it going?
+
+      Chandler Bing: Hey.
+
+      Phoebe Buffay: Hey! Umm, well, only okay because I just got back from, from
+      the hospital.
+
+      Rachel Green: What?
+
+      Ross Geller: Is everything okay?
+
+      Joey Tribbiani: Are you all right?
+
+      Phoebe Buffay: Oh yeah, no-no-no. I''m fine. I''m okay, but umm, my Grandma
+      sorta died.
+
+      Joey Tribbiani: Pheebs! Sorry!
+
+      Phoebe Buffay: It''s okay, I mean she had a really incredible life. And it''s
+      not like I''m never gonna see her again, y''know she''s gonna visit.
+
+      Rachel Green:'
+- - characters: Chandler Bing,Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
+    episode_done: false
+    eval_labels:
+    - Yeah. Your teeth? Yes, I saw them from outside. You guys are never going to
+      believe this. But, Phoebe made out with Ralph Lauren.
+    id: friends:rachel
+    text: 'Ross Geller: Hey guys.
+
+      Chandler Bing: Hey.
+
+      Ross Geller: What''s up?
+
+      Chandler Bing: You know...Oh My God.
+
+      Monica Geller: What happened to your teeth.
+
+      Ross Geller: I whitened them.
+
+      Chandler Bing: Really.
+
+      Ross Geller: Yeah. What do you think.
+
+      Monica Geller: Well, I think I shouldn''t look directly at them.
+
+      Ross Geller: Come on, seriously.
+
+      Monica Geller: Ross they''re really, really, really white.
+
+      Chandler Bing: Yeah, what was wrong with your old...human teeth.
+
+      Ross Geller: Ahh, I-I did leave the gel on a little longer then it said to.
+
+      Monica Geller: How much longer?
+
+      Ross Geller: A-A day.
+
+      Monica Geller: Ross you know that tonight is your date with Hillary?
+
+      Ross Geller: I know. That''s why I did it. Come on, are they really that bad?
+
+      Chandler Bing: No, no no no. You''ll be fine. Hillary''s bind, right?
+
+      Monica Geller: She will be after tonight.
+
+      Chandler Bing: Yeah.
+
+      Ross Geller: Oh, hey, hey Rach, do you notice anything..ahh...
+
+      Rachel Green:'
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_ross_test.yml
+++ b/parlai/tasks/friends/test/friends_ross_test.yml
@@ -2,36 +2,21 @@ acts:
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Ross Geller: __SILENCE__'
-    id: friends:ross
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
-    episode_done: false
-    eval_labels:
-    - 'Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what
-      is life without love?'
-    id: friends:ross
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
-
-      Rachel Green: Ooy.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
-    episode_done: false
-    eval_labels:
-    - 'Ross Geller: __SILENCE__'
+    - And to love. Ah, love. L-O-V-E, love. L is for life. And what is life without
+      love?
     id: friends:ross
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
 
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?'
+      Ross Geller:'
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of
-      events, which I''m still fine with by the way. E is for how extremely normal
-      I find it. That you two are together. And now one day you might get married
-      and have children of your own.'
+    - O is for "oh, wow!" The V is for this very surprising turn of events, which
+      I'm still fine with by the way. E is for how extremely normal I find it. That
+      you two are together. And now one day you might get married and have children
+      of your own.
     id: friends:ross
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
@@ -40,11 +25,13 @@ acts:
       Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
       life without love?
 
-      Rachel Green: Oh my god, are we supposed to answer?'
+      Rachel Green: Oh my god, are we supposed to answer?
+
+      Ross Geller:'
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Ross Geller: __SILENCE__'
+    - Totally.
     id: friends:ross
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
@@ -58,6 +45,68 @@ acts:
       Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
       which I''m still fine with by the way. E is for how extremely normal I find
       it. That you two are together. And now one day you might get married and have
-      children of your own.'
+      children of your own.
+
+      Joey Tribbiani: Dude, are you okay?
+
+      Ross Geller:'
+- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+    episode_done: false
+    eval_labels:
+    - I'm sorry, it must be the pressure of entertaining. I think everyone would feel
+      better if we had some flan.
+    id: friends:ross
+    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+
+      Rachel Green: Ooy.
+
+      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
+      life without love?
+
+      Rachel Green: Oh my god, are we supposed to answer?
+
+      Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
+      which I''m still fine with by the way. E is for how extremely normal I find
+      it. That you two are together. And now one day you might get married and have
+      children of your own.
+
+      Joey Tribbiani: Dude, are you okay?
+
+      Ross Geller: Totally.
+
+      Rachel Green: Ross, you don''t seem okay.
+
+      Ross Geller:'
+- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+    episode_done: false
+    eval_labels:
+    - No!
+    id: friends:ross
+    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+
+      Rachel Green: Ooy.
+
+      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
+      life without love?
+
+      Rachel Green: Oh my god, are we supposed to answer?
+
+      Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
+      which I''m still fine with by the way. E is for how extremely normal I find
+      it. That you two are together. And now one day you might get married and have
+      children of your own.
+
+      Joey Tribbiani: Dude, are you okay?
+
+      Ross Geller: Totally.
+
+      Rachel Green: Ross, you don''t seem okay.
+
+      Ross Geller: I''m sorry, it must be the pressure of entertaining. I think everyone
+      would feel better if we had some flan.
+
+      Charlie Wheeler: Wait, Ross. Ross. I - I have to take off.
+
+      Ross Geller:'
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_ross_train.yml
+++ b/parlai/tasks/friends/test/friends_ross_train.yml
@@ -3,33 +3,16 @@ acts:
     episode_done: false
     id: friends:ross
     labels:
-    - 'Ross Geller: Hi!'
-    text: 'Phoebe Buffay: Oh hey! Wait up!'
-- - characters: Phoebe Buffay,Ross Geller
-    episode_done: false
-    id: friends:ross
-    labels:
-    - 'Ross Geller: __SILENCE__'
+    - Hi!
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
-      Ross Geller: Hi!'
+      Ross Geller:'
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:ross
     labels:
-    - 'Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.'
-    text: 'Phoebe Buffay: Oh hey! Wait up!
-
-      Ross Geller: Hi!
-
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.'
-- - characters: Phoebe Buffay,Ross Geller
-    episode_done: false
-    id: friends:ross
-    labels:
-    - 'Ross Geller: __SILENCE__'
+    - What, that we had a baby? Come on let's give him a little credit, although,
+      he did eat a piece of plastic fruit earlier.
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -37,13 +20,12 @@ acts:
       Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
       ''cause I didn''t know if he knew yet.
 
-      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.'
+      Ross Geller:'
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:ross
     labels:
-    - 'Ross Geller: What?'
+    - What?
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -54,6 +36,59 @@ acts:
       Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
       although, he did eat a piece of plastic fruit earlier.
 
-      Phoebe Buffay: No! No, that you and Rachel are engaged!'
+      Phoebe Buffay: No! No, that you and Rachel are engaged!
+
+      Ross Geller:'
+- - characters: Phoebe Buffay,Ross Geller
+    episode_done: false
+    id: friends:ross
+    labels:
+    - Phoebe, there is no secret. Okay? I didn't propose.
+    text: 'Phoebe Buffay: Oh hey! Wait up!
+
+      Ross Geller: Hi!
+
+      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
+      ''cause I didn''t know if he knew yet.
+
+      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
+      although, he did eat a piece of plastic fruit earlier.
+
+      Phoebe Buffay: No! No, that you and Rachel are engaged!
+
+      Ross Geller: What?
+
+      Phoebe Buffay: Oh, it''s a secret. Oh goodie! Yes! We haven''t done the secret
+      thing in a long time.
+
+      Ross Geller:'
+- - characters: Phoebe Buffay,Ross Geller
+    episode_done: false
+    id: friends:ross
+    labels:
+    - I am a doctor! Y'know what? I'm just gonna go and talk to Rachel myself.
+    text: 'Phoebe Buffay: Oh hey! Wait up!
+
+      Ross Geller: Hi!
+
+      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
+      ''cause I didn''t know if he knew yet.
+
+      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
+      although, he did eat a piece of plastic fruit earlier.
+
+      Phoebe Buffay: No! No, that you and Rachel are engaged!
+
+      Ross Geller: What?
+
+      Phoebe Buffay: Oh, it''s a secret. Oh goodie! Yes! We haven''t done the secret
+      thing in a long time.
+
+      Ross Geller: Phoebe, there is no secret. Okay? I didn''t propose.
+
+      Phoebe Buffay: Are you lying? Is this like that time you tried to convince us
+      that you were a doctor?
+
+      Ross Geller:'
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_ross_valid.yml
+++ b/parlai/tasks/friends/test/friends_ross_valid.yml
@@ -3,41 +3,7 @@ acts:
       Geller
     episode_done: false
     eval_labels:
-    - 'Ross Geller: __SILENCE__'
-    id: friends:ross
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Ross Geller: __SILENCE__'
-    id: friends:ross
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Ross Geller: Hey.'
-    id: friends:ross
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!
-
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
-
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Ross Geller: __SILENCE__'
+    - Hey.
     id: friends:ross
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -48,12 +14,12 @@ acts:
       Chandler Bing: Look, for the first time in my life I''m in a real relationship.
       Okay, I''m not gonna screw that up by y''know, telling the truth.
 
-      Ross Geller: Hey.'
+      Ross Geller:'
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
-    - 'Ross Geller: Sorry.'
+    - Sorry.
     id: friends:ross
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -66,6 +32,133 @@ acts:
 
       Ross Geller: Hey.
 
-      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!'
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - This would be the place where you explain the hat.
+    id: friends:ross
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Hey Pheebs, how's it going?
+    id: friends:ross
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Is everything okay?
+    id: friends:ross
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller: Sorry.
+
+      Chandler Bing: And the bunny got away.
+
+      Ross Geller: This would be the place where you explain the hat.
+
+      Joey Tribbiani: Oh! Yeah, look there''s this play all right? And I''m up for
+      the part of this real cool like suave international guy. A real clothes horse.
+      So I figure that everyone at the audition is gonna be wearing this kinda y''know,
+      ultra-hip, high fashion stuff.
+
+      Chandler Bing: And you''re gonna make them all disappear.
+
+      Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
+
+      Chandler Bing: Done.
+
+      Rachel Green: Joey, if you wanna look good, why don''t you just come down to
+      the store? I''ll help you out.
+
+      Joey Tribbiani: Great! Thanks, Rach!
+
+      Rachel Green: Sure! God, please take those off!
+
+      Joey Tribbiani: All right.
+
+      Ross Geller: Hey Pheebs, how''s it going?
+
+      Chandler Bing: Hey.
+
+      Phoebe Buffay: Hey! Umm, well, only okay because I just got back from, from
+      the hospital.
+
+      Rachel Green: What?
+
+      Ross Geller:'
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_test.yml
+++ b/parlai/tasks/friends/test/friends_test.yml
@@ -2,36 +2,26 @@ acts:
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Rachel Green: Ooy.'
-    id: friends
-    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.'
-- - characters: Joey Tribbiani,Rachel Green,Ross Geller
-    episode_done: false
-    eval_labels:
-    - 'Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what
-      is life without love?'
+    - Ooy.
     id: friends
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
-      Rachel Green: Ooy.'
+      Rachel Green:'
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Rachel Green: Oh my god, are we supposed to answer?'
+    - And to love. Ah, love. L-O-V-E, love. L is for life. And what is life without
+      love?
     id: friends
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
 
-      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
-      life without love?'
+      Ross Geller:'
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of
-      events, which I''m still fine with by the way. E is for how extremely normal
-      I find it. That you two are together. And now one day you might get married
-      and have children of your own.'
+    - Oh my god, are we supposed to answer?
     id: friends
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
@@ -40,11 +30,29 @@ acts:
       Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
       life without love?
 
-      Rachel Green: Oh my god, are we supposed to answer?'
+      Rachel Green:'
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
-    - 'Joey Tribbiani: Dude, are you okay?'
+    - O is for "oh, wow!" The V is for this very surprising turn of events, which
+      I'm still fine with by the way. E is for how extremely normal I find it. That
+      you two are together. And now one day you might get married and have children
+      of your own.
+    id: friends
+    text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
+
+      Rachel Green: Ooy.
+
+      Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
+      life without love?
+
+      Rachel Green: Oh my god, are we supposed to answer?
+
+      Ross Geller:'
+- - characters: Joey Tribbiani,Rachel Green,Ross Geller
+    episode_done: false
+    eval_labels:
+    - Dude, are you okay?
     id: friends
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
@@ -58,6 +66,8 @@ acts:
       Ross Geller: O is for "oh, wow!" The V is for this very surprising turn of events,
       which I''m still fine with by the way. E is for how extremely normal I find
       it. That you two are together. And now one day you might get married and have
-      children of your own.'
+      children of your own.
+
+      Joey Tribbiani:'
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_train.yml
+++ b/parlai/tasks/friends/test/friends_train.yml
@@ -3,34 +3,27 @@ acts:
     episode_done: false
     id: friends
     labels:
-    - 'Ross Geller: Hi!'
-    text: 'Phoebe Buffay: Oh hey! Wait up!'
-- - characters: Phoebe Buffay,Ross Geller
-    episode_done: false
-    id: friends
-    labels:
-    - 'Phoebe Buffay: Congratulations! I didn''t want to say anything in front of
-      Joey ''cause I didn''t know if he knew yet.'
+    - Hi!
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
-      Ross Geller: Hi!'
+      Ross Geller:'
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends
     labels:
-    - 'Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.'
+    - Congratulations! I didn't want to say anything in front of Joey 'cause I didn't
+      know if he knew yet.
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
 
-      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
-      ''cause I didn''t know if he knew yet.'
+      Phoebe Buffay:'
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends
     labels:
-    - 'Phoebe Buffay: No! No, that you and Rachel are engaged!'
+    - What, that we had a baby? Come on let's give him a little credit, although,
+      he did eat a piece of plastic fruit earlier.
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -38,13 +31,12 @@ acts:
       Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
       ''cause I didn''t know if he knew yet.
 
-      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
-      although, he did eat a piece of plastic fruit earlier.'
+      Ross Geller:'
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends
     labels:
-    - 'Ross Geller: What?'
+    - No! No, that you and Rachel are engaged!
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -55,6 +47,24 @@ acts:
       Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
       although, he did eat a piece of plastic fruit earlier.
 
-      Phoebe Buffay: No! No, that you and Rachel are engaged!'
+      Phoebe Buffay:'
+- - characters: Phoebe Buffay,Ross Geller
+    episode_done: false
+    id: friends
+    labels:
+    - What?
+    text: 'Phoebe Buffay: Oh hey! Wait up!
+
+      Ross Geller: Hi!
+
+      Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
+      ''cause I didn''t know if he knew yet.
+
+      Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
+      although, he did eat a piece of plastic fruit earlier.
+
+      Phoebe Buffay: No! No, that you and Rachel are engaged!
+
+      Ross Geller:'
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_valid.yml
+++ b/parlai/tasks/friends/test/friends_valid.yml
@@ -3,29 +3,19 @@ acts:
       Geller
     episode_done: false
     eval_labels:
-    - 'Joey Tribbiani: Chandler, if it really hurts that bad you should just tell
-      her.'
-    id: friends
-    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
-      it was like she was torturing me for information. And I wanted to give it up
-      I just-I didn''t know what it was!'
-- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
-      Geller
-    episode_done: false
-    eval_labels:
-    - 'Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.'
+    - Chandler, if it really hurts that bad you should just tell her.
     id: friends
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
 
-      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.'
+      Joey Tribbiani:'
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
-    - 'Ross Geller: Hey.'
+    - Look, for the first time in my life I'm in a real relationship. Okay, I'm not
+      gonna screw that up by y'know, telling the truth.
     id: friends
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -33,13 +23,12 @@ acts:
 
       Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
 
-      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
-      Okay, I''m not gonna screw that up by y''know, telling the truth.'
+      Chandler Bing:'
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
-    - 'Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!'
+    - Hey.
     id: friends
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -50,12 +39,12 @@ acts:
       Chandler Bing: Look, for the first time in my life I''m in a real relationship.
       Okay, I''m not gonna screw that up by y''know, telling the truth.
 
-      Ross Geller: Hey.'
+      Ross Geller:'
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
-    - 'Ross Geller: Sorry.'
+    - Whoa, dude, look out! You almost crushed my hat!
     id: friends
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
@@ -68,6 +57,26 @@ acts:
 
       Ross Geller: Hey.
 
-      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!'
+      Joey Tribbiani:'
+- - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
+      Geller
+    episode_done: false
+    eval_labels:
+    - Sorry.
+    id: friends
+    text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
+      it was like she was torturing me for information. And I wanted to give it up
+      I just-I didn''t know what it was!
+
+      Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
+
+      Chandler Bing: Look, for the first time in my life I''m in a real relationship.
+      Okay, I''m not gonna screw that up by y''know, telling the truth.
+
+      Ross Geller: Hey.
+
+      Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
+
+      Ross Geller:'
 num_episodes: 308
 num_examples: 5855


### PR DESCRIPTION
**Patch description**

* Add a command line option `--include-speaker-in-context` (defaults to `True`) in the teacher to include speaker in the context, instead of in the label.
```
Before
    text: A: Hello!
    label: B: Hi!

After
    text: A: Hello!
          B:
    label: Hi!
```
* Add a command line option `--silence-token-dropout` (defaults to `1`) that determines the dropout rate for including `__SILENCE__` token in the generated training examples.

**Testing steps**
`pytest test.py`

**Data Display**

`parlai dd --task friends`

<img width="1305" alt="image" src="https://user-images.githubusercontent.com/2521639/180575428-26e2229b-46c0-4e57-8d64-7eea7b639f98.png">

