### PR TITLE
[Bug fix]Display data breaks when emoji in text

### DIFF
--- a/parlai/scripts/display_data.py
+++ b/parlai/scripts/display_data.py
@@ -51,9 +51,13 @@ def simple_display(opt, world, turn):
     act = world.get_acts()[0]
     if turn == 0:
         text = "- - - NEW EPISODE: " + act.get('id', "[no agent id]") + " - - -"
-        print(colorize(text, 'highlight'))
+        print(
+            colorize(
+                text.encode('utf-16', 'surrogatepass').decode('utf-16'), 'highlight'
+            )
+        )
     text = act.get('text', '[no text field]')
-    print(colorize(text, 'text'))
+    print(colorize(text.encode('utf-16', 'surrogatepass').decode('utf-16'), 'text'))
     labels = act.get('labels', act.get('eval_labels', ['[no labels field]']))
     labels = '|'.join(labels)
     print('   ' + colorize(labels, 'labels'))


### PR DESCRIPTION
**Patch description**
The display data script breaks when the text contains an emoji. We use utf-16 to fix this.
```
  File "/private/home/daju/ParlAI/parlai/scripts/display_data.py", line 109, in run
    return display_data(self.opt)
  File "/private/home/daju/ParlAI/parlai/scripts/display_data.py", line 83, in display_data
    simple_display(opt, world, turn)
  File "/private/home/daju/ParlAI/parlai/scripts/display_data.py", line 56, in simple_display
    print(colorize(text, 'text'))
UnicodeEncodeError: 'utf-8' codec can't encode characters in position 7726-7727: surrogates not allowed
```

