### PR TITLE
Added shared embedding option to director model.

### DIFF
--- a/projects/director/director_agent.py
+++ b/projects/director/director_agent.py
@@ -26,19 +26,38 @@ from parlai.core.torch_generator_agent import PPLMetric
 import parlai.utils.logging as logging
 
 
+class ScalarLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.params = nn.Parameter(torch.Tensor([1.0, 0.0]))
+
+    def forward(self, input: torch.Tensor):
+        return input * self.params[0].expand_as(input) + self.params[1].expand_as(input)
+
+
 class DirectorModel(TransformerGeneratorModel):
     """
     Director model that extends TransformerGeneratorModel and adds |V| binary classifier
     heads.
     """
 
-    def __init__(self, opt: Opt, dictionary: DictionaryAgent, **kwargs):
+    def __init__(
+        self,
+        opt: Opt,
+        dictionary: DictionaryAgent,
+        use_shared_embedding=False,
+        **kwargs,
+    ):
         super().__init__(opt, dictionary, **kwargs)
 
         vocabulary_size = len(dictionary)
 
         decoder_output_dim = self.decoder.out_dim
-        self.classifier_heads = nn.Linear(decoder_output_dim, vocabulary_size)
+        self.use_shared_embedding = use_shared_embedding
+        if self.use_shared_embedding:
+            self.classifier_heads = ScalarLayer()
+        else:
+            self.classifier_heads = nn.Linear(decoder_output_dim, vocabulary_size)
 
         self.infer_gamma = opt['train_gamma']
         if opt.get('infer_gamma') is not None:
@@ -55,6 +74,9 @@ class DirectorModel(TransformerGeneratorModel):
     def classifier_output(self, input: torch.Tensor):
         if self.freeze_decoder:
             input = input.detach()
+
+        if self.use_shared_embedding:
+            input = self.generator_output(input)
 
         return self.classifier_heads(input)
 
@@ -182,6 +204,12 @@ class DirectorAgent(TransformerGeneratorAgent):
             default=False,
             help='Train the generation head with the positive examples from the feedback data.',
         )
+        group.add_argument(
+            '--director-use-shared-embedding',
+            type=bool,
+            default=False,
+            help='Use a shared final embedding for the generator and classifier head of the director.',
+        )
         return parser
 
     def __init__(self, opt: Opt, shared=None):
@@ -220,7 +248,11 @@ class DirectorAgent(TransformerGeneratorAgent):
         """
         Build and return model.
         """
-        model = DirectorModel(self.opt, self.dict)
+        model = DirectorModel(
+            self.opt,
+            self.dict,
+            use_shared_embedding=self.opt['director_use_shared_embedding'],
+        )
         if self.opt['embedding_type'] != 'random':
             self._copy_embeddings(
                 model.encoder.embeddings.weight, self.opt['embedding_type']

--- a/projects/director/director_agent.py
+++ b/projects/director/director_agent.py
@@ -45,7 +45,6 @@ class DirectorModel(TransformerGeneratorModel):
         self,
         opt: Opt,
         dictionary: DictionaryAgent,
-        use_shared_embedding=False,
         **kwargs,
     ):
         super().__init__(opt, dictionary, **kwargs)
@@ -53,7 +52,7 @@ class DirectorModel(TransformerGeneratorModel):
         vocabulary_size = len(dictionary)
 
         decoder_output_dim = self.decoder.out_dim
-        self.use_shared_embedding = use_shared_embedding
+        self.use_shared_embedding = opt.get('director_use_shared_embedding', False)
         if self.use_shared_embedding:
             self.classifier_heads = ScalarLayer()
         else:
@@ -248,11 +247,7 @@ class DirectorAgent(TransformerGeneratorAgent):
         """
         Build and return model.
         """
-        model = DirectorModel(
-            self.opt,
-            self.dict,
-            use_shared_embedding=self.opt['director_use_shared_embedding'],
-        )
+        model = DirectorModel(self.opt, self.dict)
         if self.opt['embedding_type'] != 'random':
             self._copy_embeddings(
                 model.encoder.embeddings.weight, self.opt['embedding_type']


### PR DESCRIPTION
Added an option (with flag --director-use-shared-embedding) to share the generation and classification heads of the director. Only two additional parameters are introduced to scale the logits before applying the sigmoid (for the classification).