### PR TITLE
[BB3] Return token logprobs when scoring or generating.

### DIFF
--- a/parlai/agents/hugging_face/dict.py
+++ b/parlai/agents/hugging_face/dict.py
@@ -34,6 +34,7 @@ class HuggingFaceDictionaryAgent(DictionaryAgent, ABC):
     """
 
     def __init__(self, opt: Opt, shared=None):
+        super().__init__(opt, shared)
         if not shared:
             self.hf_tokenizer = self.get_tokenizer(opt)
             self.tok2ind = self.hf_tokenizer.get_vocab()

--- a/parlai/agents/regard/combo.py
+++ b/parlai/agents/regard/combo.py
@@ -1,0 +1,31 @@
+from typing import Optional
+from parlai.core.torch_agent import Batch
+from projects.seeker.agents.seeker import ComboFidGoldDocumentAgent
+
+import torch
+
+
+class ComboFidGoldDocumentAgentWithPrefixTokens(ComboFidGoldDocumentAgent):
+    def get_prefix_tokens(self, batch: Batch) -> Optional[torch.LongTensor]:
+        # Set the prompts themselves (Message.text) as the prefixes
+        # so that the generation is a strict continuation. batch.text_vec
+        # contains eos tokens so this copies everything up to
+        # but not including them.
+        new_vectors = []
+        for vector in batch.text_vec.tolist():
+            new_vector = []
+            for i in vector:
+                if i == self.START_IDX:
+                    continue
+                if i == self.END_IDX:
+                    break
+                new_vector.append(int(i))
+            new_vectors.append(new_vector)
+
+        if batch.batchsize > 1:
+            tensor, _ = self._pad_tensor(new_vectors)
+        else:
+            tensor = torch.LongTensor(new_vectors)
+
+        dev = batch.text_vec.device
+        return tensor.to(dev)

--- a/projects/bb3/agents/opt_api_agent.py
+++ b/projects/bb3/agents/opt_api_agent.py
@@ -433,8 +433,14 @@ class SimpleOPTAgent(Agent):
             # for-else means we execute this unless we were missing labels
             results = self.get_echo_results(observations)
             label_ppls, all_ppls = APIUtils.compute_perplexities(observations, results)
-            for ppl, ctxt_ppl, msg in zip(label_ppls, all_ppls, messages):
+            for ppl, ctxt_ppl, msg, r in zip(label_ppls, all_ppls, messages, results):
                 msg['metrics'] = {'ppl': ppl, 'ctxt_label_ppl': ctxt_ppl}
+                if self.opt['skip_generation']:
+                    msg['text'] = r['choices'][0]['text'].strip()
+                    msg['logprobs'] = sum(r['choices'][0]['logprobs']['token_logprobs'])
+                    msg['token_logprobs'] = r['choices'][0]['logprobs'][
+                        'token_logprobs'
+                    ]
 
         # actual generations
         if not self.opt['skip_generation']:
@@ -484,6 +490,7 @@ class SimpleOPTAgent(Agent):
                     else:
                         m['text'] = r['choices'][0]['text'].strip()
                     m['logprobs'] = sum(r['choices'][0]['logprobs']['token_logprobs'])
+                    m['token_logprobs'] = r['choices'][0]['logprobs']['token_logprobs']
 
         # we might have batch padding that we skipped earlier. collate it back.
         messages_out = []


### PR DESCRIPTION
**Patch description**
* Updates BB3OPTAgent to pass along the token log-probs returned by OPT. This enables evals that require fine-grained access to that information.
* Also ensures that the following keys are always set whether scoring labels or generating new text: `text`, `logprobs`, `token_logprobs`

**Testing steps**
Ran a few evaluations from metaseq.

**Other information**
N/A
