### PR TITLE
[BB3] Memory Heuristics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,26 +208,26 @@ commands:
             - setupcuda
       - fixgit
       - restore_cache:
-          key: deps-20220819c-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20220831-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - << parameters.more_installs >>
       - save_cache:
-          key: deps-20220819c-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20220831-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
       - findtests:
           marker: << parameters.marker >>
       - restore_cache:
-          key: data-20220819c-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20220831-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
       - run:
           name: Run tests
           no_output_timeout: 60m
           command: |
             coverage run -m pytest -m << parameters.marker >> << parameters.pytest_flags >> --junitxml=test-results/junit.xml
       - save_cache:
-          key: data-20220819c-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20220831-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
           paths:
             - "~/ParlAI/data"
       - codecov
@@ -244,12 +244,12 @@ commands:
       - checkout
       - fixgit
       - restore_cache:
-          key: deps-20220819c-bw-{{ checksum "requirements.txt" }}
+          key: deps-20220831-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - installtorchgpu
       - save_cache:
-          key: deps-20220819c-bw-{{ checksum "requirements.txt" }}
+          key: deps-20220831-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,7 @@ commands:
             pip install -v -r requirements.txt
             python setup.py develop
             python -c "import nltk; nltk.download('punkt')"
+            python -c "import nltk; nltk.download('stopwords')"
 
   installtorchgpu:
     description: Install torch GPU and dependencies

--- a/parlai/opt_presets/gen/opt_bb3.opt
+++ b/parlai/opt_presets/gen/opt_bb3.opt
@@ -73,6 +73,10 @@
   "mkm_penalize_repetitions": true,
   "mkm_model": "projects.bb3.agents.opt_api_agent:BB3OPTAgent",
   "mkm_server": "opt_server",
+  "ignore_in_session_memories_mkm": false,
+  "memory_overlap_threshold": 0,
+  "memory_hard_block_for_n_turns": 0,
+  "memory_soft_block_decay_factor": 0,
 
   "contextual_knowledge_control_token": "",
   "contextual_knowledge_decision": "compute",
@@ -192,6 +196,5 @@
   "include_prompt": false,
   "knowledge_chunk_size": 100,
   "max_prompt_len": 1912,
-  "all_vanilla_prompt": false,
-  "ignore_in_session_memories_mkm": false
+  "all_vanilla_prompt": false
 }

--- a/parlai/opt_presets/gen/opt_pt.opt
+++ b/parlai/opt_presets/gen/opt_pt.opt
@@ -73,6 +73,10 @@
   "mkm_penalize_repetitions": false,
   "mkm_model": "projects.bb3.agents.opt_api_agent:BB3OPTAgent",
   "mkm_server": "opt_server",
+  "ignore_in_session_memories_mkm": false,
+  "memory_overlap_threshold": 0,
+  "memory_hard_block_for_n_turns": 0,
+  "memory_soft_block_decay_factor": 0,
 
   "contextual_knowledge_control_token": "",
   "contextual_knowledge_decision": "compute",
@@ -192,6 +196,5 @@
   "include_prompt": true,
   "knowledge_chunk_size": 100,
   "max_prompt_len": 1912,
-  "all_vanilla_prompt": false,
-  "ignore_in_session_memories_mkm": false
+  "all_vanilla_prompt": false
 }

--- a/projects/bb3/agents/opt_bb3_agent.py
+++ b/projects/bb3/agents/opt_bb3_agent.py
@@ -285,16 +285,7 @@ class BlenderBot3Agent(R2C2Agent):
             prefixed_memories,
             set(),
             dictionary=self.dictionary,
-            ignore_in_session_memories=self.opt.get(
-                'ignore_in_session_memories_mkm', False
-            ),
-            memory_overlap_threshold=self.opt.get('memory_overlap_threshold', 0.0),
-            memory_hard_block_for_n_turns=self.opt.get(
-                'memory_hard_block_for_n_turns', 0
-            ),
-            memory_soft_block_decay_factor=self.opt.get(
-                'memory_soft_block_decay_factor', 0.0
-            ),
+            **self._get_memory_heuristic_values(),
         )
         if not memories_to_use:
             # we need at least one memory to open with...
@@ -314,11 +305,11 @@ class BlenderBot3Agent(R2C2Agent):
         This function is designed to handle legacy cases where memories are
         presented as a list, rather than a dict.
 
-        :param observation:
-            incoming message
+        :param memories:
+            memories from the opening message
 
         :return opening_memories:
-            return the set of opening memories
+            return the set of true opening memories
         """
         opening_memories = None
         if memories:

--- a/projects/bb3/agents/opt_bb3_agent.py
+++ b/projects/bb3/agents/opt_bb3_agent.py
@@ -153,13 +153,6 @@ class BlenderBot3Agent(R2C2Agent):
             help='Number of times to retry on API request failures (< 0 for unlimited retry).',
         )
         parser.add_argument('--metaseq-server-timeout', default=20.0, type=float)
-        parser.add_argument(
-            '--ignore-in-session-memories-mkm',
-            type='bool',
-            default=False,
-            help='If true, we do not look at the in-session memories when '
-            'generating from the MKM',
-        )
         return parser
 
     def __init__(self, opt, shared=None):
@@ -177,12 +170,8 @@ class BlenderBot3Agent(R2C2Agent):
             self.agents[Module.SEARCH_KNOWLEDGE.agent_name()] = top_agent
             self.agents[Module.SEARCH_KNOWLEDGE] = top_agent
 
-        self.dictionary = top_agent.dictionary
         # continue
         self.max_prompt_len = opt.get('max_prompt_len', PROMPT.MAX_PROMPT_LEN)
-        self.ignore_in_session_memories_mkm = opt.get(
-            'ignore_in_session_memories_mkm', False
-        )
         self.search_agent = SearchAgent(
             {
                 'server': self.opt.get('search_server', 'default'),
@@ -270,7 +259,7 @@ class BlenderBot3Agent(R2C2Agent):
         return ag_obs
 
     def get_orm_observation(
-        self, observation: Message, opening_memories: List[str]
+        self, observation: Message, opening_memories: Dict[str, int]
     ) -> Message:
         """
         Return the appropriate ORM observation.
