### PR TITLE
Multilight teacher

### DIFF
--- a/parlai/core/teachers.py
+++ b/parlai/core/teachers.py
@@ -1733,8 +1733,8 @@ class ConversationTeacher(DialogTeacher):
             turn['text'] = xturn.get('text')
             turn['labels'] = [yturn.get('text')]
 
-            turn['x_turn'] = xturn
-            turn['y_turn'] = yturn
+            turn['x_turn'] = dict(xturn)
+            turn['y_turn'] = dict(yturn)
 
             eps.append(turn)
         return eps
@@ -1841,8 +1841,8 @@ class AbstractImageTeacher(FixedDialogTeacher):
         available_model_names = self.get_available_image_mode_names()
         if a not in available_model_names:
             raise argparse.ArgumentTypeError(
-                '\"%s\" unknown image model name. Choose from: %s. Currently suggested resnet is resnet152 and resnext is resnext101_32x48d_wsl.'
-                % (a, available_model_names)
+                f'"{a}" unknown image model name. Choose from: {available_model_names}.'
+                'Currently suggested resnet is resnet152 and resnext is resnext101_32x48d_wsl.'
             )
         return a
 

--- a/parlai/tasks/lccc/test/lccc_test.yml
+++ b/parlai/tasks/lccc/test/lccc_test.yml
@@ -4,25 +4,55 @@ acts:
     - 去相机家里吃……
     id: lccc
     text: 我饿了。
+    x_turn:
+      id: partner1
+      text: 我饿了。
+    y_turn:
+      id: partner2
+      text: 去相机家里吃……
 - - episode_done: true
     eval_labels:
     - 你过来我们什么关系
     id: lccc
     text: 网络大实话里说的是也许你能在网络里找到你想要的友情但永远不会找到你想要的爱情
+    x_turn:
+      id: partner1
+      text: 网络大实话里说的是也许你能在网络里找到你想要的友情但永远不会找到你想要的爱情
+    y_turn:
+      id: partner2
+      text: 你过来我们什么关系
 - - episode_done: true
     eval_labels:
     - 我不挑食
     id: lccc
     text: 老铁家好吃贾三不好吃
+    x_turn:
+      id: partner1
+      text: 老铁家好吃贾三不好吃
+    y_turn:
+      id: partner2
+      text: 我不挑食
 - - episode_done: true
     eval_labels:
     - 死鱼皮真会安慰人那不是翘臀是肥肉不！是赘肉！
     id: lccc
     text: 你有翘臀啊！！！！你的脸还不够小啊？？？？？
+    x_turn:
+      id: partner1
+      text: 你有翘臀啊！！！！你的脸还不够小啊？？？？？
+    y_turn:
+      id: partner2
+      text: 死鱼皮真会安慰人那不是翘臀是肥肉不！是赘肉！
 - - episode_done: false
     eval_labels:
     - 哈哈哈快到南方来
     id: lccc
     text: 好羡慕原来你们那真的可以光腿
+    x_turn:
+      id: partner1
+      text: 好羡慕原来你们那真的可以光腿
+    y_turn:
+      id: partner2
+      text: 哈哈哈快到南方来
 num_episodes: 10000
 num_examples: 12943

--- a/parlai/tasks/lccc/test/lccc_train.yml
+++ b/parlai/tasks/lccc/test/lccc_train.yml
@@ -4,25 +4,55 @@ acts:
     labels:
     - 道歉！！再有时间找你去
     text: 你去那儿竟然不喊我生气了，快点给我道歉
+    x_turn:
+      id: partner1
+      text: 你去那儿竟然不喊我生气了，快点给我道歉
+    y_turn:
+      id: partner2
+      text: 道歉！！再有时间找你去
 - - episode_done: true
     id: lccc
     labels:
     - SEED早上刚被禁用还有一个月的VIP路线呢禁了之后才买的另一个买了一年结果用了一下午就挂了现在用了个极速网速差的很
     text: 我用SEED.24小时签到一次可以用4小时，对于我这种每天晚上逛一下的感觉不错
+    x_turn:
+      id: partner1
+      text: 我用SEED.24小时签到一次可以用4小时，对于我这种每天晚上逛一下的感觉不错
+    y_turn:
+      id: partner2
+      text: SEED早上刚被禁用还有一个月的VIP路线呢禁了之后才买的另一个买了一年结果用了一下午就挂了现在用了个极速网速差的很
 - - episode_done: true
     id: lccc
     labels:
     - 干完这一票我的会员等级就要升了！
     text: 咬咬牙这回要全入了！
+    x_turn:
+      id: partner1
+      text: 咬咬牙这回要全入了！
+    y_turn:
+      id: partner2
+      text: 干完这一票我的会员等级就要升了！
 - - episode_done: true
     id: lccc
     labels:
     - 代表了哪里的普通人？
     text: 记得还…我们普通人要搬三天砖才赚来的20元
+    x_turn:
+      id: partner1
+      text: 记得还…我们普通人要搬三天砖才赚来的20元
+    y_turn:
+      id: partner2
+      text: 代表了哪里的普通人？
 - - episode_done: true
     id: lccc
     labels:
     - 好得差不多啦
     text: 早点好起来啊。生日快乐
+    x_turn:
+      id: partner1
+      text: 早点好起来啊。生日快乐
+    y_turn:
+      id: partner2
+      text: 好得差不多啦
 num_episodes: 6820506
 num_examples: 8869637

--- a/parlai/tasks/lccc/test/lccc_valid.yml
+++ b/parlai/tasks/lccc/test/lccc_valid.yml
@@ -4,25 +4,55 @@ acts:
     - 那个饭凉了吧唧的怎么吃啊摔
     id: lccc
     text: 啊我好爱虾仁蛋黄酱金枪鱼蛋黄酱
+    x_turn:
+      id: partner1
+      text: 啊我好爱虾仁蛋黄酱金枪鱼蛋黄酱
+    y_turn:
+      id: partner2
+      text: 那个饭凉了吧唧的怎么吃啊摔
 - - episode_done: true
     eval_labels:
     - 看了下全文，那女的考试当天就表明身体不舒服了，考试不是她预约是教练自己安排的，教练还让她考试不就是教练的错吗？而且她住院花了31万，赔30万不过分吧
     id: lccc
     text: 考试撞墙关驾校屁事？你怎么不顺便把考场施工单位也告了？
+    x_turn:
+      id: partner1
+      text: 考试撞墙关驾校屁事？你怎么不顺便把考场施工单位也告了？
+    y_turn:
+      id: partner2
+      text: 看了下全文，那女的考试当天就表明身体不舒服了，考试不是她预约是教练自己安排的，教练还让她考试不就是教练的错吗？而且她住院花了31万，赔30万不过分吧
 - - episode_done: true
     eval_labels:
     - 好好好，偶遇我大闺蜜
     id: lccc
     text: 我先去穿衣服，准备走了
+    x_turn:
+      id: partner1
+      text: 我先去穿衣服，准备走了
+    y_turn:
+      id: partner2
+      text: 好好好，偶遇我大闺蜜
 - - episode_done: true
     eval_labels:
     - 保存一下
     id: lccc
     text: 期待小猎豹的表现
+    x_turn:
+      id: partner1
+      text: 期待小猎豹的表现
+    y_turn:
+      id: partner2
+      text: 保存一下
 - - episode_done: true
     eval_labels:
     - 给你一个么么哒
     id: lccc
     text: 为了你们新年有惊喜，我也是用心良苦了
+    x_turn:
+      id: partner1
+      text: 为了你们新年有惊喜，我也是用心良苦了
+    y_turn:
+      id: partner2
+      text: 给你一个么么哒
 num_episodes: 20000
 num_examples: 25558

--- a/parlai/tasks/light_multiparty/README.md
+++ b/parlai/tasks/light_multiparty/README.md
@@ -1,0 +1,7 @@
+Task: Multi-party chat in LIGHT
+================
+
+Multi-party async conversation between 3 role-playing characters.
+For more information, please see our projects page: https://parl.ai/projects/multilight.
+
+Tags: #All, #ChitChat, #LIGHT

--- a/parlai/tasks/light_multiparty/__init__.py
+++ b/parlai/tasks/light_multiparty/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/parlai/tasks/light_multiparty/agents.py
+++ b/parlai/tasks/light_multiparty/agents.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) Meta, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
@@ -74,6 +74,7 @@ def get_speaker_name_from_index(utt: Message, index: int) -> str:
 class BaseTeacher(DialogTeacher):
     """
     Base class for MultiLIGHT teacher.
+
     This is an abstract class: do NOT use directly!
     """
 
@@ -309,7 +310,8 @@ class BaseTeacher(DialogTeacher):
 
     def get_extra_context_before(self, conv: Message):
         """
-        Generates the persona and location, which goes *before* the conversation context.
+        Generates the persona and location, which goes *before* the conversation
+        context.
         """
         extra_context_before = []
 
