### PR TITLE
[BB3/SeeKeR/BB2] Simplify Retriever Building

### DIFF
--- a/parlai/agents/rag/modules.py
+++ b/parlai/agents/rag/modules.py
@@ -28,7 +28,7 @@ from parlai.core.opt import Opt
 from parlai.core.torch_generator_agent import TorchGeneratorModel
 from parlai.utils.torch import padded_tensor
 
-from parlai.agents.rag.retrievers import retriever_factory, Document
+from parlai.agents.rag.retrievers import RagRetriever, retriever_factory, Document
 
 
 class RagModel(TorchGeneratorModel):
@@ -81,7 +81,7 @@ class RagModel(TorchGeneratorModel):
         self.min_doc_token_length = opt['min_doc_token_length']
 
         # modules
-        self.retriever = retriever_factory(opt, dictionary, shared=retriever_shared)
+        self.retriever = self.build_retriever(opt, dictionary, retriever_shared)
         self.seq2seq_encoder = self.build_encoder(
             opt,
             dictionary=dictionary,
@@ -129,6 +129,15 @@ class RagModel(TorchGeneratorModel):
             )
         else:
             return decoder_class(opt, *args, **kwargs)
+
+    @classmethod
+    def build_retriever(
+        cls,
+        opt: Opt,
+        dictionary: DictionaryAgent,
+        retriever_shared: Optional[Dict[str, Any]],
+    ) -> Optional[RagRetriever]:
+        return retriever_factory(opt, dictionary, shared=retriever_shared)
 
     def tokenize_query(self, query: str) -> List[int]:
         """

--- a/projects/bb3/agents/README.md
+++ b/projects/bb3/agents/README.md
@@ -9,10 +9,16 @@ The top level BB3 agents initialize a series of sub-agents that accomplish the n
 
 **Per-Module Interaction**: To interact with a module on its own (outside of a BB3 context), you can simply specify the following:
 
-_BB3 3B_
+_BB3 3B without search_
 ```bash
-parlai interactive --model projects.bb3.agents.r2c2_bb3_agent:BB3SubSearchAgent --module <MODULE_PREFIX>
+parlai interactive --model projects.bb3.agents.r2c2_bb3_agent:BB3SubSearchAgent --model-file zoo:bb3/bb3_3B/model --force-skip-retrieval True --search-server none
 ```
+
+_BB3 3B with search_
+```bash
+parlai interactive --model projects.bb3.agents.r2c2_bb3_agent:BB3SubSearchAgent --model-file zoo:bb3/bb3_3B/model --rag-retriever-type search_engine --search-server RELEVANT_SEARCH_SERVER
+```
+
 _BB3 30B/175B_
 ```bash
 parlai interactive --model projects.bb3.agents.opt_api_agent:BB3OPTAgent --module <MODULE_PREFIX>

--- a/projects/bb3/agents/r2c2_bb3_agent.py
+++ b/projects/bb3/agents/r2c2_bb3_agent.py
@@ -82,10 +82,14 @@ class BB3Model(ComboFidModel):
     Override the ComboFid model to allow memory computation.
     """
 
