### PR TITLE
Mephisto test skip when there is no Mephisto

### DIFF
--- a/parlai/utils/testing.py
+++ b/parlai/utils/testing.py
@@ -62,6 +62,14 @@ except ImportError:
     FAIRSEQ_AVAILABLE = False
 
 
+try:
+    import mephisto  # noqa: F401
+
+    MEPHISTO_AVAILABLE = True
+except ImportError:
+    MEPHISTO_AVAILABLE = False
+
+
 def is_this_circleci():
     """
     Return if we are currently running in CircleCI.
@@ -128,6 +136,13 @@ def skipUnlessFairseq(testfn, reason='fairseq not installed'):
     Decorate a test to skip unless fairseq is installed.
     """
     return unittest.skipUnless(FAIRSEQ_AVAILABLE, reason)(testfn)
+
+
+def skipUnlessMephisto(testfn, reason='mephisto not installed'):
+    """
+    Decorate a test to skip unless mephisto is installed.
+    """
+    return unittest.skipUnless(MEPHISTO_AVAILABLE, reason)(testfn)
 
 
 class retry(object):


### PR DESCRIPTION
**Patch description**
Decorators to skip the tests related to mephisto and crowd sourcing if Mephisto was not installed.