### PR TITLE
[BB3] Handle non-ints in memories dict

### DIFF
--- a/projects/bb3/agents/opt_bb3_agent.py
+++ b/projects/bb3/agents/opt_bb3_agent.py
@@ -314,7 +314,7 @@ class BlenderBot3Agent(R2C2Agent):
         opening_memories = None
         if memories:
             if isinstance(memories, dict):
-                opening_memories = memories
+                opening_memories = {mem: int(turns) for mem, turns in memories.items()}
             elif isinstance(memories, list):
                 opening_memories = {}
                 for mem in memories:

--- a/projects/bb3/agents/utils.py
+++ b/projects/bb3/agents/utils.py
@@ -396,6 +396,7 @@ class MemoryUtils:
         """
         available_memory = []
         for memory, turns_since_used in memories.items():
+            turns_since_used = int(turns_since_used)
             # check if we should ignore in session memories
             if ignore_in_session_memories and memory in in_session_memories:
                 continue

--- a/tests/nightly/gpu/test_bb3.py
+++ b/tests/nightly/gpu/test_bb3.py
@@ -611,6 +611,8 @@ class TestMemorySoftBlockThreshold(TestOptFtBase):
 
     def test_memory_utils(self):
         memories = self.memories
+        # test that it works with floats as well
+        memories = {m: float(t) for m, t in memories.items()}
         decay_factor = 0.99
         success = False
         for _ in range(10):


### PR DESCRIPTION
**Patch description**
@JoshDLane pointed out that our memory soft blocking would not work if `turns_since_used` was not an integer; this fix ensures that it is.

**Testing steps**
Updated CI