@@ -321,7 +323,8 @@ class BaseTeacher(DialogTeacher):
 
     def get_extra_context_after(self, conv: Message):
         """
-        Generates the timestep and speaker prompt, which goes *after* the conversation context.
+        Generates the timestep and speaker prompt, which goes *after* the conversation
+        context.
         """
         extra_context_after = []
         if self.add_current_timestep_to_context:
@@ -441,8 +444,9 @@ class SpeakerPredictionTeacher(AllSpeakersTeacher):
 class SingleSpeakerTeacher(ABC, BaseTeacher):
     """
     Generaes the utterances for a single character only.
-    The label will be the silent token if that character doesn't speak that round.
-    This is an abstract class: do NOT use directly!
+
+    The label will be the silent token if that character doesn't speak that round. This
+    is an abstract class: do NOT use directly!
     """
 
     def __init__(self, opt: Opt, shared=None):

--- a/parlai/tasks/light_multiparty/agents.py
+++ b/parlai/tasks/light_multiparty/agents.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from abc import ABC, abstractclassmethod
+import copy
+import jsonlines
+import random
+import os
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from parlai.core.message import Message
+from parlai.core.metrics import ExactMatchMetric, F1Metric
+from parlai.core.opt import Opt
+from parlai.core.params import ParlaiParser
+from parlai.core.teachers import DialogTeacher
+from parlai.core.torch_classifier_agent import ConfusionMatrixMetric
+from parlai.utils.data import DatatypeHelper
+
+from parlai.tasks.light_multiparty.build import build, DATASET_NAME
+
+START_TOKEN = "__START__"
+SILENCE_TOKEN = "__SILENCE__"
+SPEAKER_TOKEN_DELIM = ":"
+
+
+def _format_timestep(timestamp: str, first_utterance_timestamp: str):
+    """
+    Outputs timestep in the format of '00:00:00' relative to `first_utterance_timestamp`
+    """
+    time_delta = int(float(timestamp) - float(first_utterance_timestamp))
+    hour = time_delta // 3600
+    time_delta %= 3600
+    minute = time_delta // 60
+    time_delta %= 60
+    second = time_delta
+    return f"{hour:02d}:{minute:02d}:{second:02d}"
+
+
+def get_clean_text(message: Message) -> str:
+    return message["text"].replace("\n", " ")
+
+
+def flatten_personas(
+    personas: List[Dict[str, str]], delim: Optional[str] = "\n"
+) -> str:
+    personass_str_parts = []
+    personass_str_parts.append("__personas__")
+    personass_str_parts.extend([f"{p['name']}: {p['persona']}" for p in personas])
+    personass_str_parts.append("__end-personas__")
+    return delim.join(personass_str_parts)
+
+
+def flatten_location(location: Dict[str, str], delim: Optional[str] = "\n") -> str:
+    location_str_parts = [
+        "__location__",
+        f"{location['name']}: {location['description']}",
+        "__end-location__",
+    ]
+    return delim.join(location_str_parts)
+
+
+def get_speaker_names(utt: Message) -> List[str]:
+    return [p["name"] for p in utt["personas"]]
+
+
+def get_speaker_name_from_index(utt: Message, index: int) -> str:
+    return utt["personas"][index]["name"]
+
+
+class BaseTeacher(DialogTeacher):
+    """
+    Base class for MultiLIGHT teacher.
+    This is an abstract class: do NOT use directly!
+    """
+
+    def __init__(self, opt: Opt, shared=None):
+        opt = copy.deepcopy(opt)
+        build(opt)
+        # We often also call folds splits (for example in the build file here).
+        self.fold = DatatypeHelper.fold(opt["datatype"])
+        opt["datafile"] = os.path.join(
+            opt["datapath"], DATASET_NAME, f"{self.fold}.jsonl"
+        )
+
+        self.episode_quality_tiers = self._get_data_quality_tiers(
+            opt["episode_quality_tiers"]
+        )
+        self.speaker_quality_tiers = self._get_data_quality_tiers(
+            opt["speaker_quality_tiers"]
+        )
+        self.utterance_delimiter = opt["utterance_delimiter"]
+        self.use_start_token = opt["use_start_token"]
+        self.start_token = opt["start_token"]
+        self.include_speaker_in_context = opt["include_speaker_in_context"]
+        self.include_speaker_in_label = opt["include_speaker_in_label"]
+        self.add_speaker_to_context_end = opt["add_speaker_to_context_end"]
+        self.speaker_token_delimiter = opt["speaker_token_delimiter"]
+        self.include_timestep_in_context = opt["include_timestep_in_context"]
+        self.add_current_timestep_to_context = opt["add_current_timestep_to_context"]
+        self.add_personas_to_context = opt["add_personas_to_context"]
+        self.add_location_to_context = opt["add_location_to_context"]
+        self.id = "light_multiparty_dialogue"
+
+        super().__init__(opt, shared)
+
+    @classmethod
+    def add_cmdline_args(
+        cls, parser: ParlaiParser, partial_opt: Optional[Opt] = None
+    ) -> ParlaiParser:
+        super().add_cmdline_args(parser, partial_opt)
+        agent = parser.add_argument_group("MultiLIGHT Teacher Arguments")
+        agent.add_argument(
+            "--episode-quality-tiers",
+            type=str,
+            default="1,2",
+            help="Comma separated list of tiers of data quality for episodes to include. "
+            "The available tiers are 1 (high), 2 (low) quality."
+            " NOTE: only training data split has tiers. valid and test are only tier 1 data.",
+        )
+        agent.add_argument(
+            "--speaker-quality-tiers",
+            type=str,
+            default="1,2",
+            help="Comma separated list of tiers of data quality for speakers to include. "
+            "The available tiers are 1 (high), 2 (low) quality."
+            " NOTE: only training data split has tiers. valid and test are only tier 1 data.",
+        )
+        agent.add_argument(
+            "--utterance-delimiter",
+            type=str,
+            default="\n",
+            help="A string used to separate each utterance in the context. Defaults to newline. For example, 'A: Hello\nB: Hi there'.",
+        )
+        agent.add_argument(
+            "--use-start-token",
+            type="bool",
+            default=False,
+            help="Use start token at the beginning of each conversation, and include the first sentence as a training example.",
+        )
+        agent.add_argument(
+            "--start-token",
+            type=str,
+            default=START_TOKEN,
+            help=f"The token to use to indicate the beginning of a conversation. Defaults to {START_TOKEN}",
+        )
+        agent.add_argument(
+            "--include-speaker-in-label",
+            type="bool",
+            default=True,
+            help="Whether to include speaker labels in the label. "
+            "For example, message = { label: 'Rachel: Hi' } instead of message = { label: 'Hi' }",
+        )
+        agent.add_argument(
+            "--include-speaker-in-context",
+            type="bool",
+            default=True,
+            help="Whether to include speaker labels in the context. "
+            "For example, message = { text: 'Rachel: Hi' } instead of message = { text: 'Hi' }",
+        )
+        agent.add_argument(
+            "--add-speaker-to-context-end",
+            type="bool",
+            default=False,
+            help="Append the current speaker (who says `label`) to the end of each context. Defaults to True.",
+        )
+        agent.add_argument(
+            "--speaker-token-delimiter",
+            type=str,
+            default=SPEAKER_TOKEN_DELIM,
+            help="The token to use to separate the speaker label from the actual utterance in `obs['text']`.",
+        )
+        agent.add_argument(
+            "--include-timestep-in-context",
+            type="bool",
+            default=False,
+            help="If true, will add the timestep as part of the context for each previous utterance.",
+        )
+        agent.add_argument(
+            "--add-current-timestep-to-context",
+            type="bool",
+            default=False,
+            help="If true, will add the current timestep at the end of the context.",
+        )
+        agent.add_argument(
+            "--add-personas-to-context",
+            type="bool",
+            default=False,
+            help="If true, will prepend the flattened persona descriptions to the context.",
+        )
+        agent.add_argument(
+            "--add-location-to-context",
+            type="bool",
+            default=False,
+            help="If true, will prepend the flattened location description to the context.",
+        )
+        return parser
+
+    def _get_data_quality_tiers(self, tiers_str: str) -> Set[int]:
+        tiers = set([int(t) for t in tiers_str.split(",")])
+        for t in tiers:
+            assert t in (
+                1,
+                2,
+            ), f"Requested data tier ({t}) is invalid. Available tiers are 1 and 2 (only)."
+        return tiers
+
+    def get_speaker_prompt(self, utt: Message, ts: Optional[str] = None) -> str:
+        spkr = utt["speaker"]
+        return (
+            f"{spkr} {ts} {self.speaker_token_delimiter}"
+            if ts and self.include_timestep_in_context
+            else f"{spkr}{self.speaker_token_delimiter}"
+        )
+
+    def get_utterance_context(self, utt: Message, ts: Optional[str] = None) -> str:
+        text = get_clean_text(utt)
+        if self.include_speaker_in_context:
+            text = f"{self.get_speaker_prompt(utt, ts)} {text}"
+        return text
+
+    def get_utterance_label(self, utt: Dict[str, Any]) -> str:
+        label = get_clean_text(utt)
+        if self.include_speaker_in_label:
+            label = f"{self.get_speaker_prompt(utt)} {label}"
+        return label
+
+    def setup_data(self, datafile: str) -> List[Message]:
+        with jsonlines.open(datafile) as reader:
+            conversations = [dl for dl in reader]
+
+        assert conversations, "No data was loaded by teacher."
+
+        for conv in conversations:
+            if conv["quality_tier"] not in self.episode_quality_tiers:
+                continue
+            last_utterance_index = len(conv["messages"]) - 1
+
+            first_utterance_timestamp = 0
+            characters_index = dict()
+            personas = []
+            for i, c in enumerate(conv["characters"]):
+                personas.append({"name": c["name"], "persona": c["persona"]})
+                characters_index[c["name"]] = i + 1
+
+            location = {
+                "name": conv["location"]["name"],
+                "description": conv["location"]["description"],
+            }
+
+            context = []
+
+            for index, utterance in enumerate(conv["messages"]):
+                speaker = utterance["speaker"]
+                utterance["speaker_id"] = characters_index[speaker]
+                if index == 0:
+                    new_episode = True
+                    # Setting the start time for the relative timestamps after this.
+                    first_utterance_timestamp = utterance["timestamp"]
+
+                    if self.use_start_token:
+                        context.append(self.start_token)
+                    else:
+                        # If it is the first utterance,
+                        # we just add it to the context for the next round.
+                        context.append(
+                            self.get_utterance_context(
+                                utt=utterance, ts=_format_timestep(0, 0)
+                            )
+                        )
+                        # skip the first utterance after creating the initial context.
+                        continue
+
+                isConversationDone = index == last_utterance_index
+
+                timestamp = utterance["timestamp"]
+                timestep = _format_timestep(timestamp, first_utterance_timestamp)
+
+                yield {
+                    "timestep": timestep,
+                    "location": location,
+                    "personas": personas,
+                    "speaker": speaker,
+                    "characters": [p["name"] for p in personas],
+                    "speaker_id": utterance["speaker_id"],
+                    "full_context": context,
+                    "speaker_worker_tier": conv['workers_quality_check'][
+                        utterance["speaker_id"] - 1
+                    ]["worker_tier"],
+                    "quality_tier": conv["quality_tier"],
+                    "text": None,  # This is an abstract class, we will feel in the text later.
+                    "label": self.get_utterance_label(utterance),
+                }, new_episode
+
+                new_episode = False
+                # Generating context for the next round.
+                if not isConversationDone:
+                    context.append(
+                        self.get_utterance_context(utt=utterance, ts=timestep)
+                    )
+
+    def get_utterance_speaker_id(self, personas: Dict[str, str], speaker: str):
+        for idx, persona in enumerate(personas):
+            if persona["name"] == speaker:
+                return idx
+
+    def get_extra_context_before(self, conv: Message):
+        """
+        Generates the persona and location, which goes *before* the conversation context.
+        """
+        extra_context_before = []
+
+        if self.add_location_to_context:
+            extra_context_before.append(flatten_location(conv["location"]))
+        if self.add_personas_to_context:
+            extra_context_before.append(flatten_personas(conv["personas"]))
+        return extra_context_before
+
+    def get_extra_context_after(self, conv: Message):
+        """
+        Generates the timestep and speaker prompt, which goes *after* the conversation context.
+        """
+        extra_context_after = []
+        if self.add_current_timestep_to_context:
+            extra_context_after.append(conv["timestep"])
+        if self.add_speaker_to_context_end:
+            # Adding the speaker prompt to the end of the context
+            extra_context_after.append(self.get_speaker_prompt(conv))
+        return extra_context_after
+
+
+class AllSpeakersTeacher(BaseTeacher):
+    def __init__(self, opt: Opt, shared=None):
+        super().__init__(opt, shared)
+        self.id = "multilight_dialogue_:all_speakers"
+
+    def setup_data(self, datafile: str) -> List[Message]:
+        for utt, _ in super().setup_data(datafile):
+            ret = copy.deepcopy(utt)
+            extra_context_before = self.get_extra_context_before(ret)
+            extra_context_after = self.get_extra_context_after(ret)
+
+            ret["text"] = self.utterance_delimiter.join(
+                extra_context_before + ret["full_context"] + extra_context_after
+            )
+            if utt["speaker_worker_tier"] in self.speaker_quality_tiers:
+                yield ret, True
+
+    def custom_evaluation(
+        self,
+        teacher_action: Message,
+        labels: Optional[Tuple[str]],
+        model_response: Message,
+    ) -> None:
+        model_response = Message(model_response)
+        if model_response.is_padding() or (not model_response.get("text", None)):
+            return
+
+        # Finding speaker label accuracy, only if it was included in the teacher labels
+        if self.include_speaker_in_label:
+            resp = model_response.get("text")
+            parts = resp.split(self.speaker_token_delimiter)
+
+            # If model predicts a speaker label, there should be at leat two parts separted by ':'
+            if len(parts) >= 2:
+                predited_speaker = parts[0].strip()
+            else:
+                # A dummy string to trigger this as the wrong speaker.
+                predited_speaker = "__NO_SPEAKER__"
+
+            # The teacher will always include the correct speaker label in the 'speaker' field
+            expected_speaker = teacher_action.get("speaker")
+            # Predicted speaker accuracy
+            self.metrics.add(
+                "speaker_acc",
+                ExactMatchMetric.compute(predited_speaker, [expected_speaker]),
+            )
+
+            # unigram F1 Metric for the speech part only, removing the speaker token
+            speech_text = parts[-1]
+            label_speech_text = labels[0].split(self.speaker_token_delimiter)[-1]
+            self.metrics.add(
+                "speech_f1",
+                F1Metric.compute(speech_text, [label_speech_text]),
+            )
+
+
+class SpeakerPredictionTeacher(AllSpeakersTeacher):
+    """
+    Generates the speaker name for the current turn.
+    """
+
+    def __init__(self, opt: Opt, shared=None):
+        self.add_current_turn = opt["add_current_turn"]
+        super().__init__(opt, shared)
+        self.id = "SpeakerPrediction"
+
+    @classmethod
+    def add_cmdline_args(
+        cls, parser: ParlaiParser, partial_opt: Optional[Opt] = None
+    ) -> ParlaiParser:
+        super().add_cmdline_args(parser, partial_opt)
+        agent = parser.add_argument_group("MultiLIGHT Speaker prediction.")
+        agent.add_argument(
+            "--add-current-turn",
+            type="bool",
+            default=False,
+            help="Whether to include the current turn in the text.",
+        )
+
+    def _label_text(self, message: Message):
+        """
+        Removes the speaker when the last utterance is being added to the context.
+        """
+        label = message["label"]
+        if self.include_speaker_in_label:
+            # Just a quick check to be extra sure about the data format.
+            label_speaker, label_text = label.split(self.speaker_token_delimiter, 1)
+            assert (
+                label_speaker.strip() == message["speaker"]
+            ), "Wrong speaker in the label."
+            label = label_text.strip()
+        return label
+
+    def setup_data(self, datafile: str) -> List[Message]:
+        for utt, _e in super().setup_data(datafile):
+            msg = copy.deepcopy(utt)
+            current_turn_utterance = self._label_text(msg)
+            msg["label"] = msg["speaker"]
+            msg["label_candidates"] = get_speaker_names(msg)
+            if self.add_current_turn:
+                msg["text"] = self.utterance_delimiter.join(
+                    [msg["text"], current_turn_utterance]
+                )
+            yield msg, _e
+
+
+class SingleSpeakerTeacher(ABC, BaseTeacher):
+    """
+    Generaes the utterances for a single character only.
+    The label will be the silent token if that character doesn't speak that round.
+    This is an abstract class: do NOT use directly!
+    """
+
+    def __init__(self, opt: Opt, shared=None):
+        self.silence_token = opt["silence_token"]
+        self.silence_token_dropout = opt["silence_token_dropout"]
+        assert (
+            0 <= self.silence_token_dropout <= 1
+        ), "--silence-token-dropout must be a number in [0, 1]"
+        super().__init__(opt, shared)
+
+    @classmethod
+    def add_cmdline_args(
+        cls, parser: ParlaiParser, partial_opt: Optional[Opt] = None
+    ) -> ParlaiParser:
+        super().add_cmdline_args(parser, partial_opt)
+        agent = parser.add_argument_group(
+            "MultiLIGHT Teacher Arguments (Single Speaker Teacher)"
+        )
+        agent.add_argument(
+            "--silence-token",
+            type=str,
+            default=SILENCE_TOKEN,
+            help=f"The token to use to indicate the chosen speaker is silent. Defaults to {SILENCE_TOKEN}",
+        )
+        agent.add_argument(
+            "--silence-token-dropout",
+            type=float,
+            default=0,
+            help="Dropout probability for using silence token to generate training example"
+            " for sentences where the chosen speaker is not speaking. "
+            "When set to 0, all silence tokens will generate training examples. "
+            "When set to 1, no silence tokens will generate training examples.",
+        )
+        return parser
+
+    @abstractclassmethod
+    def get_speaker_index(self) -> int:
+        """
+        Returns the index of the speaker in the dataset (0, 1, 2)
+        """
+
+    def generate_silence_label(self, speaker: str) -> str:
+        label = self.silence_token
+        if self.include_speaker_in_label:
+            label = f"{speaker}{self.speaker_token_delimiter} {label}"
+        return label
+
+    def is_this_speaker_turn(self, utt: Message) -> bool:
+        return (
+            self.get_utterance_speaker_id(utt["personas"], utt["speaker"])
+            == self.get_speaker_index()
+        )
+
+    def setup_data(self, datafile: str) -> List[Message]:
+        episode_needs_reset = False
+
+        for utt, new_episode in super().setup_data(datafile):
+            # checking if we need to skip this round because of the speaker tier
+            if utt["speaker_worker_tier"] not in self.speaker_quality_tiers:
+                continue
+
+            if new_episode:
+                last_speaker_trun = -1
+                turn_num = 0
+            else:
+                turn_num += 1
+
+            is_silence_turn = not self.is_this_speaker_turn(utt)
+            if (
+                is_silence_turn
+                and self.silence_token_dropout
+                and random.random() < self.silence_token_dropout
+            ):
+                if new_episode:
+                    # We keep this to reset the episode next round around.
+                    episode_needs_reset = True
+                continue
+
+            if episode_needs_reset:
+                # Setting new episode because we missed the original one due to silence drop out.
+                episode_needs_reset = False
+                new_episode = True
+
+            ret = copy.deepcopy(utt)
+            context = ret["full_context"][(last_speaker_trun + 1) :]
+
+            if not context:
+                context = [self.silence_token] if turn_num > 0 else [self.start_token]
+
+            if last_speaker_trun < 0:
+                # Only adding the extra context on the first episode that will get yielded
+                ret["text"] = self.utterance_delimiter.join(
+                    self.get_extra_context_before(ret) + context
+                )
+            else:
+                ret["text"] = self.utterance_delimiter.join(context)
+
+            last_speaker_trun = turn_num
+            # Setting the speaker to the current speaker.
+            # Even if the speaker doesn't speak, the silence term is this speaker's action.
+            ret["speaker"] = get_speaker_name_from_index(utt, self.get_speaker_index())
+
+            # Adding the prompot to the temp_history for not keeping it in the full history.
+            # There is also an extra \n to make the format more alike the other teachers.
+            ret["temp_history"] = "\n".join([""] + self.get_extra_context_after(ret))
+            if is_silence_turn:
+                ret["label"] = self.generate_silence_label(ret["speaker"])
+            else:
+                last_speaker_trun += 1
+
+            yield ret, new_episode
+
+    def custom_evaluation(
+        self,
+        teacher_action: Message,
+        labels: Optional[Tuple[str]],
+        model_response: Message,
+    ) -> None:
+        if model_response.is_padding() or (not model_response.get("text", None)):
+            return
+
+        model_predicted_speak = str(self.silence_token not in model_response["text"])
+        label_was_speak = str(self.silence_token not in labels[0])
+        self.metrics.add(
+            "self_speaker_acc",
+            ExactMatchMetric.compute(model_predicted_speak, [label_was_speak]),
+        )
+        # Precited speaker confusion metrics
+        precision, recall, f1 = ConfusionMatrixMetric.compute_metrics(
+            [model_predicted_speak], [label_was_speak], "True"
+        )
+        self.metrics.add("self_speaker_precision", precision[0])
+        self.metrics.add("self_speaker_recall", recall[0])
+        self.metrics.add("self_speaker_f1", f1[0])
+
+
+class FirstSpeakerTeacher(SingleSpeakerTeacher):
+    def __init__(self, opt: Opt, shared=None):
+        super().__init__(opt, shared)
+        self.id = "multilight_dialogue:first_speaker"
+
+    def get_speaker_index(self) -> int:
+        return 0
+
+
+class SecondSpeakerTeacher(SingleSpeakerTeacher):
+    def __init__(self, opt: Opt, shared=None):
+        super().__init__(opt, shared)
+        self.id = "multilight_dialogue:second_speaker"
+
+    def get_speaker_index(self) -> int:
+        return 1
+
+
+class ThirdSpeakerTeacher(SingleSpeakerTeacher):
+    def __init__(self, opt: Opt, shared=None):
+        super().__init__(opt, shared)
+        self.id = "multilight_dialogue:third_speaker"
+
+    def get_speaker_index(self) -> int:
+        return 2
+
+
+class DefaultTeacher(AllSpeakersTeacher):
+    pass