@@ -285,27 +274,74 @@ class BlenderBot3Agent(R2C2Agent):
         """
         agent = self.agents[Module.OPENING_DIALOGUE]
         agent.reset()
-        for i, mem in enumerate(opening_memories):
+        prefixed_memories = {}
+        for mem, val in opening_memories.items():
             mem = MemoryUtils.maybe_add_memory_prefix(mem, 'partner', self.MODEL_TYPE)
-            opening_memories[i] = mem
+            prefixed_memories[mem] = val
 
         new_obs = copy.deepcopy(observation)
-        new_obs.force_set(
-            'text', self._check_and_limit_len('\n'.join(opening_memories))
+        memories_to_use = MemoryUtils.get_available_memories(
+            '',
+            prefixed_memories,
+            set(),
+            dictionary=self.dictionary,
+            ignore_in_session_memories=self.opt.get(
+                'ignore_in_session_memories_mkm', False
+            ),
+            memory_overlap_threshold=self.opt.get('memory_overlap_threshold', 0.0),
+            memory_hard_block_for_n_turns=self.opt.get(
+                'memory_hard_block_for_n_turns', 0
+            ),
+            memory_soft_block_decay_factor=self.opt.get(
+                'memory_soft_block_decay_factor', 0.0
+            ),
         )
-        new_obs.force_set('memories', opening_memories)
+        if not memories_to_use:
+            # we need at least one memory to open with...
+            memories_to_use = random.sample(list(prefixed_memories.keys()), 1)
+
+        new_obs.force_set('text', self._check_and_limit_len('\n'.join(memories_to_use)))
+        new_obs.force_set('memories', prefixed_memories)
 
         return agent.observe(new_obs)
+
+    def get_opening_memories(
+        self, memories: Optional[Union[List[str], Dict[str, int]]]
+    ) -> Optional[Dict[str, int]]:
+        """
+        Get the opening memories, if applicable.
+
+        This function is designed to handle legacy cases where memories are
+        presented as a list, rather than a dict.
+
+        :param observation:
+            incoming message
+
+        :return opening_memories:
+            return the set of opening memories
+        """
+        opening_memories = None
+        if memories:
+            if isinstance(memories, dict):
+                opening_memories = memories
+            elif isinstance(memories, list):
+                opening_memories = {}
+                for mem in memories:
+                    opening_memories = MemoryUtils.add_memory(mem, opening_memories)
+
+        assert not opening_memories or isinstance(opening_memories, dict)
+        return opening_memories
 
     def observe(self, observation: Message) -> Dict[Module, Message]:
         # handle passed memories as well
         observation = Message(observation)
-        opening_memories = observation.pop('memories', None)
+        opening_memories = self.get_opening_memories(observation.pop('memories', None))
         observations = super().observe(observation)
         for m in Module.dialogue_modules():
             ag_obs = copy.deepcopy(observation)
             observations[m] = self.agents[m].observe(ag_obs)
         if is_opener(observation['text'], opening_memories):
+            assert opening_memories
             orm_obs = self.get_orm_observation(observation, opening_memories)
             self.memories = orm_obs['memories']
             observations[Module.OPENING_DIALOGUE] = orm_obs
@@ -425,10 +461,7 @@ class BlenderBot3Agent(R2C2Agent):
             for module in Module:
                 obs = all_obs[module]
                 if module is Module.MEMORY_KNOWLEDGE and i in memory_indices:
-                    memories = MemoryUtils.maybe_reduce_memories(
-                        all_obs['raw']['text'], available_memory[i], self.dictionary
-                    )
-                    memories = '\n'.join(memories)
+                    memories = '\n'.join(available_memory[i])
                     new_prompt = self._check_and_limit_len(
                         obs['prompt'].replace(module.opt_pre_context_tok(), memories)
                     )
@@ -701,7 +734,15 @@ class BlenderBot3Agent(R2C2Agent):
             retries += 1
             n_mems = [min(1, len(obs['memories']) // 3) for obs in opening_obs]
             for i, o in enumerate(opening_obs):
-                o.force_set('memories', random.sample(o['memories'], n_mems[i]))
+                mem_indices = random.sample(range(len(o['memories'])), n_mems[i])
+                o.force_set(
+                    'memories',
+                    {
+                        m: v
+                        for i, (m, v) in enumerate(o['memories'].items())
+                        if i in mem_indices
+                    },
+                )
         if _failed_messages(batch_act):
             for reply in batch_act:
                 text = reply.pop('text')
@@ -782,15 +823,8 @@ class BlenderBot3Agent(R2C2Agent):
             for _ in range(len(observations))
         ]
         # Step 1: determine whether we're searching or accessing memory
-        all_memory = [o['raw']['memories'] for o in observations]
-        available_memory = [
-            MemoryUtils.get_available_memories(
-                o['raw']['memories'],
-                o['raw']['in_session_memories'],
-                self.ignore_in_session_memories_mkm,
-            )
-            for o in observations
-        ]
+        all_memory: List[Dict[str, int]] = [o['raw']['memories'] for o in observations]
+        available_memory = self.get_available_memories(observations)
 
         batch_reply_sdm, search_indices = self.batch_act_decision(
             observations,
@@ -908,18 +942,4 @@ class BlenderBot3Agent(R2C2Agent):
                 agent.self_observe(self_message)
         if self.vanilla:
             return
-        memory_key = Module.MEMORY_GENERATOR.message_name()
-        for person in ['self', 'partner']:
-            memory_candidate = self_message.get(f"{memory_key}_{person}")
-            if not memory_candidate:
-                continue
-            if MemoryUtils.is_valid_memory(
-                self.memories,
-                memory_candidate,
-                MemoryUtils.get_memory_prefix(person, self.MODEL_TYPE),
-            ):
-                memory_to_add = MemoryUtils.add_memory_prefix(
-                    memory_candidate, person, self.MODEL_TYPE
-                )
-                self.memories.append(memory_to_add)
-                self.in_session_memories.add(memory_to_add)
+        self.self_observe_memory(self_message)

--- a/projects/bb3/agents/r2c2_bb3_agent.py
+++ b/projects/bb3/agents/r2c2_bb3_agent.py
@@ -673,7 +673,7 @@ class BlenderBot3Agent(ModularAgentMixin):
 
     def _get_memory_heuristic_values(self) -> Dict[str, Union[str, float, bool]]:
         """
