### PR TITLE
Fix for None token logprobs

### DIFF
--- a/projects/bb3/agents/opt_api_agent.py
+++ b/projects/bb3/agents/opt_api_agent.py
@@ -448,7 +448,11 @@ class SimpleOPTAgent(Agent):
                 msg['metrics'] = {'ppl': ppl, 'ctxt_label_ppl': ctxt_ppl}
                 if self.opt['skip_generation']:
                     msg['text'] = r['choices'][0]['text'].strip()
-                    msg['logprobs'] = sum(r['choices'][0]['logprobs']['token_logprobs'])
+                    # API returns null logprob for EOS when echoing
+                    token_logprobs = r['choices'][0]['logprobs']['token_logprobs']
+                    if self.echo and token_logprobs[0] is None:
+                        token_logprobs = token_logprobs[1:]
+                    msg['logprobs'] = sum(token_logprobs)
                     msg['token_logprobs'] = r['choices'][0]['logprobs'][
                         'token_logprobs'
                     ]

--- a/projects/bb3/agents/utils.py
+++ b/projects/bb3/agents/utils.py
@@ -630,11 +630,13 @@ class APIUtils:
         observations: List[Message], results: List[Dict[str, Any]]
     ) -> Tuple[List[PPLMetric], List[PPLMetric]]:
         """
+
         Compute perplexities from API call.
         :param observations:
             incoming observations
         :param results:
             results from API call
+
         :return ppls:
             return list of perplexities
         """

--- a/projects/bb3/agents/utils.py
+++ b/projects/bb3/agents/utils.py
@@ -630,8 +630,8 @@ class APIUtils:
         observations: List[Message], results: List[Dict[str, Any]]
     ) -> Tuple[List[PPLMetric], List[PPLMetric]]:
         """
-
         Compute perplexities from API call.
+
         :param observations:
             incoming observations
         :param results:

--- a/projects/bb3/agents/utils.py
+++ b/projects/bb3/agents/utils.py
@@ -631,12 +631,10 @@ class APIUtils:
     ) -> Tuple[List[PPLMetric], List[PPLMetric]]:
         """
         Compute perplexities from API call.
-
         :param observations:
             incoming observations
         :param results:
             results from API call
-
         :return ppls:
             return list of perplexities
         """
@@ -650,7 +648,11 @@ class APIUtils:
             start_label = [i for i, off in enumerate(text_off) if off <= prompt_len]
             assert len(start_label) > 0
             start_label = start_label[-1]
-            all_log_probs = result['choices'][0]['logprobs']['token_logprobs']
+            all_log_probs = [
+                lp
+                for lp in result['choices'][0]['logprobs']['token_logprobs']
+                if lp is not None
+            ]
             if not all(l <= 0 for l in all_log_probs):
                 logging.warning(
                     f'Out of {len(all_log_probs)} log probs, {len([l for l in all_log_probs if l > 0])} are > 0. '


### PR DESCRIPTION
The first token logprob value returned by the API is None, so it needs to be filtered out. Bring in code from `main` for this, including https://github.com/facebookresearch/ParlAI/pull/4899.