--- a/parlai/tasks/light_multiparty/build.py
+++ b/parlai/tasks/light_multiparty/build.py
@@ -3,11 +3,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import os
+
 import parlai.core.build_data as build_data
 import parlai.utils.logging as logging
-
-import parlai.tasks.wizard_of_internet.constants as CONST
 
 
 DATASET_NAME = 'parlai_multilight'

--- a/parlai/tasks/light_multiparty/build.py
+++ b/parlai/tasks/light_multiparty/build.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+import parlai.core.build_data as build_data
+import parlai.utils.logging as logging
+
+import parlai.tasks.wizard_of_internet.constants as CONST
+
+
+DATASET_NAME = 'parlai_multilight'
+DATASET_FILE = build_data.DownloadableFile(
+    f'http://parl.ai/downloads/projects/multilight/{DATASET_NAME}.tar.gz',
+    f'{DATASET_NAME}.tar.gz',
+    'cbc20e4fa7a551c0efec4a4129e75335d3f3586797d6f767e320403079f4a6b2',
+)
+
+
+def build(opt):
+    dpath = opt['datapath']
+    version = '1.0'
+    if not build_data.built(dpath, version):
+        logging.info(
+            f'[building data: {dpath}]\nThis may take a while but only heppens once.'
+        )
+        if build_data.built(dpath):
+            # An older version exists, so remove these outdated files.
+            build_data.remove_dir(dpath)
+        build_data.make_dir(dpath)
+
+        # Download the data.
+        DATASET_FILE.download_file(dpath)
+        logging.info('Finished downloading dataset files successfully.')
+
+        build_data.mark_done(dpath, version)