-        Extract heuristics from self.opt
+        Extract heuristics from self.opt.
         """
         return {
             'ignore_in_session_memories': self.opt.get(

--- a/projects/bb3/agents/r2c2_bb3_agent.py
+++ b/projects/bb3/agents/r2c2_bb3_agent.py
@@ -337,6 +337,33 @@ class BlenderBot3Agent(ModularAgentMixin):
             'separate: condition on all knowledge separately, re-ranke later'
             'both: do both combined and separate and re-rank final beam',
         )
+        parser.add_argument(
+            '--ignore-in-session-memories-mkm',
+            type='bool',
+            default=False,
+            help='If true, we do not look at the in-session memories when '
+            'generating from the MKM',
+        )
+        parser.add_argument(
+            '--memory-overlap-threshold',
+            type=float,
+            default=0.0,
+            help='Threshold word overlap between memory and incoming text. If '
+            'below this threshold, we exclude the memory from consideration.',
+        )
+        parser.add_argument(
+            '--memory-hard-block-for-n-turns',
+            type=int,
+            default=0,
+            help='If set > 0, we block memories from being used for n turns',
+        )
+        parser.add_argument(
+            '--memory-soft-block-decay-factor',
+            type=float,
+            default=0.0,
+            help='If set > 0, we randomly block a memory with probability '
+            '(decay ^ n_turns_since_used)',
+        )
         # Copied from Seeker
         group.add_argument(
             '--search-decision-do-search-reply',
@@ -424,7 +451,9 @@ class BlenderBot3Agent(ModularAgentMixin):
             self.agents[Module.SEARCH_KNOWLEDGE.agent_name()] = agent
             self.agents[Module.SEARCH_KNOWLEDGE] = agent
 
-        self.memories = []
+        self.dictionary = self.agents[Module.SEARCH_KNOWLEDGE.agent_name()].dictionary
+        # Memories is a mapping from memory to turns_since_used.
+        self.memories: Dict[str, int] = {}
         self.in_session_memories = set()
         self.search_knowledge_responses = ['__SILENCE__']
         self.memory_knowledge_responses = ['__SILENCE__']
@@ -533,7 +562,7 @@ class BlenderBot3Agent(ModularAgentMixin):
             self.search_knowledge_responses = ['__SILENCE__']
             self.contextual_knowledge_responses = ['__SILENCE__']
             self.memory_knowledge_responses = ['__SILENCE__']
-            self.memories = []
+            self.memories = {}
             self.in_session_memories = set()
 
     def _construct_subagent_opts(self, opt: Opt):
@@ -641,6 +670,38 @@ class BlenderBot3Agent(ModularAgentMixin):
             memories = f"your persona: {' '.join(self_memories)}\npartner's persona: {' '.join(partner_memories)}"
             ag_obs.force_set('text', '\n'.join([memories, ag_obs['text']]))
         return ag_obs
+
+    def get_available_memories(
+        self, observations: List[Dict[Union[str, Module], Message]]
+    ) -> List[List[str]]:
+        """
+        Get available memories for the agent.
+
+        :param observations:
+            incoming batch observations
+
+        :return memories:
+            return a list of memories for each batch item.
+        """
+        return [
+            MemoryUtils.get_available_memories(
+                o['raw']['text'],
+                o['raw']['memories'],
+                o['raw']['in_session_memories'],
+                self.dictionary,
+                ignore_in_session_memories=self.opt.get(
+                    'ignore_in_session_memories_mkm', False
+                ),
+                memory_overlap_threshold=self.opt.get('memory_overlap_threshold', 0.0),
+                memory_hard_block_for_n_turns=self.opt.get(
+                    'memory_hard_block_for_n_turns', 0
+                ),
+                memory_soft_block_decay_factor=self.opt.get(
+                    'memory_soft_block_decay_factor', 0.0
+                ),
+            )
+            for o in observations
+        ]
 
     def observe(self, observation: Message) -> Dict[Module, Message]:
         """
