### PR TITLE
modify ROUGEMetric to return any of precision, recall, f1-score in metrics.py

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -35,6 +35,7 @@ from parlai.utils.typing import TScalar, TVector
 
 DEFAULT_METRICS = {'bleu-4', 'accuracy', 'f1'}
 ROUGE_METRICS = {'rouge-1', 'rouge-2', 'rouge-L'}
+ROUGE_METRICS_MEASURES = {'r', 'f', 'p'}
 BLEU_METRICS = {'bleu-1', 'bleu-2', 'bleu-3', 'bleu-4'}
 DISTINCT_METRICS = {
     'interdistinct-1',
@@ -708,7 +709,7 @@ class RougeMetric(AverageMetric):
 
     @staticmethod
     def compute_many(
-        guess: str, answers: List[str]
+        guess: str, answers: List[str], measure: str = 'r'
     ) -> Tuple[Optional[RougeMetric], Optional[RougeMetric], Optional[RougeMetric]]:
         """
         Compute ROUGE score between guess and *any* answer.
@@ -717,6 +718,9 @@ class RougeMetric(AverageMetric):
 
         :return: (rouge-1, rouge-2, rouge-L)
         """
+        measure = measure.lower()
+        assert measure in ROUGE_METRICS_MEASURES, "Use one of recall 'r' (default), f1 'f', or precision 'p'."
+
         # possible global initialization
         try:
             import rouge
@@ -743,9 +747,9 @@ class RougeMetric(AverageMetric):
             )
             return None, None, None
 
-        scores_rouge1 = max(score['rouge-1']['r'] for score in scores)
-        scores_rouge2 = max(score['rouge-2']['r'] for score in scores)
-        scores_rougeL = max(score['rouge-l']['r'] for score in scores)
+        scores_rouge1 = max(score['rouge-1'][measure] for score in scores)
+        scores_rouge2 = max(score['rouge-2'][measure] for score in scores)
+        scores_rougeL = max(score['rouge-l'][measure] for score in scores)
         return (
             RougeMetric(scores_rouge1),
             RougeMetric(scores_rouge2),


### PR DESCRIPTION
allows user to determine which measure of `rouge.Rouge` (precision, recall, f1-score) to use 

**Patch description**
Although recall may be the most used rouge score measure, it is important to allow the user to determine which measure to return while invoking `RougeMetric.compute_many()`. User can continue to not pass `measure` as a parameter and the function defaults to `recall 'r'`.

**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
