### PR TITLE
Allow flan-t5 models in ParlAI with fp16 improvment

### DIFF
--- a/parlai/agents/hugging_face/t5.py
+++ b/parlai/agents/hugging_face/t5.py
@@ -86,7 +86,18 @@ class T5Agent(TorchGeneratorAgent):
             '--t5-model-arch',
             type=str,
             default='t5-base',
-            choices=["t5-small", "t5-base", "t5-large", "t5-3b", "t5-11b"],
+            choices=[
+                "t5-small",
+                "t5-base",
+                "t5-large",
+                "t5-3b",
+                "t5-11b",
+                "google/flan-t5-small",
+                "google/flan-t5-base",
+                "google/flan-t5-large",
+                "google/flan-t5-xl",
+                "google/flan-t5-xxl",
+            ],
         )
         group.add_argument(
             '--t5-model-parallel',

--- a/parlai/agents/hugging_face/t5.py
+++ b/parlai/agents/hugging_face/t5.py
@@ -41,8 +41,9 @@ def check_hf_version(v: Tuple[int, int]) -> bool:
 def build_t5(opt: Opt) -> T5ForConditionalGeneration:
     if not check_hf_version(HF_VERSION):
         raise RuntimeError('Must use transformers package >= 4.3 to use t5')
+    torch_dtype = torch.float16 if opt['fp16'] else torch.float32
     return T5ForConditionalGeneration.from_pretrained(
-        opt['t5_model_arch'], dropout_rate=opt['t5_dropout']
+        opt['t5_model_arch'], dropout_rate=opt['t5_dropout'], torch_dtype=torch_dtype
     )
 
 


### PR DESCRIPTION
**Patch description**
The current setting does allow flan-t5 model to run under parlai hugging face agent seamlessly. Adding Flan-t5 options in the agent. 

**Testing steps**
```
parlai train_model -t convai2  -dt train --batchsize 1  --fp16 True  --gradient-clip 1.0 --label-truncate 256 --text-truncate 512 --log-every-n-secs 30 --lr-scheduler reduceonplateau --max-train-time 169344.0 --model hugging_face/t5 --save-after-valid True --skip-generation True --optimizer adam -lr 1e-05 -veps 0.15 -vmm min -vmt ppl -vp 15 -tblog True --t5-model-arch google/flan-t5-large  --t5-model-parallel True --dict-tokenizer gpt2
```