@@ -901,9 +962,8 @@ class BlenderBot3Agent(ModularAgentMixin):
                 message[f'{Module.SEARCH_KNOWLEDGE.message_name()}_top_docs'] = docs
                 search_offset += 1
             if i in memory_indices:
-                message[Module.MEMORY_KNOWLEDGE.message_name()] = batch_reply_mkm[
-                    memory_offset
-                ]['text']
+                memory_knowledge = batch_reply_mkm[memory_offset]['text']
+                message[Module.MEMORY_KNOWLEDGE.message_name()] = memory_knowledge
                 logging.debug(
                     f"Memory KNOWLEDGE for example {i}: {message[Module.MEMORY_KNOWLEDGE.message_name()]}"
                 )
@@ -1140,7 +1200,7 @@ class BlenderBot3Agent(ModularAgentMixin):
         batch_reply_mgm_partner: List[Message],
         batch_reply_knowledge: List[Message],
         batch_reply_dialogue: List[Message],
-        available_memory: List[List[str]],
+        available_memory: Union[List[List[str]], List[Dict[str, int]]],
     ) -> List[Message]:
         """
         Collate all of the batch acts from the various modules.
@@ -1184,35 +1244,20 @@ class BlenderBot3Agent(ModularAgentMixin):
                 f'{Module.MEMORY_GENERATOR.message_name()}_partner',
                 mgm_partner.get('text', ''),
             )
+            mems = copy.deepcopy(mems)
+            for message, person in zip([mgm_self, mgm_partner], ['self', 'partner']):
+                if MemoryUtils.is_valid_memory(
+                    mems,
+                    message.get('text', ''),
+                    MemoryUtils.get_memory_prefix(person, self.MODEL_TYPE),
+                ):
+                    mems = MemoryUtils.add_memory(
+                        MemoryUtils.add_memory_prefix(
+                            message['text'], person, self.MODEL_TYPE
+                        ),
+                        mems,
+                    )
             reply.force_set('memories', mems)
-            if MemoryUtils.is_valid_memory(
-                reply['memories'],
-                mgm_self.get('text', ''),
-                MemoryUtils.get_memory_prefix('self', self.MODEL_TYPE),
-            ):
-                reply.force_set(
-                    'memories',
-                    reply['memories']
-                    + [
-                        MemoryUtils.add_memory_prefix(
-                            mgm_self['text'], 'self', self.MODEL_TYPE
-                        )
-                    ],
-                )
-            if MemoryUtils.is_valid_memory(
-                reply['memories'],
-                mgm_partner.get('text', ''),
-                MemoryUtils.get_memory_prefix('partner', self.MODEL_TYPE),
-            ):
-                reply.force_set(
-                    'memories',
-                    reply['memories']
-                    + [
-                        MemoryUtils.add_memory_prefix(
-                            mgm_partner['text'], 'partner', self.MODEL_TYPE
-                        )
-                    ],
-                )
             reply.force_set(
                 Module.SEARCH_KNOWLEDGE.message_name(),
                 km.get(Module.SEARCH_KNOWLEDGE.message_name(), ''),
@@ -1278,9 +1323,8 @@ class BlenderBot3Agent(ModularAgentMixin):
         """
         # First, determine whether we're searching or accessing memory
         try:
-            self.agents[Module.MEMORY_KNOWLEDGE].set_memory(
-                [o['raw']['memories'] for o in observations]
-            )
+            memory_to_set = self.get_available_memories(observations)
+            self.agents[Module.MEMORY_KNOWLEDGE].set_memory(memory_to_set)
             available_memory = self.agents[Module.MEMORY_KNOWLEDGE].get_memory()
         except AttributeError:
             # Gold Docs
@@ -1401,22 +1445,7 @@ class BlenderBot3Agent(ModularAgentMixin):
         self.memory_knowledge_responses.append(
             self_message.get(Module.MEMORY_KNOWLEDGE.message_name(), '')
         )
