### PR TITLE
[LIGHT] Who Am I - Preventing doubleloading model

### DIFF
--- a/projects/light_whoami/agents/pacer.py
+++ b/projects/light_whoami/agents/pacer.py
@@ -74,10 +74,14 @@ class PacerAgentMixin:
     def __init__(self, opt: Opt, shared=None):
         super().__init__(opt, shared)
         reranker_class = self.get_partial_only_reranker_class()
-        if not (shared and 'classifier' in shared):
-            self.classifier = reranker_class(opt)
-        else:
+        if shared and 'classifier' in shared:
             self.classifier = shared['classifier']
+        elif shared and 'reranker' in shared:
+            self.classifier = shared['reranker']
+        elif hasattr(self, 'reranker'):
+            self.classifier = self.reranker
+        else:
+            self.classifier = reranker_class(opt)
         assert opt[
             'beam_block_full_context'
         ], 'must set --beam-block-full-context True to use PACER'


### PR DESCRIPTION
**Patch description**
Made a small update to the PACER model plugin that allows for it to be added to other agents (like the `ExpandedAttentionDecoderAndPacerAgent`) without doubly loading the base model by instead checking to see if the reranking model has been initialized in some other form.

**Testing steps**
Was consuming 1.2Gb more GPU space than expected and observed logs loading the reranker model twice before this change.

Model works correctly (as tested in the LIGHT game) after this change.

**Other information**
<!-- Any other information or context you would like to provide. -->
