### PR TITLE
[TGA] Fix TGA Compatibility with Pytorch>=1.13

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -1596,7 +1596,7 @@ class TreeSearch(object):
             hyp_device = self.partial_hyps.get_device()
         self.partial_hyps = torch.cat(
             (
-                self.partial_hyps[path_selection.hypothesis_ids.long()],
+                self.partial_hyps[path_selection.hypothesis_ids.long().to(hyp_device)],
                 path_selection.token_ids.view(path_selection.token_ids.shape[0], -1).to(
                     hyp_device
                 ),


### PR DESCRIPTION
**Patch description**
Seems pytorch>=1.13 is strict about accessing cpu tensors with gpu items; this PR fixes that.

Addresses #4869 

**Testing steps**
Local testing, + running CI on pytorch 1.13 (which failed before)

```
$ pytest test_tga.py
=====test session starts =====
platform linux -- Python 3.9.15, pytest-5.3.2, py-1.11.0, pluggy-0.13.1
rootdir: /private/home/kshuster/ParlAI, inifile: pytest.ini
plugins: requests-mock-1.7.0, hydra-core-1.2.0, datadir-1.4.1, regressions-2.1.1
collected 8 items

test_tga.py ........                                                                                                                                                                                                                                                                                                                                                [100%]

===== slowest 10 test durations =====
2.89s call     tests/test_tga.py::TestTGA::test_block_full_context
2.88s call     tests/test_tga.py::TestTGA::test_no_greedy_largebeam
0.59s call     tests/test_tga.py::TestGeneration::test_token_level_loss_logging
0.22s call     tests/test_tga.py::TestGeneration::test_full_context_block
0.21s call     tests/test_tga.py::TestTGA::test_file_inference
0.13s call     tests/test_tga.py::TestGeneration::test_prefix_tokens
0.02s call     tests/test_tga.py::TestGeneration::test_tree_search

(0.00 durations hidden.  Use -vv to show these durations.)
=====8 passed, 13 warnings in 77.97s (0:01:17) =====

```

