### PR TITLE
Dropping the none probabilities

### DIFF
--- a/projects/bb3/agents/utils.py
+++ b/projects/bb3/agents/utils.py
@@ -650,7 +650,7 @@ class APIUtils:
             start_label = [i for i, off in enumerate(text_off) if off <= prompt_len]
             assert len(start_label) > 0
             start_label = start_label[-1]
-            all_log_probs = result['choices'][0]['logprobs']['token_logprobs']
+            all_log_probs = [lp for lp in result['choices'][0]['logprobs']['token_logprobs'] if lp]
             if not all(l <= 0 for l in all_log_probs):
                 logging.warning(
                     f'Out of {len(all_log_probs)} log probs, {len([l for l in all_log_probs if l > 0])} are > 0. '

--- a/projects/bb3/agents/utils.py
+++ b/projects/bb3/agents/utils.py
@@ -650,7 +650,9 @@ class APIUtils:
             start_label = [i for i, off in enumerate(text_off) if off <= prompt_len]
             assert len(start_label) > 0
             start_label = start_label[-1]
-            all_log_probs = [lp for lp in result['choices'][0]['logprobs']['token_logprobs'] if lp]
+            all_log_probs = [
+                lp for lp in result['choices'][0]['logprobs']['token_logprobs'] if lp
+            ]
             if not all(l <= 0 for l in all_log_probs):
                 logging.warning(
                     f'Out of {len(all_log_probs)} log probs, {len([l for l in all_log_probs if l > 0])} are > 0. '

--- a/projects/bb3/agents/utils.py
+++ b/projects/bb3/agents/utils.py
@@ -651,7 +651,9 @@ class APIUtils:
             assert len(start_label) > 0
             start_label = start_label[-1]
             all_log_probs = [
-                lp for lp in result['choices'][0]['logprobs']['token_logprobs'] if lp
+                lp
+                for lp in result['choices'][0]['logprobs']['token_logprobs']
+                if lp is not None
             ]
             if not all(l <= 0 for l in all_log_probs):
                 logging.warning(


### PR DESCRIPTION
**Patch description**
Running some evaluations that were using the OPT model as their backend server, I noticed that sometime they were crashing while calculating the PPL. Digging deeper it turned out there is a `None` value in the `token_logprobs` returned from the server. Adding this filter resolved the crashing issue.

![Screen Shot 2022-11-30 at 12 47 51 PM](https://user-images.githubusercontent.com/11262163/204873157-455addab-a81d-4973-af0a-afabddcbe9aa.png)

**PS**: I am not sure if this has any unwanted consequences on the validity of the metric.
