### PR TITLE
[Crowdsourcing] Fix 2 critical errors with static turn annotations

### DIFF
--- a/parlai/crowdsourcing/tasks/turn_annotations_static/webapp/src/components/core_components.jsx
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/webapp/src/components/core_components.jsx
@@ -15,7 +15,7 @@ function LoadingScreen() {
 }
 
 function TaskFrontend({ taskData, taskConfig, isOnboarding, onSubmit }) {
-  if (!taskData) {
+  if (!taskData || (!isOnboarding && taskData[0] === undefined)) {
     return <LoadingScreen />;
   }
   if (isOnboarding) {

--- a/parlai/crowdsourcing/tasks/turn_annotations_static/webapp/src/components/task_components.jsx
+++ b/parlai/crowdsourcing/tasks/turn_annotations_static/webapp/src/components/task_components.jsx
@@ -170,7 +170,7 @@ var handleSubtaskSubmit = function (subtaskIndex, setIndex, numSubtasks, initial
       alert('Unable to submit task due to malformed data. Please contact requester.');
       return;
     }
-    mephistoSubmit(window.workerAnswers);
+    mephistoSubmit({final_data: window.workerAnswers});
   }
   showDisableCssNextButton();
   setIndex(subtaskIndex + 1); 


### PR DESCRIPTION
**Patch description**
- Fixes frontend error in static_turn_annotations, caused by frontend supplying a temporary `taskData` object in the interim transitioning between onboarding and the full world 
- Fixes the issue that the final submitted data needs to be part of a dict with a `'final_data'` key

(thanks @JackUrb for the fixes!)

**Testing steps**
```
python parlai/crowdsourcing/tasks/turn_annotations_static/run.py \
conf=test00.yaml \
mephisto.database._database_type=singleton \
mephisto.log_level=debug \
mephisto.task.maximum_units_per_worker=100000 \
mephisto.blueprint.onboarding_qualification=test_2023_02_17__04 \
--config-dir ${DIR}`