### PR TITLE
SKR project page  typo

### DIFF
--- a/projects/seeker/README.md
+++ b/projects/seeker/README.md
@@ -177,7 +177,7 @@ $ python -m parlai.scripts.multiprocessing_train \
 Same command as above, except specify the following for `--init-opt` and `--init-model`:
 
 ```shell
---init-opt arc/r2c2_base_400M --init-model zoo:seeker/r2c2_blenderbot_400M/model
+--init-opt arch/r2c2_base_400M --init-model zoo:seeker/r2c2_blenderbot_400M/model
 ```
 
 ### SeeKeR LM Training


### PR DESCRIPTION
**Patch description**
Ran into a problem trying to fine-tune the R2C2 SKR model. Turns out the problem was because I copied a typo from the readme file of project. 
