### PR TITLE
Fix the api call and api response mismatch issue

### DIFF
--- a/parlai/tasks/taskmaster2/agents.py
+++ b/parlai/tasks/taskmaster2/agents.py
@@ -175,6 +175,8 @@ class Taskmaster2Parser(tod_agents.TodStructuredDataParser):
                         api_resp_machine=api_resp,
                         sys_utt=sys_utt,
                     )
+                    if len(api_call) > 0:
+                        goal_calls.append(api_call)
                 else:
                     cum_api_call = self.process_call_for_cumlative_standalone_api(
                         api_call, cum_api_call
@@ -182,13 +184,12 @@ class Taskmaster2Parser(tod_agents.TodStructuredDataParser):
                     r = tod.TodStructuredRound(
                         user_utt=user_utt,
                         api_call_machine=cum_api_call if len(api_resp) > 0 else {},
-                        api_resp_machine=api_resp if len(api_resp) > 0 else {},
+                        api_resp_machine=api_resp if len(cum_api_call) > 0 else {},
                         sys_utt=sys_utt,
                     )
-
+                    if len(cum_api_call) > 0:
+                        goal_calls.append(cum_api_call)
                 rounds.append(r)
-                if len(api_call) > 0:
-                    goal_calls.append(api_call)
 
             episode = tod.TodStructuredEpisode(
                 domain=tod.SerializationHelpers.inner_list_join(row["domain"]),


### PR DESCRIPTION
This PR is to 
1.  Fixed a bug: also consider cum_api_call when processing the goal_calls
2. In taskmaster2 data structure, sometime there's api response in system without user api call. And it will cause problems when people want to implement lookup table DB in the simulation scenario. So, using len(cum_api_call) > 0 and len(api_resp) > 0 as a constraint.