### PR TITLE
upgrade protobuf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,26 +219,26 @@ commands:
             - setupcuda
       - fixgit
       - restore_cache:
-          key: deps-20221102-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20221031-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - << parameters.more_installs >>
       - save_cache:
-          key: deps-20221102-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20221031-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
       - findtests:
           marker: << parameters.marker >>
       - restore_cache:
-          key: data-20221102-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20221031-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
       - run:
           name: Run tests
           no_output_timeout: 60m
           command: |
             coverage run -m pytest -m << parameters.marker >> << parameters.pytest_flags >> --junitxml=test-results/junit.xml
       - save_cache:
-          key: data-20221102-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20221031-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
           paths:
             - "~/ParlAI/data"
       - codecov
@@ -255,12 +255,12 @@ commands:
       - checkout
       - fixgit
       - restore_cache:
-          key: deps-20221102-bw-{{ checksum "requirements.txt" }}
+          key: deps-20221031-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - installtorchgpu
       - save_cache:
-          key: deps-20221102-bw-{{ checksum "requirements.txt" }}
+          key: deps-20221031-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,26 +219,26 @@ commands:
             - setupcuda
       - fixgit
       - restore_cache:
-          key: deps-20221027-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20221101-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - << parameters.more_installs >>
       - save_cache:
-          key: deps-20221027-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20221101-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
       - findtests:
           marker: << parameters.marker >>
       - restore_cache:
-          key: data-20221027-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20221101-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
       - run:
           name: Run tests
           no_output_timeout: 60m
           command: |
             coverage run -m pytest -m << parameters.marker >> << parameters.pytest_flags >> --junitxml=test-results/junit.xml
       - save_cache:
-          key: data-20221027-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20221101-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
           paths:
             - "~/ParlAI/data"
       - codecov
@@ -255,12 +255,12 @@ commands:
       - checkout
       - fixgit
       - restore_cache:
-          key: deps-20221027-bw-{{ checksum "requirements.txt" }}
+          key: deps-20221101-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - installtorchgpu
       - save_cache:
-          key: deps-20221027-bw-{{ checksum "requirements.txt" }}
+          key: deps-20221101-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,26 +219,26 @@ commands:
             - setupcuda
       - fixgit
       - restore_cache:
-          key: deps-20221101-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20221102-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - << parameters.more_installs >>
       - save_cache:
-          key: deps-20221101-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20221102-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
       - findtests:
           marker: << parameters.marker >>
       - restore_cache:
-          key: data-20221101-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20221102-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
       - run:
           name: Run tests
           no_output_timeout: 60m
           command: |
             coverage run -m pytest -m << parameters.marker >> << parameters.pytest_flags >> --junitxml=test-results/junit.xml
       - save_cache:
-          key: data-20221101-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20221102-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
           paths:
             - "~/ParlAI/data"
       - codecov
@@ -255,12 +255,12 @@ commands:
       - checkout
       - fixgit
       - restore_cache:
-          key: deps-20221101-bw-{{ checksum "requirements.txt" }}
+          key: deps-20221102-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - installtorchgpu
       - save_cache:
-          key: deps-20221101-bw-{{ checksum "requirements.txt" }}
+          key: deps-20221102-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,6 @@ numpy~=1.22
 markdown<=3.3.2 # Pin to something that works so tests are happy
 jinja2==3.0.3
 ninja~=1.10.2.3
-protobuf~=3.20.1
+protobuf==3.20.1
 contractions~=0.1.72
 fsspec~=2022.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ sphinx_rtd_theme==0.4.3
 sphinx-autodoc-typehints~=1.10.3
 Sphinx~=2.2.0
 subword-nmt==0.3.7
-tensorboardX==2.1
+tensorboardX==2.5.1
 tokenizers>=0.8.0
 tomli>=2.0.0
 torchtext>=0.5.0,<=0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,3 +58,4 @@ ninja~=1.10.2.3
 protobuf<=3.20.1,>=3.8.0
 contractions~=0.1.72
 fsspec~=2022.2.0
+google-api-core<=2.10.1 # Latest 2.10.2 requires latest protobuf

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,6 @@ numpy~=1.22
 markdown<=3.3.2 # Pin to something that works so tests are happy
 jinja2==3.0.3
 ninja~=1.10.2.3
-protobuf~=3.20
+protobuf==3.20.1
 contractions~=0.1.72
 fsspec~=2022.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,6 @@ numpy~=1.22
 markdown<=3.3.2 # Pin to something that works so tests are happy
 jinja2==3.0.3
 ninja~=1.10.2.3
-protobuf~=3.20.1
+protobuf<=3.20.1,>=3.8.0
 contractions~=0.1.72
 fsspec~=2022.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,6 @@ numpy~=1.22
 markdown<=3.3.2 # Pin to something that works so tests are happy
 jinja2==3.0.3
 ninja~=1.10.2.3
-protobuf<=3.19.6,>=3.19.5
+protobuf~=3.20
 contractions~=0.1.72
 fsspec~=2022.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,6 @@ numpy~=1.22
 markdown<=3.3.2 # Pin to something that works so tests are happy
 jinja2==3.0.3
 ninja~=1.10.2.3
-protobuf==3.20.1
+protobuf~=3.20.1
 contractions~=0.1.72
 fsspec~=2022.2.0


### PR DESCRIPTION
**Patch description**
Fixing dependencies

Protobuf is limited by TensorboardX. Looks like they are working on bumping the version anytime soon, can be tracked here: https://github.com/lanpa/tensorboardX/blob/master/test-requirements.txt
and PR here: https://github.com/lanpa/tensorboardX/pull/675 