-    def __init__(self, opt: Opt, dictionary: DictionaryAgent, retriever_shared=None):
-        super().__init__(opt, dictionary, retriever_shared)
-        self.retriever = bb3_retriever_factory(opt, dictionary, shared=retriever_shared)
-        self.top_docs = []
+    @classmethod
+    def build_retriever(
+        cls,
+        opt: Opt,
+        dictionary: DictionaryAgent,
+        retriever_shared: Optional[Dict[str, Any]],
+    ) -> Optional[RagRetriever]:
+        return bb3_retriever_factory(opt, dictionary, retriever_shared)
 
     def set_memory(self, memories: List[List[str]]):
         """

--- a/projects/blenderbot2/agents/modules.py
+++ b/projects/blenderbot2/agents/modules.py
@@ -9,7 +9,7 @@ import random
 import time
 import torch
 import torch.nn
-from typing import List, Tuple, Dict, Optional
+from typing import List, Tuple, Dict, Optional, Any
 
 from parlai.agents.fid.fid import FidModel, T5FidModel, concat_enc_outs, Fid
 from parlai.agents.rag.args import RetrieverType
@@ -81,13 +81,9 @@ class BlenderBot2RagModel(RagModel):
     def __init__(self, opt: Opt, dictionary: DictionaryAgent, retriever_shared=None):
         from .blenderbot2 import RAG_MODELS
 
-        # TODO: Get rid of this hack
-        opt['converting'] = True
         super().__init__(opt, dictionary, retriever_shared)
-        opt['converting'] = False
         self.opt = opt
         self.dummy_retriever = DummyRetriever(opt, dictionary)
-        self.retriever = retriever_factory(opt, dictionary, shared=retriever_shared)
         assert self.retriever is not None
         query_encoder = (
             self.retriever.query_encoder
@@ -117,6 +113,15 @@ class BlenderBot2RagModel(RagModel):
             self.knowledge_access_method
             not in [KnowledgeAccessMethod.MEMORY_ONLY, KnowledgeAccessMethod.NONE]
         )
+
+    @classmethod
+    def build_retriever(
+        cls,
+        opt: Opt,
+        dictionary: DictionaryAgent,
+        retriever_shared: Optional[Dict[str, Any]],
+    ) -> Optional[RagRetriever]:
+        return retriever_factory(opt, dictionary, retriever_shared)
 
     def has_query_generator(self) -> bool:
         """

--- a/projects/seeker/agents/seeker.py
+++ b/projects/seeker/agents/seeker.py
@@ -23,7 +23,6 @@ from parlai.agents.bart.bart import BartAgent
 from parlai.agents.fid.fid import (
     FidAgent,
     GoldDocRetrieverFiDAgent,
-    SearchQueryFiDAgent,
     SearchQuerySearchEngineFiDAgent,
     WizIntGoldDocRetrieverFiDAgent,
 )
@@ -164,7 +163,7 @@ class ComboFidAgent(FidAgent):
         return output
 
 
-class ComboFidSearchQueryAgent(ComboFidAgent, SearchQueryFiDAgent):
+class ComboFidSearchQueryAgent(ComboFidAgent, SearchQuerySearchEngineFiDAgent):
     pass
 
 

--- a/projects/seeker/agents/seeker_modules.py
+++ b/projects/seeker/agents/seeker_modules.py
@@ -7,7 +7,7 @@
 Modules for SeeKeR.
 """
 import torch
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Dict, Any
 
 from parlai.agents.fid.fid import FidModel
 from parlai.agents.rag.args import RetrieverType
@@ -171,10 +171,16 @@ class ComboFidModel(FidModel):
 
     def __init__(self, opt: Opt, dictionary: DictionaryAgent, retriever_shared=None):
         super().__init__(opt, dictionary, retriever_shared)
-        self.retriever = combo_fid_retriever_factory(
-            opt, dictionary, shared=retriever_shared
-        )
         self.top_docs = []
+
+    @classmethod
+    def build_retriever(
+        cls,
+        opt: Opt,
+        dictionary: DictionaryAgent,
+        retriever_shared: Optional[Dict[str, Any]],
+    ) -> Optional[RagRetriever]:
+        return combo_fid_retriever_factory(opt, dictionary, retriever_shared)
 
     def set_search_queries(self, queries: List[str]):
         """


### PR DESCRIPTION
**Patch description**
I've abstracted building the retriever/search engine object such that we no longer require hacky opt-setting to make sure that the correct retriever is built for an agent. Any model that subclasses `RagModel` (i.e., BB2, BB3, SeeKeR, FiD, etc.) can now specify a `build_retriever` method.

**Testing steps**
Relying on existing CI