### PR TITLE
fix spelling error and add Contributors Avatar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ You can find information about contributing to ParlAI in our
 [Contributing](https://github.com/facebookresearch/ParlAI/blob/main/CONTRIBUTING.md)
 document.
 
+ParlAI thanks to all of our amazing contributors!
+
+<a href="https://github.com/facebookresearch/ParlAI/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=facebookresearch/ParlAI&r="  width="800px"/>
+</a>
 
 ## The Team
 ParlAI is currently maintained by Moya Chen, Emily Dinan, Dexter Ju, Mojtaba

--- a/docs/sample_model_cards/safety_multi/model_card.md
+++ b/docs/sample_model_cards/safety_multi/model_card.md
@@ -68,7 +68,7 @@ Note: The display dataset commands were auto generated, so please visit [here](h
 
 ## Evaluation Results
 
-For evalution, we used the same training datasets; check the [Datasets Used](#datasets-used) section for more information
+For evaluation, we used the same training datasets; check the [Datasets Used](#datasets-used) section for more information
 
 
 We used the metric `class notok f1`, the f1 scores for the class notok as the validation metric. Recall that `class___notok___f1` is unigram F1 overlap, under a standardized (model-independent) tokenizer.


### PR DESCRIPTION
**Patch description**
detail info 
1. fix spelling error docs/sample_model_cards/safety_multi/model_card.md on line 71
2. add Contributors Avatar in README.md
    After adjustment
![WL7HFRl4Ve](https://github.com/facebookresearch/ParlAI/assets/55081697/02426ea4-fccf-4975-a601-1d050f772d04)


**Testing steps**
Not involved

<!-- Any other information or context you would like to provide. -->
