### PR TITLE
fixing reasoning perturbation issues

### DIFF
--- a/parlai/tasks/math_dataset/agents.py
+++ b/parlai/tasks/math_dataset/agents.py
@@ -109,7 +109,10 @@ class MathDatasetStepByStepReasoningTeacher(MWPStepsReasoningTeacher):
                 rand_steps = self._clean_steps(
                     self.math_random.choice(data)["solution"]
                 ).split(". ")
-                random_step = self.math_random.choice(rand_steps)
+                random_step = ""
+                # find non-empty random step
+                while random_step == "" or random_step == " ":
+                    random_step = self.math_random.choice(rand_steps)
             if convert:
                 question = self._latex_conversion(question)
                 final_answer = self._latex_conversion(final_answer)

--- a/parlai/tasks/math_dataset/agents.py
+++ b/parlai/tasks/math_dataset/agents.py
@@ -20,7 +20,7 @@ from parlai.tasks.math_dataset.build import build
 from parlai.core.opt import Opt
 from parlai.core.params import ParlaiParser
 from parlai.utils.io import PathManager
-from typing import Optional
+from typing import List, Optional
 
 from parlai.tasks.reasoning.agents import MWPStepsReasoningTeacher
 
@@ -72,7 +72,7 @@ class MathDatasetStepByStepReasoningTeacher(MWPStepsReasoningTeacher):
         self.math_random = random.Random(42)
         super().__init__(opt, shared)
 
-    def load_data(self, domains):
+    def load_data(self, domains) -> List[str]:
         data = []
         data_path = self.opt['datafile']
         for domain in domains:
@@ -106,13 +106,7 @@ class MathDatasetStepByStepReasoningTeacher(MWPStepsReasoningTeacher):
             answer_blob = self._clean_steps(answer_blob)
             steps = answer_blob.split(". ")
             if extrinsic_step:
-                rand_steps = self._clean_steps(
-                    self.math_random.choice(data)["solution"]
-                ).split(". ")
-                random_step = ""
-                # find non-empty random step
-                while random_step == "" or random_step == " ":
-                    random_step = self.math_random.choice(rand_steps)
+                random_step = self._find_nonempty_random_step(data)
             if convert:
                 question = self._latex_conversion(question)
                 final_answer = self._latex_conversion(final_answer)
@@ -227,6 +221,29 @@ class MathDatasetStepByStepReasoningTeacher(MWPStepsReasoningTeacher):
             final_answer = final_answer.replace(',', '')
 
         return final_answer
+
+    def _find_nonempty_random_step(self, dataset: List[str]) -> str:
+        '''Here we *ASSUME* that the whole dataset contains at least one non-empty step
+        Otherwise it will go into infinite loop looking for the one
+        '''
+        # what we call an empty step
+        empty_steps = ["", " "]
+        # first find chain with at least one non-empty step
+        rand_steps = self._clean_steps(
+            self.math_random.choice(dataset)["solution"]
+        ).split(". ")
+        # make sure this chain has at least one non-empty step
+        i = 0
+        while i < len(rand_steps) and rand_steps[i] in empty_steps:
+            i += 1
+        # if it doesn't, try again
+        if i == len(rand_steps):
+            return self._find_nonempty_random_step(dataset)
+        random_step = empty_steps[0]
+        # find non-empty random step (and we know it exists in this chain)
+        while random_step in empty_steps:
+            random_step = self.math_random.choice(rand_steps)
+        return random_step
 
     def get_boxed_answer(self, answer):
         boxed_idx = answer.find("boxed{")

--- a/parlai/tasks/proof_writer/agents.py
+++ b/parlai/tasks/proof_writer/agents.py
@@ -330,6 +330,9 @@ class ProofWriterStepByStepReasoningTeacher(
             if extrinsic_step:
                 random_step = None
                 # make sure new step is from a different context
+                # here we aasume that there is at least one step in the set
+                # with different context, otherwise it will go in the
+                # infinite loop
                 while not random_step or random_step in m["question"]:
                     rand_steps = self.proofwriter_random.choice(messages)["steps"]
                     random_step = self.proofwriter_random.choice(rand_steps)

--- a/parlai/tasks/proof_writer/agents.py
+++ b/parlai/tasks/proof_writer/agents.py
@@ -328,8 +328,11 @@ class ProofWriterStepByStepReasoningTeacher(
 
         for m in messages:
             if extrinsic_step:
-                rand_steps = self.proofwriter_random.choice(messages)["steps"]
-                random_step = self.proofwriter_random.choice(rand_steps)
+                random_step = None
+                # make sure new step is from a different context
+                while not random_step or random_step in m["question"]:
+                    rand_steps = self.proofwriter_random.choice(messages)["steps"]
+                    random_step = self.proofwriter_random.choice(rand_steps)
                 m["extrinsic_step"] = random_step
                 yield m
             else:

--- a/projects/roscoe/baselines/scores.py
+++ b/projects/roscoe/baselines/scores.py
@@ -223,7 +223,9 @@ class BartscoreFineTunedBaselineScorer(BartscoreBase):
         )
         # Path here to fine-tuend BART Model
         try:
-            self.scorer.load(BART_SCORE_REPO + "/train/reproduce/trained/bart_6000.pth")
+            self.scorer.load(
+                BART_SCORE_REPO + "/train/reproduce/trained/fine_tuned_bartscore.pth"
+            )
         except FileNotFoundError:
             raise FileNotFoundError(
                 f"Path here should be to fine tuned BART model from"


### PR DESCRIPTION
**Patch description**
Fixing some issues with perturbations:
1. Math selecting empty steps to insert as hallucination. Ideally, we would want to remove this empty steps at tokenization, but that would change all our MATH data and affect all scores. So instead this patch.
2. In proofwriter, use only those hallucinated steps that are not part of the context
3. In Grammar, compare with tokenized step, to avoid situation where chains are identical everywhere except some random spaces
4. Fix the name of the finetuned BART model to align with what was uploaded to S3
