### PR TITLE
Changing the numpy version for the

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,26 +219,26 @@ commands:
             - setupcuda
       - fixgit
       - restore_cache:
-          key: deps-20221202-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20230209-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - << parameters.more_installs >>
       - save_cache:
-          key: deps-20221202-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
+          key: deps-20230209-<< parameters.cachename >>-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"
       - findtests:
           marker: << parameters.marker >>
       - restore_cache:
-          key: data-20221202-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20230209-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
       - run:
           name: Run tests
           no_output_timeout: 60m
           command: |
             coverage run -m pytest -m << parameters.marker >> << parameters.pytest_flags >> --junitxml=test-results/junit.xml
       - save_cache:
-          key: data-20221202-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
+          key: data-20230209-<< parameters.cachename >>-{{ checksum "teststorun.txt" }}
           paths:
             - "~/ParlAI/data"
       - codecov
@@ -255,12 +255,12 @@ commands:
       - checkout
       - fixgit
       - restore_cache:
-          key: deps-20221202-bw-{{ checksum "requirements.txt" }}
+          key: deps-20230209-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
       - installtorchgpu
       - save_cache:
-          key: deps-20221202-bw-{{ checksum "requirements.txt" }}
+          key: deps-20230209-bw-{{ checksum "requirements.txt" }}
           paths:
             - "~/venv/bin"
             - "~/venv/lib"

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ Unidecode==1.1.1
 urllib3<1.27,>=1.26.5
 websocket-client==0.56.0
 jsonlines==1.2.0
-numpy~=1.22
+numpy~=1.23
 markdown<=3.3.2 # Pin to something that works so tests are happy
 jinja2==3.0.3
 ninja~=1.10.2.3


### PR DESCRIPTION
NLTK crash error because of the deprecated `numpy.int`.