### PR TITLE
Add FairScore Perturber to Model Zoo

### DIFF
--- a/parlai/zoo/fairscore/build.py
+++ b/parlai/zoo/fairscore/build.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+FairScore Demographic Perturber model, which is BART finetuned on the PANDA dataset consisting of demographic rewrites.
+
+See paper for more details: https://arxiv.org/abs/2205.12586
+"""
+from parlai.core.build_data import built, download_models
+import os
+import os.path
+
+
+def download(datapath):
+    opt = {'datapath': datapath}
+    version = 'v1'
+    fnames = [f'models_{version}.tar.gz']
+    # Path to local build
+    local_dir = os.path.join(datapath, 'models', 'fairscore')
+    if not built(local_dir, version):
+        print("Downloading models to {}".format(local_dir))
+        download_models(
+            opt,
+            fnames,
+            model_folder='fairscore',
+            version=version,
+            use_model_type=False,
+        )
+    else:
+        print("Found existing build at {}".format(local_dir))

--- a/parlai/zoo/model_list.py
+++ b/parlai/zoo/model_list.py
@@ -3060,4 +3060,26 @@ Finished evaluating tasks ['google_sgd_simulation_splits:OutDomainSystemTeacher'
             [Bart]: I am an AI researcher. I love my job.
         """,
     },
+    {
+        "title": "FairScore Demographic Perturber",
+        "id": "fairscore",
+        "path": "zoo:fairscore/model",
+        "agent": "bart",
+        "task": "jsonfile",
+        "project": "https://github.com/facebookresearch/ResponsibleNLP",
+        "description": (
+            "FairScore Demographic Perturber - a controlled generation BART model trained to rewrite text to change demographic "
+            "references along gender, race and age axes."
+        ),
+        "example": ("parlai i -m bart -mf zoo:fairscore/model"),
+        "result": """
+            Enter Your Message: Jane, man <PERT_SEP> Jane cooks dinner for her family every night.
+            [Bart]: John cooks dinner for his family every night.
+            Enter Your Message: [DONE]
+            CHAT DONE
+            ... preparing new chat...
+            Enter Your Message: old, young <PERT_SEP> The old man tripped and fell, dropping his groceries.
+            [Bart]: The young man tripped and fell, dropping his groceries.
+        """,
+    },
 ]


### PR DESCRIPTION
**Patch description**
This PR creates a `fairscore` entry in the model zoo for the demographic perturber model. The perturber is trained to rewrite text to change demographic references along gender, race and age axes.

**Testing steps**
Tested downloads locally by serving model files on localhost, as well as downloads from S3.
Example usage: `parlai i -m bart -mf zoo:fairscore/model`

```
Enter Your Message: Jane, man <PERT_SEP> Jane cooks dinner for her family every night.
[Bart]: John cooks dinner for his family every night.
Enter Your Message: [DONE]
CHAT DONE
... preparing new chat...
Enter Your Message: old, young <PERT_SEP> The old man tripped and fell, dropping his groceries.
[Bart]: The young man tripped and fell, dropping his groceries.
```