### PR TITLE
Custom metrics from `compute_loss` in TGA (2nd try)

### DIFF
--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -717,7 +717,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         """
         return self._model_input(batch)
 
-    def custom_loss_metrics(self, batch, loss_per_token):
+    def record_per_token_metrics(self, batch, loss_per_token):
         """
         Override this method for custom loss values that require loss_per_token.
         """
@@ -758,7 +758,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         self.record_local_metric(
             'token_em', AverageMetric.many(num_tokens_correct == num_target_tokens)
         )
-        self.custom_loss_metrics(batch, loss_per_token)
+        self.record_per_token_metrics(batch, loss_per_token)
 
         # actually do backwards loss
         loss = loss_per_token.sum(dim=1)

--- a/parlai/core/torch_generator_agent.py
+++ b/parlai/core/torch_generator_agent.py
@@ -717,6 +717,12 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         """
         return self._model_input(batch)
 
+    def custom_loss_metrics(self, batch, loss_per_token):
+        """
+        Override this method for custom loss values that require loss_per_token.
+        """
+        pass
+
     def compute_loss(self, batch, return_output=False):
         """
         Compute and return the loss for the given batch.
@@ -752,6 +758,7 @@ class TorchGeneratorAgent(TorchAgent, ABC):
         self.record_local_metric(
             'token_em', AverageMetric.many(num_tokens_correct == num_target_tokens)
         )
+        self.custom_loss_metrics(batch, loss_per_token)
 
         # actually do backwards loss
         loss = loss_per_token.sum(dim=1)


### PR DESCRIPTION
**Patch description**
The `compute_loss` function in TGA generates the `loss_per_token` values but they are not accessible from outside this method. This PR adds a handle for calculating custom metrics that require `loss_per_token`. The added method (`custom_loss_metrics`) can be overridden by its children to work with the `loss_per_token` and `batch` for generating custom metrics. 

**NOTE**: this is cleaned up version of [4905](https://github.com/facebookresearch/ParlAI/pull/4905) which became corrupted with other commits after some bad rebase and merge.