### PR TITLE
fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ tornado==6.0.4
 tqdm~=4.62.1
 typing-extensions==3.7.4.3
 Unidecode==1.1.1
-urllib3>=1.26.5
+urllib3<1.27,>=1.26.5
 websocket-client==0.56.0
 jsonlines==1.2.0
 numpy~=1.22 


### PR DESCRIPTION
**Patch description**
Builds are failing with new version of urllib with "error: urllib3 2.0.0a1 is installed but urllib3<1.27,>=1.21.1 is required by {'requests'}"
Example: https://app.circleci.com/pipelines/github/facebookresearch/ParlAI/12089/workflows/2ea77664-d675-4b71-893a-63da1d3cd7f3/jobs/97780

Changing version as required