-        for person in ['self', 'partner']:
-            if MemoryUtils.is_valid_memory(
-                self.memories,
-                self_message.get(
-                    f'{Module.MEMORY_GENERATOR.message_name()}_{person}', ''
-                ),
-                MemoryUtils.get_memory_prefix(person, self.MODEL_TYPE),
-            ):
-                memory_to_add = MemoryUtils.add_memory_prefix(
-                    self_message[f'{Module.MEMORY_GENERATOR.message_name()}_{person}'],
-                    person,
-                    self.MODEL_TYPE,
-                )
-
-                self.memories.append(memory_to_add)
-                self.in_session_memories.add(memory_to_add)
+        self.self_observe_memory(self_message)
         observation = {
             'text': clean_text(
                 self.agents[Module.SEARCH_KNOWLEDGE].history.get_history_str() or ''
@@ -1434,3 +1463,36 @@ class BlenderBot3Agent(ModularAgentMixin):
                 agent.history.update_history(
                     observation, temp_history=agent.get_temp_history(observation)
                 )
+
+    def self_observe_memory(self, self_message: Message):
+        """
+        Self observe memory for person.
+
+        First, add new memories to the memory.
+        Second, update memory usage.
+
+        :param memory:
+            potential memory
+        :param person:
+            whose memory it is
+        """
+        # add new memories
+        memory_key = Module.MEMORY_GENERATOR.message_name()
+        for person in ['self', 'partner']:
+            memory_candidate = self_message.get(f"{memory_key}_{person}")
+            if not memory_candidate:
+                continue
+            if MemoryUtils.is_valid_memory(
+                self.memories,
+                memory_candidate,
+                MemoryUtils.get_memory_prefix(person, self.MODEL_TYPE),
+            ):
+                memory_to_add = MemoryUtils.add_memory_prefix(
+                    memory_candidate, person, self.MODEL_TYPE
+                )
+                self.memories = MemoryUtils.add_memory(memory_to_add, self.memories)
+                self.in_session_memories.add(memory_to_add)
+
+        # update mem usage
+        used_memory = self_message.get(Module.MEMORY_KNOWLEDGE.message_name(), '')
+        self.memories = MemoryUtils.update_memory_usage(used_memory, self.memories)

--- a/projects/bb3/agents/utils.py
+++ b/projects/bb3/agents/utils.py
@@ -8,16 +8,19 @@ import asyncio
 from enum import Enum
 import json
 import math
+from nltk.corpus import stopwords as nltk_stopwords
 from nltk.tokenize import word_tokenize
 from nltk.stem import PorterStemmer
 import os
+import random
 import string
 import time
-from typing import List, Tuple, Optional, Dict, Any, Set
+from typing import List, Tuple, Optional, Dict, Any, Set, Union
 
 from parlai.agents.ir_baseline.ir_baseline import score_match, MaxPriorityQueue
 from parlai.core.dict import DictionaryAgent
 from parlai.core.message import Message
+from parlai.core.metrics import F1Metric
 from parlai.core.torch_generator_agent import PPLMetric
 import parlai.utils.logging as logging
 import projects.bb3.constants as CONST
@@ -58,8 +61,14 @@ _STOP_WORDS = set(
 )
 
 
+_STOP_WORDS_WITH_PRONOUNS = set(nltk_stopwords.words('english')).union(_STOP_WORDS)
+
+
 def normal_tokenizer(
-    text: str, remove_contractions: bool = True, stem=True
+    text: str,
+    remove_contractions: bool = True,
+    stem=True,
+    include_pronouns: bool = False,
 ) -> List[str]:
     """
     Returns normalized tokens for `text`
@@ -76,7 +85,8 @@ def normal_tokenizer(
 
     if stem:
         tokens = [STEMMER.stem(t) for t in tokens]
-    tokens = [t for t in tokens if t not in _STOP_WORDS]
+    stop_words = _STOP_WORDS if not include_pronouns else _STOP_WORDS_WITH_PRONOUNS
+    tokens = [t for t in tokens if t not in stop_words]
 
     return tokens
 
@@ -138,14 +148,14 @@ class Decision(Enum):
     COMPUTE = 'compute'
 
 
-def is_opener(text: str, mems: Optional[List[str]]):
+def is_opener(text: str, mems: Optional[Dict[str, int]]):
     """
     Return if message is an opener!
     """
     return (
         text == PROMPT.OPENING_PREFIX
         and mems is not None
-        and isinstance(mems, list)
+        and (isinstance(mems, list) or isinstance(mems, dict))
         and len(mems) > 0
     )
 
@@ -221,7 +231,9 @@ class MemoryUtils:
 
     @staticmethod
     def is_valid_memory(
-        chatbot_memory: List[str], new_memory: str, new_memory_prefix: str
+        chatbot_memory: Union[List[str], Dict[str, int]],
+        new_memory: str,
+        new_memory_prefix: str,
     ) -> bool:
         """
         Return whether the memory is valid.
@@ -361,13 +373,20 @@ class MemoryUtils:
 
     @staticmethod
     def get_available_memories(
-        memories: List[str],
+        text: str,
+        memories: Dict[str, int],
         in_session_memories: Set[str],
-        ignore_in_session_memories: bool,
+        dictionary: Optional[DictionaryAgent] = None,
+        ignore_in_session_memories: bool = False,
+        memory_overlap_threshold: float = 0.0,
+        memory_hard_block_for_n_turns: int = 0,
+        memory_soft_block_decay_factor: float = 0.0,
     ) -> List[str]:
         """
         Return available memories.
 
+        :param text:
+            incoming partner text
         :param memories:
             list of all memories
         :param in_session_memories:
@@ -375,11 +394,75 @@ class MemoryUtils:
         :param ignore_in_session_memories:
             whether to ignore memories generated within the session
         """
-        return [
-            m
-            for m in memories
-            if m not in in_session_memories or not ignore_in_session_memories
-        ]
+        available_memory = []
+        for memory, turns_since_used in memories.items():
+            # check if we should ignore in session memories
+            if ignore_in_session_memories and memory in in_session_memories:
+                continue
+            # check overlap
+            non_stopword_memory = ' '.join(
+                normal_tokenizer(memory.split(':')[-1], include_pronouns=True)
+            )
+            non_stopword_text = ' '.join(normal_tokenizer(text, include_pronouns=True))
+            if (
+                F1Metric.compute(non_stopword_memory, [non_stopword_text]).value()
+                < memory_overlap_threshold
+            ):
+                continue
+            # check hard block
+            if turns_since_used < memory_hard_block_for_n_turns:
+                continue
+            # check soft block
+            if memory_soft_block_decay_factor > 0 and random.random() < (
+                memory_soft_block_decay_factor**turns_since_used
+            ):
+                continue
+
+            available_memory.append(memory)
+        return MemoryUtils.maybe_reduce_memories(text, available_memory, dictionary)
+
+    @staticmethod
+    def add_memory(memory: str, memories: Dict[str, int]) -> Dict[str, int]:
+        """
+        Add memory to the memory store
+
+        :param memory:
+            memory to add
+        :param memories:
+            all the memories
+
+        :return memories:
+            return memories with new memory
+        """
+        # TODO: FIGURE THIS OUT
+        if not memory:
+            return memories
+        assert memory not in memories
+        memories[memory] = 0
+        return memories
+
+    @staticmethod
+    def update_memory_usage(
+        used_memory: str, memories: Dict[str, int]
+    ) -> Dict[str, int]:
+        """
+        Update memories to indicate that a memory was used.
+
+        :param memory:
+            used memory
+        :param memories:
+            all the memories
+
+        :return memories:
+            return memories with usage updated
+        """
+        assert not used_memory or used_memory in memories
+        for mem in memories:
+            if mem == used_memory:
+                memories[mem] = 0
+            else:
+                memories[mem] += 1
+        return memories
 
 
 #################

--- a/projects/bb3/agents/utils.py
+++ b/projects/bb3/agents/utils.py
@@ -434,7 +434,6 @@ class MemoryUtils:
         :return memories:
             return memories with new memory
         """
-        # TODO: FIGURE THIS OUT
         if not memory:
             return memories
         assert memory not in memories

--- a/projects/bb3/agents/utils.py
+++ b/projects/bb3/agents/utils.py
@@ -400,15 +400,18 @@ class MemoryUtils:
             if ignore_in_session_memories and memory in in_session_memories:
                 continue
             # check overlap
-            non_stopword_memory = ' '.join(
-                normal_tokenizer(memory.split(':')[-1], include_pronouns=True)
-            )
-            non_stopword_text = ' '.join(normal_tokenizer(text, include_pronouns=True))
-            if (
-                F1Metric.compute(non_stopword_memory, [non_stopword_text]).value()
-                < memory_overlap_threshold
-            ):
-                continue
+            if memory_overlap_threshold > 0:
+                non_stopword_memory = ' '.join(
+                    normal_tokenizer(memory.split(':')[-1], include_pronouns=True)
+                )
+                non_stopword_text = ' '.join(
+                    normal_tokenizer(text, include_pronouns=True)
+                )
+                if (
+                    F1Metric.compute(non_stopword_memory, [non_stopword_text]).value()
+                    < memory_overlap_threshold
+                ):
+                    continue
             # check hard block
             if turns_since_used < memory_hard_block_for_n_turns:
                 continue
@@ -424,7 +427,7 @@ class MemoryUtils:
     @staticmethod
     def add_memory(memory: str, memories: Dict[str, int]) -> Dict[str, int]:
         """
-        Add memory to the memory store
+        Add memory to the memory store.
 
         :param memory:
             memory to add

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ jsonlines==1.2.0
 numpy~=1.22 
 markdown<=3.3.2 # Pin to something that works so tests are happy
 jinja2==3.0.3
-ninja
+ninja~=1.10.2.3
 protobuf~=3.20
 contractions~=0.1.72
+fsspec~=2022.2.0

--- a/tests/nightly/gpu/test_bb3.py
+++ b/tests/nightly/gpu/test_bb3.py
@@ -19,7 +19,7 @@ from projects.bb3.agents.utils import normal_tokenizer, no_overlap, MemoryUtils
 from projects.bb3.tests.opt_presets import INIT_OPT
 
 
-LOCAL = False
+LOCAL = True
 
 
 def _self_memory(text):
@@ -128,13 +128,16 @@ class TestOptFtBase(unittest.TestCase):
         self.message = Message({'text': 'Hey, how is it going?', 'episode_done': False})
 
         # Opening
-        self.memories = [
-            MemoryUtils.add_memory_prefix("I am a chatbot", "partner", 'OPT')
-        ]
+        self.memories = dict()
+        self.memories = MemoryUtils.add_memory(
+            MemoryUtils.add_memory_prefix("I am a chatbot", "partner", 'OPT'),
+            self.memories,
+        )
         for animal in ['cats', 'dogs', 'horses', 'parrots']:
             action = random.choice(['like', 'hate', 'have'])
-            self.memories.append(
-                MemoryUtils.add_memory_prefix(f"I {action} {animal}", 'partner', 'OPT')
+            MemoryUtils.add_memory(
+                MemoryUtils.add_memory_prefix(f"I {action} {animal}", 'partner', 'OPT'),
+                self.memories,
             )
         self.opening_message = Message(
             {
@@ -275,7 +278,9 @@ class TestOptOpening(TestOptFtBase):
         agent.observe(self.opening_message)
         prompt = agent.observations[Module.OPENING_DIALOGUE].get('prompt')
         assert prompt
-        assert prompt == '\n'.join(self.memories + [f"{PROMPT.OPENING_PREFIX}:"])
+        assert prompt == '\n'.join(
+            list(self.memories.keys()) + [f"{PROMPT.OPENING_PREFIX}:"]
+        )
         act = agent.act()
         assert_all_keys_in_replies(act, Module.OPENING_DIALOGUE)
 
@@ -285,7 +290,7 @@ class TestOptOpening(TestOptFtBase):
         agent.observe(message2)
         act = agent.act()
         # memories now has one more entry
-        assert len(agent.memories) == len(self.memories)
+        assert len(agent.memories) == len(self.memories) + 1
         assert_all_keys_in_replies(act, Module.SEARCH_DIALOGUE)
         assert_all_keys_in_replies(act, Module.MEMORY_DIALOGUE)
 
@@ -293,7 +298,7 @@ class TestOptOpening(TestOptFtBase):
         message3 = copy.deepcopy(self.message)
         agent.observe(message3)
         agent.act()
-        assert len(agent.memories) == len(self.memories)
+        assert len(agent.memories) == len(self.memories) + 1
 
         # check we do not get an opener if we send OPENING_PREFIX, but no memories
         agent.reset()
@@ -349,7 +354,7 @@ class TestOptMainServerBase(TestOptFtBase):
         for k, v in overrides.items():
             opt[k] = v
             opt['override'][k] = v
-        self.opt = opt
+        self.opt = copy.deepcopy(opt)
 
         self.batch_agent = create_agent(opt)
 
@@ -357,7 +362,8 @@ class TestOptMainServerBase(TestOptFtBase):
 @unittest.skipUnless(LOCAL, "must be local to specify opt server")
 class TestOptMainServerBatching(TestOptMainServerBase):
     def test_batching(self):
-        self.batch_agent = create_agent(self.opt)
+        opt = copy.deepcopy(self.opt)
+        self.batch_agent = create_agent(opt)
         agents = [self.batch_agent.clone() for _ in range(8)]
         observations = [a.observe(self.opening_message) for a in agents]
         assert_all_keys_in_obs(observations)
@@ -408,9 +414,11 @@ class TestInjectQueryString(TestOptFtBase):
 
 class TestMemoryTFIDF(TestOptFtBase):
     def test_memory_tfidf(self):
-        agent = create_agent(self.opt)
+        opt = copy.deepcopy(self.opt)
+        agent = create_agent(opt)
         dictionary = agent.dictionary
-        memories = self.memories * 100
+        memories = {f"{m}_{i}": v for m, v in self.memories.items() for i in range(100)}
+        memories = {**self.memories, **memories}
         new_memories = MemoryUtils.maybe_reduce_memories(
             'I wish I could see my cats again!',
             memories,
@@ -471,21 +479,146 @@ class TestIgnoreInSessionMemories(TestOptFtBase):
         act = agent.act()
         assert all(
             m in act['memories']
-            for m in original_memories + list(agent.in_session_memories)
+            for m in list(original_memories.keys()) + list(agent.in_session_memories)
         )
         assert len(agent.in_session_memories) == (
             len(act['memories']) - len(original_memories)
         )
 
     def test_memory_utils(self):
-        new_memories = ['in session memory 1', 'in session memory 2']
-        memories = self.memories + new_memories
+        new_memories = {'in session memory 1': 1, 'in session memory 2': 1}
+        memories = {**self.memories, **new_memories}
         in_session_memories = set(new_memories)
         available_memories = MemoryUtils.get_available_memories(
-            memories, in_session_memories, ignore_in_session_memories=False
+            '', memories, in_session_memories, ignore_in_session_memories=False
         )
-        assert available_memories == memories
+        assert available_memories == list(memories.keys())
         available_memories = MemoryUtils.get_available_memories(
-            memories, in_session_memories, ignore_in_session_memories=True
+            '', memories, in_session_memories, ignore_in_session_memories=True
         )
-        assert available_memories == self.memories
+        assert available_memories == list(self.memories.keys())
+
+
+class TestMemoryOverlapThresholdBlocking(TestOptFtBase):
+    def test_overlap_threshold_blocking(self):
+        opt = copy.deepcopy(self.opt)
+        opt['knowledge_conditioning'] = 'separate'
+        opt['override']['knowledge_conditioning'] = 'separate'
+        threshold = 0.1
+        opt['memory_overlap_threshold'] = threshold
+        opt['override']['memory_overlap_threshold'] = threshold
+        agent = create_agent(opt)
+
+        # first, check with text with no overlap with memories
+        agent.observe(self.opening_message)
+        agent.act()
+        message = copy.deepcopy(self.message)
+        text = 'I am traveling to Japan'
+        message.force_set('text', text)
+        agent.observe(message)
+        act = agent.act()
+        # this memory does not overlap with the memories, so nothing should be there
+        assert not act[Module.MEMORY_DIALOGUE.message_name()]
+
+        # next, check with text with some overlap with memories
+        message = copy.deepcopy(self.message)
+        text = 'I love chatbots'
+        message.force_set('text', text)
+        agent.observe(message)
+        act = agent.act()
+        assert act[Module.MEMORY_DIALOGUE.message_name()]
+
+    def test_memory_utils(self):
+        memories = self.memories
+        available_memories = MemoryUtils.get_available_memories(
+            'I am traveling to Japan', memories, set(), memory_overlap_threshold=0.1
+        )
+        assert not available_memories
+        available_memories = MemoryUtils.get_available_memories(
+            'I love my cat', memories, set(), memory_overlap_threshold=0.1
+        )
+        assert len(available_memories) >= 1
+
+
+class TestMemoryNTurnsHardBlocking(TestOptFtBase):
+    def test_hard_blocking(self):
+        opt = copy.deepcopy(self.opt)
+        opt['knowledge_conditioning'] = 'separate'
+        opt['override']['knowledge_conditioning'] = 'separate'
+        n_turns_hardblock = 5
+        opt['memory_hard_block_for_n_turns'] = n_turns_hardblock
+        opt['override']['memory_hard_block_for_n_turns'] = n_turns_hardblock
+        agent = create_agent(opt)
+
+        agent.observe(self.opening_message)
+        agent.act()
+
+        acts = []
+        for _ in range(n_turns_hardblock):
+            agent.observe(self.message)
+            acts.append(agent.act())
+
+        assert all(not a[Module.MEMORY_DIALOGUE.message_name()] for a in acts[:-1])
+        assert acts[-1][Module.MEMORY_DIALOGUE.message_name()]
+
+    def test_memory_utils(self):
+        memories = self.memories
+        n_turns = 2
+        available_memories = MemoryUtils.get_available_memories(
+            '', memories, set(), memory_hard_block_for_n_turns=n_turns
+        )
+        assert not available_memories
+        for mem in memories:
+            memories[mem] = n_turns + 1
+        available_memories = MemoryUtils.get_available_memories(
+            '', memories, set(), memory_hard_block_for_n_turns=n_turns
+        )
+        assert available_memories == list(memories.keys())
+
+
+class TestMemorySoftBlockThreshold(TestOptFtBase):
+    def test_softblocking(self):
+        opt = copy.deepcopy(self.opt)
+        opt['knowledge_conditioning'] = 'separate'
+        opt['override']['knowledge_conditioning'] = 'separate'
+        decay_factor = 0.99
+        opt['memory_soft_block_decay_factor'] = decay_factor
+        opt['override']['memory_soft_block_decay_factor'] = decay_factor
+        agent = create_agent(opt)
+
+        success = False
+        for _ in range(5):
+            # basically, we're hoping that probabilistically we'll have
+            # fewer turns here using memory than not.
+            agent.reset()
+            agent.observe(self.opening_message)
+            agent.act()
+            acts = []
+            for _ in range(10):
+                agent.observe(self.message)
+                acts.append(agent.act())
+            n_with_memory = len(
+                [a for a in acts if a[Module.MEMORY_DIALOGUE.message_name()]]
+            )
+            n_without_mem = len(
+                [a for a in acts if not a[Module.MEMORY_DIALOGUE.message_name()]]
+            )
+            if n_with_memory < n_without_mem:
+                success = True
+                break
+
+        assert success
+
+    def test_memory_utils(self):
+        memories = self.memories
+        decay_factor = 0.99
+        available_memories = MemoryUtils.get_available_memories(
+            '', memories, set(), memory_hard_block_for_n_turns=decay_factor
+        )
+        assert not available_memories
+        for mem in memories:
+            memories[mem] = 1000000
+        available_memories = MemoryUtils.get_available_memories(
+            '', memories, set(), memory_hard_block_for_n_turns=decay_factor
+        )
+        assert available_memories == list(memories.keys())

--- a/tests/nightly/gpu/test_bb3.py
+++ b/tests/nightly/gpu/test_bb3.py
@@ -19,7 +19,7 @@ from projects.bb3.agents.utils import normal_tokenizer, no_overlap, MemoryUtils
 from projects.bb3.tests.opt_presets import INIT_OPT
 
 
-LOCAL = True
+LOCAL = False
 
 
 def _self_memory(text):
@@ -612,10 +612,15 @@ class TestMemorySoftBlockThreshold(TestOptFtBase):
     def test_memory_utils(self):
         memories = self.memories
         decay_factor = 0.99
-        available_memories = MemoryUtils.get_available_memories(
-            '', memories, set(), memory_hard_block_for_n_turns=decay_factor
-        )
-        assert not available_memories
+        success = False
+        for _ in range(10):
+            available_memories = MemoryUtils.get_available_memories(
+                '', memories, set(), memory_hard_block_for_n_turns=decay_factor
+            )
+            if not available_memories:
+                success = True
+                break
+        assert success
         for mem in memories:
             memories[mem] = 1000000
         available_memories = MemoryUtils.get_available_memories(


### PR DESCRIPTION
**Patch description**
Implement the following memory heuristics when selecting what memories to show the bot when crafting a response:

1. `memory_overlap_threshold` --> if set to > 0, we block any memories that do not have this F1 overlap with the incoming text
2. `memory_hard_block_for_n_turns` --> if set to > 0, we block memories that have been used in the last n turns
3. `memory_soft_block_decay_factor` --> if set to > 0, we block memories according the following probability: `pr(block) = random.random() < decay_factor ** n_turns_since_used`

This required an overhaul of how `memories` are stored in the agent; rather than a list of memories, we now use a dictionary mapping `memory: n_turns_since_use`

**Testing steps**
Several more tests added
