### PR TITLE
None metrics

### DIFF
--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -292,7 +292,8 @@ class Metric(ABC):
         cls, metric_per_token: torch.Tensor, mask: torch.Tensor
     ) -> List[Metric]:
         """
-        From token-level metrics, returns an aggregate MyMetric per example in the batch.
+        From token-level metrics, returns an aggregate MyMetric per example in the
+        batch.
 
         :param metric_per_token:
             a (batchsize x num_tokens) Tensor

--- a/parlai/core/metrics.py
+++ b/parlai/core/metrics.py
@@ -1097,6 +1097,8 @@ class TeacherMetrics(Metrics):
         # User-reported metrics
         if 'metrics' in observation:
             for uk, v in observation['metrics'].items():
+                if v is None:
+                    continue
                 if uk in ALL_METRICS:
                     # don't let the user override our metrics
                     uk = f'USER_{uk}'

--- a/projects/cringe/cringe_loss.py
+++ b/projects/cringe/cringe_loss.py
@@ -88,9 +88,15 @@ class ContrastiveCrossEntropyLoss(CrossEntropyLoss):
 
         # concatenate the logits of the preds with the actual label's logits
         x_target = x[torch.arange(x.shape[0]), y]
-        x_ct = torch.concat(
-            [x_target.unsqueeze(1), sample_preds_values.unsqueeze(1)], -1
-        )
+        if hasattr(torch, 'concat'):
+            # torch > 1.10
+            x_ct = torch.concat(
+                [x_target.unsqueeze(1), sample_preds_values.unsqueeze(1)], -1
+            )
+        else:
+            x_ct = torch.cat(
+                [x_target.unsqueeze(1), sample_preds_values.unsqueeze(1)], -1
+            )
         # get the y's for the x_ct (the correct label is index 0 if
         # the target is positive and index 1 if the target is negative)
         y_ct = torch.abs(torch.abs(classifier_labels) - 1).type(y.dtype).to(x_ct.device)

--- a/projects/cringe/cringe_loss.py
+++ b/projects/cringe/cringe_loss.py
@@ -88,15 +88,7 @@ class ContrastiveCrossEntropyLoss(CrossEntropyLoss):
 
         # concatenate the logits of the preds with the actual label's logits
         x_target = x[torch.arange(x.shape[0]), y]
-        if hasattr(torch, 'concat'):
-            # torch > 1.10
-            x_ct = torch.concat(
-                [x_target.unsqueeze(1), sample_preds_values.unsqueeze(1)], -1
-            )
-        else:
-            x_ct = torch.cat(
-                [x_target.unsqueeze(1), sample_preds_values.unsqueeze(1)], -1
-            )
+        x_ct = torch.cat([x_target.unsqueeze(1), sample_preds_values.unsqueeze(1)], -1)
         # get the y's for the x_ct (the correct label is index 0 if
         # the target is positive and index 1 if the target is negative)
         y_ct = torch.abs(torch.abs(classifier_labels) - 1).type(y.dtype).to(x_ct.device)


### PR DESCRIPTION
**Patch description**
Running the `projects.cringe.cringe_loss:ContrastiveTransformerGeneratorAgent`, noticed some issues about calculating metrics for some `None` values; this was crashing the model during the training.
This was due to dropping some of the values in the Generator Agent ([example](https://github.com/facebookresearch/ParlAI/blob/4c96c8867061fba34fdd03a1f87481f8c3623439/projects/cringe/cringe_loss.py#L285-L293)).
This patch fixes that by ignoring the `None` values in an observation.