--- a/parlai/tasks/light_multiparty/test.py
+++ b/parlai/tasks/light_multiparty/test.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from parlai.utils.testing import AutoTeacherTest
+
+
+class TestDefaultTeacher(AutoTeacherTest):
+    task = 'light_multiparty'
+
+
+class TestSpeakerPredictionTeacher(AutoTeacherTest):
+    task = f'light_multiparty:SpeakerPredictionTeacher'
+
+
+class TestSpeakersTeacher(AutoTeacherTest):
+    task = f'light_multiparty:SpeakerPredictionTeacher'
+
+
+class TestFirstSpeakerTeacher(AutoTeacherTest):
+    task = f'light_multiparty:FirstSpeakerTeacher'
+
+
+class TestSecondSpeakerTeacher(AutoTeacherTest):
+    task = f'light_multiparty:SecondSpeakerTeacher'
+
+
+class TestThirdSpeakerTeacher(AutoTeacherTest):
+    task = f'light_multiparty:ThirdSpeakerTeacher'

--- a/parlai/tasks/light_multiparty/test/light_multiparty_FirstSpeakerTeacher_test.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_FirstSpeakerTeacher_test.yml
@@ -1,0 +1,178 @@
+acts:
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'Albino fish, totally blind: __SILENCE__'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    id: multilight_dialogue:first_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: Albino fish, totally blind
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'bear: I need to get out of this dark gave and eat I am starving'
+    timestep: 00:00:11
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    id: multilight_dialogue:first_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: Albino fish, totally blind
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    timestep: 00:00:26
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'Albino fish, totally blind: __SILENCE__'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    id: multilight_dialogue:first_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: Albino fish, totally blind
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: __SILENCE__
+    timestep: 00:00:31
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'Albino fish, totally blind: __SILENCE__'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    - 'bear: I wont eat him I prefer salmon'
+    id: multilight_dialogue:first_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: Albino fish, totally blind
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'bear: I wont eat him I prefer salmon'
+    timestep: 00:00:45
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'Albino fish, totally blind: __SILENCE__'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    - 'bear: I wont eat him I prefer salmon'
+    - 'undead warrior: What is a fish doing in a dark cave anyway?'
+    id: multilight_dialogue:first_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: Albino fish, totally blind
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'undead warrior: What is a fish doing in a dark cave anyway?'
+    timestep: 00:01:00
+num_episodes: 9164
+num_examples: 9164

