### PR TITLE
[BB3] Option to ignore in session memories

### DIFF
--- a/parlai/opt_presets/gen/opt_bb3.opt
+++ b/parlai/opt_presets/gen/opt_bb3.opt
@@ -192,5 +192,6 @@
   "include_prompt": false,
   "knowledge_chunk_size": 100,
   "max_prompt_len": 1912,
-  "all_vanilla_prompt": false
+  "all_vanilla_prompt": false,
+  "ignore_in_session_memories_mkm": false,
 }

--- a/parlai/opt_presets/gen/opt_bb3.opt
+++ b/parlai/opt_presets/gen/opt_bb3.opt
@@ -193,5 +193,5 @@
   "knowledge_chunk_size": 100,
   "max_prompt_len": 1912,
   "all_vanilla_prompt": false,
-  "ignore_in_session_memories_mkm": false,
+  "ignore_in_session_memories_mkm": false
 }

--- a/parlai/opt_presets/gen/opt_pt.opt
+++ b/parlai/opt_presets/gen/opt_pt.opt
@@ -192,5 +192,6 @@
   "include_prompt": true,
   "knowledge_chunk_size": 100,
   "max_prompt_len": 1912,
-  "all_vanilla_prompt": false
+  "all_vanilla_prompt": false,
+  "ignore_in_session_memories_mkm": false,
 }

--- a/parlai/opt_presets/gen/opt_pt.opt
+++ b/parlai/opt_presets/gen/opt_pt.opt
@@ -193,5 +193,5 @@
   "knowledge_chunk_size": 100,
   "max_prompt_len": 1912,
   "all_vanilla_prompt": false,
-  "ignore_in_session_memories_mkm": false,
+  "ignore_in_session_memories_mkm": false
 }

--- a/projects/bb3/agents/r2c2_bb3_agent.py
+++ b/projects/bb3/agents/r2c2_bb3_agent.py
@@ -421,6 +421,7 @@ class BlenderBot3Agent(ModularAgentMixin):
             self.agents[Module.SEARCH_KNOWLEDGE] = agent
 
         self.memories = []
+        self.in_session_memories = set()
         self.search_knowledge_responses = ['__SILENCE__']
         self.memory_knowledge_responses = ['__SILENCE__']
         self.contextual_knowledge_responses = ['__SILENCE__']
@@ -529,6 +530,7 @@ class BlenderBot3Agent(ModularAgentMixin):
             self.contextual_knowledge_responses = ['__SILENCE__']
             self.memory_knowledge_responses = ['__SILENCE__']
             self.memories = []
+            self.in_session_memories = set()
 
     def _construct_subagent_opts(self, opt: Opt):
         """
@@ -657,6 +659,7 @@ class BlenderBot3Agent(ModularAgentMixin):
 
         raw_observation = copy.deepcopy(observation)
         raw_observation['memories'] = self.memories
+        raw_observation['in_session_memories'] = self.in_session_memories
         observations['raw'] = raw_observation
 
         if observation.get('episode_done'):
@@ -1402,15 +1405,14 @@ class BlenderBot3Agent(ModularAgentMixin):
                 ),
                 MemoryUtils.get_memory_prefix(person, self.MODEL_TYPE),
             ):
-                self.memories.append(
-                    MemoryUtils.add_memory_prefix(
-                        self_message[
-                            f'{Module.MEMORY_GENERATOR.message_name()}_{person}'
-                        ],
-                        person,
-                        self.MODEL_TYPE,
-                    )
+                memory_to_add = MemoryUtils.add_memory_prefix(
+                    self_message[f'{Module.MEMORY_GENERATOR.message_name()}_{person}'],
+                    person,
+                    self.MODEL_TYPE,
                 )
+
+                self.memories.append(memory_to_add)
+                self.in_session_memories.add(memory_to_add)
         observation = {
             'text': clean_text(
                 self.agents[Module.SEARCH_KNOWLEDGE].history.get_history_str() or ''

--- a/tests/nightly/gpu/test_bb3.py
+++ b/tests/nightly/gpu/test_bb3.py
@@ -456,14 +456,14 @@ class TestIgnoreInSessionMemories(TestOptFtBase):
         agent.observe(self.opening_message)
         agent.act()
         assert all(m in agent.memories for m in agent.in_session_memories)
-        assert not all(m in agent.in_session_memories for m in agent.memories)
+        assert not any(m in agent.in_session_memories for m in agent.memories)
 
         # set ignore in session memories to True; ensure that final returned memories
         # still have all the memories, but that we don't use the memory module
         agent.in_session_memories = set()
         agent.ignore_in_session_memories_mkm = True
-        message3 = copy.deepcopy(self.message)
-        agent.observe(message3)
+        message = copy.deepcopy(self.message)
+        agent.observe(message)
         act = agent.act()
         assert all(
             m in act['memories']


### PR DESCRIPTION
**Patch description**
Provide an option to ignore in-session memories when generating a dialogue response. An "in session memory" is any memory that is generated during the current dialogue session; a "session" is the life-cycle of the BB3 agent. 

If set to `True`, *only* memories seeded in the first observation (with the correct `Opening:` prefix) will be used throughout a conversation.

**Testing steps**
Several added tests. Note: this depends on #4749 , so tests will fail until that is merged
