### PR TITLE
[Bug Fix]handle utf-16 in display data -v mode

### DIFF
--- a/parlai/scripts/display_data.py
+++ b/parlai/scripts/display_data.py
@@ -82,7 +82,10 @@ def display_data(opt):
         # NOTE: If you want to look at the data from here rather than calling
         # world.display() you could access world.acts[0] directly, see simple_display above.
         if opt.get('verbose', False) or opt.get('display_add_fields', ''):
-            print(world.display() + '\n~~')
+            print(
+                world.display().encode('utf-16', 'surrogatepass').decode('utf-16')
+                + '\n~~'
+            )
         else:
             simple_display(opt, world, turn)
             turn += 1


### PR DESCRIPTION
**Patch description**
The current display data code will break in -v mode when emoji presented. 
```
Traceback (most recent call last):
  File "/private/home/daju/.conda/envs/mep/bin/parlai", line 33, in <module>
    sys.exit(load_entry_point('parlai', 'console_scripts', 'parlai')())
  File "/private/home/daju/ParlAI/parlai/__main__.py", line 14, in main
    superscript_main()
  File "/private/home/daju/ParlAI/parlai/core/script.py", line 325, in superscript_main
    return SCRIPT_REGISTRY[cmd].klass._run_from_parser_and_opt(opt, parser)
  File "/private/home/daju/ParlAI/parlai/core/script.py", line 108, in _run_from_parser_and_opt
    return script.run()
  File "/private/home/daju/ParlAI/parlai/scripts/display_data.py", line 113, in run
    return display_data(self.opt)
  File "/private/home/daju/ParlAI/parlai/scripts/display_data.py", line 85, in display_data
    print(world.display() + '\n~~')
UnicodeEncodeError: 'utf-8' codec can't encode characters in position 2079-2080: surrogates not allowed
```
This code fixes this issue. 