--- a/parlai/tasks/light_multiparty/test/light_multiparty_FirstSpeakerTeacher_train.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_FirstSpeakerTeacher_train.yml
@@ -1,0 +1,193 @@
+acts:
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    id: multilight_dialogue:first_speaker
+    labels:
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: young boy
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'captain: Greetings to both of you.'
+    timestep: 00:00:03
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    id: multilight_dialogue:first_speaker
+    labels:
+    - 'young boy: __SILENCE__'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: young boy
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: __SILENCE__
+    timestep: 00:00:22
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    id: multilight_dialogue:first_speaker
+    labels:
+    - 'young boy: It does! I saw a ghost on it last night!'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: young boy
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'boat captain: Well I imagine this ship holds many secrets!'
+    timestep: 00:00:44
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    - 'young boy: It does! I saw a ghost on it last night!'
+    id: multilight_dialogue:first_speaker
+    labels:
+    - 'young boy: __SILENCE__'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: young boy
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: __SILENCE__
+    timestep: 00:01:03
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    - 'young boy: It does! I saw a ghost on it last night!'
+    - 'captain: And what did this ghost look like?'
+    id: multilight_dialogue:first_speaker
+    labels:
+    - 'young boy: __SILENCE__'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: young boy
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'captain: And what did this ghost look like?'
+    timestep: 00:01:07
+num_episodes: 293264
+num_examples: 293264

--- a/parlai/tasks/light_multiparty/test/light_multiparty_FirstSpeakerTeacher_valid.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_FirstSpeakerTeacher_valid.yml
@@ -1,0 +1,183 @@
+acts:
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'princess: Oh yes of course!'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    id: multilight_dialogue:first_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: princess
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'unicorn hunters: It is great to be in such a wonderful place. '
+    timestep: 00:00:06
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'princess: __SILENCE__'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    id: multilight_dialogue:first_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: princess
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: __SILENCE__
+    timestep: 00:00:17
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'princess: Just look out upon the hills, the rolling hills!  The kingdom that
+      is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    id: multilight_dialogue:first_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: princess
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'king: I am proud to call this my place! '
+    timestep: 00:00:29
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'princess: __SILENCE__'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    - 'princess: Just look out upon the hills, the rolling hills!  The kingdom that
+      is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    id: multilight_dialogue:first_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: princess
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: __SILENCE__
+    timestep: 00:00:34
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'princess: __SILENCE__'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    - 'princess: Just look out upon the hills, the rolling hills!  The kingdom that
+      is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    - 'unicorn hunters: I dont know what I have done to deserve to be in the presence
+      of royalty. I am glad I am here. '
+    id: multilight_dialogue:first_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: princess
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'unicorn hunters: I dont know what I have done to deserve to be in the presence
+      of royalty. I am glad I am here. '
+    timestep: 00:00:59
+num_episodes: 11005
+num_examples: 11005

--- a/parlai/tasks/light_multiparty/test/light_multiparty_SecondSpeakerTeacher_test.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_SecondSpeakerTeacher_test.yml
@@ -1,0 +1,178 @@
+acts:
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'bear: __SILENCE__'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    id: multilight_dialogue:second_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: bear
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'bear: I need to get out of this dark gave and eat I am starving'
+    timestep: 00:00:11
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'bear: __SILENCE__'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    id: multilight_dialogue:second_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: bear
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    timestep: 00:00:26
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'bear: I wont eat him I prefer salmon'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    id: multilight_dialogue:second_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: bear
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    timestep: 00:00:31
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'bear: __SILENCE__'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    - 'bear: I wont eat him I prefer salmon'
+    id: multilight_dialogue:second_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: bear
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: __SILENCE__
+    timestep: 00:00:45
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'bear: He probably lost his way since he can''t see.'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    - 'bear: I wont eat him I prefer salmon'
+    - 'undead warrior: What is a fish doing in a dark cave anyway?'
+    id: multilight_dialogue:second_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: bear
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'undead warrior: What is a fish doing in a dark cave anyway?'
+    timestep: 00:01:00
+num_episodes: 9164
+num_examples: 9164

--- a/parlai/tasks/light_multiparty/test/light_multiparty_SecondSpeakerTeacher_train.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_SecondSpeakerTeacher_train.yml
@@ -1,0 +1,193 @@
+acts:
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    id: multilight_dialogue:second_speaker
+    labels:
+    - 'boat captain: __SILENCE__'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: boat captain
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'captain: Greetings to both of you.'
+    timestep: 00:00:03
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    id: multilight_dialogue:second_speaker
+    labels:
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: boat captain
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    timestep: 00:00:22
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    id: multilight_dialogue:second_speaker
+    labels:
+    - 'boat captain: __SILENCE__'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: boat captain
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: __SILENCE__
+    timestep: 00:00:44
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    - 'young boy: It does! I saw a ghost on it last night!'
+    id: multilight_dialogue:second_speaker
+    labels:
+    - 'boat captain: __SILENCE__'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: boat captain
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'young boy: It does! I saw a ghost on it last night!'
+    timestep: 00:01:03
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    - 'young boy: It does! I saw a ghost on it last night!'
+    - 'captain: And what did this ghost look like?'
+    id: multilight_dialogue:second_speaker
+    labels:
+    - 'boat captain: Young boy do you know all the pirates milling about the ship? '
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: boat captain
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'captain: And what did this ghost look like?'
+    timestep: 00:01:07
+num_episodes: 293264
+num_examples: 293264

--- a/parlai/tasks/light_multiparty/test/light_multiparty_SecondSpeakerTeacher_valid.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_SecondSpeakerTeacher_valid.yml
@@ -1,0 +1,183 @@
+acts:
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'unicorn hunters: __SILENCE__'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    id: multilight_dialogue:second_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: unicorn hunters
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'unicorn hunters: It is great to be in such a wonderful place. '
+    timestep: 00:00:06
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'unicorn hunters: __SILENCE__'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    id: multilight_dialogue:second_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: unicorn hunters
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'princess: Oh yes of course!'
+    timestep: 00:00:17
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'unicorn hunters: __SILENCE__'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    id: multilight_dialogue:second_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: unicorn hunters
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'king: I am proud to call this my place! '
+    timestep: 00:00:29
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'unicorn hunters: I dont know what I have done to deserve to be in the presence
+      of royalty. I am glad I am here. '
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    - 'princess: Just look out upon the hills, the rolling hills!  The kingdom that
+      is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    id: multilight_dialogue:second_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: unicorn hunters
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'princess: Just look out upon the hills, the rolling hills!  The kingdom
+      that is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    timestep: 00:00:34
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'unicorn hunters: __SILENCE__'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    - 'princess: Just look out upon the hills, the rolling hills!  The kingdom that
+      is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    - 'unicorn hunters: I dont know what I have done to deserve to be in the presence
+      of royalty. I am glad I am here. '
+    id: multilight_dialogue:second_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: unicorn hunters
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: __SILENCE__
+    timestep: 00:00:59
+num_episodes: 11005
+num_examples: 11005

--- a/parlai/tasks/light_multiparty/test/light_multiparty_SpeakerPredictionTeacher_test.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_SpeakerPredictionTeacher_test.yml
@@ -1,0 +1,213 @@
+acts:
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: true
+    eval_labels:
+    - undead warrior
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    id: SpeakerPrediction
+    label_candidates:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: undead warrior
+    speaker_id: 3
+    speaker_worker_tier: 1
+    text: 'bear: I need to get out of this dark gave and eat I am starving'
+    timestep: 00:00:11
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: true
+    eval_labels:
+    - Albino fish, totally blind
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    id: SpeakerPrediction
+    label_candidates:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: Albino fish, totally blind
+    speaker_id: 1
+    speaker_worker_tier: 1
+    text: 'bear: I need to get out of this dark gave and eat I am starving
+
+      undead warrior: Bear, there is an albino fish. It looks blind.'
+    timestep: 00:00:26
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: true
+    eval_labels:
+    - bear
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    id: SpeakerPrediction
+    label_candidates:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: bear
+    speaker_id: 2
+    speaker_worker_tier: 1
+    text: 'bear: I need to get out of this dark gave and eat I am starving
+
+      undead warrior: Bear, there is an albino fish. It looks blind.
+
+      Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    timestep: 00:00:31
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: true
+    eval_labels:
+    - undead warrior
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    - 'bear: I wont eat him I prefer salmon'
+    id: SpeakerPrediction
+    label_candidates:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: undead warrior
+    speaker_id: 3
+    speaker_worker_tier: 1
+    text: 'bear: I need to get out of this dark gave and eat I am starving
+
+      undead warrior: Bear, there is an albino fish. It looks blind.
+
+      Albino fish, totally blind: I am blind, but it''s a good thing you see...
+
+      bear: I wont eat him I prefer salmon'
+    timestep: 00:00:45
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: true
+    eval_labels:
+    - bear
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    - 'bear: I wont eat him I prefer salmon'
+    - 'undead warrior: What is a fish doing in a dark cave anyway?'
+    id: SpeakerPrediction
+    label_candidates:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: bear
+    speaker_id: 2
+    speaker_worker_tier: 1
+    text: 'bear: I need to get out of this dark gave and eat I am starving
+
+      undead warrior: Bear, there is an albino fish. It looks blind.
+
+      Albino fish, totally blind: I am blind, but it''s a good thing you see...
+
+      bear: I wont eat him I prefer salmon
+
+      undead warrior: What is a fish doing in a dark cave anyway?'
+    timestep: 00:01:00
+num_episodes: 9164
+num_examples: 9164

