### PR TITLE
[image_chat] remove decode methods for handling HTTP requests, add torchvision requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,12 +219,12 @@ commands:
             - setupcuda
       - fixgit
       - restore_cache:
-          key: deps-20221031-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20221115-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - << parameters.more_installs >>
       - save_cache:
-          key: deps-20221031-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20221115-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
@@ -238,7 +238,7 @@ commands:
           command: |
             coverage run -m pytest -m << parameters.marker >> << parameters.pytest_flags >> --junitxml=test-results/junit.xml
       - save_cache:
-          key: data-20221031-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20221115-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
           paths:
             - "~/ParlAI/data"
       - codecov
@@ -255,12 +255,12 @@ commands:
       - checkout
       - fixgit
       - restore_cache:
-          key: deps-20221031-bw-{{ checksum "requirements.txt" }}
+          key: deps-20221115-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - installtorchgpu
       - save_cache:
-          key: deps-20221031-bw-{{ checksum "requirements.txt" }}
+          key: deps-20221115-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ commands:
       - findtests:
           marker: << parameters.marker >>
       - restore_cache:
-          key: data-20221031-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20221115-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
       - run:
           name: Run tests
           no_output_timeout: 60m

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ GitPython==3.0.3
 hydra-core>=1.1.0
 ipython==7.31.1
 torch<1.13.0,>=1.4.0
+torchvision<0.14.0,>=0.5.0
 joblib==1.2.0
 nltk==3.6.6
 omegaconf>=2.1.1


### PR DESCRIPTION
Thank you for your nice tools. I'm enjoying a lot.

**Patch description**
- Fix AttributeError for `image_chat`
- Add `torchvision` requirement for `image_chat`

**Testing steps**
`python ./projects/image_chat/interactive.py -mf models:image_chat/transresnet_multimodal/model`
##### Before this PR
```
Visit http://0.0.0.0:8082/ to chat with the model!
127.0.0.1 - - [08/Nov/2022 15:27:17] "GET / HTTP/1.1" 200 -
127.0.0.1 - - [08/Nov/2022 15:27:17] "GET /Examples.png HTTP/1.1" 500 -
127.0.0.1 - - [08/Nov/2022 15:27:17] "GET /favicon.ico HTTP/1.1" 202 -
----------------------------------------
Exception happened during processing of request from ('127.0.0.1', 46272)
Traceback (most recent call last):
  File "/home/obinata/anaconda3/envs/parlai-dev/lib/python3.8/socketserver.py", line 316, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/home/obinata/anaconda3/envs/parlai-dev/lib/python3.8/socketserver.py", line 347, in process_request
    self.finish_request(request, client_address)
  File "/home/obinata/anaconda3/envs/parlai-dev/lib/python3.8/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/home/obinata/anaconda3/envs/parlai-dev/lib/python3.8/socketserver.py", line 747, in __init__
    self.handle()
  File "/home/obinata/anaconda3/envs/parlai-dev/lib/python3.8/http/server.py", line 427, in handle
    self.handle_one_request()
  File "/home/obinata/anaconda3/envs/parlai-dev/lib/python3.8/http/server.py", line 415, in handle_one_request
    method()
  File "./projects/image_chat/interactive.py", line 264, in do_POST
    if postvars["image"][0].decode() != "":
AttributeError: 'str' object has no attribute 'decode'
----------------------------------------
```

It might be for python2 ???