### PR TITLE
limiting torch  version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,26 +219,26 @@ commands:
             - setupcuda
       - fixgit
       - restore_cache:
-          key: deps-20221024-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20221028-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - << parameters.more_installs >>
       - save_cache:
-          key: deps-20221024-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20221028-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
       - findtests:
           marker: << parameters.marker >>
       - restore_cache:
-          key: data-20221024-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20221028-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
       - run:
           name: Run tests
           no_output_timeout: 60m
           command: |
             coverage run -m pytest -m << parameters.marker >> << parameters.pytest_flags >> --junitxml=test-results/junit.xml
       - save_cache:
-          key: data-20221024-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20221028-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
           paths:
             - "~/ParlAI/data"
       - codecov
@@ -255,12 +255,12 @@ commands:
       - checkout
       - fixgit
       - restore_cache:
-          key: deps-20221024-bw-{{ checksum "requirements.txt" }}
+          key: deps-20221028-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - installtorchgpu
       - save_cache:
-          key: deps-20221024-bw-{{ checksum "requirements.txt" }}
+          key: deps-20221028-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,26 +219,26 @@ commands:
             - setupcuda
       - fixgit
       - restore_cache:
-          key: deps-20221028-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20221027-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - << parameters.more_installs >>
       - save_cache:
-          key: deps-20221028-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20221027-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
       - findtests:
           marker: << parameters.marker >>
       - restore_cache:
-          key: data-20221028-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20221027-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
       - run:
           name: Run tests
           no_output_timeout: 60m
           command: |
             coverage run -m pytest -m << parameters.marker >> << parameters.pytest_flags >> --junitxml=test-results/junit.xml
       - save_cache:
-          key: data-20221028-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20221027-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
           paths:
             - "~/ParlAI/data"
       - codecov
@@ -255,12 +255,12 @@ commands:
       - checkout
       - fixgit
       - restore_cache:
-          key: deps-20221028-bw-{{ checksum "requirements.txt" }}
+          key: deps-20221027-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - installtorchgpu
       - save_cache:
-          key: deps-20221028-bw-{{ checksum "requirements.txt" }}
+          key: deps-20221027-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,5 +1,5 @@
 # ParlAI Projects
-test
+
 Here we list projects undertaken in the ParlAI framework that are shared publicly, either in the form of papers, public tasks (with leaderboards) and/or shared model code.
 
 This directory also contains subfolders for some of the projects which are housed in the ParlAI repo, others are maintained via external websites. Please also refer to ParlAI's [agents](https://github.com/facebookresearch/ParlAI/tree/main/parlai/agents), [tasks](https://github.com/facebookresearch/ParlAI/tree/main/parlai/tasks) and [model zoo](https://github.com/facebookresearch/ParlAI/tree/main/parlai/zoo) for what else is in ParlAI.

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,5 +1,5 @@
 # ParlAI Projects
-
+test
 Here we list projects undertaken in the ParlAI framework that are shared publicly, either in the form of papers, public tasks (with leaderboards) and/or shared model code.
 
 This directory also contains subfolders for some of the projects which are housed in the ParlAI repo, others are maintained via external websites. Please also refer to ParlAI's [agents](https://github.com/facebookresearch/ParlAI/tree/main/parlai/agents), [tasks](https://github.com/facebookresearch/ParlAI/tree/main/parlai/tasks) and [model zoo](https://github.com/facebookresearch/ParlAI/tree/main/parlai/zoo) for what else is in ParlAI.

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ subword-nmt==0.3.7
 tensorboardX==2.1
 tokenizers>=0.8.0
 tomli>=2.0.0
-torchtext>=0.5.0
+torchtext>=0.5.0,<1.14.0
 tornado==6.0.4
 tqdm~=4.62.1
 typing-extensions==3.7.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ gitdb2==2.0.5
 GitPython==3.0.3
 hydra-core>=1.1.0
 ipython==7.31.1
-torch>=1.4.0
+torch<1.13.0,>=1.4.0
 joblib==0.14.1
 nltk==3.6.6
 omegaconf>=2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ subword-nmt==0.3.7
 tensorboardX==2.1
 tokenizers>=0.8.0
 tomli>=2.0.0
-torchtext>=0.5.0,<1.14.0
+torchtext>=0.5.0,<=1.13.1
 tornado==6.0.4
 tqdm~=4.62.1
 typing-extensions==3.7.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ subword-nmt==0.3.7
 tensorboardX==2.1
 tokenizers>=0.8.0
 tomli>=2.0.0
-torchtext>=0.5.0,<=1.13.1
+torchtext>=0.5.0,<=0.13.1
 tornado==6.0.4
 tqdm~=4.62.1
 typing-extensions==3.7.4.3


### PR DESCRIPTION
**Patch description**
New torch version 1.13 was released today, and it fails builds due to compatibility issues.
Successful run with torch 1.12.1: https://app.circleci.com/pipelines/github/facebookresearch/ParlAI/11995/workflows/a83bca91-5066-45a3-8a25-492f51a6c795/jobs/97126
2 h later, failed run with torch 1.13.0: https://app.circleci.com/pipelines/github/facebookresearch/ParlAI/11996/workflows/82f9a6fd-c1c0-425f-a065-05aa4dc1921a/jobs/97133

Fixing torch version in requirements.txt to avoid failures

**Testing steps**
See tests below:

test/commit 1: reproducing failure before fix: https://app.circleci.com/pipelines/github/facebookresearch/ParlAI/12006/workflows/073ad777-d787-42c8-9fd4-84afafc48274/jobs/97211

test/commit 2: fixing torch version passes test: https://app.circleci.com/pipelines/github/facebookresearch/ParlAI/12011/workflows/3a0762e8-a904-429f-ab2c-70894718845f/jobs/97225