### PR TITLE
multiparty BB2

### DIFF
--- a/projects/blenderbot2/agents/blenderbot2.py
+++ b/projects/blenderbot2/agents/blenderbot2.py
@@ -247,6 +247,15 @@ class BlenderBot2RagAgent(RagAgent):
             'none => do not access any knowledge.\n',
         )
         bb2_group.add_argument(
+            '--use-multiparty',
+            type=bool,
+            default=False,
+            help='Whether to enable multiparty mode by disabling calls to _remove_person_tokens and '
+            "disabling adding prefixes ('your persona: ', 'partner's persona: ') to text. "
+            'Assumes the speaker label is already in the text. '
+            'Defaults to False.',
+        )
+        bb2_group.add_argument(
             '--memory-key',
             type=str,
             default='full_text',
@@ -290,7 +299,7 @@ class BlenderBot2RagAgent(RagAgent):
         )
         bb2_group.add_argument(
             '--memory-extractor-phrase',
-            type=str,
+            type='nonestr',
             default='persona:',
             help="phrase used to extract memories from `--memory-key` in the observation. "
             "For example, set to 'your persona:' to limit memories to only lines that "
@@ -576,7 +585,7 @@ class BlenderBot2RagAgent(RagAgent):
                 self.opt['retriever_ignore_phrase'],
                 delimiter=self.opt['retriever_delimiter'],
             )
-        if self.add_person_tokens:
+        if self.add_person_tokens and not self.opt['use_multiparty']:
             query_str = self._remove_person_tokens(query_str)
         observation['query_vec'] = self.model_api.tokenize_query(query_str)
         return observation
@@ -645,7 +654,7 @@ class BlenderBot2RagAgent(RagAgent):
                     self.opt['query_generator_ignore_phrase'],
                     self.opt['query_generator_delimiter'],
                 )
-            if self.add_person_tokens:
+            if self.add_person_tokens and not self.opt['use_multiparty']:
                 query_generator_input = self._remove_person_tokens(
                     query_generator_input
                 )
@@ -742,7 +751,7 @@ class BlenderBot2RagAgent(RagAgent):
                     self.opt['memory_decoder_ignore_phrase'],
                     self.opt['memory_decoder_delimiter'],
                 )
-            if self.add_person_tokens:
+            if self.add_person_tokens and not self.opt['use_multiparty']:
                 memory_decoder_input = self._remove_person_tokens(memory_decoder_input)
             conv_lines = [
                 t


### PR DESCRIPTION
## Summary
After reading through the entire `BB2` codebase, it looks like to support multiparty chat, the only changes necessary are disabling adding the prefixes (`“partner’s persona: “`, `“your persona: “`) in the `_extract_from_raw_memories` method of `MemoryDecoder`, and disabling the removal of `__P1__` and `__P2__` tokens in `_remove_person_tokens`.

`BB2` removes `__P1__` and `__P2__` tokens from `obs[‘full_text’]` before adding the prefixes; if `opt[‘add_person_tokens’]` is `True` in `TorchAgent`, then `BB2` calls `_remove_person_tokens` before vectorizing the text and saves them in `obs[‘query_vec’]`, `obs[‘query_generator_vec’]`, and `obs[‘memory_decoder_vec’]`.

Since [the multiparty teacher](https://github.com/fairinternal/ParlAI-Internal/pull/3312) has the speaker labels in `obs[‘full_text’]` already,  we can skip `_remove_person_tokens` and also skip adding the prefixes. Since no distinction in memory is made for different personas in `LongtermMemory`, its methods (`write_memory`, `score_memories`, and `retrieve_and_score`) or relevant methods (e.g. `access_long_term_memory` in `BlenderBot2RagModel`), just having the correct speaker labels for each persona would be sufficient to support multiparty chat.

## Relevant `opt`

* `—-add-person-tokens`
	* Change behavior of calling `_remove_person_tokens` when `--add-person-tokens` is `True`
* `--retriever-ignore-phrase`
	* Defaults to `"persona: "`.
	* No need to change. Not gonna ignore anything, and `“persona: “` is not in my teacher’s `obs['"full_text”]`
* `--memory-key`
	* Set to `personas`
* `--memory-extractor-phrase`
	* Set this to `None` so it doesn’t filter out everything
* `--memory-reader-model`
	* Choose from  `['bert', 'bert_from_parlai_rag', 'dropout_poly']`

## Proposed Changes  

Add an `--use-multiparty` (`bool`) that disables calling `_remove_person_tokens` and disables adding prefixes