### PR TITLE
Friends Dataset Teacher Add `speakers` field and flag to exclude speaker labels in `text`

### DIFF
--- a/parlai/tasks/friends/agents.py
+++ b/parlai/tasks/friends/agents.py
@@ -36,10 +36,12 @@ class DefaultTeacher(DialogTeacher):
         self.characters = opt['characters'].split(',')
         self.character = opt['character']
         self.include_speaker_in_context = opt['include_speaker_in_context']
+        self.add_speaker_to_context_end = opt['add_speaker_to_context_end']
         self.silence_token_dropout = opt['silence_token_dropout']
         self.silence_token = opt['silence_token']
         self.use_start_token = opt['use_start_token']
         self.start_token = opt['start_token']
+        self.utterance_delimiter = opt['utterance_delimiter']
         super().__init__(opt, shared)
 
     def setup_data(self, datafile):
@@ -64,6 +66,7 @@ class DefaultTeacher(DialogTeacher):
                 sorted(list(characters))
             )  # sorted to ensure same order across runs
             last_utterance_index = len(utterances) - 1
+            speakers = []
 
             for index, utterance in enumerate(utterances):
                 if index == 0:
@@ -72,15 +75,38 @@ class DefaultTeacher(DialogTeacher):
 
                     else:  # skip the first utterance since there's no context
                         speaker = utterance['speaker']
-                        text = utterance['text']
-                        context = f'{speaker}: {text}'
+                        speakers.append(speaker)
+
+                        # Replace newline character by whitespace so that the data
+                        # format plays nicely with BB2, which splits each utterance
+                        # by newline and expects a corresponding speaker label
+                        # (if we don't replace the newline character here, we have
+                        # to later match each speaker label back to variable number of
+                        # sentences, which overly complicates things)
+                        # c.f. line 606 of projects/blenerbot2/agents/blenderbot2.py
+                        text = utterance['text'].replace('\n', ' ')
+                        if self.include_speaker_in_context:
+                            context = f'{speaker}: {text}'
+                        else:
+                            context = text
                         continue
 
                 speaker = utterance['speaker']
-                text = utterance['text']
+                speakers.append(speaker)
 
+                # Replace newline character by whitespace so that the data
+                # format plays nicely with BB2, which splits each utterance
+                # by newline and expects a corresponding speaker label
+                # (if we don't replace the newline character here, we have
+                # to later match each speaker label back to variable number of
+                # sentences, which overly complicates things)
+                # c.f. line 606 of projects/blenerbot2/agents/blenderbot2.py
+                text = utterance['text'].replace('\n', ' ')
                 prev_context = context
-                context += '\n' + f'{speaker}: {text}'
+                if self.include_speaker_in_context:
+                    context += self.utterance_delimiter + f'{speaker}: {text}'
+                else:
+                    context += self.utterance_delimiter + {text}
 
                 isConversationDone = index == last_utterance_index
 
@@ -89,23 +115,52 @@ class DefaultTeacher(DialogTeacher):
                 if (
                     self.character == 'All' and speaker in self.characters
                 ) or speaker == self.character:
+                    text, label, speakers = self._get_message_fields(
+                        text, speaker, speakers, prev_context
+                    )
                     yield {
-                        "text": prev_context + f'\n{speaker}:'
-                        if self.include_speaker_in_context
-                        else prev_context,
-                        "label": text
-                        if self.include_speaker_in_context
-                        else f'{speaker}: {text}',
+                        "text": text,
+                        "label": label,
                         "characters": characters_string,
+                        "speakers": speakers[:],
                     }, isConversationDone
                 elif random.random() > self.silence_token_dropout:
+                    text, label, speakers = self._get_message_fields(
+                        self.silence_token, self.character, speakers, prev_context
+                    )
                     yield {
-                        "text": prev_context,
-                        "label": self.silence_token
-                        if self.include_speaker_in_context
-                        else f'{self.character}: {self.silence_token}',
+                        "text": text,
+                        "label": label,
                         "characters": characters_string,
+                        "speakers": speakers[:],
                     }, isConversationDone
+
+    def _get_message_fields(self, text, speaker, speakers, prev_context):
+        """
+        If `include_speaker_in_context` is True, keep speaker ids in the text.
+        If `add_speaker_to_context_end` is True, add speaker ids at the end of text, and remove speaker ids from the labels.
+        If `include_speaker_in_context` is False, but `add_speaker_to_context_end` is True, add an empty sentence at the end of
+        text and add the current speaker id to the list of speakers, to indicate the speaker for the empty sentence.
+        """
+        if self.include_speaker_in_context:
+            if self.add_speaker_to_context_end:
+                label = text
+                text = prev_context + f'{self.utterance_delimiter}{speaker}:'
+            else:
+                label = f'{speaker}: {text}'
+                text = prev_context
+        else:
+            if self.add_speaker_to_context_end:
+                label = text
+                # The whitespace is left at the end to indicate an empty utterance
+                text = prev_context + f'{self.utterance_delimiter} '
+                # Save current spaker as the speaker for the empty utterance
+                speakers.append(speaker)
+            else:
+                label = f'{speaker}: {text}'
+                text = prev_context
+
+        return text, label, speakers
 
     @classmethod
     def add_cmdline_args(
@@ -135,7 +190,26 @@ class DefaultTeacher(DialogTeacher):
             help='A comma-separated list of characters to train on when `--character` == `All`',
         )
         agent.add_argument(
+            '--utterance-delimiter',
+            type=str,
+            default='\n',
+            help="A string used to separate each utterance in the context. Defaults to newline. For example, 'A: Hello\nB: Hi there'.",
+        )
+        agent.add_argument(
+            '--use-separate-speakers-field',
+            type=bool,
+            default=False,
+            help="Whether to store speaker labels for each utterance in a separate 'speakers' field of the message."
+            "For example, message = { text: 'Hello\nHow are you', speakers: ['Rachel', 'Monica'] }",
+        )
+        agent.add_argument(
             '--include-speaker-in-context',
+            type='bool',
+            default=True,
+            help="Whether to include speaker labels in the context. For example, message = { text: 'Rachel: Hi' } instead of message = { text: 'Hi' }",
+        )
+        agent.add_argument(
+            '--add-speaker-to-context-end',
             type='bool',
             default=True,
             help='Append speaker to the end of each context. Defaults to True.',

--- a/parlai/tasks/friends/agents.py
+++ b/parlai/tasks/friends/agents.py
@@ -77,14 +77,7 @@ class DefaultTeacher(DialogTeacher):
                         speaker = utterance['speaker']
                         speakers.append(speaker)
 
-                        # Replace newline character by whitespace so that the data
-                        # format plays nicely with BB2, which splits each utterance
-                        # by newline and expects a corresponding speaker label
-                        # (if we don't replace the newline character here, we have
-                        # to later match each speaker label back to variable number of
-                        # sentences, which overly complicates things)
-                        # c.f. line 606 of projects/blenerbot2/agents/blenderbot2.py
-                        text = utterance['text'].replace('\n', ' ')
+                        text = self._get_text(utterance)
                         if self.include_speaker_in_context:
                             context = f'{speaker}: {text}'
                         else:
@@ -93,14 +86,7 @@ class DefaultTeacher(DialogTeacher):
 
                 speaker = utterance['speaker']
 
-                # Replace newline character by whitespace so that the data
-                # format plays nicely with BB2, which splits each utterance
-                # by newline and expects a corresponding speaker label
-                # (if we don't replace the newline character here, we have
-                # to later match each speaker label back to variable number of
-                # sentences, which overly complicates things)
-                # c.f. line 606 of projects/blenerbot2/agents/blenderbot2.py
-                text = utterance['text'].replace('\n', ' ')
+                text = self._get_text(utterance)
                 prev_context = context
                 if self.include_speaker_in_context:
                     context += self.utterance_delimiter + f'{speaker}: {text}'
@@ -141,6 +127,18 @@ class DefaultTeacher(DialogTeacher):
                     }, isConversationDone
                 else:
                     speakers.append(speaker)