--- a/parlai/tasks/light_multiparty/test/light_multiparty_SpeakerPredictionTeacher_train.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_SpeakerPredictionTeacher_train.yml
@@ -1,0 +1,228 @@
+acts:
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: true
+    full_context:
+    - 'captain: Greetings to both of you.'
+    id: SpeakerPrediction
+    label_candidates:
+    - young boy
+    - boat captain
+    - captain
+    labels:
+    - young boy
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: young boy
+    speaker_id: 1
+    speaker_worker_tier: 1
+    text: 'captain: Greetings to both of you.'
+    timestep: 00:00:03
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: true
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    id: SpeakerPrediction
+    label_candidates:
+    - young boy
+    - boat captain
+    - captain
+    labels:
+    - boat captain
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: boat captain
+    speaker_id: 2
+    speaker_worker_tier: 1
+    text: 'captain: Greetings to both of you.
+
+      young boy: Hi Captains! It is so nice out on the ocean today!'
+    timestep: 00:00:22
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: true
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    id: SpeakerPrediction
+    label_candidates:
+    - young boy
+    - boat captain
+    - captain
+    labels:
+    - young boy
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: young boy
+    speaker_id: 1
+    speaker_worker_tier: 1
+    text: 'captain: Greetings to both of you.
+
+      young boy: Hi Captains! It is so nice out on the ocean today!
+
+      boat captain: Well I imagine this ship holds many secrets!'
+    timestep: 00:00:44
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: true
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    - 'young boy: It does! I saw a ghost on it last night!'
+    id: SpeakerPrediction
+    label_candidates:
+    - young boy
+    - boat captain
+    - captain
+    labels:
+    - captain
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: captain
+    speaker_id: 3
+    speaker_worker_tier: 1
+    text: 'captain: Greetings to both of you.
+
+      young boy: Hi Captains! It is so nice out on the ocean today!
+
+      boat captain: Well I imagine this ship holds many secrets!
+
+      young boy: It does! I saw a ghost on it last night!'
+    timestep: 00:01:03
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: true
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    - 'young boy: It does! I saw a ghost on it last night!'
+    - 'captain: And what did this ghost look like?'
+    id: SpeakerPrediction
+    label_candidates:
+    - young boy
+    - boat captain
+    - captain
+    labels:
+    - boat captain
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: boat captain
+    speaker_id: 2
+    speaker_worker_tier: 1
+    text: 'captain: Greetings to both of you.
+
+      young boy: Hi Captains! It is so nice out on the ocean today!
+
+      boat captain: Well I imagine this ship holds many secrets!
+
+      young boy: It does! I saw a ghost on it last night!
+
+      captain: And what did this ghost look like?'
+    timestep: 00:01:07
+num_episodes: 293264
+num_examples: 293264

--- a/parlai/tasks/light_multiparty/test/light_multiparty_SpeakerPredictionTeacher_valid.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_SpeakerPredictionTeacher_valid.yml
@@ -1,0 +1,206 @@
+acts:
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: true
+    eval_labels:
+    - princess
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    id: SpeakerPrediction
+    label_candidates:
+    - princess
+    - unicorn hunters
+    - king
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: princess
+    speaker_id: 1
+    speaker_worker_tier: 1
+    text: 'unicorn hunters: It is great to be in such a wonderful place. '
+    timestep: 00:00:06
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: true
+    eval_labels:
+    - king
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    id: SpeakerPrediction
+    label_candidates:
+    - princess
+    - unicorn hunters
+    - king
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: king
+    speaker_id: 3
+    speaker_worker_tier: 1
+    text: "unicorn hunters: It is great to be in such a wonderful place. \nprincess:\
+      \ Oh yes of course!"
+    timestep: 00:00:17
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: true
+    eval_labels:
+    - princess
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    id: SpeakerPrediction
+    label_candidates:
+    - princess
+    - unicorn hunters
+    - king
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: princess
+    speaker_id: 1
+    speaker_worker_tier: 1
+    text: "unicorn hunters: It is great to be in such a wonderful place. \nprincess:\
+      \ Oh yes of course!\nking: I am proud to call this my place! "
+    timestep: 00:00:29
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: true
+    eval_labels:
+    - unicorn hunters
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    - 'princess: Just look out upon the hills, the rolling hills!  The kingdom that
+      is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    id: SpeakerPrediction
+    label_candidates:
+    - princess
+    - unicorn hunters
+    - king
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: unicorn hunters
+    speaker_id: 2
+    speaker_worker_tier: 1
+    text: "unicorn hunters: It is great to be in such a wonderful place. \nprincess:\
+      \ Oh yes of course!\nking: I am proud to call this my place! \nprincess: Just\
+      \ look out upon the hills, the rolling hills!  The kingdom that is all mine!\
+      \  It is nearly as beautiful as my glimmering jewels!"
+    timestep: 00:00:34
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: true
+    eval_labels:
+    - king
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    - 'princess: Just look out upon the hills, the rolling hills!  The kingdom that
+      is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    - 'unicorn hunters: I dont know what I have done to deserve to be in the presence
+      of royalty. I am glad I am here. '
+    id: SpeakerPrediction
+    label_candidates:
+    - princess
+    - unicorn hunters
+    - king
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: king
+    speaker_id: 3
+    speaker_worker_tier: 1
+    text: "unicorn hunters: It is great to be in such a wonderful place. \nprincess:\
+      \ Oh yes of course!\nking: I am proud to call this my place! \nprincess: Just\
+      \ look out upon the hills, the rolling hills!  The kingdom that is all mine!\
+      \  It is nearly as beautiful as my glimmering jewels!\nunicorn hunters: I dont\
+      \ know what I have done to deserve to be in the presence of royalty. I am glad\
+      \ I am here. "
+    timestep: 00:00:59
+num_episodes: 11005
+num_examples: 11005

--- a/parlai/tasks/light_multiparty/test/light_multiparty_ThirdSpeakerTeacher_test.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_ThirdSpeakerTeacher_test.yml
@@ -1,0 +1,178 @@
+acts:
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    id: multilight_dialogue:third_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: undead warrior
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'bear: I need to get out of this dark gave and eat I am starving'
+    timestep: 00:00:11
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'undead warrior: __SILENCE__'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    id: multilight_dialogue:third_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: undead warrior
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: __SILENCE__
+    timestep: 00:00:26
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'undead warrior: __SILENCE__'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    id: multilight_dialogue:third_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: undead warrior
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    timestep: 00:00:31
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'undead warrior: What is a fish doing in a dark cave anyway?'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    - 'bear: I wont eat him I prefer salmon'
+    id: multilight_dialogue:third_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: undead warrior
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'bear: I wont eat him I prefer salmon'
+    timestep: 00:00:45
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: false
+    eval_labels:
+    - 'undead warrior: __SILENCE__'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    - 'bear: I wont eat him I prefer salmon'
+    - 'undead warrior: What is a fish doing in a dark cave anyway?'
+    id: multilight_dialogue:third_speaker
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: undead warrior
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: __SILENCE__
+    timestep: 00:01:00
+num_episodes: 9164
+num_examples: 9164

--- a/parlai/tasks/light_multiparty/test/light_multiparty_ThirdSpeakerTeacher_train.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_ThirdSpeakerTeacher_train.yml
@@ -1,0 +1,193 @@
+acts:
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    id: multilight_dialogue:third_speaker
+    labels:
+    - 'captain: __SILENCE__'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: captain
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'captain: Greetings to both of you.'
+    timestep: 00:00:03
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    id: multilight_dialogue:third_speaker
+    labels:
+    - 'captain: __SILENCE__'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: captain
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    timestep: 00:00:22
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    id: multilight_dialogue:third_speaker
+    labels:
+    - 'captain: __SILENCE__'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: captain
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'boat captain: Well I imagine this ship holds many secrets!'
+    timestep: 00:00:44
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    - 'young boy: It does! I saw a ghost on it last night!'
+    id: multilight_dialogue:third_speaker
+    labels:
+    - 'captain: And what did this ghost look like?'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: captain
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'young boy: It does! I saw a ghost on it last night!'
+    timestep: 00:01:03
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: false
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    - 'young boy: It does! I saw a ghost on it last night!'
+    - 'captain: And what did this ghost look like?'
+    id: multilight_dialogue:third_speaker
+    labels:
+    - 'captain: __SILENCE__'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: captain
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: __SILENCE__
+    timestep: 00:01:07
+num_episodes: 293264
+num_examples: 293264

