### PR TITLE
fix datatype

### DIFF
--- a/parlai/tasks/wizard_of_internet/agents.py
+++ b/parlai/tasks/wizard_of_internet/agents.py
@@ -150,7 +150,7 @@ class WizardOfInternetBaseTeacher(DialogTeacher):
 
     def __init__(self, opt: Opt, shared=None):
         opt = deepcopy(opt)
-        self.datatype = get_dtype(opt)
+        self.datatype = opt.get('datatype', 'train')
         opt['datafile'] = _path(opt)
         self.include_persona = opt.get('include_persona', CONST.INCLUDE_PERSONA_DEFAULT)
         self.skip_empty_text = opt.get(


### PR DESCRIPTION
**Patch description**
Fix a bug of wizard_of_internet task. This bug led to a wrong number of examples when use "train:evalmode" as datatype.
The problem is like this:
![image](https://user-images.githubusercontent.com/27731754/219908168-17716de9-8f12-48e0-a6e9-8f33b08c9ed4.png)

**Testing steps**
To test this PR, you can run `parlai convert_to_json -t wizard_of_internet --datatype train:evalmode`
Expect to get the correct number of samples.
![image](https://user-images.githubusercontent.com/27731754/219908114-a3bf860c-5548-446b-b7fc-078f296d70a7.png)

