### PR TITLE
final prefix space

### DIFF
--- a/projects/bb3/agents/opt_api_agent.py
+++ b/projects/bb3/agents/opt_api_agent.py
@@ -238,6 +238,7 @@ class SimpleOPTAgent(Agent):
         parser.add_argument(
             '--final-prefix-space',
             default=False,
+            type='bool',
             help="Specify to include a space after the final prefix.",
         )
         parser.add_argument(


### PR DESCRIPTION
**Patch description**
Before the fix it parsed "False" in cmd line as string instead of boolean, thus always add final prefix space as long as one set `--final-prefix-space` in cmd line
**Testing steps**
<!-- Enter steps to test your pull request. Give a clear and concise description of
what you expected to happen during testing. Include any logs in ```backticks``` if you have them.
Also make sure you have connected your account to CircleCI and those tests run successfully. -->

**Other information**
<!-- Any other information or context you would like to provide. -->