--- a/parlai/tasks/light_multiparty/test/light_multiparty_ThirdSpeakerTeacher_valid.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_ThirdSpeakerTeacher_valid.yml
@@ -1,0 +1,184 @@
+acts:
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'king: __SILENCE__'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    id: multilight_dialogue:third_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: king
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'unicorn hunters: It is great to be in such a wonderful place. '
+    timestep: 00:00:06
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'king: I am proud to call this my place! '
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    id: multilight_dialogue:third_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: king
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'princess: Oh yes of course!'
+    timestep: 00:00:17
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'king: __SILENCE__'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    id: multilight_dialogue:third_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: king
+    speaker_id: 1
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: __SILENCE__
+    timestep: 00:00:29
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'king: __SILENCE__'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    - 'princess: Just look out upon the hills, the rolling hills!  The kingdom that
+      is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    id: multilight_dialogue:third_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: king
+    speaker_id: 2
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'princess: Just look out upon the hills, the rolling hills!  The kingdom
+      that is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    timestep: 00:00:34
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: false
+    eval_labels:
+    - 'king: You both deserve good. I rule you both, and am proud that you both are
+      happy with this place!'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    - 'princess: Just look out upon the hills, the rolling hills!  The kingdom that
+      is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    - 'unicorn hunters: I dont know what I have done to deserve to be in the presence
+      of royalty. I am glad I am here. '
+    id: multilight_dialogue:third_speaker
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: king
+    speaker_id: 3
+    speaker_worker_tier: 1
+    temp_history: ''
+    text: 'unicorn hunters: I dont know what I have done to deserve to be in the presence
+      of royalty. I am glad I am here. '
+    timestep: 00:00:59
+num_episodes: 11005
+num_examples: 11005

--- a/parlai/tasks/light_multiparty/test/light_multiparty_test.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_test.yml
@@ -1,0 +1,193 @@
+acts:
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: true
+    eval_labels:
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    id: multilight_dialogue_:all_speakers
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: undead warrior
+    speaker_id: 3
+    speaker_worker_tier: 1
+    text: 'bear: I need to get out of this dark gave and eat I am starving'
+    timestep: 00:00:11
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: true
+    eval_labels:
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    id: multilight_dialogue_:all_speakers
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: Albino fish, totally blind
+    speaker_id: 1
+    speaker_worker_tier: 1
+    text: 'bear: I need to get out of this dark gave and eat I am starving
+
+      undead warrior: Bear, there is an albino fish. It looks blind.'
+    timestep: 00:00:26
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: true
+    eval_labels:
+    - 'bear: I wont eat him I prefer salmon'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    id: multilight_dialogue_:all_speakers
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: bear
+    speaker_id: 2
+    speaker_worker_tier: 1
+    text: 'bear: I need to get out of this dark gave and eat I am starving
+
+      undead warrior: Bear, there is an albino fish. It looks blind.
+
+      Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    timestep: 00:00:31
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: true
+    eval_labels:
+    - 'undead warrior: What is a fish doing in a dark cave anyway?'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    - 'bear: I wont eat him I prefer salmon'
+    id: multilight_dialogue_:all_speakers
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: undead warrior
+    speaker_id: 3
+    speaker_worker_tier: 1
+    text: 'bear: I need to get out of this dark gave and eat I am starving
+
+      undead warrior: Bear, there is an albino fish. It looks blind.
+
+      Albino fish, totally blind: I am blind, but it''s a good thing you see...
+
+      bear: I wont eat him I prefer salmon'
+    timestep: 00:00:45
+- - characters:
+    - Albino fish, totally blind
+    - bear
+    - undead warrior
+    episode_done: true
+    eval_labels:
+    - 'bear: He probably lost his way since he can''t see.'
+    full_context:
+    - 'bear: I need to get out of this dark gave and eat I am starving'
+    - 'undead warrior: Bear, there is an albino fish. It looks blind.'
+    - 'Albino fish, totally blind: I am blind, but it''s a good thing you see...'
+    - 'bear: I wont eat him I prefer salmon'
+    - 'undead warrior: What is a fish doing in a dark cave anyway?'
+    id: multilight_dialogue_:all_speakers
+    location:
+      description: Its dark, not much light can be seen in this hollow and empty cave
+        site. Its made of stone that has been here seemingly since time began, the
+        walls are hard as diamond, yet black like darkness itself.
+      name: Dark Cave
+    personas:
+    - name: Albino fish, totally blind
+      persona: I am an albino blind fish. I like to swim in a tiny pool. I lost my
+        sight at birth.
+    - name: bear
+      persona: I am a very large mammal. I have a lot of fur and a lot of body fat
+        and muscle. I need to eat a lot of food including river beds full of salmon.
+        I usually hibernate and wake up even hungrier than before.
+    - name: undead warrior
+      persona: I am an undead warrior from the nearby village. I have slain many men.
+        I am decaying and rotting.
+    quality_tier: 1
+    speaker: bear
+    speaker_id: 2
+    speaker_worker_tier: 1
+    text: 'bear: I need to get out of this dark gave and eat I am starving
+
+      undead warrior: Bear, there is an albino fish. It looks blind.
+
+      Albino fish, totally blind: I am blind, but it''s a good thing you see...
+
+      bear: I wont eat him I prefer salmon
+
+      undead warrior: What is a fish doing in a dark cave anyway?'
+    timestep: 00:01:00
+num_episodes: 9164
+num_examples: 9164

--- a/parlai/tasks/light_multiparty/test/light_multiparty_train.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_train.yml
@@ -1,0 +1,208 @@
+acts:
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: true
+    full_context:
+    - 'captain: Greetings to both of you.'
+    id: multilight_dialogue_:all_speakers
+    labels:
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: young boy
+    speaker_id: 1
+    speaker_worker_tier: 1
+    text: 'captain: Greetings to both of you.'
+    timestep: 00:00:03
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: true
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    id: multilight_dialogue_:all_speakers
+    labels:
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: boat captain
+    speaker_id: 2
+    speaker_worker_tier: 1
+    text: 'captain: Greetings to both of you.
+
+      young boy: Hi Captains! It is so nice out on the ocean today!'
+    timestep: 00:00:22
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: true
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    id: multilight_dialogue_:all_speakers
+    labels:
+    - 'young boy: It does! I saw a ghost on it last night!'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: young boy
+    speaker_id: 1
+    speaker_worker_tier: 1
+    text: 'captain: Greetings to both of you.
+
+      young boy: Hi Captains! It is so nice out on the ocean today!
+
+      boat captain: Well I imagine this ship holds many secrets!'
+    timestep: 00:00:44
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: true
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    - 'young boy: It does! I saw a ghost on it last night!'
+    id: multilight_dialogue_:all_speakers
+    labels:
+    - 'captain: And what did this ghost look like?'
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: captain
+    speaker_id: 3
+    speaker_worker_tier: 1
+    text: 'captain: Greetings to both of you.
+
+      young boy: Hi Captains! It is so nice out on the ocean today!
+
+      boat captain: Well I imagine this ship holds many secrets!
+
+      young boy: It does! I saw a ghost on it last night!'
+    timestep: 00:01:03
+- - characters:
+    - young boy
+    - boat captain
+    - captain
+    episode_done: true
+    full_context:
+    - 'captain: Greetings to both of you.'
+    - 'young boy: Hi Captains! It is so nice out on the ocean today!'
+    - 'boat captain: Well I imagine this ship holds many secrets!'
+    - 'young boy: It does! I saw a ghost on it last night!'
+    - 'captain: And what did this ghost look like?'
+    id: multilight_dialogue_:all_speakers
+    labels:
+    - 'boat captain: Young boy do you know all the pirates milling about the ship? '
+    location:
+      description: A majestic, shimmering, black pirate ship sits upon the water.
+        Its numerous cannons give it a menacing look. Tons of pirates hop upon its
+        decks in a furious jig. The lone captain plods around in his cabin, plotting
+        on where to seize his treasure next.
+      name: Pirate Ship
+    personas:
+    - name: young boy
+      persona: I am the son of the ship's captain. I am being trained to take over
+        for my father when is no longer able to drive the boat safely. For now, I'm
+        a deck hand and I work just as hard as the other deck hands.
+    - name: boat captain
+      persona: I am the captain of the world's biggest boat. I know that I am paid
+        too much for the work I do. I have dark secrets I have told no one.
+    - name: captain
+      persona: I am the captain of a glorious ship in the king's naval fleet. I am
+        a boisterous man with a lot of ambition which is how I made it to my current
+        position. Everyone on my ship follows my every command because I am an excellent
+        leader.
+    quality_tier: 1
+    speaker: boat captain
+    speaker_id: 2
+    speaker_worker_tier: 1
+    text: 'captain: Greetings to both of you.
+
+      young boy: Hi Captains! It is so nice out on the ocean today!
+
+      boat captain: Well I imagine this ship holds many secrets!
+
+      young boy: It does! I saw a ghost on it last night!
+
+      captain: And what did this ghost look like?'
+    timestep: 00:01:07
+num_episodes: 293264
+num_examples: 293264

