### PR TITLE
Website deploy test passing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,6 @@ commands:
           key: deps-20230404-bw-{{ checksum "requirements.txt" }}
       - setup
       - installdeps
-      - installtorchgpu
       - save_cache:
           key: deps-20230404-bw-{{ checksum "requirements.txt" }}
           paths:


### PR DESCRIPTION
**Patch description**
This was more of a fix on the CircleCI (adding the AWS credentials for uploading the built website). But removed the extra step on installing GPU packages, which seems unnecessary for the markdown build and S3 bucket sync.