### PR TITLE
fixed broken arXiv link for the Ubuntu task

### DIFF
--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -671,7 +671,7 @@ task_list = [
             "Dialogs between an Ubuntu user and an expert trying to fix issue, "
             "we use the V2 version, which cleaned the data to some extent. "
         ),
-        "links": {"arXiv": "https://arxiv.org/abs/1506.08909."},
+        "links": {"arXiv": "https://arxiv.org/abs/1506.08909"},
     },
     {
         "id": "WebQuestions",


### PR DESCRIPTION
**Patch description**
Fixes an arXiv link for the Ubuntu task (Ubuntu Dialogue Corpus)

**Testing steps**
Follow link to correct page.