--- a/parlai/tasks/light_multiparty/test/light_multiparty_valid.yml
+++ b/parlai/tasks/light_multiparty/test/light_multiparty_valid.yml
@@ -1,0 +1,189 @@
+acts:
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: true
+    eval_labels:
+    - 'princess: Oh yes of course!'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    id: multilight_dialogue_:all_speakers
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: princess
+    speaker_id: 1
+    speaker_worker_tier: 1
+    text: 'unicorn hunters: It is great to be in such a wonderful place. '
+    timestep: 00:00:06
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: true
+    eval_labels:
+    - 'king: I am proud to call this my place! '
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    id: multilight_dialogue_:all_speakers
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: king
+    speaker_id: 3
+    speaker_worker_tier: 1
+    text: "unicorn hunters: It is great to be in such a wonderful place. \nprincess:\
+      \ Oh yes of course!"
+    timestep: 00:00:17
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: true
+    eval_labels:
+    - 'princess: Just look out upon the hills, the rolling hills!  The kingdom that
+      is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    id: multilight_dialogue_:all_speakers
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: princess
+    speaker_id: 1
+    speaker_worker_tier: 1
+    text: "unicorn hunters: It is great to be in such a wonderful place. \nprincess:\
+      \ Oh yes of course!\nking: I am proud to call this my place! "
+    timestep: 00:00:29
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: true
+    eval_labels:
+    - 'unicorn hunters: I dont know what I have done to deserve to be in the presence
+      of royalty. I am glad I am here. '
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    - 'princess: Just look out upon the hills, the rolling hills!  The kingdom that
+      is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    id: multilight_dialogue_:all_speakers
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: unicorn hunters
+    speaker_id: 2
+    speaker_worker_tier: 1
+    text: "unicorn hunters: It is great to be in such a wonderful place. \nprincess:\
+      \ Oh yes of course!\nking: I am proud to call this my place! \nprincess: Just\
+      \ look out upon the hills, the rolling hills!  The kingdom that is all mine!\
+      \  It is nearly as beautiful as my glimmering jewels!"
+    timestep: 00:00:34
+- - characters:
+    - princess
+    - unicorn hunters
+    - king
+    episode_done: true
+    eval_labels:
+    - 'king: You both deserve good. I rule you both, and am proud that you both are
+      happy with this place!'
+    full_context:
+    - 'unicorn hunters: It is great to be in such a wonderful place. '
+    - 'princess: Oh yes of course!'
+    - 'king: I am proud to call this my place! '
+    - 'princess: Just look out upon the hills, the rolling hills!  The kingdom that
+      is all mine!  It is nearly as beautiful as my glimmering jewels!'
+    - 'unicorn hunters: I dont know what I have done to deserve to be in the presence
+      of royalty. I am glad I am here. '
+    id: multilight_dialogue_:all_speakers
+    location:
+      description: The unicorn palace is so beautiful! It is covered in pastel colors,
+        and wherever you look they form a rainbow.  The floor is made of special glittering
+        grass that the unicorns feed on.
+      name: Inside the Unicorn palace
+    personas:
+    - name: princess
+      persona: My mother is the queen.  I will be queen one day.  The kingdom will
+        be mine soon enough.  I to wear jewels.
+    - name: unicorn hunters
+      persona: I am a unicorn hunter who is very brave and loyal . I travel around
+        the world looking for unicorns . I eat unicorn meat and take the horns for
+        magic.
+    - name: king
+      persona: I am ruler over all I see.  I think my subjects admire me.  I love
+        gold.
+    quality_tier: 1
+    speaker: king
+    speaker_id: 3
+    speaker_worker_tier: 1
+    text: "unicorn hunters: It is great to be in such a wonderful place. \nprincess:\
+      \ Oh yes of course!\nking: I am proud to call this my place! \nprincess: Just\
+      \ look out upon the hills, the rolling hills!  The kingdom that is all mine!\
+      \  It is nearly as beautiful as my glimmering jewels!\nunicorn hunters: I dont\
+      \ know what I have done to deserve to be in the presence of royalty. I am glad\
+      \ I am here. "
+    timestep: 00:00:59
+num_episodes: 11005
+num_examples: 11005

--- a/parlai/tasks/task_list.py
+++ b/parlai/tasks/task_list.py
@@ -1698,4 +1698,15 @@ task_list = [
             + "clauses and rules imply."
         ),
     },
+    {
+        "id": "MultiLIGHT",
+        "display_name": "Multi-party LIGHT",
+        "task": "light_multiparty",
+        "tags": ["All", "ChitChat"],
+        "links": {
+            "paper": "https://arxiv.org/pdf/2304.13835.pdf",
+            "website": "http://parl.ai/projects/light_multiparty",
+        },
+        "description": "Multi-party async conversation between 3 role-playing characters.",
+    },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,8 @@ joblib==1.2.0
 nltk==3.6.6
 omegaconf>=2.1.1
 pandas==1.4.0
-pytest_regressions==2.1.1
-pytest==5.3.2
+pytest_regressions==2.4.2
+pytest==7.3.0
 pexpect==4.7.0
 Pillow==9.3.0
 py-gfm==1.0.2
@@ -46,7 +46,7 @@ tomli>=2.0.0
 torchtext==0.15.1
 tornado==6.0.4
 tqdm~=4.62.1
-typing-extensions==3.7.4.3
+typing-extensions==4.5.0
 Unidecode==1.1.1
 urllib3<1.27,>=1.26.5
 websocket-client==0.56.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ scipy==1.8.0
 sh==1.12.14
 sphinx_rtd_theme==0.4.3
 sphinx-autodoc-typehints~=1.10.3
-Sphinx<4
+Sphinx~=5.1.0
 subword-nmt==0.3.7
 tensorboardX<=2.5.0
 tokenizers>=0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ scipy==1.8.0
 sh==1.12.14
 sphinx_rtd_theme==0.4.3
 sphinx-autodoc-typehints~=1.10.3
-Sphinx~=5.1.0
+Sphinx<4
 subword-nmt==0.3.7
 tensorboardX<=2.5.0
 tokenizers>=0.8.0

--- a/tests/test_teachers.py
+++ b/tests/test_teachers.py
@@ -154,8 +154,9 @@ class TestConversationTeacher(unittest.TestCase):
                     '{"dialog": [[{"id": "speaker1"}, {"text": "Hello.", "id": "speaker2"}]]}\n'
                 )
             opt = {'task': 'jsonfile', 'jsonfile_datapath': fp, 'verbose': True}
-            with self.assertRaises(AttributeError):
-                testing_utils.display_data(opt)
+
+            train_out, _, _ = testing_utils.display_data(opt)
+            self.assertTrue("'text': None" in train_out.split('\n')[1])
 
     def test_firstspeaker_label(self):
         with testing_utils.tempdir() as tmpdir:
@@ -175,7 +176,7 @@ class TestConversationTeacher(unittest.TestCase):
                 l.split(':', 1)[-1].strip()
                 for l in train_out.split('\n')
                 if l in train_out
-                if 'text' in l
+                if '[text]' in l
             ]
             labels = [
                 l.split(':', 1)[-1].strip()
@@ -204,7 +205,7 @@ class TestConversationTeacher(unittest.TestCase):
                 l.split(':', 1)[-1].strip()
                 for l in train_out.split('\n')
                 if l in train_out
-                if 'text' in l
+                if '[text]' in l
             ]
             labels = [
                 l.split(':', 1)[-1].strip()
@@ -233,7 +234,7 @@ class TestConversationTeacher(unittest.TestCase):
                 l.split(':', 1)[-1].strip()
                 for l in train_out.split('\n')
                 if l in train_out
-                if 'text' in l
+                if '[text]' in l
             ]
             labels = [
                 l.split(':', 1)[-1].strip()


### PR DESCRIPTION
**Patch description**
Adding a custom version of the multilight teachers to the ParlAI side. These teachers only focus on the conversation side of the dataset and do not have the graph elements like their [LIGHT counterpart](https://github.com/facebookresearch/LIGHT/tree/main/light/modeling/tasks/multilight).

**Testing steps**
Added teachers tests as well as running them manually:

`parlai dd -t light_multiparty`
<img width="787" alt="Screenshot 2023-05-30 at 4 14 18 PM" src="https://github.com/facebookresearch/ParlAI/assets/11262163/7985b4f3-bab7-4523-b554-c14ef2e83124">


`parlai dd -t light_multiparty --add-location-to-context true --add-personas-to-context true --include-speaker-in-label false --add-speaker-to-context-end true --datatype valid`

<img width="1510" alt="Screenshot 2023-05-30 at 4 14 47 PM" src="https://github.com/facebookresearch/ParlAI/assets/11262163/a16dc168-4739-45f3-862b-dffda3e8d65b">

`parlai dd -t light_multiparty:SpeakerPredictionTeacher`

<img width="800" alt="Screenshot 2023-05-30 at 4 13 30 PM" src="https://github.com/facebookresearch/ParlAI/assets/11262163/4cf1a5e4-9c03-4205-8b22-23a7ad42d346">
