### PR TITLE
Reverting emoji response patch in model chat

### DIFF
--- a/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
+++ b/parlai/crowdsourcing/tasks/model_chat/frontend/components/response_panes.jsx
@@ -8,7 +8,6 @@
 
 import React from "react";
 
-import InputEmoji from 'react-input-emoji'
 import { Button, Col, ControlLabel, Form, FormControl, FormGroup } from "react-bootstrap";
 
 
@@ -161,7 +160,7 @@ function FinalSurvey({ taskConfig, onMessageSend, active, currentCheckboxes }) {
   }
 }
 
-function CheckboxTextResponse({ onMessageSend, taskConfig, active, currentCheckboxes }) {
+function CheckboxTextResponse({ onMessageSend, active, currentCheckboxes }) {
   const [textValue, setTextValue] = React.useState("");
   const [sending, setSending] = React.useState(false);
 
@@ -197,56 +196,32 @@ function CheckboxTextResponse({ onMessageSend, taskConfig, active, currentCheckb
     [tryMessageSend]
   );
 
-  if (taskConfig.emoji_picker){
-    return (
-      <div className="response-type-module">
-        <div className="response-bar">
-        <InputEmoji
-            value={textValue}
-            className="response-text-input"
-            onEnter={(e) => handleKeyPress(e)}
-            onChange={setTextValue}
-            placeholder="Please enter here..."
-          /> 
-          <Button
-            className="btn btn-primary submit-response"
-            id="id_send_msg_button"
-            disabled={textValue === "" || !active || sending}
-            onClick={() => tryMessageSend()}
-          >
-            Send
-          </Button>
-        </div>
-      </div>
-    );
-  } else {
-    return (
-      <div className="response-type-module">
-        <div className="response-bar">
+  return (
+    <div className="response-type-module">
+      <div className="response-bar">
         <FormControl
-            type="text"
-            className="response-text-input"
-            inputRef={(ref) => {
-              inputRef.current = ref;
-            }}
-            value={textValue}
-            placeholder="Please enter here..."
-            onKeyPress={(e) => handleKeyPress(e)}
-            onChange={(e) => setTextValue(e.target.value)}
-            disabled={!active || sending}
-          /> 
-          <Button
-            className="btn btn-primary submit-response"
-            id="id_send_msg_button"
-            disabled={textValue === "" || !active || sending}
-            onClick={() => tryMessageSend()}
-          >
-            Send
-          </Button>
-        </div>
+          type="text"
+          className="response-text-input"
+          inputRef={(ref) => {
+            inputRef.current = ref;
+          }}
+          value={textValue}
+          placeholder="Please enter here..."
+          onKeyPress={(e) => handleKeyPress(e)}
+          onChange={(e) => setTextValue(e.target.value)}
+          disabled={!active || sending}
+        />
+        <Button
+          className="btn btn-primary submit-response"
+          id="id_send_msg_button"
+          disabled={textValue === "" || !active || sending}
+          onClick={() => tryMessageSend()}
+        >
+          Send
+        </Button>
       </div>
-    );    
-  }
+    </div>
+  );
 }
 
 function ResponseComponent({ taskConfig, appSettings, onMessageSend, active }) {
@@ -272,7 +247,6 @@ function ResponseComponent({ taskConfig, appSettings, onMessageSend, active }) {
     return (
       <CheckboxTextResponse
         onMessageSend={onMessageSend}
-        taskConfig={taskConfig}
         active={computedActive}
         currentCheckboxes={lastMessageAnnotations}
       />

--- a/parlai/crowdsourcing/tasks/model_chat/hydra_configs/conf/example.yaml
+++ b/parlai/crowdsourcing/tasks/model_chat/hydra_configs/conf/example.yaml
@@ -17,7 +17,6 @@ mephisto:
     conversation_start_mode: 'hi'
     annotation_question: Does this comment from your partner have any of the following attributes? (Check all that apply)
     conversations_needed_string: "blender_90M:10"
-    emoji_picker: false
   task:
     allowed_concurrent: 1
     assignment_duration_in_seconds: 600

--- a/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
+++ b/parlai/crowdsourcing/tasks/model_chat/model_chat_blueprint.py
@@ -155,10 +155,6 @@ class BaseModelChatBlueprintArgs(ParlAIChatBlueprintArgs):
             "in order to override the parlai parser defaults."
         },
     )
-    emoji_picker: bool = field(
-        default=False,
-        metadata={"help": "Show emoji picker."},
-    )
 
 
 class BaseModelChatBlueprint(ParlAIChatBlueprint, ABC):
@@ -299,7 +295,6 @@ class BaseModelChatBlueprint(ParlAIChatBlueprint, ABC):
             "frame_height": 650,
             "final_rating_question": self.args.blueprint.final_rating_question,
             "block_mobile": True,
-            "emoji_picker": self.args.blueprint.emoji_picker,
         }
 
 


### PR DESCRIPTION
**Patch description**

Revert "add emoji input functionality to model chat crowdsourcing task (#4666)"

This reverts commit 2f42a5b90bdbbd4fc67970d4c051d4955787445c.

Ran into some issue running the the human-model chat. After consulting with @pringshia it was related to the changes in this PR. @meganung confirms that there is not going to be major side effects reverting this. 