+
+    def _get_text(self, utterance):
+        """
+        Replace newline character by whitespace so that the data format plays nicely
+        with BB2, which splits each utterance by newline and expects a corresponding
+        speaker label (if we don't replace the newline character here, we have to later
+        match each speaker label back to variable number of sentences, which overly
+        complicates things) c.f.
+
+        line 606 of projects/blenerbot2/agents/blenderbot2.py
+        """
+        return utterance['text'].replace('\n', ' ')
 
     def _get_message_fields(self, text, speaker, speakers, prev_context):
         """

--- a/parlai/tasks/friends/test/friends_all_characters_test.yml
+++ b/parlai/tasks/friends/test/friends_all_characters_test.yml
@@ -4,25 +4,37 @@ acts:
     eval_labels:
     - Ooy.
     id: friends:all_characters
+    speakers:
+    - Ross Geller
+    - Rachel Green
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - And to love. Ah, love. L-O-V-E, love. L is for life. And what is life without
       love?
     id: friends:all_characters
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - Oh my god, are we supposed to answer?
     id: friends:all_characters
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -30,7 +42,7 @@ acts:
       Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
       life without love?
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
@@ -39,6 +51,12 @@ acts:
       you two are together. And now one day you might get married and have children
       of your own.
     id: friends:all_characters
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -48,12 +66,19 @@ acts:
 
       Rachel Green: Oh my god, are we supposed to answer?
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - Dude, are you okay?
     id: friends:all_characters
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -68,6 +93,6 @@ acts:
       it. That you two are together. And now one day you might get married and have
       children of your own.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_all_characters_train.yml
+++ b/parlai/tasks/friends/test/friends_all_characters_train.yml
@@ -4,26 +4,38 @@ acts:
     id: friends:all_characters
     labels:
     - Hi!
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:all_characters
     labels:
     - Congratulations! I didn't want to say anything in front of Joey 'cause I didn't
       know if he knew yet.
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:all_characters
     labels:
     - What, that we had a baby? Come on let's give him a little credit, although,
       he did eat a piece of plastic fruit earlier.
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -31,12 +43,18 @@ acts:
       Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
       ''cause I didn''t know if he knew yet.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:all_characters
     labels:
     - No! No, that you and Rachel are engaged!
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -47,12 +65,19 @@ acts:
       Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
       although, he did eat a piece of plastic fruit earlier.
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:all_characters
     labels:
     - What?
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -65,6 +90,6 @@ acts:
 
       Phoebe Buffay: No! No, that you and Rachel are engaged!
 
-      Ross Geller:'
+      Ross Geller: '
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_all_characters_valid.yml
+++ b/parlai/tasks/friends/test/friends_all_characters_valid.yml
@@ -5,11 +5,14 @@ acts:
     eval_labels:
     - Chandler, if it really hurts that bad you should just tell her.
     id: friends:all_characters
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
@@ -17,19 +20,28 @@ acts:
     - Look, for the first time in my life I'm in a real relationship. Okay, I'm not
       gonna screw that up by y'know, telling the truth.
     id: friends:all_characters
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
 
       Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Hey.
     id: friends:all_characters
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -39,13 +51,19 @@ acts:
       Chandler Bing: Look, for the first time in my life I''m in a real relationship.
       Okay, I''m not gonna screw that up by y''know, telling the truth.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Whoa, dude, look out! You almost crushed my hat!
     id: friends:all_characters
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -57,13 +75,20 @@ acts:
 
       Ross Geller: Hey.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Sorry.
     id: friends:all_characters
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -77,6 +102,6 @@ acts:
 
       Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
 
-      Ross Geller:'
+      Ross Geller: '
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_chandler_test.yml
+++ b/parlai/tasks/friends/test/friends_chandler_test.yml
@@ -5,18 +5,28 @@ acts:
     - I'm gonna hold him a different way. Look I don't understand, if you hated it
       so much, why did you buy it in the first place?
     id: friends:chandler
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
     text: 'Chandler Bing: Hey look, are we gonna have to bring this out every time
       Ross comes over?
 
       Joey Tribbiani: He paid a lot of money for it.
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing,Joey Tribbiani
     episode_done: false
     eval_labels:
     - So is he housetrained or is he gonna leave little bathroom tiles all over the
       place? Stay. Good, STAY! Good fake dog.
     id: friends:chandler
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
     text: 'Chandler Bing: Hey look, are we gonna have to bring this out every time
       Ross comes over?
 
@@ -28,23 +38,40 @@ acts:
       Joey Tribbiani: Well, I had a whole ceramic zoo thing goin'' over there but
       now, without the other ones, it just looks tacky.
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay
     episode_done: false
     eval_labels:
     - You totally screwed him over.
     id: friends:chandler
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
     text: 'Chandler Bing: You told him to play the boxer gay!!
 
       Joey Tribbiani: Well, I-I might''ve said supergay.
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - You're an actor!
     id: friends:chandler
+    speakers:
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
+    - Phoebe Buffay
+    - Monica Geller
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Monica Geller
+    - Joey Tribbiani
+    - Chandler Bing
     text: 'Monica Geller: Hey you guys?
 
       Ross Geller: What?
@@ -70,16 +97,20 @@ acts:
       Joey Tribbiani: No way! Look, Halloween is so stupid! Dressing up, pretending
       to be someone you''re not...
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing,Joey Tribbiani
     episode_done: false
     eval_labels:
     - Hey-hey-hey. So what happened? A forest tick you off?
     id: friends:chandler
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
     text: 'Chandler Bing: Hey!
 
       Joey Tribbiani: Hey!
 
-      Chandler Bing:'
+      Chandler Bing: '
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_chandler_train.yml
+++ b/parlai/tasks/friends/test/friends_chandler_train.yml
@@ -5,17 +5,27 @@ acts:
     labels:
     - Oh, no, no, I'm an intern, just like you guys... except for the tie, the briefcase...
       and the fact that I can rent a car.
+    speakers:
+    - Chandler Bing
+    - Intern
+    - Chandler Bing
     text: 'Chandler Bing: Good morning, everybody.
 
       Intern: Can I get you a cup of coffee, Sir?
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing
     episode_done: false
     id: friends:chandler
     labels:
     - Yeah, well, I'm kinda heading into a new career direction and, you know, you
       gotta start at the bottom.
+    speakers:
+    - Chandler Bing
+    - Intern
+    - Chandler Bing
+    - Intern
+    - Chandler Bing
     text: 'Chandler Bing: Good morning, everybody.
 
       Intern: Can I get you a cup of coffee, Sir?
@@ -25,13 +35,21 @@ acts:
 
       Intern: Seriously, you''re an intern?
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing
     episode_done: false
     id: friends:chandler
     labels:
     - Right. Look, I know I'm a little bit older than you guys, but it's not like
       I'm Bob Hope.
+    speakers:
+    - Chandler Bing
+    - Intern
+    - Chandler Bing
+    - Intern
+    - Chandler Bing
+    - Intern
+    - Chandler Bing
     text: 'Chandler Bing: Good morning, everybody.
 
       Intern: Can I get you a cup of coffee, Sir?
@@ -46,12 +64,21 @@ acts:
 
       Intern: Dude!
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing
     episode_done: false
     id: friends:chandler
     labels:
     - The comedian? USO?!
+    speakers:
+    - Chandler Bing
+    - Intern
+    - Chandler Bing
+    - Intern
+    - Chandler Bing
+    - Intern
+    - Chandler Bing
+    - Chandler Bing
     text: 'Chandler Bing: Good morning, everybody.
 
       Intern: Can I get you a cup of coffee, Sir?
@@ -69,14 +96,17 @@ acts:
       Chandler Bing: Right. Look, I know I''m a little bit older than you guys, but
       it''s not like I''m Bob Hope.
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing,Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:chandler
     labels:
     - Oh, hey.
+    speakers:
+    - Phoebe Buffay
+    - Chandler Bing
     text: 'Phoebe Buffay: Um, Chandler, Ross, this is Robert.
 
-      Chandler Bing:'
+      Chandler Bing: '
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_chandler_valid.yml
+++ b/parlai/tasks/friends/test/friends_chandler_valid.yml
@@ -6,19 +6,31 @@ acts:
     - Look, for the first time in my life I'm in a real relationship. Okay, I'm not
       gonna screw that up by y'know, telling the truth.
     id: friends:chandler
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
 
       Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - And the bunny got away.
     id: friends:chandler
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -34,13 +46,24 @@ acts:
 
       Ross Geller: Sorry.
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - And you're gonna make them all disappear.
     id: friends:chandler
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -65,13 +88,26 @@ acts:
       So I figure that everyone at the audition is gonna be wearing this kinda y''know,
       ultra-hip, high fashion stuff.
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Done.
     id: friends:chandler
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -100,13 +136,32 @@ acts:
 
       Joey Tribbiani: Yeah, like you could find something as sophisticated as this.
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Hey.
     id: friends:chandler
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -148,6 +203,6 @@ acts:
 
       Ross Geller: Hey Pheebs, how''s it going?
 
-      Chandler Bing:'
+      Chandler Bing: '
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_joey_test.yml
+++ b/parlai/tasks/friends/test/friends_joey_test.yml
@@ -4,6 +4,13 @@ acts:
     eval_labels:
     - Dude, are you okay?
     id: friends:joey
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -18,12 +25,39 @@ acts:
       it. That you two are together. And now one day you might get married and have
       children of your own.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - You know what? I think I'm gonna stay here and make sure he's okay.
     id: friends:joey
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Charlie Wheeler
+    - Rachel Green
+    - Charlie Wheeler
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Ross Geller
+    - Joey Tribbiani
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -83,12 +117,41 @@ acts:
 
       Ross Geller: I don''t even know what that''s for.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: true
     eval_labels:
     - Yeah. I'll see you in the morning.
     id: friends:joey
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Charlie Wheeler
+    - Rachel Green
+    - Charlie Wheeler
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Ross Geller
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -153,12 +216,43 @@ acts:
 
       Rachel Green: Yeah, that''s probably a good idea.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - It doesn't look good, does it?
     id: friends:joey
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Charlie Wheeler
+    - Rachel Green
+    - Charlie Wheeler
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Ross Geller
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -228,15 +322,18 @@ acts:
       Rachel Green: Uh-huh. Okay. You know what, Joey, I don''t think he''s ever gonna
       be okay with this.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Chandler Bing,Joey Tribbiani
     episode_done: false
     eval_labels:
     - He paid a lot of money for it.
     id: friends:joey
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
     text: 'Chandler Bing: Hey look, are we gonna have to bring this out every time
       Ross comes over?
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_joey_train.yml
+++ b/parlai/tasks/friends/test/friends_joey_train.yml
@@ -4,15 +4,23 @@ acts:
     id: friends:joey
     labels:
     - Well, you must be new here. Why don't we get a table and I'll buy you a drink.
+    speakers:
+    - The Casting Director
+    - Joey Tribbiani
     text: 'The Casting Director: Any time you''re ready, Joey.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Joey Tribbiani
     episode_done: false
     id: friends:joey
     labels:
     - Yeah, sure. Well, you must be new here. Maybe we should-I'm sorry, can I ask
       you something?
+    speakers:
+    - The Casting Director
+    - Joey Tribbiani
+    - The Casting Director
+    - Joey Tribbiani
     text: 'The Casting Director: Any time you''re ready, Joey.
 
       Joey Tribbiani: Well, you must be new here. Why don''t we get a table and I''ll
@@ -20,12 +28,19 @@ acts:
 
       The Casting Director: I''m sorry. Could you, could you try it without the purse?
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Joey Tribbiani
     episode_done: false
     id: friends:joey
     labels:
     - Well, first it's not a purse.
+    speakers:
+    - The Casting Director
+    - Joey Tribbiani
+    - The Casting Director
+    - Joey Tribbiani
+    - The Casting Director
+    - Joey Tribbiani
     text: 'The Casting Director: Any time you''re ready, Joey.
 
       Joey Tribbiani: Well, you must be new here. Why don''t we get a table and I''ll
@@ -38,12 +53,21 @@ acts:
 
       The Casting Director: Sure. What?
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Joey Tribbiani
     episode_done: false
     id: friends:joey
     labels:
     - I mean if-if you're thinking it's a woman's bag, it's not. It's a man's bag!
+    speakers:
+    - The Casting Director
+    - Joey Tribbiani
+    - The Casting Director
+    - Joey Tribbiani
+    - The Casting Director
+    - Joey Tribbiani
+    - The Casting Director
+    - Joey Tribbiani
     text: 'The Casting Director: Any time you''re ready, Joey.
 
       Joey Tribbiani: Well, you must be new here. Why don''t we get a table and I''ll
@@ -60,13 +84,24 @@ acts:
 
       The Casting Director: Okay, anytime.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Joey Tribbiani
     episode_done: false
     id: friends:joey
     labels:
     - All right look, let me show you the catalog! See? Huh? It's the latest thing!
       Everyone's got one! Men! Women! Children! Everyone's carrying them!
+    speakers:
+    - The Casting Director
+    - Joey Tribbiani
+    - The Casting Director
+    - Joey Tribbiani
+    - The Casting Director
+    - Joey Tribbiani
+    - The Casting Director
+    - Joey Tribbiani
+    - The Casting Director
+    - Joey Tribbiani
     text: 'The Casting Director: Any time you''re ready, Joey.
 
       Joey Tribbiani: Well, you must be new here. Why don''t we get a table and I''ll
@@ -88,6 +123,6 @@ acts:
 
       The Casting Director: Okayyyy! Anddd, go!
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_joey_valid.yml
+++ b/parlai/tasks/friends/test/friends_joey_valid.yml
@@ -5,17 +5,26 @@ acts:
     eval_labels:
     - Chandler, if it really hurts that bad you should just tell her.
     id: friends:joey
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Whoa, dude, look out! You almost crushed my hat!
     id: friends:joey
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -27,7 +36,7 @@ acts:
 
       Ross Geller: Hey.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
@@ -37,6 +46,16 @@ acts:
       everyone at the audition is gonna be wearing this kinda y'know, ultra-hip, high
       fashion stuff.
     id: friends:joey
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -56,13 +75,25 @@ acts:
 
       Ross Geller: This would be the place where you explain the hat.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Yeah, like you could find something as sophisticated as this.
     id: friends:joey
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -89,13 +120,28 @@ acts:
 
       Chandler Bing: And you''re gonna make them all disappear.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Great! Thanks, Rach!
     id: friends:joey
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -129,6 +175,6 @@ acts:
       Rachel Green: Joey, if you wanna look good, why don''t you just come down to
       the store? I''ll help you out.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_monica_test.yml
+++ b/parlai/tasks/friends/test/friends_monica_test.yml
@@ -4,30 +4,45 @@ acts:
     eval_labels:
     - Joey, you're this guy's teacher. I mean how could you do this?
     id: friends:monica
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Monica Geller
     text: 'Chandler Bing: You told him to play the boxer gay!!
 
       Joey Tribbiani: Well, I-I might''ve said supergay.
 
       Chandler Bing: You totally screwed him over.
 
-      Monica Geller:'
+      Monica Geller: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - I know it's last minute, but we decided to have a Halloween party.
     id: friends:monica
+    speakers:
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
     text: 'Monica Geller: Hey you guys?
 
       Ross Geller: What?
 
-      Monica Geller:'
+      Monica Geller: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - And everybody has to wear costumes. Come on! It'll be fun!
     id: friends:monica
+    speakers:
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
+    - Phoebe Buffay
+    - Monica Geller
     text: 'Monica Geller: Hey you guys?
 
       Ross Geller: What?
@@ -37,13 +52,24 @@ acts:
 
       Phoebe Buffay: Oh good!
 
-      Monica Geller:'
+      Monica Geller: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - You have to!
     id: friends:monica
+    speakers:
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
+    - Phoebe Buffay
+    - Monica Geller
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Monica Geller
     text: 'Monica Geller: Hey you guys?
 
       Ross Geller: What?
@@ -64,13 +90,27 @@ acts:
 
       Joey Tribbiani: Look, I''ll come to the party but I''m not dressing up.
 
-      Monica Geller:'
+      Monica Geller: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - So Ross, are you gonna bring Mona?
     id: friends:monica
+    speakers:
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
+    - Phoebe Buffay
+    - Monica Geller
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Monica Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Monica Geller
     text: 'Monica Geller: Hey you guys?
 
       Ross Geller: What?
@@ -98,6 +138,6 @@ acts:
 
       Chandler Bing: You''re an actor!
 
-      Monica Geller:'
+      Monica Geller: '
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_monica_train.yml
+++ b/parlai/tasks/friends/test/friends_monica_train.yml
@@ -4,6 +4,13 @@ acts:
     id: friends:monica
     labels:
     - Ohh, sweetie! Hey, I bet you anything that he's gonna call you again.
+    speakers:
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Monica Geller
     text: 'Rachel Green: Well, I just called Joshua...
 
       Phoebe Buffay: Oh, how did it go?
@@ -16,12 +23,25 @@ acts:
       Rachel Green: Well uh, his answering machine was very understanding. Ugh. I
       feel blue.
 
-      Monica Geller:'
+      Monica Geller: '
 - - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:monica
     labels:
     - Again. Y'know what? I think we all did.
+    speakers:
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Monica Geller
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Monica Geller
     text: 'Rachel Green: Well, I just called Joshua...
 
       Phoebe Buffay: Oh, how did it go?
@@ -52,12 +72,27 @@ acts:
       again, off again? I guess I just figured that somewhere down the road, we would
       be on again.
 
-      Monica Geller:'
+      Monica Geller: '
 - - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:monica
     labels:
     - Hey!
+    speakers:
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Monica Geller
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
     text: 'Rachel Green: Well, I just called Joshua...
 
       Phoebe Buffay: Oh, how did it go?
@@ -92,13 +127,49 @@ acts:
 
       Ross Geller: Hey!
 
-      Monica Geller:'
+      Monica Geller: '
 - - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:monica
     labels:
     - Oh, I wish there was a job where I could wear this all the time. Maybe someday,
       there will be.
+    speakers:
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Monica Geller
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Rachel Green
+    - Monica Geller
     text: 'Rachel Green: Well, I just called Joshua...
 
       Phoebe Buffay: Oh, how did it go?
@@ -177,12 +248,49 @@ acts:
 
       Rachel Green: Y''know, I gotta tell ya, this really does put in a better mood.
 
-      Monica Geller:'
+      Monica Geller: '
 - - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:monica
     labels:
     - Oh God! He's gonna come by and borrow some candles for his big date!
+    speakers:
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Monica Geller
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Rachel Green
+    - Monica Geller
+    - Monica Geller
     text: 'Rachel Green: Well, I just called Joshua...
 
       Phoebe Buffay: Oh, how did it go?
@@ -264,6 +372,6 @@ acts:
       Monica Geller: Oh, I wish there was a job where I could wear this all the time.
       Maybe someday, there will be.
 
-      Monica Geller:'
+      Monica Geller: '
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_monica_valid.yml
+++ b/parlai/tasks/friends/test/friends_monica_valid.yml
@@ -5,6 +5,35 @@ acts:
     eval_labels:
     - Guys! Guys! I just saw two people having sex in a car right outside.
     id: friends:monica
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Phoebe Buffay
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Monica Geller
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -70,13 +99,44 @@ acts:
       Phoebe Buffay: Yeah, her first day on a new spiritual plane and she''s gonna
       come to the coffeehouse!
 
-      Monica Geller:'
+      Monica Geller: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Ohh my God, I'm so sorry.
     id: friends:monica
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Phoebe Buffay
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -146,13 +206,46 @@ acts:
 
       Ross Geller: Uhh, Pheebs'' Grandmother just died.
 
-      Monica Geller:'
+      Monica Geller: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Not the way they're doing it. What, what happened? How did she die?
     id: friends:monica
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Phoebe Buffay
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
+    - Phoebe Buffay
+    - Monica Geller
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -227,12 +320,18 @@ acts:
       Phoebe Buffay: It''s okay. Actually y''know what, it''s kinda cool. ''Cause
       it''s like y''know, one life ends and another begins.
 
-      Monica Geller:'
+      Monica Geller: '
 - - characters: Chandler Bing,Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - What happened to your teeth.
     id: friends:monica
+    speakers:
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Chandler Bing
+    - Monica Geller
     text: 'Ross Geller: Hey guys.
 
       Chandler Bing: Hey.
@@ -241,12 +340,22 @@ acts:
 
       Chandler Bing: You know...Oh My God.
 
-      Monica Geller:'
+      Monica Geller: '
 - - characters: Chandler Bing,Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - Well, I think I shouldn't look directly at them.
     id: friends:monica
+    speakers:
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Chandler Bing
+    - Monica Geller
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Monica Geller
     text: 'Ross Geller: Hey guys.
 
       Chandler Bing: Hey.
@@ -263,6 +372,6 @@ acts:
 
       Ross Geller: Yeah. What do you think.
 
-      Monica Geller:'
+      Monica Geller: '
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_phoebe_test.yml
+++ b/parlai/tasks/friends/test/friends_phoebe_test.yml
@@ -4,6 +4,10 @@ acts:
     eval_labels:
     - Alright... Susie, can I call you Susie?
     id: friends:phoebe
+    speakers:
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Okay, bye. Alright, so Mike''s on his way over. See, you
       thought you guys were meeting here, and he thought you were meeting at the restaurant,
       so you know... Doesn''t really matter who''s right or wrong. Point is... I''m
@@ -12,7 +16,7 @@ acts:
       Precious: I''m not letting you leave until you tell me what''s going on here.
       I mean, are you guys getting back together or something?
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Phoebe Buffay
     episode_done: false
     eval_labels:
@@ -21,6 +25,12 @@ acts:
       relationship with him. And he's very sorry about that and wishes you the best
       of luck in all your endeavours.
     id: friends:phoebe
+    speakers:
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Okay, bye. Alright, so Mike''s on his way over. See, you
       thought you guys were meeting here, and he thought you were meeting at the restaurant,
       so you know... Doesn''t really matter who''s right or wrong. Point is... I''m
@@ -33,12 +43,20 @@ acts:
 
       Precious: My name is Precious.
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Phoebe Buffay
     episode_done: false
     eval_labels:
     - Well, I don't...
     id: friends:phoebe
+    speakers:
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Okay, bye. Alright, so Mike''s on his way over. See, you
       thought you guys were meeting here, and he thought you were meeting at the restaurant,
       so you know... Doesn''t really matter who''s right or wrong. Point is... I''m
@@ -58,12 +76,22 @@ acts:
 
       Precious: I just can''t believe this... Why?
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Phoebe Buffay
     episode_done: false
     eval_labels:
     - Nothing, there's nothing wrong with you.
     id: friends:phoebe
+    speakers:
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Okay, bye. Alright, so Mike''s on his way over. See, you
       thought you guys were meeting here, and he thought you were meeting at the restaurant,
       so you know... Doesn''t really matter who''s right or wrong. Point is... I''m
@@ -87,12 +115,24 @@ acts:
 
       Precious: Oh, why would he do this? I mean, what''s wrong with me?
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Phoebe Buffay
     episode_done: false
     eval_labels:
     - Damn it woman, pull yourself together! Have some pride, for the love of God.
     id: friends:phoebe
+    speakers:
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
+    - Precious
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Okay, bye. Alright, so Mike''s on his way over. See, you
       thought you guys were meeting here, and he thought you were meeting at the restaurant,
       so you know... Doesn''t really matter who''s right or wrong. Point is... I''m
@@ -120,6 +160,6 @@ acts:
 
       Precious: I mean, what the hell am I supposed to do now?
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_phoebe_train.yml
+++ b/parlai/tasks/friends/test/friends_phoebe_train.yml
@@ -5,16 +5,26 @@ acts:
     labels:
     - Congratulations! I didn't want to say anything in front of Joey 'cause I didn't
       know if he knew yet.
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:phoebe
     labels:
     - No! No, that you and Rachel are engaged!
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -25,13 +35,21 @@ acts:
       Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
       although, he did eat a piece of plastic fruit earlier.
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:phoebe
     labels:
     - Oh, it's a secret. Oh goodie! Yes! We haven't done the secret thing in a long
       time.
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -46,13 +64,23 @@ acts:
 
       Ross Geller: What?
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:phoebe
     labels:
     - Are you lying? Is this like that time you tried to convince us that you were
       a doctor?
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -72,12 +100,24 @@ acts:
 
       Ross Geller: Phoebe, there is no secret. Okay? I didn''t propose.
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:phoebe
     labels:
     - All right, me too. Should we wake her up?
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -103,6 +143,6 @@ acts:
       Ross Geller: I am a doctor! Y''know what? I''m just gonna go and talk to Rachel
       myself.
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_phoebe_valid.yml
+++ b/parlai/tasks/friends/test/friends_phoebe_valid.yml
@@ -5,6 +5,26 @@ acts:
     eval_labels:
     - Hey! Umm, well, only okay because I just got back from, from the hospital.
     id: friends:phoebe
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Phoebe Buffay
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -48,13 +68,37 @@ acts:
 
       Chandler Bing: Hey.
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Oh yeah, no-no-no. I'm fine. I'm okay, but umm, my Grandma sorta died.
     id: friends:phoebe
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Phoebe Buffay
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Phoebe Buffay
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -107,7 +151,7 @@ acts:
 
       Joey Tribbiani: Are you all right?
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
@@ -115,6 +159,32 @@ acts:
     - It's okay, I mean she had a really incredible life. And it's not like I'm never
       gonna see her again, y'know she's gonna visit.
     id: friends:phoebe
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Phoebe Buffay
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Joey Tribbiani
+    - Phoebe Buffay
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -172,13 +242,41 @@ acts:
 
       Joey Tribbiani: Pheebs! Sorry!
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Yeah, her first day on a new spiritual plane and she's gonna come to the coffeehouse!
     id: friends:phoebe
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Phoebe Buffay
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -241,7 +339,7 @@ acts:
 
       Rachel Green: Well maybe, maybe she''s with us right now?
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
@@ -249,6 +347,38 @@ acts:
     - It's okay. Actually y'know what, it's kinda cool. 'Cause it's like y'know, one
       life ends and another begins.
     id: friends:phoebe
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Phoebe Buffay
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
+    - Phoebe Buffay
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -320,6 +450,6 @@ acts:
 
       Monica Geller: Ohh my God, I''m so sorry.
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_rachel_test.yml
+++ b/parlai/tasks/friends/test/friends_rachel_test.yml
@@ -4,14 +4,22 @@ acts:
     eval_labels:
     - Ooy.
     id: friends:rachel
+    speakers:
+    - Ross Geller
+    - Rachel Green
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - Oh my god, are we supposed to answer?
     id: friends:rachel
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -19,12 +27,21 @@ acts:
       Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
       life without love?
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - Ross, you don't seem okay.
     id: friends:rachel
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Rachel Green
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -43,12 +60,31 @@ acts:
 
       Ross Geller: Totally.
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - Oh, that's okay, girls tend not to like me.
     id: friends:rachel
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Charlie Wheeler
+    - Rachel Green
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -90,12 +126,34 @@ acts:
 
       Charlie Wheeler: God, Rachel, what Ross just said that is just so..
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - You know what, Ross? I think we're gonna take off too.
     id: friends:rachel
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
+    - Charlie Wheeler
+    - Charlie Wheeler
+    - Rachel Green
+    - Charlie Wheeler
+    - Ross Geller
+    - Rachel Green
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -143,6 +201,6 @@ acts:
 
       Ross Geller: Okay, I guess it''s just flan for three! Hey, hey, that rhymed!
 
-      Rachel Green:'
+      Rachel Green: '
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_rachel_train.yml
+++ b/parlai/tasks/friends/test/friends_rachel_train.yml
@@ -5,16 +5,26 @@ acts:
     labels:
     - Well, I did my best to convince him that I'm not some crazy girl who is dying
       to get married-I'm just going through a hard time.
+    speakers:
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
     text: 'Rachel Green: Well, I just called Joshua...
 
       Phoebe Buffay: Oh, how did it go?
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:rachel
     labels:
     - Well uh, his answering machine was very understanding. Ugh. I feel blue.
+    speakers:
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
     text: 'Rachel Green: Well, I just called Joshua...
 
       Phoebe Buffay: Oh, how did it go?
@@ -24,7 +34,7 @@ acts:
 
       Phoebe Buffay: What did he say?
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:rachel
@@ -32,6 +42,14 @@ acts:
     - Yeah, maybe, but I don't think I even care. I don't think he's the one I'm sad
       about. Y'know, I know that I said that I am totally okay with Ross getting married,
       but as it turns out, I don't think I'm handling it all that well.
+    speakers:
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Monica Geller
+    - Rachel Green
     text: 'Rachel Green: Well, I just called Joshua...
 
       Phoebe Buffay: Oh, how did it go?
@@ -47,12 +65,22 @@ acts:
       Monica Geller: Ohh, sweetie! Hey, I bet you anything that he''s gonna call you
       again.
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:rachel
     labels:
     - And I-I am just trying to figure out why.
+    speakers:
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Monica Geller
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
     text: 'Rachel Green: Well, I just called Joshua...
 
       Phoebe Buffay: Oh, how did it go?
@@ -75,13 +103,25 @@ acts:
 
       Phoebe Buffay: Yeah, maybe.
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     id: friends:rachel
     labels:
     - Well, yeah, y'know how Ross and I were on again, off again, on again, off again?
       I guess I just figured that somewhere down the road, we would be on again.
+    speakers:
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Monica Geller
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
+    - Phoebe Buffay
+    - Rachel Green
     text: 'Rachel Green: Well, I just called Joshua...
 
       Phoebe Buffay: Oh, how did it go?
@@ -108,6 +148,6 @@ acts:
 
       Phoebe Buffay: Any luck?
 
-      Rachel Green:'
+      Rachel Green: '
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_rachel_valid.yml
+++ b/parlai/tasks/friends/test/friends_rachel_valid.yml
@@ -6,6 +6,20 @@ acts:
     - Joey, if you wanna look good, why don't you just come down to the store? I'll
       help you out.
     id: friends:rachel
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -36,13 +50,29 @@ acts:
 
       Chandler Bing: Done.
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Sure! God, please take those off!
     id: friends:rachel
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -78,13 +108,34 @@ acts:
 
       Joey Tribbiani: Great! Thanks, Rach!
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - What?
     id: friends:rachel
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Phoebe Buffay
+    - Rachel Green
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -131,13 +182,40 @@ acts:
       Phoebe Buffay: Hey! Umm, well, only okay because I just got back from, from
       the hospital.
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Well maybe, maybe she's with us right now?
     id: friends:rachel
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Phoebe Buffay
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Joey Tribbiani
+    - Phoebe Buffay
+    - Rachel Green
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -198,13 +276,36 @@ acts:
       Phoebe Buffay: It''s okay, I mean she had a really incredible life. And it''s
       not like I''m never gonna see her again, y''know she''s gonna visit.
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Chandler Bing,Monica Geller,Phoebe Buffay,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - Yeah. Your teeth? Yes, I saw them from outside. You guys are never going to
       believe this. But, Phoebe made out with Ralph Lauren.
     id: friends:rachel
+    speakers:
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Chandler Bing
+    - Monica Geller
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
+    - Chandler Bing
+    - Ross Geller
+    - Monica Geller
+    - Ross Geller
+    - Monica Geller
+    - Ross Geller
+    - Chandler Bing
+    - Monica Geller
+    - Chandler Bing
+    - Ross Geller
+    - Rachel Green
     text: 'Ross Geller: Hey guys.
 
       Chandler Bing: Hey.
@@ -247,6 +348,6 @@ acts:
 
       Ross Geller: Oh, hey, hey Rach, do you notice anything..ahh...
 
-      Rachel Green:'
+      Rachel Green: '
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_ross_test.yml
+++ b/parlai/tasks/friends/test/friends_ross_test.yml
@@ -5,11 +5,15 @@ acts:
     - And to love. Ah, love. L-O-V-E, love. L is for life. And what is life without
       love?
     id: friends:ross
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
@@ -18,6 +22,12 @@ acts:
       you two are together. And now one day you might get married and have children
       of your own.
     id: friends:ross
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -27,12 +37,20 @@ acts:
 
       Rachel Green: Oh my god, are we supposed to answer?
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - Totally.
     id: friends:ross
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -49,13 +67,23 @@ acts:
 
       Joey Tribbiani: Dude, are you okay?
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - I'm sorry, it must be the pressure of entertaining. I think everyone would feel
       better if we had some flan.
     id: friends:ross
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -76,12 +104,24 @@ acts:
 
       Rachel Green: Ross, you don''t seem okay.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - No!
     id: friends:ross
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Charlie Wheeler
+    - Ross Geller
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -107,6 +147,6 @@ acts:
 
       Charlie Wheeler: Wait, Ross. Ross. I - I have to take off.
 
-      Ross Geller:'
+      Ross Geller: '
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_ross_train.yml
+++ b/parlai/tasks/friends/test/friends_ross_train.yml
@@ -4,15 +4,23 @@ acts:
     id: friends:ross
     labels:
     - Hi!
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:ross
     labels:
     - What, that we had a baby? Come on let's give him a little credit, although,
       he did eat a piece of plastic fruit earlier.
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -20,12 +28,19 @@ acts:
       Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
       ''cause I didn''t know if he knew yet.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:ross
     labels:
     - What?
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -38,12 +53,21 @@ acts:
 
       Phoebe Buffay: No! No, that you and Rachel are engaged!
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:ross
     labels:
     - Phoebe, there is no secret. Okay? I didn't propose.
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -61,12 +85,23 @@ acts:
       Phoebe Buffay: Oh, it''s a secret. Oh goodie! Yes! We haven''t done the secret
       thing in a long time.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends:ross
     labels:
     - I am a doctor! Y'know what? I'm just gonna go and talk to Rachel myself.
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -89,6 +124,6 @@ acts:
       Phoebe Buffay: Are you lying? Is this like that time you tried to convince us
       that you were a doctor?
 
-      Ross Geller:'
+      Ross Geller: '
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_ross_valid.yml
+++ b/parlai/tasks/friends/test/friends_ross_valid.yml
@@ -5,6 +5,11 @@ acts:
     eval_labels:
     - Hey.
     id: friends:ross
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -14,13 +19,20 @@ acts:
       Chandler Bing: Look, for the first time in my life I''m in a real relationship.
       Okay, I''m not gonna screw that up by y''know, telling the truth.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Sorry.
     id: friends:ross
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -34,13 +46,22 @@ acts:
 
       Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - This would be the place where you explain the hat.
     id: friends:ross
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -58,13 +79,31 @@ acts:
 
       Chandler Bing: And the bunny got away.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Hey Pheebs, how's it going?
     id: friends:ross
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -104,13 +143,35 @@ acts:
 
       Joey Tribbiani: All right.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Is everything okay?
     id: friends:ross
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Rachel Green
+    - Joey Tribbiani
+    - Rachel Green
+    - Joey Tribbiani
+    - Ross Geller
+    - Chandler Bing
+    - Phoebe Buffay
+    - Rachel Green
+    - Ross Geller
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -159,6 +220,6 @@ acts:
 
       Rachel Green: What?
 
-      Ross Geller:'
+      Ross Geller: '
 num_episodes: 308
 num_examples: 5855

--- a/parlai/tasks/friends/test/friends_test.yml
+++ b/parlai/tasks/friends/test/friends_test.yml
@@ -4,25 +4,37 @@ acts:
     eval_labels:
     - Ooy.
     id: friends
+    speakers:
+    - Ross Geller
+    - Rachel Green
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - And to love. Ah, love. L-O-V-E, love. L is for life. And what is life without
       love?
     id: friends
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - Oh my god, are we supposed to answer?
     id: friends
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -30,7 +42,7 @@ acts:
       Ross Geller: And to love. Ah, love. L-O-V-E, love. L is for life. And what is
       life without love?
 
-      Rachel Green:'
+      Rachel Green: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
@@ -39,6 +51,12 @@ acts:
       you two are together. And now one day you might get married and have children
       of your own.
     id: friends
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -48,12 +66,19 @@ acts:
 
       Rachel Green: Oh my god, are we supposed to answer?
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Joey Tribbiani,Rachel Green,Ross Geller
     episode_done: false
     eval_labels:
     - Dude, are you okay?
     id: friends
+    speakers:
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Rachel Green
+    - Ross Geller
+    - Joey Tribbiani
     text: 'Ross Geller: Everyone? I would like to make a toast to Rachel and Joey.
 
       Rachel Green: Ooy.
@@ -68,6 +93,6 @@ acts:
       it. That you two are together. And now one day you might get married and have
       children of your own.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 num_episodes: 302
 num_examples: 5774

--- a/parlai/tasks/friends/test/friends_train.yml
+++ b/parlai/tasks/friends/test/friends_train.yml
@@ -4,26 +4,38 @@ acts:
     id: friends
     labels:
     - Hi!
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends
     labels:
     - Congratulations! I didn't want to say anything in front of Joey 'cause I didn't
       know if he knew yet.
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends
     labels:
     - What, that we had a baby? Come on let's give him a little credit, although,
       he did eat a piece of plastic fruit earlier.
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -31,12 +43,18 @@ acts:
       Phoebe Buffay: Congratulations! I didn''t want to say anything in front of Joey
       ''cause I didn''t know if he knew yet.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends
     labels:
     - No! No, that you and Rachel are engaged!
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -47,12 +65,19 @@ acts:
       Ross Geller: What, that we had a baby? Come on let''s give him a little credit,
       although, he did eat a piece of plastic fruit earlier.
 
-      Phoebe Buffay:'
+      Phoebe Buffay: '
 - - characters: Phoebe Buffay,Ross Geller
     episode_done: false
     id: friends
     labels:
     - What?
+    speakers:
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
+    - Phoebe Buffay
+    - Ross Geller
     text: 'Phoebe Buffay: Oh hey! Wait up!
 
       Ross Geller: Hi!
@@ -65,6 +90,6 @@ acts:
 
       Phoebe Buffay: No! No, that you and Rachel are engaged!
 
-      Ross Geller:'
+      Ross Geller: '
 num_episodes: 2427
 num_examples: 46610

--- a/parlai/tasks/friends/test/friends_valid.yml
+++ b/parlai/tasks/friends/test/friends_valid.yml
@@ -5,11 +5,14 @@ acts:
     eval_labels:
     - Chandler, if it really hurts that bad you should just tell her.
     id: friends
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
@@ -17,19 +20,28 @@ acts:
     - Look, for the first time in my life I'm in a real relationship. Okay, I'm not
       gonna screw that up by y'know, telling the truth.
     id: friends
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
 
       Joey Tribbiani: Chandler, if it really hurts that bad you should just tell her.
 
-      Chandler Bing:'
+      Chandler Bing: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Hey.
     id: friends
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -39,13 +51,19 @@ acts:
       Chandler Bing: Look, for the first time in my life I''m in a real relationship.
       Okay, I''m not gonna screw that up by y''know, telling the truth.
 
-      Ross Geller:'
+      Ross Geller: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Whoa, dude, look out! You almost crushed my hat!
     id: friends
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -57,13 +75,20 @@ acts:
 
       Ross Geller: Hey.
 
-      Joey Tribbiani:'
+      Joey Tribbiani: '
 - - characters: Chandler Bing,Joey Tribbiani,Monica Geller,Phoebe Buffay,Rachel Green,Ross
       Geller
     episode_done: false
     eval_labels:
     - Sorry.
     id: friends
+    speakers:
+    - Chandler Bing
+    - Joey Tribbiani
+    - Chandler Bing
+    - Ross Geller
+    - Joey Tribbiani
+    - Ross Geller
     text: 'Chandler Bing: I''m telling you, she gives the worst massages ever!! Okay,
       it was like she was torturing me for information. And I wanted to give it up
       I just-I didn''t know what it was!
@@ -77,6 +102,6 @@ acts:
 
       Joey Tribbiani: Whoa, dude, look out! You almost crushed my hat!
 
-      Ross Geller:'
+      Ross Geller: '
 num_episodes: 308
 num_examples: 5855


### PR DESCRIPTION
**Patch Description**
This patch adds a `speakers` field in the message generated from the teacher for the Friends dataset.

It also adds an option to exclude speaker ids from the `text`. This option is named `--include-speaker-in-context`. The original `--include-speaker-in-context` flag, which determines whether speaker labels are added at the end of `text`, is renamed to `--add-speaker-to-context-end`.

Together, these changes make it convenient to feed the data into downstream models such as BlenderBot2 that require cleaned `text` input without speaker labels, but need to restore the speaker labels later.


**Sample Output**
`parlai dd -t friends -n 2 --verbose --include-speaker-in-context True --add-speaker-to-context-end True`
This is the default behavior.
![image](https://user-images.githubusercontent.com/2521639/181841668-4fd8b891-c55f-467d-aed1-213bd23c6a91.png)


`parlai dd -t friends -n 2 --verbose --include-speaker-in-context True --add-speaker-to-context-end False`
![image](https://user-images.githubusercontent.com/2521639/181841735-b12f80da-bc87-4fae-92f6-17ff69c62f2b.png)


`parlai dd -t friends -n 2 --verbose --include-speaker-in-context False --add-speaker-to-context-end True`
Notice the empty line which marks an empty sentence, and notice how the current speaker label is also added to the `speakers` field.
![image](https://user-images.githubusercontent.com/2521639/181841808-eb30f926-7999-498d-81a6-70c8e9886604.png)


`parlai dd -t friends -n 2 --verbose --include-speaker-in-context False --add-speaker-to-context-end False`
![image](https://user-images.githubusercontent.com/2521639/181841861-1c931d11-f00a-4cd9-875b-608c9cd2adbc.png)
