### PR TITLE
Fix starspace

### DIFF
--- a/parlai/agents/starspace/modules.py
+++ b/parlai/agents/starspace/modules.py
@@ -17,7 +17,6 @@ class Starspace(nn.Module):
             opt['embeddingsize'],
             0,
             sparse=True,
-            max_norm=opt['embeddingnorm'],
         )
         if not opt['tfidf']:
             dict = None
@@ -28,7 +27,6 @@ class Starspace(nn.Module):
                 opt['embeddingsize'],
                 0,
                 sparse=True,
-                max_norm=opt['embeddingnorm'],
             )
             self.encoder2 = Encoder(self.lt2, dict)
         else:

--- a/parlai/agents/starspace/starspace.py
+++ b/parlai/agents/starspace/starspace.py
@@ -242,7 +242,7 @@ class StarspaceAgent(Agent):
         :param weight:   weights of lookup table (nn.Embedding/nn.EmbeddingBag)
         :param emb_type: pretrained embedding type
         """
-        weight = self.model.lt.weight
+        weight = self.model.lt.weight.clone()
         emb_type = self.opt.get('embedding_type', 'random')
         if emb_type == 'random':
             return

--- a/parlai/agents/starspace/starspace.py
+++ b/parlai/agents/starspace/starspace.py
@@ -242,7 +242,7 @@ class StarspaceAgent(Agent):
         :param weight:   weights of lookup table (nn.Embedding/nn.EmbeddingBag)
         :param emb_type: pretrained embedding type
         """
-        weight = self.model.lt.weight.clone()
+        weight = self.model.lt.weight
         emb_type = self.opt.get('embedding_type', 'random')
         if emb_type == 'random':
             return


### PR DESCRIPTION
**Patch description**
There is an in-place Variable error when training the current starspace models. This has to do with a known issue in using `max_norm` with `nn.Embedding`: https://github.com/pytorch/pytorch/issues/26596

I have been unable to track down the root of the cause (it has something to do with accessing the embedding weights directly?) but simply removing the `max_norm` allows us to pass tests

**Testing steps**
To identify that it was an issue with the embedding, I wrapped the forward call with

```python
with torch.autograd.set_detect_anomaly(True):
```

Which leads to this traceback:
```
  File "/private/home/kshuster/ParlAI/parlai/agents/starspace/starspace.py", line 415, in predict
    xe, ye = self.model(xs, ys, negs)
  File "/private/home/kshuster/.conda/envs/parlai_py39_pyt113/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1190, in _call_impl
    return forward_call(*input, **kwargs)
  File "/private/home/kshuster/ParlAI/parlai/agents/starspace/modules.py", line 54, in forward
    c_emb = self.encoder2(c)
  File "/private/home/kshuster/.conda/envs/parlai_py39_pyt113/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1190, in _call_impl
    return forward_call(*input, **kwargs)
  File "/private/home/kshuster/ParlAI/parlai/agents/starspace/modules.py", line 75, in forward
    xs_emb = self.lt(xs)
  File "/private/home/kshuster/.conda/envs/parlai_py39_pyt113/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1190, in _call_impl
    return forward_call(*input, **kwargs)
  File "/private/home/kshuster/.conda/envs/parlai_py39_pyt113/lib/python3.9/site-packages/torch/nn/modules/sparse.py", line 160, in forward
    return F.embedding(
  File "/private/home/kshuster/.conda/envs/parlai_py39_pyt113/lib/python3.9/site-packages/torch/nn/functional.py", line 2210, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
  File "/private/home/kshuster/.conda/envs/parlai_py39_pyt113/lib/python3.9/site-packages/torch/fx/traceback.py", line 57, in format_stack
    return traceback.format_stack()
 (Triggered internally at /opt/conda/conda-bld/pytorch_1666643016022/work/torch/csrc/autograd/python_anomaly_mode.cpp:114.)
```
You can see that the error originates from `xs_emb = self.lt(xs)`

Interestingly, the error seems to only come about when embedding candidate vectors -- *NOT THE INPUT* -- so there might be something going on there too.

Anyway, tests pass after this, I believe 

cc @jaseweston for whether `max_norm` is required